### PR TITLE
feat(ui): centralized theme system, visual polish, Esc confirm (#33)

### DIFF
--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -7,21 +7,21 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	"golang.org/x/term"
 
 	errorspkg "github.com/danieljustus/OpenPass/internal/errors"
 	"github.com/danieljustus/OpenPass/internal/health"
+	cliout "github.com/danieljustus/OpenPass/internal/ui/cliout"
 )
 
 var (
-	doctorJSON        bool
-	doctorNoNetwork   bool
-	doctorStrict      bool
-	doctorOnly        []string
-	doctorExclude     []string
-	doctorFix         bool
-	doctorFixDryRun   bool
-	doctorQuick       bool
+	doctorJSON      bool
+	doctorNoNetwork bool
+	doctorStrict    bool
+	doctorOnly      []string
+	doctorExclude   []string
+	doctorFix       bool
+	doctorFixDryRun bool
+	doctorQuick     bool
 )
 
 var doctorCmd = &cobra.Command{
@@ -94,31 +94,17 @@ Use --no-network to skip checks that require network access (git remote reachabi
 }
 
 func outputDoctorText(cmd *cobra.Command, vaultDir string, results []health.Result) error {
-	isTTY := term.IsTerminal(int(os.Stdout.Fd()))
-	noColor := os.Getenv("NO_COLOR") != ""
-	useColor := isTTY && !noColor
-
-	colorize := func(code, s string) string {
-		if !useColor {
-			return s
-		}
-		return code + s + "\033[0m"
-	}
-
 	cmd.Printf("OpenPass Doctor — Vault: %s\n\n", vaultDir)
 
 	for _, r := range results {
-		var symbol, colorCode string
+		var symbol string
 		switch r.Status {
 		case health.StatusOK:
 			symbol = " ✓ "
-			colorCode = "\033[32m" // green
 		case health.StatusWarn:
 			symbol = " ⚠ "
-			colorCode = "\033[33m" // yellow
 		case health.StatusFail:
 			symbol = " ✗ "
-			colorCode = "\033[31m" // red
 		}
 
 		fixedTag := ""
@@ -129,11 +115,19 @@ func outputDoctorText(cmd *cobra.Command, vaultDir string, results []health.Resu
 		if r.Fixable && r.Status != health.StatusOK {
 			fixableTag = " (fixable — run with --fix)"
 		}
-		line := fmt.Sprintf("%-3s %-40s %s%s%s", symbol, r.Name, r.Message, fixedTag, fixableTag)
-		cmd.Println(colorize(colorCode, line))
+		formatted := fmt.Sprintf("%-3s %-40s %s%s%s", symbol, r.Name, r.Message, fixedTag, fixableTag)
+
+		switch r.Status {
+		case health.StatusOK:
+			cmd.Println(cliout.ColorizeSuccess(formatted))
+		case health.StatusWarn:
+			cmd.Println(cliout.ColorizeWarn(formatted))
+		case health.StatusFail:
+			cmd.Println(cliout.ColorizeError(formatted))
+		}
 		if r.Hint != "" {
 			indent := strings.Repeat(" ", 4)
-			cmd.Println(colorize("\033[2m", indent+"→ "+r.Hint))
+			cmd.Println(cliout.ColorizeDim(indent + "→ " + r.Hint))
 		}
 	}
 
@@ -141,10 +135,10 @@ func outputDoctorText(cmd *cobra.Command, vaultDir string, results []health.Resu
 	total := ok + warn + fail
 	cmd.Printf("\nScore: %d/%d OK", ok, total)
 	if warn > 0 {
-		cmd.Printf(" · %s", colorize("\033[33m", fmt.Sprintf("%d warning(s)", warn)))
+		cmd.Printf(" · %s", cliout.ColorizeWarn(fmt.Sprintf("%d warning(s)", warn)))
 	}
 	if fail > 0 {
-		cmd.Printf(" · %s", colorize("\033[31m", fmt.Sprintf("%d failed", fail)))
+		cmd.Printf(" · %s", cliout.ColorizeError(fmt.Sprintf("%d failed", fail)))
 	}
 	cmd.Println()
 	return nil

--- a/internal/ui/cliout/cliout.go
+++ b/internal/ui/cliout/cliout.go
@@ -7,21 +7,15 @@ import (
 	"os"
 	"sync"
 
+	"github.com/charmbracelet/lipgloss"
 	"golang.org/x/term"
+
+	"github.com/danieljustus/OpenPass/internal/ui/theme"
 )
 
 var (
 	quiet bool
 	mu    sync.RWMutex
-)
-
-// ANSI color codes.
-const (
-	red    = "\033[31m"
-	yellow = "\033[33m"
-	green  = "\033[32m"
-	blue   = "\033[34m"
-	reset  = "\033[0m"
 )
 
 // SetQuiet enables or disables quiet mode.
@@ -45,11 +39,11 @@ func noColor() bool {
 	return !term.IsTerminal(int(os.Stderr.Fd()))
 }
 
-func colorize(color, format string, args ...any) string {
+func colorize(style lipgloss.Style, format string, args ...any) string {
 	if noColor() {
 		return fmt.Sprintf(format, args...)
 	}
-	return color + fmt.Sprintf(format, args...) + reset
+	return style.Render(fmt.Sprintf(format, args...))
 }
 
 // Errorf prints a red error message to stderr unless quiet mode is enabled.
@@ -57,7 +51,7 @@ func Errorf(format string, args ...any) {
 	if isQuiet() {
 		return
 	}
-	fmt.Fprintln(os.Stderr, colorize(red, format, args...))
+	fmt.Fprintln(os.Stderr, colorize(theme.ErrorStyle, format, args...))
 }
 
 // Warnf prints a yellow warning message to stderr unless quiet mode is enabled.
@@ -65,13 +59,49 @@ func Warnf(format string, args ...any) {
 	if isQuiet() {
 		return
 	}
-	fmt.Fprintln(os.Stderr, colorize(yellow, format, args...))
+	fmt.Fprintln(os.Stderr, colorize(theme.WarnStyle, format, args...))
 }
 
-// Hintf prints a green/blue hint message to stderr unless quiet mode is enabled.
+// Hintf prints a green success hint message to stderr unless quiet mode is enabled.
 func Hintf(format string, args ...any) {
 	if isQuiet() {
 		return
 	}
-	fmt.Fprintln(os.Stderr, colorize(green, format, args...))
+	fmt.Fprintln(os.Stderr, colorize(theme.SuccessStyle, format, args...))
+}
+
+// ColorizeSuccess returns text styled with the success/green color.
+// It respects NO_COLOR and terminal detection.
+func ColorizeSuccess(text string) string {
+	if noColor() {
+		return text
+	}
+	return theme.SuccessStyle.Render(text)
+}
+
+// ColorizeWarn returns text styled with the warning/yellow color.
+// It respects NO_COLOR and terminal detection.
+func ColorizeWarn(text string) string {
+	if noColor() {
+		return text
+	}
+	return theme.WarnStyle.Render(text)
+}
+
+// ColorizeError returns text styled with the error/red color.
+// It respects NO_COLOR and terminal detection.
+func ColorizeError(text string) string {
+	if noColor() {
+		return text
+	}
+	return theme.ErrorStyle.Render(text)
+}
+
+// ColorizeDim returns text styled with muted/dim foreground color.
+// It respects NO_COLOR and terminal detection.
+func ColorizeDim(text string) string {
+	if noColor() {
+		return text
+	}
+	return theme.DimStyle.Render(text)
 }

--- a/internal/ui/cliout/cliout_test.go
+++ b/internal/ui/cliout/cliout_test.go
@@ -88,12 +88,41 @@ func TestColorWithCodes(t *testing.T) {
 	}
 }
 
-func TestColorize_TTYBehavior(t *testing.T) {
+func TestColorizeFunctions(t *testing.T) {
 	os.Unsetenv("NO_COLOR")
-	// Direct call to colorize is the only way to test color formatting
-	// without a real TTY; this documents the format.
-	got := red + "msg" + reset
-	if !strings.Contains(got, "\033[") {
-		t.Errorf("colorize format missing ANSI prefix, got %q", got)
+	// When stderr is piped (as in tests), color is suppressed.
+	// Verify the functions return text correctly in either case.
+	cases := []struct {
+		name string
+		fn   func(string) string
+	}{
+		{"ColorizeError", ColorizeError},
+		{"ColorizeWarn", ColorizeWarn},
+		{"ColorizeSuccess", ColorizeSuccess},
+		{"ColorizeDim", ColorizeDim},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.fn("hello")
+			if !strings.Contains(got, "hello") {
+				t.Errorf("%s = %q, want to contain 'hello'", tc.name, got)
+			}
+		})
+	}
+}
+
+func TestColorizeFunctionsNoColor(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
+	got := ColorizeError("secret")
+	if strings.Contains(got, "\033[") {
+		t.Errorf("ColorizeError with NO_COLOR should not contain ANSI, got %q", got)
+	}
+	got = ColorizeWarn("secret")
+	if strings.Contains(got, "\033[") {
+		t.Errorf("ColorizeWarn with NO_COLOR should not contain ANSI, got %q", got)
+	}
+	got = ColorizeSuccess("secret")
+	if strings.Contains(got, "\033[") {
+		t.Errorf("ColorizeSuccess with NO_COLOR should not contain ANSI, got %q", got)
 	}
 }

--- a/internal/ui/theme/symbols.go
+++ b/internal/ui/theme/symbols.go
@@ -1,0 +1,10 @@
+package theme
+
+// Consistent symbol set for status indicators across all UI surfaces.
+const (
+	SymbolSuccess = "✓"
+	SymbolWarning = "⚠"
+	SymbolError   = "✗"
+	SymbolCursor  = "▸"
+	SymbolBullet  = "·"
+)

--- a/internal/ui/theme/theme.go
+++ b/internal/ui/theme/theme.go
@@ -1,0 +1,73 @@
+// Package theme provides centralized color tokens and shared lipgloss styles for
+// the OpenPass UI, TUI, wizard, doctor, and CLI output. All UI components should
+// import this package rather than defining their own color constants.
+//
+// Colors use lipgloss.AdaptiveColor so they render legibly on both dark and light
+// terminal backgrounds.
+package theme
+
+import "github.com/charmbracelet/lipgloss"
+
+// Adaptive color tokens — each pair specifies a Light (light-background) and Dark
+// (dark-background) color value from the 256-color terminal palette.
+var (
+	// ColorPrimary is the primary accent (pink/magenta). Used for titles, headers.
+	ColorPrimary = lipgloss.AdaptiveColor{Light: "162", Dark: "212"}
+
+	// ColorFocused is the focused accent (cyan). Used for focused items, keys.
+	ColorFocused = lipgloss.AdaptiveColor{Light: "30", Dark: "86"}
+
+	// ColorError is the error/danger color (red).
+	ColorError = lipgloss.AdaptiveColor{Light: "124", Dark: "203"}
+
+	// ColorMuted is muted/secondary text (medium gray).
+	ColorMuted = lipgloss.AdaptiveColor{Light: "243", Dark: "240"}
+
+	// ColorDim is dim/subtle text (lighter gray).
+	ColorDim = lipgloss.AdaptiveColor{Light: "245", Dark: "245"}
+
+	// ColorWarning is warning/amber.
+	ColorWarning = lipgloss.AdaptiveColor{Light: "130", Dark: "220"}
+
+	// ColorSuccess is success/green.
+	ColorSuccess = lipgloss.AdaptiveColor{Light: "28", Dark: "82"}
+
+	// ColorSelectedBg is the selection/highlight background (blue).
+	ColorSelectedBg = lipgloss.AdaptiveColor{Light: "26", Dark: "62"}
+
+	// ColorSelectedFg is the selection/highlight foreground (cream/yellow).
+	ColorSelectedFg = lipgloss.AdaptiveColor{Light: "229", Dark: "229"}
+)
+
+// Pre-built lipgloss styles shared across all UI components.
+var (
+	// TitleStyle is used for headings and section titles.
+	TitleStyle = lipgloss.NewStyle().Bold(true).Foreground(ColorPrimary)
+
+	// FocusedStyle is used for the currently focused/active item.
+	FocusedStyle = lipgloss.NewStyle().Foreground(ColorFocused).Bold(true)
+
+	// ErrorStyle is used for error messages and danger indicators.
+	ErrorStyle = lipgloss.NewStyle().Foreground(ColorError)
+
+	// MutedStyle is used for secondary/less important text.
+	MutedStyle = lipgloss.NewStyle().Foreground(ColorMuted)
+
+	// DimStyle is used for the most subtle text (hints, placeholders).
+	DimStyle = lipgloss.NewStyle().Foreground(ColorDim)
+
+	// WarnStyle is used for warning messages.
+	WarnStyle = lipgloss.NewStyle().Foreground(ColorWarning)
+
+	// SuccessStyle is used for success messages and positive indicators.
+	SuccessStyle = lipgloss.NewStyle().Foreground(ColorSuccess)
+
+	// KeyStyle is used for keyboard shortcut labels.
+	KeyStyle = lipgloss.NewStyle().Foreground(ColorFocused).Bold(true)
+
+	// SelectedStyle is used for the currently selected list item.
+	SelectedStyle = lipgloss.NewStyle().
+			Foreground(ColorSelectedFg).
+			Background(ColorSelectedBg).
+			Bold(true)
+)

--- a/internal/ui/tui.go
+++ b/internal/ui/tui.go
@@ -19,6 +19,7 @@ import (
 
 	clipboardapp "github.com/danieljustus/OpenPass/internal/clipboard"
 	vaultcrypto "github.com/danieljustus/OpenPass/internal/crypto"
+	theme "github.com/danieljustus/OpenPass/internal/ui/theme"
 	vaultpkg "github.com/danieljustus/OpenPass/internal/vault"
 	vaultsvc "github.com/danieljustus/OpenPass/internal/vaultsvc"
 )
@@ -120,20 +121,11 @@ var (
 
 	borderStyle = lipgloss.NewStyle().
 			Border(lipgloss.RoundedBorder()).
-			BorderForeground(lipgloss.Color("240"))
+			BorderForeground(theme.ColorMuted)
 
-	titleStyle = lipgloss.NewStyle().
-			Bold(true).
-			Foreground(lipgloss.Color("212"))
-
-	selectedStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("229")).
-			Background(lipgloss.Color("62")).
-			Bold(true)
-
-	mutedStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("245"))
-	errorStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("203"))
-	keyStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("86")).Bold(true)
+	borderFocusStyle = lipgloss.NewStyle().
+				Border(lipgloss.RoundedBorder()).
+				BorderForeground(theme.ColorFocused)
 )
 
 // NewTUIModel creates a Bubble Tea model backed by the provided vault service.
@@ -289,8 +281,12 @@ func (m TUIModel) View() string {
 	leftWidth := max(24, m.width/3)
 	rightWidth := max(32, m.width-leftWidth-8)
 
-	left := borderStyle.Width(leftWidth).Height(contentHeight).Render(m.leftView(leftWidth, contentHeight))
-	right := borderStyle.Width(rightWidth).Height(contentHeight).Render(m.rightView(rightWidth, contentHeight))
+	bs := borderStyle
+	if m.mode == modeFilter || m.mode == modeTagFilter {
+		bs = borderFocusStyle
+	}
+	left := bs.Width(leftWidth).Height(contentHeight).Render(m.leftView(leftWidth, contentHeight))
+	right := bs.Width(rightWidth).Height(contentHeight).Render(m.rightView(rightWidth, contentHeight))
 	body := lipgloss.JoinHorizontal(lipgloss.Top, left, right)
 
 	footer := m.statusView()
@@ -557,9 +553,13 @@ func (m TUIModel) copySelectedPassword() tea.Cmd {
 
 func (m TUIModel) leftView(width, height int) string {
 	var b strings.Builder
-	b.WriteString(titleStyle.Render("Entries"))
+	pos := ""
+	if len(m.filtered) > 0 {
+		pos = fmt.Sprintf(" [%d/%d]", m.selected+1, len(m.filtered))
+	}
+	b.WriteString(theme.TitleStyle.Render("Entries" + pos))
 	b.WriteString(" ")
-	b.WriteString(mutedStyle.Render(fmt.Sprintf("[sort: %s]", m.sortLabel())))
+	b.WriteString(theme.MutedStyle.Render(fmt.Sprintf("[sort: %s]", m.sortLabel())))
 	b.WriteString("\n")
 	if m.mode == modeFilter {
 		b.WriteString(m.filterInput.View())
@@ -568,18 +568,18 @@ func (m TUIModel) leftView(width, height int) string {
 		tags := m.availableTags()
 		if len(tags) > 0 {
 			b.WriteString("\n")
-			b.WriteString(mutedStyle.Render("tags: " + strings.Join(tags, " ")))
+			b.WriteString(theme.MutedStyle.Render("tags: " + strings.Join(tags, " ")))
 		}
 	} else if q := strings.TrimSpace(m.filterInput.Value()); q != "" {
-		b.WriteString(mutedStyle.Render("Filter: " + q))
+		b.WriteString(theme.MutedStyle.Render("Filter: " + q))
 		if m.filterTag != "" {
 			b.WriteString(" ")
-			b.WriteString(mutedStyle.Render(fmt.Sprintf("[tag:%s]", m.filterTag)))
+			b.WriteString(theme.MutedStyle.Render(fmt.Sprintf("[tag:%s]", m.filterTag)))
 		}
 	} else if m.filterTag != "" {
-		b.WriteString(mutedStyle.Render(fmt.Sprintf("Tag: %s", m.filterTag)))
+		b.WriteString(theme.MutedStyle.Render(fmt.Sprintf("Tag: %s", m.filterTag)))
 	} else {
-		b.WriteString(mutedStyle.Render("/ filter · t tag · s sort"))
+		b.WriteString(theme.MutedStyle.Render("/ filter · t tag · s sort"))
 	}
 	b.WriteString("\n\n")
 
@@ -588,7 +588,7 @@ func (m TUIModel) leftView(width, height int) string {
 		return b.String()
 	}
 	if len(m.filtered) == 0 {
-		b.WriteString(mutedStyle.Render("No entries"))
+		b.WriteString(theme.MutedStyle.Render("No entries"))
 		return b.String()
 	}
 
@@ -602,7 +602,7 @@ func (m TUIModel) leftView(width, height int) string {
 	for i := start; i < end; i++ {
 		line := truncate(m.filtered[i], width-4)
 		if i == m.selected {
-			line = selectedStyle.Width(width - 4).Render(line)
+			line = theme.SelectedStyle.Width(width - 4).Render(line)
 		}
 		b.WriteString(line)
 		b.WriteString("\n")
@@ -613,16 +613,16 @@ func (m TUIModel) leftView(width, height int) string {
 func (m TUIModel) rightView(width, height int) string {
 	path := m.selectedPath()
 	if path == "" {
-		return titleStyle.Render("Details") + "\n\n" + mutedStyle.Render("Select an entry")
+		return theme.TitleStyle.Render("Details") + "\n\n" + theme.MutedStyle.Render("Select an entry")
 	}
 	if m.entry == nil || m.entryFor != path {
-		return titleStyle.Render(path) + "\n\n" + mutedStyle.Render("Loading details...")
+		return theme.TitleStyle.Render(path) + "\n\n" + theme.MutedStyle.Render("Loading details...")
 	}
 
 	var b strings.Builder
-	b.WriteString(titleStyle.Render(path))
+	b.WriteString(theme.TitleStyle.Render(path))
 	b.WriteString("\n")
-	b.WriteString(mutedStyle.Render("Updated: " + m.entry.Metadata.Updated.Format("2006-01-02 15:04")))
+	b.WriteString(theme.MutedStyle.Render("Updated: " + m.entry.Metadata.Updated.Format("2006-01-02 15:04")))
 	b.WriteString("\n\n")
 
 	keys := make([]string, 0, len(m.entry.Data))
@@ -634,14 +634,14 @@ func (m TUIModel) rightView(width, height int) string {
 	maxRows := max(1, height-6)
 	for i, key := range keys {
 		if i >= maxRows {
-			b.WriteString(mutedStyle.Render("..."))
+			b.WriteString(theme.MutedStyle.Render("..."))
 			break
 		}
 		value := fmt.Sprint(m.entry.Data[key])
 		if !m.revealed && isSensitiveField(key) {
 			value = redactedValue
 		}
-		line := fmt.Sprintf("%s: %s", keyStyle.Render(key), value)
+		line := fmt.Sprintf("%s: %s", theme.KeyStyle.Render(key), value)
 		b.WriteString(truncate(line, width-4))
 		b.WriteString("\n")
 	}
@@ -652,15 +652,15 @@ func (m TUIModel) rightView(width, height int) string {
 func (m TUIModel) statusView() string {
 	status := m.status
 	if m.err != nil {
-		status = errorStyle.Render(m.err.Error())
+		status = theme.ErrorStyle.Render(m.err.Error())
 	}
-	keys := "↑/↓ select · Enter copy password · r reveal · e edit · d delete · g generate · s sort · t tag · ? help · q quit"
-	return mutedStyle.Render(keys) + "\n" + status
+	keys := "↑/↓ select · Enter copy · r reveal · e edit · d delete · g gen · s sort · t tag · / filter · esc clear · ? help · q quit"
+	return theme.MutedStyle.Render(keys) + "\n" + status
 }
 
 func (m TUIModel) helpView() string {
 	return strings.Join([]string{
-		titleStyle.Render("Help"),
+		theme.TitleStyle.Render("Help"),
 		"↑/↓ or k/j: move selection",
 		"/: fuzzy filter entries",
 		"s: cycle sort (name/updated, asc/desc)",
@@ -679,7 +679,7 @@ func (m TUIModel) confirmView() string {
 	if m.mode == modeConfirmEdit {
 		verb = "edit"
 	}
-	return errorStyle.Render(fmt.Sprintf("Confirm %s %s?", verb, m.selectedPath())) + "  " + mutedStyle.Render("y/N")
+	return theme.ErrorStyle.Render(fmt.Sprintf("Confirm %s %s?", verb, m.selectedPath())) + "  " + theme.MutedStyle.Render("y/N")
 }
 
 func loadEntriesCmd(svc vaultsvc.Service) tea.Cmd {

--- a/internal/ui/wizard/step.go
+++ b/internal/ui/wizard/step.go
@@ -2,7 +2,6 @@ package wizard
 
 import (
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/charmbracelet/lipgloss"
 )
 
 // Step is the interface each wizard screen must implement.
@@ -81,14 +80,4 @@ const (
 	keyUp          = "up"
 	syncGit        = "git"
 	defaultProfile = "default"
-)
-
-var (
-	titleStyle   = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("212"))
-	focusedStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("86")).Bold(true)
-	errorStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("203"))
-	helpStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
-	dimStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
-	warnStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("220"))
-	successStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("82"))
 )

--- a/internal/ui/wizard/step.go
+++ b/internal/ui/wizard/step.go
@@ -78,6 +78,7 @@ const (
 	keyEnter       = "enter"
 	keyDown        = "down"
 	keyUp          = "up"
+	keyEsc         = "esc"
 	syncGit        = "git"
 	defaultProfile = "default"
 )

--- a/internal/ui/wizard/step_nextsteps.go
+++ b/internal/ui/wizard/step_nextsteps.go
@@ -37,10 +37,14 @@ func (s *NextStepsStep) View() string {
 		"",
 		"Quick-start commands:",
 		"",
-		"  " + focusedStyle.Render("openpass add <name>") + "         add your first entry",
-		"  " + focusedStyle.Render("openpass get <name>") + "         retrieve a password",
-		"  " + focusedStyle.Render("openpass doctor") + "             health check",
-		"  " + focusedStyle.Render("openpass --help") + "             show all commands",
+		"  " + focusedStyle.Render("openpass add <name>") + "           add your first entry",
+		"  " + focusedStyle.Render("openpass get <name>") + "           retrieve a password",
+		"  " + focusedStyle.Render("openpass tui") + "                  browse entries in terminal UI",
+		"  " + focusedStyle.Render("openpass autotype") + "             auto-type passwords into forms",
+		"  " + focusedStyle.Render("openpass doctor") + "               health check",
+		"  " + focusedStyle.Render("openpass mcp-config") + "           configure MCP agent integrations",
+		"  " + focusedStyle.Render("openpass auth set <method>") + "    change auth method",
+		"  " + focusedStyle.Render("openpass --help") + "               show all commands",
 	}
 
 	if st.SyncMode == syncGit && st.MultiDevice {

--- a/internal/ui/wizard/step_recipients.go
+++ b/internal/ui/wizard/step_recipients.go
@@ -50,7 +50,7 @@ func (s *RecipientsStep) Update(msg tea.Msg) (Step, tea.Cmd) {
 			}
 			s.done = true
 			return s, stepDoneCmd()
-		case "esc":
+		case keyEsc:
 			s.skip = true
 			s.done = true
 			return s, stepDoneCmd()

--- a/internal/ui/wizard/styletheme.go
+++ b/internal/ui/wizard/styletheme.go
@@ -1,0 +1,16 @@
+package wizard
+
+import "github.com/danieljustus/OpenPass/internal/ui/theme"
+
+// Theme aliases — all wizard step files reference styles by their original names.
+// These wrappers delegate to the centralized theme package so that step files
+// continue to compile without modification.
+var (
+	titleStyle   = theme.TitleStyle
+	focusedStyle = theme.FocusedStyle
+	errorStyle   = theme.ErrorStyle
+	helpStyle    = theme.DimStyle
+	dimStyle     = theme.DimStyle
+	warnStyle    = theme.WarnStyle
+	successStyle = theme.SuccessStyle
+)

--- a/internal/ui/wizard/wizard.go
+++ b/internal/ui/wizard/wizard.go
@@ -129,34 +129,7 @@ func (m WizardModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case tea.KeyMsg:
-		if m.confirmingCancel {
-			switch msg.String() {
-			case "y", "Y":
-				m.canceled = true
-				m.quitting = true
-				return m, tea.Quit
-			case "n", "N", "esc":
-				m.confirmingCancel = false
-				return m, nil
-			}
-			return m, nil
-		}
-
-		switch msg.String() {
-		case "ctrl+c":
-			if m.applying {
-				return m, nil
-			}
-			m.canceled = true
-			m.quitting = true
-			return m, tea.Quit
-		case "esc":
-			if m.applying {
-				return m, nil
-			}
-			m.confirmingCancel = true
-			return m, nil
-		}
+		return m.handleKeyMsg(msg)
 
 	case stepDone:
 		if !m.applying {
@@ -186,6 +159,48 @@ func (m WizardModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.spinner, cmd = m.spinner.Update(msg)
 			return m, cmd
 		}
+	}
+
+	if m.applying {
+		return m, nil
+	}
+
+	if m.current < len(m.steps) {
+		updated, cmd := m.steps[m.current].Update(msg)
+		m.steps[m.current] = updated
+		return m, cmd
+	}
+	return m, nil
+}
+
+func (m WizardModel) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if m.confirmingCancel {
+		switch msg.String() {
+		case "y", "Y":
+			m.canceled = true
+			m.quitting = true
+			return m, tea.Quit
+		case "n", "N", keyEsc:
+			m.confirmingCancel = false
+			return m, nil
+		}
+		return m, nil
+	}
+
+	switch msg.String() {
+	case "ctrl+c":
+		if m.applying {
+			return m, nil
+		}
+		m.canceled = true
+		m.quitting = true
+		return m, tea.Quit
+	case keyEsc:
+		if m.applying {
+			return m, nil
+		}
+		m.confirmingCancel = true
+		return m, nil
 	}
 
 	if m.applying {

--- a/internal/ui/wizard/wizard.go
+++ b/internal/ui/wizard/wizard.go
@@ -33,20 +33,21 @@ func stepDoneCmd() tea.Cmd {
 
 // WizardModel is the top-level Bubbletea model for the setup wizard.
 type WizardModel struct {
-	steps       []Step
-	current     int
-	state       WizardState
-	width       int
-	height      int
-	quitting    bool
-	canceled    bool
-	applyErr    error
-	noResume    bool
-	totalSteps  int
-	applying    bool
-	applyStep   string
-	applyErrs   []string
-	spinner     spinner.Model
+	steps            []Step
+	current          int
+	state            WizardState
+	width            int
+	height           int
+	quitting         bool
+	canceled         bool
+	confirmingCancel bool
+	applyErr         error
+	noResume         bool
+	totalSteps       int
+	applying         bool
+	applyStep        string
+	applyErrs        []string
+	spinner          spinner.Model
 }
 
 // NewWizardModel constructs the model with all steps for a given vault dir.
@@ -128,14 +129,33 @@ func (m WizardModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case tea.KeyMsg:
+		if m.confirmingCancel {
+			switch msg.String() {
+			case "y", "Y":
+				m.canceled = true
+				m.quitting = true
+				return m, tea.Quit
+			case "n", "N", "esc":
+				m.confirmingCancel = false
+				return m, nil
+			}
+			return m, nil
+		}
+
 		switch msg.String() {
-		case "ctrl+c", "esc":
+		case "ctrl+c":
 			if m.applying {
 				return m, nil
 			}
 			m.canceled = true
 			m.quitting = true
 			return m, tea.Quit
+		case "esc":
+			if m.applying {
+				return m, nil
+			}
+			m.confirmingCancel = true
+			return m, nil
 		}
 
 	case stepDone:
@@ -364,7 +384,7 @@ func (m WizardModel) View() string {
 		Foreground(lipgloss.Color("240"))
 
 	sep := strings.Repeat("─", max(m.width, 40))
-	footer := helpStyle.Render("Esc to quit")
+	footer := helpStyle.Render("Esc to cancel · Ctrl+C to quit")
 
 	if m.applying {
 		header := headerStyle.Render(fmt.Sprintf("OpenPass Setup  Step %d/%d — %s", m.totalSteps, m.totalSteps, m.applyStep))
@@ -372,10 +392,16 @@ func (m WizardModel) View() string {
 		return strings.Join([]string{header, sep, "", content, "", sep, footer}, "\n")
 	}
 
+	if m.confirmingCancel {
+		content := warnStyle.Render("Cancel setup? All progress will be lost.") + "\n" + helpStyle.Render("y/N")
+		return strings.Join([]string{"", content, "", sep, footer}, "\n")
+	}
+
 	step := m.steps[m.current]
 	pos := m.visiblePos()
 
-	header := headerStyle.Render(fmt.Sprintf("OpenPass Setup  Step %d/%d — %s", pos+1, m.totalSteps, step.Title()))
+	header := headerStyle.Render(fmt.Sprintf("OpenPass Setup  Step %d/%d%s — %s",
+		pos+1, m.totalSteps, progressBar(pos, m.totalSteps), step.Title()))
 	content := step.View()
 
 	return strings.Join([]string{header, sep, "", content, "", sep, footer}, "\n")
@@ -399,6 +425,19 @@ func (m *WizardModel) visiblePos() int {
 		}
 	}
 	return pos
+}
+
+func progressBar(pos, total int) string {
+	if total <= 1 {
+		return ""
+	}
+	const barWidth = 12
+	filled := ((pos + 1) * barWidth) / total
+	if filled > barWidth {
+		filled = barWidth
+	}
+	bar := strings.Repeat("█", filled) + strings.Repeat("░", barWidth-filled)
+	return fmt.Sprintf(" %s", bar)
 }
 
 func max(a, b int) int {


### PR DESCRIPTION
## Summary

- Centralized UI theme package (`internal/ui/theme/`) with AdaptiveColor tokens and shared styles
- Migrated TUI, Wizard, Doctor, and CLIOut to use the centralized theme
- Visual progress bar in wizard header (AC3)
- Position counter (e.g. `Entries [5/127]`) in TUI left pane (AC4)
- Active filter mode highlights border color (AC5)
- Wizard Esc → confirm dialog; Ctrl+C remains hard cancel (AC6)
- Expanded NextSteps with TUI, autotype, mcp-config, auth set commands (AC7)
- Unified help-footer wording across TUI and wizard (AC8)
- Fixed cliout test for removed ANSI constants

Closes #33