### PR TITLE
Harden MCP agent integration and tests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -28,7 +28,7 @@ body:
     attributes:
       label: Go version
       description: Required when building from source.
-      placeholder: "go1.26.2"
+      placeholder: "go1.26.3"
   - type: textarea
     id: steps
     attributes:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,13 +29,13 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
+          go-version: '1.26.3'
           cache: true
 
       - name: Run govulncheck
         uses: golang/govulncheck-action@v1
         with:
-          go-version-input: '1.26'
+          go-version-input: '1.26.3'
           go-package: ./...
         continue-on-error: true
 
@@ -49,7 +49,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
+          go-version: '1.26.3'
           cache: true
 
       - name: Run OSV Scanner
@@ -79,7 +79,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
+          go-version: '1.26.3'
           cache: true
 
       - name: Cache Go build cache
@@ -126,7 +126,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        go-version: ['1.26']
+        go-version: ['1.26.3']
       fail-fast: false
     steps:
       - name: Checkout code
@@ -237,7 +237,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
+          go-version: '1.26.3'
           cache: true
 
       - name: Cache Go build cache
@@ -277,7 +277,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
+          go-version: '1.26.3'
           cache: true
 
       - name: Cache Go build cache

--- a/.github/workflows/deferred-deps-check.yml
+++ b/.github/workflows/deferred-deps-check.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
+          go-version: '1.26.3'
           cache: true
 
       - name: Check for deferred dependency updates

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
+          go-version: '1.26.3'
           cache: true
 
       - name: Check formatting
@@ -72,7 +72,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
+          go-version: '1.26.3'
           cache: true
 
       - name: Run tests
@@ -88,13 +88,13 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
+          go-version: '1.26.3'
           cache: true
 
       - name: Run govulncheck
         uses: golang/govulncheck-action@v1
         with:
-          go-version-input: '1.26'
+          go-version-input: '1.26.3'
           go-package: ./...
 
   release:
@@ -110,7 +110,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
+          go-version: '1.26.3'
           cache: true
 
       - name: Install Cosign

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,7 +155,7 @@ Platform expansion, transport hardening, and developer experience release.
 
 ### Changed
 
-- Go version bumped to 1.26.2
+- Go version bumped to 1.26.3
 - Comprehensive CI documentation with lint gates and FreeBSD guidance
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ The script is idempotent and safe to run multiple times. Use `./scripts/setup-de
 
 If you prefer manual setup, ensure you have:
 
-- **Go 1.26 or later** (CI and release workflows currently validate with Go 1.26)
+- **Go 1.26.3 or later** (CI and release workflows currently validate with Go 1.26.3)
 - **git**
 - **make**
 - **golangci-lint** v2.11.4: `go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4`

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ For the full configuration reference, see [docs/configuration.md](docs/configura
 
 ## Dependencies
 
-- Go 1.26 or later
+- Go 1.26.3 or later
 - [filippo.io/age](https://pkg.go.dev/filippo.io/age) — encryption
 - [spf13/cobra](https://github.com/spf13/cobra) — CLI framework
 - [zalando/go-keyring](https://github.com/zalando/go-keyring) — OS keyring

--- a/cmd/policy_test.go
+++ b/cmd/policy_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestPolicyValidateCmd_Success(t *testing.T) {
+	resetVaultState(t)
 	tmpDir := t.TempDir()
 	policyFile := filepath.Join(tmpDir, "test-policy.yaml")
 
@@ -42,6 +43,7 @@ rules:
 }
 
 func TestPolicyValidateCmd_Invalid(t *testing.T) {
+	resetVaultState(t)
 	tmpDir := t.TempDir()
 	policyFile := filepath.Join(tmpDir, "invalid-policy.yaml")
 

--- a/cmd/port_utils_test.go
+++ b/cmd/port_utils_test.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"net"
 	"net/http"
 	"os"
@@ -11,28 +10,32 @@ import (
 )
 
 func TestFindAvailablePort(t *testing.T) {
-	preferredPort := getFreePort(t)
+	for attempt := 0; attempt < 20; attempt++ {
+		preferredPort := getFreePort(t)
 
-	port, isPreferred, err := findAvailablePort("127.0.0.1", preferredPort)
-	if err != nil {
-		t.Fatalf("findAvailablePort failed: %v", err)
+		port, isPreferred, err := findAvailablePort("127.0.0.1", preferredPort)
+		if err != nil {
+			t.Fatalf("findAvailablePort failed: %v", err)
+		}
+		if isPreferred && port == preferredPort {
+			return
+		}
 	}
-	if !isPreferred {
-		t.Errorf("expected preferred port, got alternative")
-	}
-	if port != preferredPort {
-		t.Errorf("expected port %d, got %d", preferredPort, port)
-	}
+	t.Fatal("findAvailablePort did not return the preferred free port after repeated attempts")
 }
 
 func TestFindAvailablePort_WhenInUse(t *testing.T) {
-	preferredPort := getFreePort(t)
-
-	listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", preferredPort))
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("failed to occupy port: %v", err)
 	}
 	defer func() { _ = listener.Close() }()
+
+	tcpAddr, ok := listener.Addr().(*net.TCPAddr)
+	if !ok {
+		t.Fatalf("failed to get TCP address from listener")
+	}
+	preferredPort := tcpAddr.Port
 
 	port, isPreferred, err := findAvailablePort("127.0.0.1", preferredPort)
 	if err != nil {

--- a/cmd/recipients_test.go
+++ b/cmd/recipients_test.go
@@ -19,22 +19,14 @@ const (
 )
 
 func TestRecipientsListCmd_VaultNotInitialized(t *testing.T) {
+	resetVaultState(t)
 	vaultDir := t.TempDir()
-	_ = os.Setenv("OPENPASS_VAULT", vaultDir)
-	defer func() { _ = os.Unsetenv("OPENPASS_VAULT") }()
-
-	vault = vaultDir
-
-	cmd := recipientsListCmd
 	buf := &bytes.Buffer{}
-	cmd.SetOut(buf)
-	cmd.SetErr(buf)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "recipients", "list"})
 
-	origArgs := os.Args
-	os.Args = []string{"openpass", "recipients", "list"}
-	defer func() { os.Args = origArgs }()
-
-	err := cmd.Execute()
+	err := rootCmd.Execute()
 	if err == nil {
 		t.Error("expected error for vault not initialized")
 	}
@@ -44,44 +36,28 @@ func TestRecipientsListCmd_VaultNotInitialized(t *testing.T) {
 }
 
 func TestRecipientsAddCmd_VaultNotInitialized(t *testing.T) {
+	resetVaultState(t)
 	vaultDir := t.TempDir()
-	_ = os.Setenv("OPENPASS_VAULT", vaultDir)
-	defer func() { _ = os.Unsetenv("OPENPASS_VAULT") }()
-
-	vault = vaultDir
-
-	cmd := recipientsAddCmd
 	buf := &bytes.Buffer{}
-	cmd.SetOut(buf)
-	cmd.SetErr(buf)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "recipients", "add", testRecipient1})
 
-	origArgs := os.Args
-	os.Args = []string{"openpass", "recipients", "add", testRecipient1}
-	defer func() { os.Args = origArgs }()
-
-	err := cmd.Execute()
+	err := rootCmd.Execute()
 	if err == nil {
 		t.Error("expected error for vault not initialized")
 	}
 }
 
 func TestRecipientsRemoveCmd_VaultNotInitialized(t *testing.T) {
+	resetVaultState(t)
 	vaultDir := t.TempDir()
-	_ = os.Setenv("OPENPASS_VAULT", vaultDir)
-	defer func() { _ = os.Unsetenv("OPENPASS_VAULT") }()
-
-	vault = vaultDir
-
-	cmd := recipientsRemoveCmd
 	buf := &bytes.Buffer{}
-	cmd.SetOut(buf)
-	cmd.SetErr(buf)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "recipients", "remove", testRecipient1})
 
-	origArgs := os.Args
-	os.Args = []string{"openpass", "recipients", "remove", testRecipient1}
-	defer func() { os.Args = origArgs }()
-
-	err := cmd.Execute()
+	err := rootCmd.Execute()
 	if err == nil {
 		t.Error("expected error for vault not initialized")
 	}

--- a/cmd/serve_deps.go
+++ b/cmd/serve_deps.go
@@ -22,6 +22,7 @@ var runHTTPServerFunc = func(ctx context.Context, bind string, port int, vault *
 	vaultDir, _ := vaultPath()
 	return serverbootstrap.RunHTTPServer(ctx, bind, port, vault, vaultDir, Version, mcp.New)
 }
+var findAvailablePortFunc = findAvailablePort
 var serveUnlockVault = unlockVault
 
 //nolint:gocyclo // Complex CLI orchestration: vault unlock + server bootstrap + signal handling
@@ -90,7 +91,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 		}()
 	}
 	if !stdioFlag {
-		actualPort, isPreferred, err := findAvailablePort(bind, port)
+		actualPort, isPreferred, err := findAvailablePortFunc(bind, port)
 		if err != nil {
 			return fmt.Errorf("port allocation failed: %w", err)
 		}

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -1138,7 +1138,19 @@ func TestServe_RunE_HTTPWithAgent(t *testing.T) {
 	}
 	vaultFlagReset(t)
 
-	port := findFreePort(t)
+	const port = 18080
+
+	origFindAvailablePort := findAvailablePortFunc
+	findAvailablePortFunc = func(bind string, preferredPort int) (int, bool, error) {
+		if bind != "127.0.0.1" {
+			t.Errorf("port allocator bind = %q, want 127.0.0.1", bind)
+		}
+		if preferredPort != port {
+			t.Errorf("preferred port = %d, want %d", preferredPort, port)
+		}
+		return preferredPort, true, nil
+	}
+	t.Cleanup(func() { findAvailablePortFunc = origFindAvailablePort })
 
 	serveSignals := make(chan chan<- os.Signal, 1)
 	origNotify := serveSignalNotify

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -29,7 +29,8 @@ import (
 // directory. LoadTokenSystem migrates legacy mcp-token files to the registry
 // and deletes the original file, so tests need a way to retrieve the token
 // after the server has started.
-var testTokens sync.Map // map[string]string
+var testTokens sync.Map            // map[string]string
+var reservedTestListeners sync.Map // map[int]net.Listener
 
 func newTestHTTPClient() *http.Client {
 	return &http.Client{
@@ -45,6 +46,27 @@ func findFreePort(t *testing.T) int {
 	}
 	port := l.Addr().(*net.TCPAddr).Port //nolint:errcheck // net.Listener.Addr() does not return an error
 	_ = l.Close()
+	return port
+}
+
+func reserveFreePort(t *testing.T) int {
+	t.Helper()
+	return reserveFreePortForBind(t, "127.0.0.1")
+}
+
+func reserveFreePortForBind(t *testing.T, bind string) int {
+	t.Helper()
+	l, err := net.Listen("tcp", net.JoinHostPort(bind, "0"))
+	if err != nil {
+		t.Fatalf("reserve free port on %s: %v", bind, err)
+	}
+	port := l.Addr().(*net.TCPAddr).Port //nolint:errcheck // listener uses tcp addr
+	reservedTestListeners.Store(port, l)
+	t.Cleanup(func() {
+		if value, ok := reservedTestListeners.LoadAndDelete(port); ok {
+			_ = value.(net.Listener).Close()
+		}
+	})
 	return port
 }
 
@@ -79,12 +101,28 @@ func newTestVault(t *testing.T) *vaultpkg.Vault {
 
 func runHTTPServerAsyncWithFactory(ctx context.Context, t *testing.T, bind string, port int, v *vaultpkg.Vault, factory func(*vaultpkg.Vault, string, string) (*mcp.Server, error)) func() {
 	t.Helper()
+	var listener net.Listener
+	if value, ok := reservedTestListeners.LoadAndDelete(port); ok {
+		listener = value.(net.Listener)
+	} else if bind == "127.0.0.1" {
+		l, err := net.Listen("tcp", fmt.Sprintf("%s:%d", bind, port))
+		if err != nil {
+			t.Fatalf("reserve HTTP listener: %v", err)
+		}
+		listener = l
+	}
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
 		vaultDir, _ := vaultPath()
-		if err := serverbootstrap.RunHTTPServer(ctx, bind, port, v, vaultDir, "dev", factory); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		var err error
+		if listener != nil {
+			err = serverbootstrap.RunHTTPServerOnListener(ctx, listener, v, vaultDir, "dev", factory)
+		} else {
+			err = serverbootstrap.RunHTTPServer(ctx, bind, port, v, vaultDir, "dev", factory)
+		}
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
 			t.Errorf("runHTTPServer error: %v", err)
 		}
 	}()
@@ -144,7 +182,7 @@ func setValidMCPHeaders(req *http.Request, token string) {
 
 func TestRunHTTPServer_HealthEndpoint(t *testing.T) {
 	v := newTestVault(t)
-	port := findFreePort(t)
+	port := reserveFreePort(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	waitForServer := runHTTPServerAsync(ctx, t, port, v)
@@ -190,7 +228,7 @@ func TestRunHTTPServer_HealthEndpoint(t *testing.T) {
 
 func TestRunHTTPServer_MetricsEndpoint(t *testing.T) {
 	v := newTestVault(t)
-	port := findFreePort(t)
+	port := reserveFreePort(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	waitForServer := runHTTPServerAsync(ctx, t, port, v)
@@ -253,7 +291,7 @@ func TestRunHTTPServer_MetricsEndpoint(t *testing.T) {
 
 func TestRunHTTPServer_MCPEndpoint_Auth(t *testing.T) {
 	v := newTestVault(t)
-	port := findFreePort(t)
+	port := reserveFreePort(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	waitForServer := runHTTPServerAsync(ctx, t, port, v)
@@ -289,7 +327,7 @@ func TestRunHTTPServer_MCPEndpoint_Auth(t *testing.T) {
 
 func TestRunHTTPServer_MCPEndpoint_WithAgent(t *testing.T) {
 	v := newTestVault(t)
-	port := findFreePort(t)
+	port := reserveFreePort(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	waitForServer := runHTTPServerAsync(ctx, t, port, v)
@@ -334,7 +372,7 @@ func TestRunHTTPServer_MCPEndpoint_WithAgent(t *testing.T) {
 
 func TestRunHTTPServer_MethodNotAllowed(t *testing.T) {
 	v := newTestVault(t)
-	port := findFreePort(t)
+	port := reserveFreePort(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	waitForServer := runHTTPServerAsync(ctx, t, port, v)
@@ -364,7 +402,7 @@ func TestRunHTTPServer_MethodNotAllowed(t *testing.T) {
 
 func TestRunHTTPServer_InvalidJSON(t *testing.T) {
 	v := newTestVault(t)
-	port := findFreePort(t)
+	port := reserveFreePort(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	waitForServer := runHTTPServerAsync(ctx, t, port, v)
@@ -411,7 +449,7 @@ func TestRunHTTPServer_InvalidJSON(t *testing.T) {
 
 func TestRunHTTPServer_HTTPTransportHeaderValidation(t *testing.T) {
 	v := newTestVault(t)
-	port := findFreePort(t)
+	port := reserveFreePort(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	waitForServer := runHTTPServerAsync(ctx, t, port, v)
@@ -453,7 +491,7 @@ func TestRunHTTPServer_HTTPTransportHeaderValidation(t *testing.T) {
 
 func TestRunHTTPServer_NotificationReturnsAccepted(t *testing.T) {
 	v := newTestVault(t)
-	port := findFreePort(t)
+	port := reserveFreePort(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	waitForServer := runHTTPServerAsync(ctx, t, port, v)
@@ -485,7 +523,7 @@ func TestRunHTTPServer_NotificationReturnsAccepted(t *testing.T) {
 
 func TestRunHTTPServer_BadOriginForbidden(t *testing.T) {
 	v := newTestVault(t)
-	port := findFreePort(t)
+	port := reserveFreePort(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	waitForServer := runHTTPServerAsync(ctx, t, port, v)
@@ -512,7 +550,7 @@ func TestRunHTTPServer_BadOriginForbidden(t *testing.T) {
 
 func TestRunHTTPServer_UnsupportedProtocolHeader(t *testing.T) {
 	v := newTestVault(t)
-	port := findFreePort(t)
+	port := reserveFreePort(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	waitForServer := runHTTPServerAsync(ctx, t, port, v)
@@ -539,7 +577,7 @@ func TestRunHTTPServer_UnsupportedProtocolHeader(t *testing.T) {
 
 func TestRunHTTPServer_HandlerCreationError(t *testing.T) {
 	v := newTestVault(t)
-	port := findFreePort(t)
+	port := reserveFreePort(t)
 
 	factory := func(_ *vaultpkg.Vault, _ string, _ string) (*mcp.Server, error) {
 		return nil, errors.New("agent not found")
@@ -597,7 +635,7 @@ func TestRunHTTPServer_HandlerCreationError(t *testing.T) {
 
 func TestRunHTTPServer_HandlerCacheHit(t *testing.T) {
 	v := newTestVault(t)
-	port := findFreePort(t)
+	port := reserveFreePort(t)
 
 	var callCount int
 	factory := func(vault *vaultpkg.Vault, agentName string, transport string) (*mcp.Server, error) {
@@ -659,7 +697,7 @@ func TestRunHTTPServer_HandlerCacheHit(t *testing.T) {
 
 func TestRunHTTPServer_CustomTokenPath(t *testing.T) {
 	v := newTestVault(t)
-	port := findFreePort(t)
+	port := reserveFreePort(t)
 
 	customTokenPath := filepath.Join(t.TempDir(), "custom-token")
 	tokenContent := "custom-test-token-12345"
@@ -715,7 +753,7 @@ func TestRunHTTPServer_CustomTokenPath(t *testing.T) {
 
 func TestRunHTTPServer_HandleMessageError(t *testing.T) {
 	v := newTestVault(t)
-	port := findFreePort(t)
+	port := reserveFreePort(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	waitForServer := runHTTPServerAsync(ctx, t, port, v)
@@ -950,7 +988,7 @@ func TestRunStdioServer_WithNilVault(t *testing.T) {
 
 func TestRunHTTPServer_MetricsEndpoint_NonLoopback_RequiresAuth(t *testing.T) {
 	v := newTestVault(t)
-	port := findFreePort(t)
+	port := reserveFreePortForBind(t, "0.0.0.0")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	waitForServer := runHTTPServerAsyncWithBind(ctx, t, "0.0.0.0", port, v)
@@ -990,7 +1028,7 @@ func TestRunHTTPServer_MetricsEndpoint_NonLoopback_AllowsWhenDisabled(t *testing
 	v.Config.MCP = &config.MCPConfig{
 		MetricsAuthRequired: false,
 	}
-	port := findFreePort(t)
+	port := reserveFreePortForBind(t, "0.0.0.0")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	waitForServer := runHTTPServerAsyncWithBind(ctx, t, "0.0.0.0", port, v)
@@ -1013,7 +1051,7 @@ func TestRunHTTPServer_MetricsEndpoint_NonLoopback_AllowsWhenDisabled(t *testing
 
 func TestRunHTTPServer_HealthEndpoint_NonLoopback(t *testing.T) {
 	v := newTestVault(t)
-	port := findFreePort(t)
+	port := reserveFreePortForBind(t, "0.0.0.0")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	waitForServer := runHTTPServerAsyncWithBind(ctx, t, "0.0.0.0", port, v)

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -126,7 +127,7 @@ func runHTTPServerAsyncWithFactory(ctx context.Context, t *testing.T, bind strin
 			t.Errorf("runHTTPServer error: %v", err)
 		}
 	}()
-	addr := fmt.Sprintf("%s:%d", bind, port)
+	addr := net.JoinHostPort(bind, strconv.Itoa(port))
 	client := newTestHTTPClient()
 	for i := 0; i < 50; i++ {
 		conn, err := net.DialTimeout("tcp", addr, 100*time.Millisecond)

--- a/cmd/test_state_test.go
+++ b/cmd/test_state_test.go
@@ -21,6 +21,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
+	_ = os.Unsetenv("OPENPASS_MCP_TOKEN")
 	restoreScryptWorkFactor := vaultcrypto.SetScryptWorkFactorForTests(12)
 	code := m.Run()
 	restoreScryptWorkFactor()

--- a/docs/agent-integration.md
+++ b/docs/agent-integration.md
@@ -11,7 +11,7 @@ metadata/read-only access, narrow `allowedPaths`, and an explicit tool allowlist
 do not give broad/default profiles wildcard paths, write access, or command
 execution by default.
 
-For Hermes and OpenClaw, see the conservative adoption packet in
+For a conservative Hermes or local-agent rollout, see the adoption packet in
 [`docs/hermes-safe-adoption.md`](hermes-safe-adoption.md). It covers a
 metadata-first profile, separate runner profiles, stdio-vs-HTTP defaults, and the
 human approval gates required before live config changes or secret migration.
@@ -22,8 +22,8 @@ Example first profile:
 agents:
   hermes-metadata:
     allowedPaths:
-      - hermes/providers/
-      - openclaw/local-dev/
+      - agents/providers/
+      - projects/local-dev/
     canWrite: false
     canRunCommands: false
     canManageConfig: false

--- a/docs/agent-integration.md
+++ b/docs/agent-integration.md
@@ -6,36 +6,56 @@ per-agent access control, bearer auth for HTTP, and audit logs.
 
 ## Recommended Setup
 
-Use a dedicated agent profile instead of sharing a human CLI profile:
+Use a dedicated agent profile instead of sharing a human CLI profile. Start with
+metadata/read-only access, narrow `allowedPaths`, and an explicit tool allowlist;
+do not give broad/default profiles wildcard paths, write access, or command
+execution by default.
+
+For Hermes and OpenClaw, see the conservative adoption packet in
+[`docs/hermes-safe-adoption.md`](hermes-safe-adoption.md). It covers a
+metadata-first profile, separate runner profiles, stdio-vs-HTTP defaults, and the
+human approval gates required before live config changes or secret migration.
+
+Example first profile:
 
 ```yaml
 agents:
-  hermes:
-    allowedPaths: ["*"]
-    canWrite: true
-    canRunCommands: true
-    approvalMode: none
-
-  openclaw:
-    allowedPaths: ["*"]
-    canWrite: true
-    canRunCommands: true
-    approvalMode: none
+  hermes-metadata:
+    allowedPaths:
+      - hermes/providers/
+      - openclaw/local-dev/
+    canWrite: false
+    canRunCommands: false
+    canManageConfig: false
+    canUseClipboard: false
+    canUseAutotype: false
+    approvalMode: deny
+    allowed_tools:
+      - health
+      - get_auth_status
+      - list_entries
+      - find_entries
+      - get_entry_metadata
 ```
 
 Use narrower `allowedPaths` for agents that should only access one area of the
-vault, for example `["paperless-ngx/", "homeassistant/"]`.
+vault, for example `["paperless-ngx/", "homeassistant/"]`. Add `get_entry`, write
+tools, clipboard/autotype, or command execution only in separate profiles with an
+explicit reason and review trail.
 
 ## Hermes
 
-Hermes has a native MCP client. Generate a ready-to-paste config snippet:
+Hermes has a native MCP client. For a local first trial, prefer stdio over HTTP
+so OpenPass does not expose a listening socket and Hermes does not need a bearer
+token in config:
 
 ```bash
-openpass --vault ~/.openpass-vault mcp-config hermes --http --format hermes
+openpass --vault ~/.openpass-vault mcp-config hermes --format hermes
 ```
 
-Add the output under `mcp_servers` in `~/.hermes/config.yaml`, then restart
-Hermes or reload MCP tools from Hermes. Verify the connection:
+Add the output under `mcp_servers` in `~/.hermes/config.yaml` only after the
+human adoption gate approves a live Hermes config change, then restart Hermes or
+reload MCP tools from Hermes. Verify the connection:
 
 ```bash
 hermes mcp test openpass
@@ -43,7 +63,12 @@ hermes mcp test openpass
 
 When connected, Hermes registers the tools with the `mcp_openpass_` prefix, for
 example `mcp_openpass_list_entries`, `mcp_openpass_get_entry`, and
-`mcp_openpass_set_entry_field`.
+`mcp_openpass_set_entry_field`. Early Hermes profiles should expose only the
+metadata-first tool subset from `hermes-safe-adoption.md`.
+
+If HTTP transport is needed later, bind OpenPass to loopback only
+(`127.0.0.1`), use scoped short-lived tokens, and keep token values out of
+committed config and chat transcripts.
 
 ### Available MCP Tools
 

--- a/docs/dependency-evaluations/protonmail-go-crypto.md
+++ b/docs/dependency-evaluations/protonmail-go-crypto.md
@@ -84,7 +84,7 @@ The following CVE-class issues were fixed between v1.1.6 and v1.4.1:
 All Git remotes are **user-configured** (typically the user's own private repository). OpenPass does not clone from untrusted sources.
 
 ### Go Version Compatibility
-- OpenPass requires **Go 1.26.0**
+- OpenPass requires **Go 1.26.3**
 - `ProtonMail/go-crypto v1.4.0+` requires **Go 1.23.0+**
 - **No Go version blocker** — OpenPass's Go version exceeds all minimum requirements
 

--- a/docs/dependency-updates.md
+++ b/docs/dependency-updates.md
@@ -155,7 +155,7 @@ trusted; for major updates, every step is mandatory.
   ```bash
   go build ./...
   ```
-  Confirm no compilation errors on the target Go version (currently Go 1.26).
+  Confirm no compilation errors on the target Go version (currently Go 1.26.3).
 
 - [ ] **7. Cross-compilation smoke test**  
   Because OpenPass ships for multiple platforms:

--- a/docs/hermes-safe-adoption.md
+++ b/docs/hermes-safe-adoption.md
@@ -1,7 +1,7 @@
-# Hermes / OpenClaw safe adoption guide
+# Agent safe adoption guide
 
 This guide describes a conservative adoption path for using OpenPass as a local,
-agent-facing secrets manager for Hermes and OpenClaw.
+agent-facing secrets manager for Hermes or other MCP-capable agents.
 
 It is intentionally not a live migration plan. Do not enable OpenPass in live
 Hermes configuration, move existing Hermes secrets, rotate credentials, or
@@ -10,9 +10,10 @@ approves that later gate.
 
 ## Roles and non-goals
 
-- 1Password remains the user's personal and canonical human password manager.
+- The user's existing password manager remains the canonical human password
+  manager.
 - OpenPass is only the local, agent-facing secrets manager used to broker
-  narrowly scoped credentials to Hermes/OpenClaw agents.
+  narrowly scoped credentials to MCP-capable agents.
 - OpenPass should not become a broad default profile that lets every Hermes
   session read raw secrets.
 - OpenPass should not initially execute commands with injected secrets unless
@@ -24,8 +25,8 @@ approves that later gate.
 1. Complete and review the OpenPass hardening work, especially masking of
    `run_command` and `execute_with_secret` output on every success and error
    path.
-2. Create synthetic-test-only OpenPass agent profiles. Do not import live Hermes
-   `.env` values or personal 1Password items.
+2. Create synthetic-test-only OpenPass agent profiles. Do not import live agent
+   `.env` values or personal password-manager items.
 3. Connect Hermes to a read-only, metadata-first profile and verify tool
    discovery and audit logging.
 4. Trial narrow raw-secret reads only for one explicit path scope and one
@@ -47,8 +48,8 @@ agents:
   hermes-metadata:
     # Replace these with the smallest path prefixes needed for the first trial.
     allowedPaths:
-      - hermes/providers/
-      - openclaw/local-dev/
+      - agents/providers/
+      - projects/local-dev/
     canWrite: false
     canRunCommands: false
     canManageConfig: false
@@ -97,7 +98,7 @@ use case rather than granting raw reads to default Hermes profiles.
 agents:
   hermes-provider-read:
     allowedPaths:
-      - hermes/providers/openrouter/
+      - agents/providers/example-provider/
     canWrite: false
     canRunCommands: false
     canManageConfig: false
@@ -132,9 +133,9 @@ reviewed.
 
 ```yaml
 agents:
-  hermes-runner-openrouter-smoke:
+  hermes-runner-provider-smoke:
     allowedPaths:
-      - hermes/providers/openrouter/
+      - agents/providers/example-provider/
     canWrite: false
     canRunCommands: true
     canManageConfig: false
@@ -160,9 +161,9 @@ Runner-profile operating rules:
 - Do not use runner profiles in broad/default Hermes profiles.
 - Disable or revoke the runner token when the specific maintenance window ends.
 
-## Hermes MCP transport defaults
+## MCP transport defaults
 
-Prefer stdio for a local Hermes/OpenClaw integration:
+Prefer stdio for a local agent integration:
 
 ```yaml
 # ~/.hermes/config.yaml snippet for a future approved trial only.
@@ -172,7 +173,7 @@ mcp_servers:
     command: openpass
     args:
       - --vault
-      - /home/openclaw/.openpass-hermes-trial
+      - /path/to/openpass-agent-trial
       - serve
       - --stdio
       - --agent
@@ -198,7 +199,7 @@ HTTP is used, bind loopback only and use a scoped token:
 mcp:
   bind: 127.0.0.1
   port: 8090
-  httpTokenFile: /home/openclaw/.openpass-hermes-trial/mcp-token
+  httpTokenFile: /path/to/openpass-agent-trial/mcp-token
 ```
 
 ```yaml
@@ -258,7 +259,7 @@ Before widening access, record:
 ## Explicit non-approval
 
 This document does not approve live adoption. It does not approve migrating
-Hermes `.env` secrets, importing 1Password data, rotating real credentials,
+agent `.env` secrets, importing personal password-manager data, rotating real credentials,
 enabling OpenPass MCP in default Hermes profiles, broad wildcard path access,
 HTTP exposure beyond loopback, or command execution with injected secrets before
 reviewed masking fixes.

--- a/docs/hermes-safe-adoption.md
+++ b/docs/hermes-safe-adoption.md
@@ -5,12 +5,12 @@ agent-facing secrets manager for Hermes and OpenClaw.
 
 It is intentionally not a live migration plan. Do not enable OpenPass in live
 Hermes configuration, move existing Hermes secrets, rotate credentials, or
-replace Janusz's personal password-management workflow until a human explicitly
+replace the user's personal password-management workflow until a human explicitly
 approves that later gate.
 
 ## Roles and non-goals
 
-- 1Password remains Janusz's personal and canonical human password manager.
+- 1Password remains the user's personal and canonical human password manager.
 - OpenPass is only the local, agent-facing secrets manager used to broker
   narrowly scoped credentials to Hermes/OpenClaw agents.
 - OpenPass should not become a broad default profile that lets every Hermes

--- a/docs/hermes-safe-adoption.md
+++ b/docs/hermes-safe-adoption.md
@@ -1,0 +1,264 @@
+# Hermes / OpenClaw safe adoption guide
+
+This guide describes a conservative adoption path for using OpenPass as a local,
+agent-facing secrets manager for Hermes and OpenClaw.
+
+It is intentionally not a live migration plan. Do not enable OpenPass in live
+Hermes configuration, move existing Hermes secrets, rotate credentials, or
+replace Janusz's personal password-management workflow until a human explicitly
+approves that later gate.
+
+## Roles and non-goals
+
+- 1Password remains Janusz's personal and canonical human password manager.
+- OpenPass is only the local, agent-facing secrets manager used to broker
+  narrowly scoped credentials to Hermes/OpenClaw agents.
+- OpenPass should not become a broad default profile that lets every Hermes
+  session read raw secrets.
+- OpenPass should not initially execute commands with injected secrets unless
+  the MCP command-output masking fixes have landed, passed regression tests, and
+  received independent review.
+
+## Adoption gates
+
+1. Complete and review the OpenPass hardening work, especially masking of
+   `run_command` and `execute_with_secret` output on every success and error
+   path.
+2. Create synthetic-test-only OpenPass agent profiles. Do not import live Hermes
+   `.env` values or personal 1Password items.
+3. Connect Hermes to a read-only, metadata-first profile and verify tool
+   discovery and audit logging.
+4. Trial narrow raw-secret reads only for one explicit path scope and one
+   explicit task class.
+5. Add a separate runner profile only after the masking fix is present and
+   reviewed.
+6. Ask for final human approval before any live Hermes config change, secret
+   migration, credential rotation, external push/upstream PR, or production use.
+
+## Recommended initial OpenPass profile
+
+Start with a dedicated Hermes profile that can inspect metadata and search only
+narrow path prefixes. Avoid `allowedPaths: ["*"]` for broad/default profiles.
+
+Example `~/.openpass/config.yaml` fragment:
+
+```yaml
+agents:
+  hermes-metadata:
+    # Replace these with the smallest path prefixes needed for the first trial.
+    allowedPaths:
+      - hermes/providers/
+      - openclaw/local-dev/
+    canWrite: false
+    canRunCommands: false
+    canManageConfig: false
+    canUseClipboard: false
+    canUseAutotype: false
+    approvalMode: deny
+    allowed_tools:
+      - health
+      - get_auth_status
+      - list_entries
+      - find_entries
+      - get_entry_metadata
+    max_reads_per_hour: 60
+    max_reads_per_day: 200
+    max_secrets_in_session: 0
+```
+
+Recommended initial Hermes/OpenPass tool allowlist:
+
+- `health`
+- `get_auth_status`
+- `list_entries`
+- `find_entries`
+- `get_entry_metadata`
+
+Do not include these in the first profile:
+
+- `get_entry` for broad/default profiles, because it can expose raw fields unless
+  a purpose-built profile redacts or limits them.
+- `set_entry_field`, `delete_entry`, `secure_input`, or `set_auth_method`,
+  because they mutate vault data or auth/config state.
+- `run_command` / `execute_with_secret`, because they inject secrets into a
+  subprocess and must wait for the masking-fix review gate.
+- `copy_to_clipboard` and `autotype`, because they move secrets outside the MCP
+  response channel and are harder to audit.
+- `generate_totp` unless the profile is explicitly intended for TOTP use and raw
+  TOTP secrets are redacted from `get_entry` responses.
+
+## Optional narrow raw-read profile
+
+After the metadata-only profile is verified, create a separate profile for a
+single narrow task that requires reading a secret value. Prefer one profile per
+use case rather than granting raw reads to default Hermes profiles.
+
+```yaml
+agents:
+  hermes-provider-read:
+    allowedPaths:
+      - hermes/providers/openrouter/
+    canWrite: false
+    canRunCommands: false
+    canManageConfig: false
+    canUseClipboard: false
+    canUseAutotype: false
+    approvalMode: deny
+    allowed_tools:
+      - health
+      - get_auth_status
+      - get_entry_metadata
+      - get_entry
+    # Keep non-required fields redacted. If only a specific key field is needed,
+    # model entries so other fields can remain hidden from the agent.
+    redactFields:
+      - totp.secret
+      - recovery_codes
+    max_reads_per_hour: 10
+    max_reads_per_day: 30
+    max_secrets_in_session: 3
+```
+
+Use this profile only when a task has a concrete reason to read a secret. The
+agent should prefer `get_entry_metadata` for freshness checks and only call
+`get_entry` when the metadata shows the local cached credential is stale or when
+there is no non-secret alternative.
+
+## Separate runner profile after masking review
+
+Command execution belongs in its own profile, not in the metadata/read profile.
+Create it only after the command-output masking work is present, tested, and
+reviewed.
+
+```yaml
+agents:
+  hermes-runner-openrouter-smoke:
+    allowedPaths:
+      - hermes/providers/openrouter/
+    canWrite: false
+    canRunCommands: true
+    canManageConfig: false
+    canUseClipboard: false
+    canUseAutotype: false
+    approvalMode: deny
+    allowed_tools:
+      - health
+      - get_entry_metadata
+      - run_command
+      - execute_with_secret
+    max_reads_per_hour: 5
+    max_reads_per_day: 20
+    max_secrets_in_session: 1
+```
+
+Runner-profile operating rules:
+
+- Use short-lived tokens for HTTP transport, scoped to only the runner tools and
+  path prefix.
+- Prefer synthetic or low-impact smoke commands first.
+- Record and review audit logs before broadening scope.
+- Do not use runner profiles in broad/default Hermes profiles.
+- Disable or revoke the runner token when the specific maintenance window ends.
+
+## Hermes MCP transport defaults
+
+Prefer stdio for a local Hermes/OpenClaw integration:
+
+```yaml
+# ~/.hermes/config.yaml snippet for a future approved trial only.
+# Do not paste this into live config until the human adoption gate approves it.
+mcp_servers:
+  openpass_metadata:
+    command: openpass
+    args:
+      - --vault
+      - /home/openclaw/.openpass-hermes-trial
+      - serve
+      - --stdio
+      - --agent
+      - hermes-metadata
+    timeout: 60
+    connect_timeout: 30
+    sampling:
+      enabled: false
+```
+
+Why stdio first:
+
+- no listening network socket;
+- no bearer token in Hermes config;
+- simple one-client lifecycle tied to the Hermes process;
+- easier audit boundary during early adoption.
+
+Use HTTP only when a shared long-running OpenPass server is genuinely needed. If
+HTTP is used, bind loopback only and use a scoped token:
+
+```yaml
+# OpenPass side, future approved trial only.
+mcp:
+  bind: 127.0.0.1
+  port: 8090
+  httpTokenFile: /home/openclaw/.openpass-hermes-trial/mcp-token
+```
+
+```yaml
+# Hermes side, future approved trial only.
+mcp_servers:
+  openpass_metadata:
+    url: http://127.0.0.1:8090/mcp
+    headers:
+      Authorization: env:OPENPASS_MCP_TOKEN
+      X-OpenPass-Agent: hermes-metadata
+    timeout: 60
+    connect_timeout: 30
+    sampling:
+      enabled: false
+```
+
+HTTP safeguards:
+
+- bind to `127.0.0.1`, not `0.0.0.0`;
+- keep bearer tokens out of committed files and chat transcripts;
+- use short token lifetimes and tool allowlists;
+- revoke trial tokens after testing;
+- do not expose the HTTP listener through a reverse proxy until a separate
+  threat-model review approves it.
+
+## Hermes profile/tooling guidance
+
+Do not attach OpenPass MCP tools to every Hermes profile by default. Create a
+separate Hermes profile or explicitly controlled worker profile for adoption
+trials. The profile should expose only the OpenPass MCP server and the minimum
+Hermes built-in tools needed to validate it.
+
+Recommended first Hermes trial surface:
+
+- OpenPass MCP server: `openpass_metadata`.
+- OpenPass MCP tools: `mcp_openpass_metadata_health`,
+  `mcp_openpass_metadata_get_auth_status`,
+  `mcp_openpass_metadata_list_entries`,
+  `mcp_openpass_metadata_find_entries`,
+  `mcp_openpass_metadata_get_entry_metadata`.
+- Hermes built-in tools: no broad terminal/file/browser tools solely for the
+  OpenPass trial unless the task specifically requires them.
+- No wildcard MCP tool exposure and no default-profile raw-secret reads.
+
+## Audit checklist for each trial
+
+Before widening access, record:
+
+- OpenPass profile name and exact `allowedPaths`.
+- Exact `allowed_tools` list.
+- Transport choice: stdio or HTTP; for HTTP, loopback bind and token lifetime.
+- Whether `get_entry` is allowed, and why metadata-only is insufficient.
+- Whether `canRunCommands` is false; if true, link to masking-fix review evidence.
+- Audit-log sample showing expected tool calls and no unexpected raw-secret reads.
+- Human approval reference for any live Hermes config change or secret migration.
+
+## Explicit non-approval
+
+This document does not approve live adoption. It does not approve migrating
+Hermes `.env` secrets, importing 1Password data, rotating real credentials,
+enabling OpenPass MCP in default Hermes profiles, broad wildcard path access,
+HTTP exposure beyond loopback, or command execution with injected secrets before
+reviewed masking fixes.

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -356,32 +356,46 @@ func PushWithResult(vaultDir string) PushResult {
 		return result
 	}
 
-	// Handle authentication errors gracefully
+	result.Error = classifyPushError(err)
+
+	return result
+}
+
+func classifyPushError(err error) *PushError {
+	if err == nil {
+		return nil
+	}
+
 	errStr := err.Error()
 	switch {
+	case strings.Contains(errStr, "known_hosts"),
+		strings.Contains(errStr, "known hosts"),
+		strings.Contains(errStr, "SSH_KNOWN_HOSTS"):
+		return &PushError{
+			Message: "SSH configuration error - please check known_hosts or SSH_KNOWN_HOSTS",
+			Cause:   err,
+		}
 	case strings.Contains(errStr, "authentication"),
 		strings.Contains(errStr, "credentials"),
 		strings.Contains(errStr, "401"),
 		strings.Contains(errStr, "403"):
-		result.Error = &PushError{
+		return &PushError{
 			Message: "authentication failed - please check your credentials",
 			Cause:   err,
 		}
 	case strings.Contains(errStr, "connection"),
 		strings.Contains(errStr, "timeout"),
 		strings.Contains(errStr, "refused"):
-		result.Error = &PushError{
+		return &PushError{
 			Message: "network error - please check your connection",
 			Cause:   err,
 		}
 	default:
-		result.Error = &PushError{
+		return &PushError{
 			Message: "push failed",
 			Cause:   err,
 		}
 	}
-
-	return result
 }
 
 // AutoCommitAndPush performs auto-commit and optionally auto-push

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -3,6 +3,7 @@ package git
 import (
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -122,6 +123,21 @@ func TestPushErrorUnwrap(t *testing.T) {
 
 	if err.Unwrap() != cause { //nolint:errorlint // comparing exact unwrapped error in test
 		t.Errorf("Unwrap() = %v, want %v", err.Unwrap(), cause)
+	}
+}
+
+func TestClassifyPushErrorSSHKnownHosts(t *testing.T) {
+	cause := errors.New("cannot create known hosts callback: unable to find any valid known_hosts file, set SSH_KNOWN_HOSTS env variable")
+	err := classifyPushError(cause)
+
+	if err == nil {
+		t.Fatal("classifyPushError should return an error")
+	}
+	if !strings.Contains(err.Error(), "SSH configuration error") {
+		t.Fatalf("classified error = %q, want SSH configuration error", err.Error())
+	}
+	if !errors.Is(err, cause) {
+		t.Fatalf("classified error should wrap cause")
 	}
 }
 
@@ -1473,12 +1489,27 @@ func TestPushWithResultSSHAuthError(t *testing.T) {
 		t.Fatalf("Init(local): %v", err)
 	}
 
+	knownHosts := filepath.Join(t.TempDir(), "known_hosts")
+	if err := os.WriteFile(knownHosts, nil, 0o600); err != nil {
+		t.Fatalf("write known_hosts: %v", err)
+	}
+	t.Setenv("SSH_KNOWN_HOSTS", knownHosts)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen on local port: %v", err)
+	}
+	remoteAddr := ln.Addr().String()
+	if err := ln.Close(); err != nil {
+		t.Fatalf("close local listener: %v", err)
+	}
+
 	repo, err := gogit.PlainOpen(local)
 	if err != nil {
 		t.Fatalf("open local: %v", err)
 	}
 
-	if _, err := repo.CreateRemote(&config.RemoteConfig{Name: "origin", URLs: []string{"ssh://git@127.0.0.1:1/repo.git"}}); err != nil {
+	if _, err := repo.CreateRemote(&config.RemoteConfig{Name: "origin", URLs: []string{"ssh://git@" + remoteAddr + "/repo.git"}}); err != nil {
 		t.Fatalf("CreateRemote(): %v", err)
 	}
 

--- a/internal/mcp/serverbootstrap/http.go
+++ b/internal/mcp/serverbootstrap/http.go
@@ -5,7 +5,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -19,9 +21,21 @@ import (
 )
 
 // RunHTTPServer starts the HTTP MCP server.
+func RunHTTPServer(ctx context.Context, bind string, port int, v *vaultpkg.Vault, vaultDir string, version string, factory func(*vaultpkg.Vault, string, string) (*mcp.Server, error)) error {
+	addr := net.JoinHostPort(bind, strconv.Itoa(port))
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		return err
+	}
+	return RunHTTPServerOnListener(ctx, listener, v, vaultDir, version, factory)
+}
+
+// RunHTTPServerOnListener starts the HTTP MCP server on an already-bound listener.
+// Tests and embedders can use this to bind :0 safely without a find-free-port race.
 //
 //nolint:gocyclo // Complex server initialization: auth, middleware, metrics, graceful shutdown
-func RunHTTPServer(ctx context.Context, bind string, port int, v *vaultpkg.Vault, vaultDir string, version string, factory func(*vaultpkg.Vault, string, string) (*mcp.Server, error)) error {
+func RunHTTPServerOnListener(ctx context.Context, listener net.Listener, v *vaultpkg.Vault, vaultDir string, version string, factory func(*vaultpkg.Vault, string, string) (*mcp.Server, error)) error {
+	bind, port := listenerAddress(listener)
 	otlpEndpoint := ""
 	if v != nil && v.Config != nil && v.Config.MCP != nil {
 		otlpEndpoint = v.Config.MCP.OTLPEndpoint
@@ -36,7 +50,7 @@ func RunHTTPServer(ctx context.Context, bind string, port int, v *vaultpkg.Vault
 		cancel()
 	}()
 
-	addr := fmt.Sprintf("%s:%d", bind, port)
+	addr := net.JoinHostPort(bind, strconv.Itoa(port))
 
 	// Load token system (registry + legacy fallback)
 	tokenPath := ""
@@ -261,8 +275,20 @@ func RunHTTPServer(ctx context.Context, bind string, port int, v *vaultpkg.Vault
 		_ = server.Shutdown(shutdownCtx)
 	}()
 
-	if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed { // #nosec G114 — bind address is user-configurable, defaults to loopback
+	if err := server.Serve(listener); err != nil && err != http.ErrServerClosed {
 		return err
 	}
 	return nil
+}
+
+func listenerAddress(listener net.Listener) (string, int) {
+	host, portText, err := net.SplitHostPort(listener.Addr().String())
+	if err != nil {
+		return "127.0.0.1", 0
+	}
+	port, err := strconv.Atoi(portText)
+	if err != nil {
+		return host, 0
+	}
+	return host, port
 }

--- a/internal/mcp/serverbootstrap/serverbootstrap_test.go
+++ b/internal/mcp/serverbootstrap/serverbootstrap_test.go
@@ -26,7 +26,8 @@ import (
 // directory. LoadTokenSystem migrates legacy mcp-token files to the registry
 // and deletes the original file, so tests need a way to retrieve the token
 // after the server has started.
-var testTokens sync.Map // map[string]string
+var testTokens sync.Map            // map[string]string
+var reservedTestListeners sync.Map // map[int]net.Listener
 
 func findFreePort(t *testing.T) int {
 	t.Helper()
@@ -36,6 +37,27 @@ func findFreePort(t *testing.T) int {
 	}
 	port := l.Addr().(*net.TCPAddr).Port //nolint:errcheck
 	_ = l.Close()
+	return port
+}
+
+func reserveFreePort(t *testing.T) int {
+	t.Helper()
+	return reserveFreePortForBind(t, "127.0.0.1")
+}
+
+func reserveFreePortForBind(t *testing.T, bind string) int {
+	t.Helper()
+	l, err := net.Listen("tcp", net.JoinHostPort(bind, "0"))
+	if err != nil {
+		t.Fatalf("reserve free port on %s: %v", bind, err)
+	}
+	port := l.Addr().(*net.TCPAddr).Port //nolint:errcheck // listener uses tcp addr
+	reservedTestListeners.Store(port, l)
+	t.Cleanup(func() {
+		if value, ok := reservedTestListeners.LoadAndDelete(port); ok {
+			_ = value.(net.Listener).Close()
+		}
+	})
 	return port
 }
 
@@ -63,6 +85,16 @@ func newTestHTTPClient() *http.Client {
 
 func runHTTPServerAsync(ctx context.Context, t *testing.T, bind string, port int, v *vaultpkg.Vault, factory func(*vaultpkg.Vault, string, string) (*mcp.Server, error)) func() {
 	t.Helper()
+	var listener net.Listener
+	if value, ok := reservedTestListeners.LoadAndDelete(port); ok {
+		listener = value.(net.Listener)
+	} else if bind == "127.0.0.1" {
+		l, err := net.Listen("tcp", net.JoinHostPort(bind, strconv.Itoa(port)))
+		if err != nil {
+			t.Fatalf("reserve HTTP listener: %v", err)
+		}
+		listener = l
+	}
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
@@ -71,7 +103,13 @@ func runHTTPServerAsync(ctx context.Context, t *testing.T, bind string, port int
 		if v != nil {
 			vaultDir = v.Dir
 		}
-		if err := RunHTTPServer(ctx, bind, port, v, vaultDir, "dev", factory); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		var err error
+		if listener != nil {
+			err = RunHTTPServerOnListener(ctx, listener, v, vaultDir, "dev", factory)
+		} else {
+			err = RunHTTPServer(ctx, bind, port, v, vaultDir, "dev", factory)
+		}
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
 			t.Errorf("RunHTTPServer error: %v", err)
 		}
 	}()
@@ -209,7 +247,7 @@ func TestRunStdioServer_Success(t *testing.T) {
 
 func TestRunHTTPServer_ContextCancelled(t *testing.T) {
 	v := newTestVault(t)
-	port := findFreePort(t)
+	port := reserveFreePort(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	waitForServer := runHTTPServerAsync(ctx, t, "127.0.0.1", port, v, mcp.New)
@@ -220,7 +258,7 @@ func TestRunHTTPServer_ContextCancelled(t *testing.T) {
 
 func TestRunHTTPServer_HealthEndpoint(t *testing.T) {
 	v := newTestVault(t)
-	port := findFreePort(t)
+	port := reserveFreePort(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	waitForServer := runHTTPServerAsync(ctx, t, "127.0.0.1", port, v, mcp.New)
@@ -266,7 +304,7 @@ func TestRunHTTPServer_HealthEndpoint(t *testing.T) {
 
 func TestRunHTTPServer_MetricsEndpoint(t *testing.T) {
 	v := newTestVault(t)
-	port := findFreePort(t)
+	port := reserveFreePort(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	waitForServer := runHTTPServerAsync(ctx, t, "127.0.0.1", port, v, mcp.New)
@@ -307,7 +345,7 @@ func TestRunHTTPServer_MetricsEndpoint(t *testing.T) {
 
 func TestRunHTTPServer_MCPMethodNotAllowed(t *testing.T) {
 	v := newTestVault(t)
-	port := findFreePort(t)
+	port := reserveFreePort(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	waitForServer := runHTTPServerAsync(ctx, t, "127.0.0.1", port, v, mcp.New)
@@ -361,7 +399,7 @@ func TestRunHTTPServer_MCPMediaTypeAndAccept(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			v := newTestVault(t)
-			port := findFreePort(t)
+			port := reserveFreePort(t)
 
 			ctx, cancel := context.WithCancel(context.Background())
 			waitForServer := runHTTPServerAsync(ctx, t, "127.0.0.1", port, v, mcp.New)
@@ -398,7 +436,7 @@ func TestRunHTTPServer_MCPMediaTypeAndAccept(t *testing.T) {
 
 func TestRunHTTPServer_MCPInvalidJSON(t *testing.T) {
 	v := newTestVault(t)
-	port := findFreePort(t)
+	port := reserveFreePort(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	waitForServer := runHTTPServerAsync(ctx, t, "127.0.0.1", port, v, mcp.New)
@@ -438,7 +476,7 @@ func TestRunHTTPServer_MCPInvalidJSON(t *testing.T) {
 
 func TestRunHTTPServer_MCPFactoryError(t *testing.T) {
 	v := newTestVault(t)
-	port := findFreePort(t)
+	port := reserveFreePort(t)
 
 	factory := func(_ *vaultpkg.Vault, _ string, _ string) (*mcp.Server, error) {
 		return nil, errors.New("agent not found")
@@ -491,7 +529,7 @@ func TestRunHTTPServer_MCPFactoryError(t *testing.T) {
 
 func TestRunHTTPServer_HandlerCache(t *testing.T) {
 	v := newTestVault(t)
-	port := findFreePort(t)
+	port := reserveFreePort(t)
 
 	var callCount int
 	factory := func(vault *vaultpkg.Vault, agentName string, transport string) (*mcp.Server, error) {
@@ -545,7 +583,7 @@ func TestRunHTTPServer_HandlerCache(t *testing.T) {
 
 func TestRunHTTPServer_CustomConfig(t *testing.T) {
 	v := newTestVault(t)
-	port := findFreePort(t)
+	port := reserveFreePort(t)
 
 	customTokenPath := filepath.Join(t.TempDir(), "custom-token")
 	tokenContent := "custom-test-token-12345"
@@ -591,7 +629,7 @@ func TestRunHTTPServer_CustomConfig(t *testing.T) {
 
 func TestRunHTTPServer_NonLoopbackMetricsRequiresAuth(t *testing.T) {
 	v := newTestVault(t)
-	port := findFreePort(t)
+	port := reserveFreePortForBind(t, "0.0.0.0")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	waitForServer := runHTTPServerAsync(ctx, t, "0.0.0.0", port, v, mcp.New)
@@ -651,7 +689,7 @@ func TestRunHTTPServer_SecurityHeaders(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			v := newTestVault(t)
-			port := findFreePort(t)
+			port := reserveFreePort(t)
 
 			ctx, cancel := context.WithCancel(context.Background())
 			waitForServer := runHTTPServerAsync(ctx, t, "127.0.0.1", port, v, mcp.New)
@@ -682,7 +720,7 @@ func TestRunHTTPServer_SecurityHeaders(t *testing.T) {
 
 func TestRunHTTPServer_NotificationReturnsAccepted(t *testing.T) {
 	v := newTestVault(t)
-	port := findFreePort(t)
+	port := reserveFreePort(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	waitForServer := runHTTPServerAsync(ctx, t, "127.0.0.1", port, v, mcp.New)
@@ -715,7 +753,7 @@ func TestRunHTTPServer_NotificationReturnsAccepted(t *testing.T) {
 
 func TestRunHTTPServer_InitializeAndToolsList(t *testing.T) {
 	v := newTestVault(t)
-	port := findFreePort(t)
+	port := reserveFreePort(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	waitForServer := runHTTPServerAsync(ctx, t, "127.0.0.1", port, v, mcp.New)

--- a/internal/mcp/test_main_test.go
+++ b/internal/mcp/test_main_test.go
@@ -1,0 +1,11 @@
+package mcp
+
+import (
+	"os"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	_ = os.Unsetenv("OPENPASS_MCP_TOKEN")
+	os.Exit(m.Run())
+}

--- a/internal/mcp/tools_execute_with_secret.go
+++ b/internal/mcp/tools_execute_with_secret.go
@@ -59,6 +59,7 @@ func (s *Server) handleExecuteWithSecret(ctx context.Context, req CallToolReques
 
 	secretRefs := make([]string, 0)
 	resolvedEnv := make(map[string]string)
+	secretEnv := make(map[string]string)
 	if refsRaw != nil {
 		refsSlice, ok := refsRaw.([]any)
 		if !ok {
@@ -107,6 +108,7 @@ func (s *Server) handleExecuteWithSecret(ctx context.Context, req CallToolReques
 			seenEnvVars[envVarName] = true
 
 			resolvedEnv[envVarName] = value
+			secretEnv[envVarName] = value
 			secretRefs = append(secretRefs, ref)
 		}
 	}
@@ -158,16 +160,19 @@ func (s *Server) handleExecuteWithSecret(ctx context.Context, req CallToolReques
 
 	if runErr != nil {
 		if result != nil {
-			return NewToolResultError(fmt.Sprintf("%v\nExit code: %d\nStdout: %s\nStderr: %s",
-				runErr, result.ExitCode, result.Stdout, result.Stderr)), nil
+			sanitizedStdout, sanitizedStderr := s.sanitizeRunOutput(result.Stdout, result.Stderr, secretEnv)
+			sanitizedErr := s.sanitizeKnownSecretValues(runErr.Error(), secretEnv)
+			return NewToolResultError(fmt.Sprintf("%s\nExit code: %d\nStdout: %s\nStderr: %s",
+				sanitizedErr, result.ExitCode, sanitizedStdout, sanitizedStderr)), nil
 		}
-		return NewToolResultError(runErr.Error()), nil
+		return NewToolResultError(s.sanitizeKnownSecretValues(runErr.Error(), secretEnv)), nil
 	}
 
+	sanitizedStdout, sanitizedStderr := s.sanitizeRunOutput(result.Stdout, result.Stderr, secretEnv)
 	resultJSON, err := json.Marshal(map[string]any{
 		"exit_code":   result.ExitCode,
-		"stdout":      result.Stdout,
-		"stderr":      result.Stderr,
+		"stdout":      sanitizedStdout,
+		"stderr":      sanitizedStderr,
 		"duration_ms": result.Duration.Milliseconds(),
 	})
 	if err != nil {

--- a/internal/mcp/tools_execute_with_secret_test.go
+++ b/internal/mcp/tools_execute_with_secret_test.go
@@ -90,8 +90,11 @@ func TestHandleExecuteWithSecret_SecretInjection(t *testing.T) {
 		t.Errorf("exit_code = %v, want 0", code)
 	}
 	stdout, _ := output["stdout"].(string)
-	if !strings.Contains(stdout, "AKIAIOSFODNN7EXAMPLE") {
-		t.Errorf("stdout = %q, want to contain injected secret value", stdout)
+	if strings.Contains(stdout, "AKIAIO...MPLE") {
+		t.Errorf("stdout = %q, should not contain plaintext secret", stdout)
+	}
+	if !strings.Contains(stdout, "***") {
+		t.Errorf("stdout = %q, want to contain masked value '***'", stdout)
 	}
 }
 
@@ -128,6 +131,52 @@ func TestHandleExecuteWithSecret_NeverExposesSecretValue(t *testing.T) {
 	resultStr := result.Text
 	if strings.Contains(resultStr, "super-secret-value-12345") {
 		t.Errorf("result contains secret value: %q", resultStr)
+	}
+}
+
+func TestHandleExecuteWithSecret_MasksSecretInStdoutAndStderr(t *testing.T) {
+	const secret = "synthetic-execute-success-secret"
+	vaultDir, identity := mockVaultWithEntry(t, "aws", map[string]any{
+		"secret_key": secret,
+	})
+
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:           "test",
+		AllowedPaths:   []string{"*"},
+		CanRunCommands: true,
+		ApprovalMode:   "none",
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+
+	req := CallToolRequest{
+		Arguments: map[string]any{
+			"command": []any{"sh", "-c", "printf '%s' \"$AWS_SECRET_KEY\"; printf '%s' \"$AWS_SECRET_KEY\" >&2"},
+			"secret_refs": []any{
+				"op://vault/aws/secret_key",
+			},
+		},
+	}
+
+	result, err := srv.handleExecuteWithSecret(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleExecuteWithSecret() error = %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handleExecuteWithSecret() returned error: %s", result.Text)
+	}
+	if strings.Contains(result.Text, secret) {
+		t.Fatalf("result contains raw secret: %q", result.Text)
+	}
+
+	var output map[string]any
+	if err := json.Unmarshal([]byte(result.Text), &output); err != nil {
+		t.Fatalf("parse result: %v", err)
+	}
+	for _, field := range []string{"stdout", "stderr"} {
+		text, _ := output[field].(string)
+		if text != "***" {
+			t.Errorf("%s = %q, want masked value '***'", field, text)
+		}
 	}
 }
 
@@ -391,6 +440,54 @@ func TestHandleExecuteWithSecret_Timeout(t *testing.T) {
 	}
 }
 
+func TestHandleExecuteWithSecret_MasksSecretOnTimeoutError(t *testing.T) {
+	const secret = "synthetic-execute-timeout-secret"
+	vaultDir, identity := mockVaultWithEntry(t, "aws", map[string]any{
+		"secret_key": secret,
+	})
+
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:           "test",
+		AllowedPaths:   []string{"*"},
+		CanRunCommands: true,
+		ApprovalMode:   "none",
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+
+	req := CallToolRequest{
+		Arguments: map[string]any{
+			"command": []any{"sh", "-c", "printf '%s' \"$AWS_SECRET_KEY\"; printf '%s' \"$AWS_SECRET_KEY\" >&2; exec sleep 10"},
+			"secret_refs": []any{
+				"op://vault/aws/secret_key",
+			},
+			"timeout": float64(1),
+		},
+	}
+
+	result, err := srv.handleExecuteWithSecret(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleExecuteWithSecret() error = %v", err)
+	}
+	if result == nil {
+		t.Fatal("handleExecuteWithSecret() returned nil result")
+	}
+	if !result.IsError {
+		t.Fatal("handleExecuteWithSecret() expected error result for timeout")
+	}
+	if strings.Contains(result.Text, secret) {
+		t.Fatalf("result contains raw secret: %q", result.Text)
+	}
+	if !strings.Contains(result.Text, "Stdout: ***") {
+		t.Fatalf("result text = %q, want masked stdout", result.Text)
+	}
+	if !strings.Contains(result.Text, "Stderr: ***") {
+		t.Fatalf("result text = %q, want masked stderr", result.Text)
+	}
+	if !strings.Contains(result.Text, "Exit code: -1") {
+		t.Fatalf("result text = %q, want exit code diagnostic", result.Text)
+	}
+}
+
 func TestHandleExecuteWithSecret_InvalidParams(t *testing.T) {
 	srv := newTestServer(t, config.AgentProfile{
 		Name:           "test",
@@ -622,6 +719,55 @@ func TestHandleExecuteWithSecret_NonZeroExit(t *testing.T) {
 	}
 	if code, _ := output["exit_code"].(float64); code != 42 {
 		t.Errorf("exit_code = %v, want 42", code)
+	}
+}
+
+func TestHandleExecuteWithSecret_MasksSecretOnNonZeroExit(t *testing.T) {
+	const secret = "synthetic-execute-nonzero-secret"
+	vaultDir, identity := mockVaultWithEntry(t, "aws", map[string]any{
+		"secret_key": secret,
+	})
+
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:           "test",
+		AllowedPaths:   []string{"*"},
+		CanRunCommands: true,
+		ApprovalMode:   "none",
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+
+	req := CallToolRequest{
+		Arguments: map[string]any{
+			"command": []any{"sh", "-c", "printf '%s' \"$AWS_SECRET_KEY\"; printf '%s' \"$AWS_SECRET_KEY\" >&2; exit 42"},
+			"secret_refs": []any{
+				"op://vault/aws/secret_key",
+			},
+		},
+	}
+
+	result, err := srv.handleExecuteWithSecret(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleExecuteWithSecret() error = %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handleExecuteWithSecret() returned error: %s", result.Text)
+	}
+	if strings.Contains(result.Text, secret) {
+		t.Fatalf("result contains raw secret: %q", result.Text)
+	}
+
+	var output map[string]any
+	if err := json.Unmarshal([]byte(result.Text), &output); err != nil {
+		t.Fatalf("parse result: %v", err)
+	}
+	if code, _ := output["exit_code"].(float64); code != 42 {
+		t.Errorf("exit_code = %v, want 42", code)
+	}
+	for _, field := range []string{"stdout", "stderr"} {
+		text, _ := output[field].(string)
+		if text != "***" {
+			t.Errorf("%s = %q, want masked value '***'", field, text)
+		}
 	}
 }
 

--- a/internal/mcp/tools_run.go
+++ b/internal/mcp/tools_run.go
@@ -103,10 +103,12 @@ func (s *Server) handleRunCommand(ctx context.Context, req CallToolRequest) (*Ca
 	if err != nil {
 		s.logAudit(ctx, "run_command", auditPath, false)
 		if result != nil {
-			return NewToolResultError(fmt.Sprintf("%v\nExit code: %d\nStdout: %s\nStderr: %s",
-				err, result.ExitCode, result.Stdout, result.Stderr)), nil
+			sanitizedStdout, sanitizedStderr := s.sanitizeRunOutput(result.Stdout, result.Stderr, resolvedEnv)
+			sanitizedErr := s.sanitizeKnownSecretValues(err.Error(), resolvedEnv)
+			return NewToolResultError(fmt.Sprintf("%s\nExit code: %d\nStdout: %s\nStderr: %s",
+				sanitizedErr, result.ExitCode, sanitizedStdout, sanitizedStderr)), nil
 		}
-		return NewToolResultError(err.Error()), nil
+		return NewToolResultError(s.sanitizeKnownSecretValues(err.Error(), resolvedEnv)), nil
 	}
 
 	s.logAudit(ctx, "run_command", auditPath, true)

--- a/internal/mcp/tools_run_test.go
+++ b/internal/mcp/tools_run_test.go
@@ -66,8 +66,8 @@ func TestHandleRunCommand_BasicRun(t *testing.T) {
 	if stdout, _ := output["stdout"].(string); !strings.Contains(stdout, "hello") {
 		t.Errorf("stdout = %q, want hello", stdout)
 	}
-	if d, _ := output["duration_ms"].(float64); d <= 0 {
-		t.Error("duration_ms should be positive")
+	if d, _ := output["duration_ms"].(float64); d < 0 {
+		t.Error("duration_ms should not be negative")
 	}
 }
 
@@ -111,6 +111,52 @@ func TestHandleRunCommand_SecretEnvInjection(t *testing.T) {
 	}
 	if !strings.Contains(stdout, "***") {
 		t.Errorf("stdout = %q, want to contain masked value '***'", stdout)
+	}
+}
+
+func TestHandleRunCommand_MasksSecretEnvInStdoutAndStderr(t *testing.T) {
+	const secret = "synthetic-run-command-success-secret"
+	vaultDir, identity := mockVaultWithEntry(t, "github", map[string]any{
+		"api_key": secret,
+	})
+
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:           "test",
+		AllowedPaths:   []string{"*"},
+		CanRunCommands: true,
+		ApprovalMode:   "none",
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+
+	req := CallToolRequest{
+		Arguments: map[string]any{
+			"command": []any{"sh", "-c", "printf '%s' \"$MY_KEY\"; printf '%s' \"$MY_KEY\" >&2"},
+			"env": map[string]any{
+				"MY_KEY": "github.api_key",
+			},
+		},
+	}
+
+	result, err := srv.handleRunCommand(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleRunCommand() error = %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handleRunCommand() returned error: %s", result.Text)
+	}
+	if strings.Contains(result.Text, secret) {
+		t.Fatalf("result contains raw secret: %q", result.Text)
+	}
+
+	var output map[string]any
+	if err := json.Unmarshal([]byte(result.Text), &output); err != nil {
+		t.Fatalf("parse result: %v", err)
+	}
+	for _, field := range []string{"stdout", "stderr"} {
+		text, _ := output[field].(string)
+		if text != "***" {
+			t.Errorf("%s = %q, want masked value '***'", field, text)
+		}
 	}
 }
 
@@ -239,6 +285,54 @@ func TestHandleRunCommand_Timeout(t *testing.T) {
 	}
 	if !strings.Contains(result.Text, "timed out") {
 		t.Fatalf("result text = %q, want 'timed out'", result.Text)
+	}
+}
+
+func TestHandleRunCommand_MasksSecretEnvOnTimeoutError(t *testing.T) {
+	const secret = "synthetic-run-command-timeout-secret"
+	vaultDir, identity := mockVaultWithEntry(t, "github", map[string]any{
+		"api_key": secret,
+	})
+
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:           "test",
+		AllowedPaths:   []string{"*"},
+		CanRunCommands: true,
+		ApprovalMode:   "none",
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+
+	req := CallToolRequest{
+		Arguments: map[string]any{
+			"command": []any{"sh", "-c", "printf '%s' \"$MY_KEY\"; printf '%s' \"$MY_KEY\" >&2; exec sleep 10"},
+			"env": map[string]any{
+				"MY_KEY": "github.api_key",
+			},
+			"timeout": float64(1),
+		},
+	}
+
+	result, err := srv.handleRunCommand(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleRunCommand() error = %v", err)
+	}
+	if result == nil {
+		t.Fatal("handleRunCommand() returned nil result")
+	}
+	if !result.IsError {
+		t.Fatal("handleRunCommand() expected error result for timeout")
+	}
+	if strings.Contains(result.Text, secret) {
+		t.Fatalf("result contains raw secret: %q", result.Text)
+	}
+	if !strings.Contains(result.Text, "Stdout: ***") {
+		t.Fatalf("result text = %q, want masked stdout", result.Text)
+	}
+	if !strings.Contains(result.Text, "Stderr: ***") {
+		t.Fatalf("result text = %q, want masked stderr", result.Text)
+	}
+	if !strings.Contains(result.Text, "Exit code: -1") {
+		t.Fatalf("result text = %q, want exit code diagnostic", result.Text)
 	}
 }
 
@@ -418,6 +512,55 @@ func TestHandleRunCommand_NonZeroExit(t *testing.T) {
 	}
 	if code, _ := output["exit_code"].(float64); code != 42 {
 		t.Errorf("exit_code = %v, want 42", code)
+	}
+}
+
+func TestHandleRunCommand_MasksSecretEnvOnNonZeroExit(t *testing.T) {
+	const secret = "synthetic-run-command-nonzero-secret"
+	vaultDir, identity := mockVaultWithEntry(t, "github", map[string]any{
+		"api_key": secret,
+	})
+
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:           "test",
+		AllowedPaths:   []string{"*"},
+		CanRunCommands: true,
+		ApprovalMode:   "none",
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+
+	req := CallToolRequest{
+		Arguments: map[string]any{
+			"command": []any{"sh", "-c", "printf '%s' \"$MY_KEY\"; printf '%s' \"$MY_KEY\" >&2; exit 42"},
+			"env": map[string]any{
+				"MY_KEY": "github.api_key",
+			},
+		},
+	}
+
+	result, err := srv.handleRunCommand(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleRunCommand() error = %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handleRunCommand() returned error: %s", result.Text)
+	}
+	if strings.Contains(result.Text, secret) {
+		t.Fatalf("result contains raw secret: %q", result.Text)
+	}
+
+	var output map[string]any
+	if err := json.Unmarshal([]byte(result.Text), &output); err != nil {
+		t.Fatalf("parse result: %v", err)
+	}
+	if code, _ := output["exit_code"].(float64); code != 42 {
+		t.Errorf("exit_code = %v, want 42", code)
+	}
+	for _, field := range []string{"stdout", "stderr"} {
+		text, _ := output[field].(string)
+		if text != "***" {
+			t.Errorf("%s = %q, want masked value '***'", field, text)
+		}
 	}
 }
 

--- a/internal/mcp/tools_sanitize.go
+++ b/internal/mcp/tools_sanitize.go
@@ -79,12 +79,13 @@ func (s *Server) buildVaultResolver() func(string) (string, bool) {
 }
 
 func (s *Server) sanitizeRunOutput(stdout, stderr string, resolvedEnv map[string]string) (string, string) {
+	return s.sanitizeKnownSecretValues(stdout, resolvedEnv), s.sanitizeKnownSecretValues(stderr, resolvedEnv)
+}
+
+func (s *Server) sanitizeKnownSecretValues(text string, resolvedEnv map[string]string) string {
 	if len(resolvedEnv) == 0 {
-		return stdout, stderr
+		return text
 	}
 
-	mask := "***"
-	sanitizedStdout := masking.SanitizeWithKnownSecrets(stdout, resolvedEnv, mask)
-	sanitizedStderr := masking.SanitizeWithKnownSecrets(stderr, resolvedEnv, mask)
-	return sanitizedStdout, sanitizedStderr
+	return masking.SanitizeWithKnownSecrets(text, resolvedEnv, "***")
 }

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tools]
-go = "1.26.2"
+go = "1.26.3"
 golangci-lint = "2.11.4"
 gosec = "github.com/securego/gosec/v2/cmd/gosec@v2.22.0"
 govulncheck = "golang.org/x/vuln/cmd/govulncheck@latest"


### PR DESCRIPTION
## Summary

This PR hardens OpenPass' MCP/agent integration and test reliability:

- Redacts resolved secret values from MCP `run_command` / `execute_with_secret` tool output, including stdout/stderr/error paths.
- Isolates MCP command and HTTP-server tests to reduce shared global/listener flakiness.
- Makes SSH push error tests hermetic and classifies SSH known-hosts/config failures more clearly.
- Pins the Go toolchain through the project config / CI paths used here.
- Adds Hermes/OpenClaw safe-adoption guidance and related docs/dependency metadata updates.
- Hardens tests against ambient `OPENPASS_MCP_TOKEN` so local `make test` remains deterministic in developer/agent shells.

## Verification

Run locally on WSL with Go 1.26.3:

```text
go version go1.26.3 linux/amd64
```

Fresh pre-PR checks:

```text
git diff --check upstream/main...HEAD
# passed

go vet ./...
# passed

go test ./cmd ./internal/mcp -race
# passed

make test
# passed; runs go test ./... -race -v
```

Independent pre-PR review verdict: PASS.

Reviewer notes:

- No blocking security or logic issues found in the diff against `upstream/main`.
- A synthetic merge-tree check against current `upstream/main` reported no conflicts.
- Remaining caveat: the local checkout still has a pre-existing untracked `OpenPass` binary; it is not part of this PR.

## Caveats / scope notes

- Secret masking is exact-value masking for resolved secrets. It is defense-in-depth, not full DLP for transformed/encoded/partial secret variants.
- This branch is from `rzyns/OpenPass:main` to `danieljustus/OpenPass:main`.
