### PR TITLE
feat: allow weak/short passwords with non-blocking assessment, auto-tagging, and diagnostics

### DIFF
--- a/cmd/input.go
+++ b/cmd/input.go
@@ -93,7 +93,7 @@ func collectPassword(data map[string]any, reader *bufio.Reader, flags entryFlags
 		if len(password) > 0 {
 			data["password"] = string(password)
 			if !flags.force {
-				if err := cryptopkg.ValidatePasswordStrength(string(password)); err != nil {
+				if err := confirmWeakPassword(string(password)); err != nil {
 					return err
 				}
 			}
@@ -222,4 +222,28 @@ func confirmInteractive(prompt string, force bool) (bool, error) {
 		return false, nil
 	}
 	return true, nil
+}
+
+// confirmWeakPassword checks if a password meets strength requirements.
+// In TTY mode, it warns and asks for confirmation if weak.
+// In non-TTY mode, it returns an error (callers should use --force to skip).
+func confirmWeakPassword(password string) error {
+	s := cryptopkg.AssessPasswordStrength(password)
+	if !s.Weak {
+		return nil
+	}
+
+	fmt.Fprintf(os.Stderr, "Warning: %s\n", s.Message)
+	if isTerminalFunc(int(os.Stdin.Fd())) {
+		ok, err := confirmInteractive("Use this password anyway?", false)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return fmt.Errorf("password rejected by user")
+		}
+		return nil
+	}
+	// Non-TTY: return blocking error (use --force to skip)
+	return fmt.Errorf("%s", s.Message)
 }

--- a/cmd/input.go
+++ b/cmd/input.go
@@ -244,6 +244,6 @@ func confirmWeakPassword(password string) error {
 		}
 		return nil
 	}
-	// Non-TTY: return blocking error (use --force to skip)
-	return fmt.Errorf("%s", s.Message)
+	// Non-TTY: return blocking error with hint about --force
+	return fmt.Errorf("%s — use --force to bypass this check (the entry will be tagged as weak)", s.Message)
 }

--- a/internal/crypto/password.go
+++ b/internal/crypto/password.go
@@ -46,11 +46,23 @@ func generatePasswordWithReader(length int, useSymbols bool, reader io.Reader) (
 	return string(result), nil
 }
 
-// ValidatePasswordStrength checks if a password meets minimum strength requirements.
-// It requires at least 10 characters and 60 bits of entropy based on charset diversity.
-func ValidatePasswordStrength(password string) error {
+// PasswordStrength represents the result of a password strength assessment.
+type PasswordStrength struct {
+	Weak    bool    `json:"weak"`
+	Message string  `json:"message,omitempty"`
+	Entropy float64 `json:"entropy"`
+}
+
+// AssessPasswordStrength evaluates password strength without blocking.
+// Returns a PasswordStrength struct with Weak=true if the password fails
+// the minimum requirements (at least 10 characters, 60 bits of entropy).
+func AssessPasswordStrength(password string) PasswordStrength {
+	var s PasswordStrength
+
 	if len(password) < 10 {
-		return fmt.Errorf("password too short: must be at least 10 characters")
+		s.Weak = true
+		s.Message = "password too short: must be at least 10 characters"
+		return s
 	}
 
 	charsetSize := 0
@@ -88,10 +100,23 @@ func ValidatePasswordStrength(password string) error {
 		charsetSize = 256
 	}
 
-	entropy := float64(len(password)) * math.Log2(float64(charsetSize))
-	if entropy < 60 {
-		return fmt.Errorf("password too weak: estimated entropy %.1f bits, need at least 60 bits", entropy)
+	s.Entropy = float64(len(password)) * math.Log2(float64(charsetSize))
+	if s.Entropy < 60 {
+		s.Weak = true
+		s.Message = fmt.Sprintf("password too weak: estimated entropy %.1f bits, need at least 60 bits", s.Entropy)
 	}
 
+	return s
+}
+
+// ValidatePasswordStrength checks if a password meets minimum strength requirements.
+// It requires at least 10 characters and 60 bits of entropy based on charset diversity.
+// This is a convenience wrapper around AssessPasswordStrength for callers that
+// want a blocking error return.
+func ValidatePasswordStrength(password string) error {
+	s := AssessPasswordStrength(password)
+	if s.Weak {
+		return fmt.Errorf("%s", s.Message)
+	}
 	return nil
 }

--- a/internal/crypto/password_test.go
+++ b/internal/crypto/password_test.go
@@ -169,3 +169,64 @@ func TestValidatePasswordStrength_Unicode(t *testing.T) {
 		t.Errorf("expected unicode password with sufficient entropy to be valid, got %v", err)
 	}
 }
+
+func TestAssessPasswordStrength_WeakShort(t *testing.T) {
+	s := AssessPasswordStrength("123")
+	if !s.Weak {
+		t.Error("expected Weak=true for short password")
+	}
+	if !strings.Contains(s.Message, "too short") {
+		t.Errorf("expected 'too short' message, got %q", s.Message)
+	}
+	if s.Entropy != 0 {
+		t.Errorf("expected Entropy=0 for short password, got %f", s.Entropy)
+	}
+}
+
+func TestAssessPasswordStrength_WeakLowEntropy(t *testing.T) {
+	s := AssessPasswordStrength("abcdefghij")
+	if !s.Weak {
+		t.Error("expected Weak=true for low entropy password")
+	}
+	if !strings.Contains(s.Message, "too weak") {
+		t.Errorf("expected 'too weak' message, got %q", s.Message)
+	}
+	if s.Entropy <= 0 {
+		t.Errorf("expected positive entropy value, got %f", s.Entropy)
+	}
+}
+
+func TestAssessPasswordStrength_Strong(t *testing.T) {
+	s := AssessPasswordStrength("StrongP@ssw0rd123")
+	if s.Weak {
+		t.Errorf("expected Weak=false for strong password, got message: %s", s.Message)
+	}
+	if s.Entropy <= 60 {
+		t.Errorf("expected entropy > 60 for strong password, got %f", s.Entropy)
+	}
+}
+
+func TestAssessPasswordStrength_Empty(t *testing.T) {
+	s := AssessPasswordStrength("")
+	if !s.Weak {
+		t.Error("expected Weak=true for empty password")
+	}
+	if !strings.Contains(s.Message, "too short") {
+		t.Errorf("expected 'too short' message, got %q", s.Message)
+	}
+}
+
+func TestAssessPasswordStrength_Unicode(t *testing.T) {
+	s := AssessPasswordStrength("HelloW0rld!日本語テスト")
+	if s.Weak {
+		t.Errorf("expected Weak=false for unicode password with sufficient entropy, got %q", s.Message)
+	}
+}
+
+func TestAssessPasswordStrength_ExactBoundary(t *testing.T) {
+	// 10 chars, all lowercase = 10 * log2(26) ≈ 47 bits → weak
+	s := AssessPasswordStrength("abcdefghij")
+	if !s.Weak {
+		t.Error("expected Weak=true for 10 lowercase chars (≈47 bits < 60)")
+	}
+}

--- a/internal/health/doctor.go
+++ b/internal/health/doctor.go
@@ -34,6 +34,9 @@ import (
 const (
 	osDarwin = "darwin"
 	osLinux  = "linux"
+
+	msgSessionNeeded  = "no active session — run `openpass unlock` first"
+	hintSessionNeeded = "run `openpass unlock` to decrypt entries for password strength analysis"
 )
 
 // Status represents the outcome of a single check.
@@ -850,7 +853,7 @@ func checkManifestIntegrity(vaultDir string, _ Options) Result {
 	identity := vault.CurrentSearchIdentity()
 	if identity == nil {
 		r.Status = StatusWarn
-		r.Message = "no active session — run `openpass unlock` first"
+		r.Message = msgSessionNeeded
 		r.Hint = "run `openpass unlock` to decrypt your identity for manifest verification"
 		return r
 	}
@@ -1289,8 +1292,8 @@ func checkPasswordStrength(vaultDir string, _ Options) Result {
 	identity := vault.CurrentSearchIdentity()
 	if identity == nil {
 		r.Status = StatusWarn
-		r.Message = "no active session — run `openpass unlock` first"
-		r.Hint = "run `openpass unlock` to decrypt entries for password strength analysis"
+		r.Message = msgSessionNeeded
+		r.Hint = hintSessionNeeded
 		return r
 	}
 
@@ -1345,7 +1348,7 @@ func checkPasswordReuse(vaultDir string, _ Options) Result {
 	identity := vault.CurrentSearchIdentity()
 	if identity == nil {
 		r.Status = StatusWarn
-		r.Message = "no active session — run `openpass unlock` first"
+		r.Message = msgSessionNeeded
 		r.Hint = "run `openpass unlock` to decrypt entries for password reuse analysis"
 		return r
 	}

--- a/internal/health/doctor.go
+++ b/internal/health/doctor.go
@@ -1377,7 +1377,6 @@ func checkPasswordReuse(vaultDir string, _ Options) Result {
 		h := sha256.Sum256([]byte(pwdStr))
 		hashHex := hex.EncodeToString(h[:])
 		hashToPaths[hashHex] = append(hashToPaths[hashHex], path)
-		vaultcrypto.Wipe([]byte(pwdStr))
 	}
 
 	var reusedGroups [][]string
@@ -1393,6 +1392,7 @@ func checkPasswordReuse(vaultDir string, _ Options) Result {
 		})
 		r.Status = StatusWarn
 		if len(reusedGroups) == 1 {
+			sort.Strings(reusedGroups[0])
 			r.Message = fmt.Sprintf("%d entries share the same password", len(reusedGroups[0]))
 			r.Hint = fmt.Sprintf("entries: %s", strings.Join(reusedGroups[0], ", "))
 		} else {
@@ -1413,7 +1413,12 @@ func checkPasswordReuse(vaultDir string, _ Options) Result {
 func formatReuseGroups(groups [][]string) string {
 	var parts []string
 	for _, g := range groups {
-		parts = append(parts, fmt.Sprintf("%d entries", len(g)))
+		sort.Strings(g)
+		entries := strings.Join(g, ", ")
+		if len(g) > 5 {
+			entries = strings.Join(g[:5], ", ") + fmt.Sprintf(", ... (%d total)", len(g))
+		}
+		parts = append(parts, fmt.Sprintf("%d entries: %s", len(g), entries))
 	}
-	return strings.Join(parts, ", ")
+	return strings.Join(parts, "; ")
 }

--- a/internal/health/doctor.go
+++ b/internal/health/doctor.go
@@ -5,6 +5,8 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"net/http"
 	"os"
@@ -12,6 +14,7 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -126,6 +129,8 @@ var allChecks = []checkDef{
 	{fn: checkSecureUI},
 	{fn: checkPreCommitHooks},
 	{fn: checkSessionKeyring},
+	{fn: checkPasswordStrength, tags: []string{"slow"}},
+	{fn: checkPasswordReuse, tags: []string{"slow"}},
 }
 
 // RunChecks runs all doctor checks against vaultDir and returns the results.
@@ -1274,4 +1279,138 @@ func checkSessionKeyring(vaultDir string, _ Options) Result {
 	r.Status = StatusOK
 	r.Message = "keyring encrypt/decrypt roundtrip OK"
 	return r
+}
+
+// --- DOC-22: Password strength check ---
+
+func checkPasswordStrength(vaultDir string, _ Options) Result {
+	r := Result{ID: "password.strength", Name: "Weak password detection"}
+
+	identity := vault.CurrentSearchIdentity()
+	if identity == nil {
+		r.Status = StatusWarn
+		r.Message = "no active session — run `openpass unlock` first"
+		r.Hint = "run `openpass unlock` to decrypt entries for password strength analysis"
+		return r
+	}
+
+	paths, err := vault.List(vaultDir, "")
+	if err != nil {
+		r.Status = StatusWarn
+		r.Message = "cannot list entries: " + err.Error()
+		return r
+	}
+
+	var weakCount int
+	var examplePaths []string
+	for _, path := range paths {
+		entry, err := vault.ReadEntry(vaultDir, path, identity)
+		if err != nil {
+			continue
+		}
+		pwd, ok := entry.GetField("password")
+		if !ok {
+			continue
+		}
+		pwdStr, ok := pwd.(string)
+		if !ok || pwdStr == "" {
+			continue
+		}
+		s := vaultcrypto.AssessPasswordStrength(pwdStr)
+		if s.Weak {
+			weakCount++
+			if len(examplePaths) < 5 {
+				examplePaths = append(examplePaths, path)
+			}
+		}
+	}
+
+	if weakCount > 0 {
+		examples := strings.Join(examplePaths, ", ")
+		r.Status = StatusWarn
+		r.Message = fmt.Sprintf("%d entries with weak passwords", weakCount)
+		r.Hint = fmt.Sprintf("review and strengthen: %s", examples)
+	} else {
+		r.Status = StatusOK
+		r.Message = "all entries meet password strength requirements"
+	}
+	return r
+}
+
+// --- DOC-23: Password reuse check ---
+
+func checkPasswordReuse(vaultDir string, _ Options) Result {
+	r := Result{ID: "password.reuse", Name: "Password reuse detection"}
+
+	identity := vault.CurrentSearchIdentity()
+	if identity == nil {
+		r.Status = StatusWarn
+		r.Message = "no active session — run `openpass unlock` first"
+		r.Hint = "run `openpass unlock` to decrypt entries for password reuse analysis"
+		return r
+	}
+
+	paths, err := vault.List(vaultDir, "")
+	if err != nil {
+		r.Status = StatusWarn
+		r.Message = "cannot list entries: " + err.Error()
+		return r
+	}
+
+	hashToPaths := make(map[string][]string)
+	for _, path := range paths {
+		entry, err := vault.ReadEntry(vaultDir, path, identity)
+		if err != nil {
+			continue
+		}
+		pwd, ok := entry.GetField("password")
+		if !ok {
+			continue
+		}
+		pwdStr, ok := pwd.(string)
+		if !ok || pwdStr == "" {
+			continue
+		}
+		h := sha256.Sum256([]byte(pwdStr))
+		hashHex := hex.EncodeToString(h[:])
+		hashToPaths[hashHex] = append(hashToPaths[hashHex], path)
+		vaultcrypto.Wipe([]byte(pwdStr))
+	}
+
+	var reusedGroups [][]string
+	for _, ec := range hashToPaths {
+		if len(ec) > 1 {
+			reusedGroups = append(reusedGroups, ec)
+		}
+	}
+
+	if len(reusedGroups) > 0 {
+		sort.Slice(reusedGroups, func(i, j int) bool {
+			return len(reusedGroups[i]) > len(reusedGroups[j])
+		})
+		r.Status = StatusWarn
+		if len(reusedGroups) == 1 {
+			r.Message = fmt.Sprintf("%d entries share the same password", len(reusedGroups[0]))
+			r.Hint = fmt.Sprintf("entries: %s", strings.Join(reusedGroups[0], ", "))
+		} else {
+			r.Message = fmt.Sprintf("%d sets of entries with shared passwords", len(reusedGroups))
+			if len(reusedGroups) > 3 {
+				r.Hint = fmt.Sprintf("top groups: %s", formatReuseGroups(reusedGroups[:3]))
+			} else {
+				r.Hint = formatReuseGroups(reusedGroups)
+			}
+		}
+	} else {
+		r.Status = StatusOK
+		r.Message = "no reused passwords detected"
+	}
+	return r
+}
+
+func formatReuseGroups(groups [][]string) string {
+	var parts []string
+	for _, g := range groups {
+		parts = append(parts, fmt.Sprintf("%d entries", len(g)))
+	}
+	return strings.Join(parts, ", ")
 }

--- a/internal/mcp/tool_registry.go
+++ b/internal/mcp/tool_registry.go
@@ -93,6 +93,7 @@ func toolDefinitions() []toolDefinition {
 				"path":  {Type: "string", Description: "Entry path"},
 				"field": {Type: "string", Description: "Field name"},
 				"value": {Type: "string", Description: "Field value"},
+				"force": {Type: "boolean", Description: "Skip password strength validation. Default: false."},
 			}),
 			Handler: (*Server).handleSet,
 		},

--- a/internal/mcp/tools_set.go
+++ b/internal/mcp/tools_set.go
@@ -70,7 +70,7 @@ func (s *Server) handleSet(ctx context.Context, req CallToolRequest) (*CallToolR
 		partialData[field] = value
 	}
 
-	if field == "password" {
+	if field == "password" && !req.GetBool("force", false) {
 		if err := crypto.ValidatePasswordStrength(value); err != nil {
 			return NewToolResultError(err.Error()), nil
 		}

--- a/internal/mcp/tools_set.go
+++ b/internal/mcp/tools_set.go
@@ -72,7 +72,7 @@ func (s *Server) handleSet(ctx context.Context, req CallToolRequest) (*CallToolR
 
 	if field == "password" && !req.GetBool("force", false) {
 		if err := crypto.ValidatePasswordStrength(value); err != nil {
-			return NewToolResultError(err.Error()), nil
+			return NewToolResultError(fmt.Sprintf("%s — re-call with force:true if you want to store this password (the entry will be tagged as weak)", err.Error())), nil
 		}
 	}
 

--- a/internal/ui/forms/add_form.go
+++ b/internal/ui/forms/add_form.go
@@ -253,7 +253,7 @@ func (f *AddEntryForm) validatePassword() {
 	}
 	s := cryptopkg.AssessPasswordStrength(password)
 	if s.Weak {
-		f.passwordErr = fmt.Errorf("%s (use Enter to confirm)", s.Message)
+		f.passwordErr = fmt.Errorf("%s (weak — press Enter to continue)", s.Message)
 	} else {
 		f.passwordErr = nil
 	}

--- a/internal/ui/forms/add_form.go
+++ b/internal/ui/forms/add_form.go
@@ -251,7 +251,12 @@ func (f *AddEntryForm) validatePassword() {
 		f.passwordErr = nil
 		return
 	}
-	f.passwordErr = cryptopkg.ValidatePasswordStrength(password)
+	s := cryptopkg.AssessPasswordStrength(password)
+	if s.Weak {
+		f.passwordErr = fmt.Errorf("%s (use Enter to confirm)", s.Message)
+	} else {
+		f.passwordErr = nil
+	}
 }
 
 func (f *AddEntryForm) Init() tea.Cmd {
@@ -504,13 +509,6 @@ func RunAddEntryForm(force bool, defaults map[string]any) (map[string]any, vault
 
 	if f.canceled {
 		return nil, vaultpkg.SecretMetadata{}, fmt.Errorf("canceled")
-	}
-
-	password := f.password.Value()
-	if password != "" && !f.force {
-		if err := cryptopkg.ValidatePasswordStrength(password); err != nil {
-			return nil, vaultpkg.SecretMetadata{}, err
-		}
 	}
 
 	return f.Data(), f.SecretMetadata(), nil

--- a/internal/vault/entry.go
+++ b/internal/vault/entry.go
@@ -68,6 +68,33 @@ func (e *Entry) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// HasTag returns true if the entry has the given tag.
+func (e *Entry) HasTag(tag string) bool {
+	for _, t := range e.Metadata.Tags {
+		if t == tag {
+			return true
+		}
+	}
+	return false
+}
+
+// AddTag adds a tag to the entry if not already present.
+func (e *Entry) AddTag(tag string) {
+	if !e.HasTag(tag) {
+		e.Metadata.Tags = append(e.Metadata.Tags, tag)
+	}
+}
+
+// RemoveTag removes a tag from the entry if present.
+func (e *Entry) RemoveTag(tag string) {
+	for i, t := range e.Metadata.Tags {
+		if t == tag {
+			e.Metadata.Tags = append(e.Metadata.Tags[:i], e.Metadata.Tags[i+1:]...)
+			return
+		}
+	}
+}
+
 // validateEntryPath ensures the entry path stays within the vault directory.
 // Returns an error if path traversal is detected.
 func validateEntryPath(vaultDir, path string) error {

--- a/internal/vault/entry.go
+++ b/internal/vault/entry.go
@@ -68,6 +68,9 @@ func (e *Entry) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// TagWeakPassword is the tag applied to entries whose password is assessed as weak.
+const TagWeakPassword = "weak-password"
+
 // HasTag returns true if the entry has the given tag.
 func (e *Entry) HasTag(tag string) bool {
 	for _, t := range e.Metadata.Tags {

--- a/internal/vault/recipients.go
+++ b/internal/vault/recipients.go
@@ -458,13 +458,18 @@ func tagEntryForWeakPassword(entry *Entry, partialData map[string]any) {
 		return
 	}
 	pwdStr, ok := pwd.(string)
-	if !ok || pwdStr == "" {
+	if !ok {
+		return
+	}
+	if pwdStr == "" {
+		// Password was cleared — remove stale tag if present.
+		entry.RemoveTag(TagWeakPassword)
 		return
 	}
 	s := vaultcrypto.AssessPasswordStrength(pwdStr)
 	if s.Weak {
-		entry.AddTag("weak-password")
+		entry.AddTag(TagWeakPassword)
 	} else {
-		entry.RemoveTag("weak-password")
+		entry.RemoveTag(TagWeakPassword)
 	}
 }

--- a/internal/vault/recipients.go
+++ b/internal/vault/recipients.go
@@ -441,8 +441,30 @@ func MergeEntryWithRecipients(vaultDir, path string, partialData map[string]any,
 		entry.Data = map[string]any{}
 	}
 	mergeMaps(entry.Data, partialData)
+	// Tag injection: assess password strength when password is updated
+	tagEntryForWeakPassword(entry, partialData)
 	if err := WriteEntryWithRecipients(vaultDir, path, entry, identity); err != nil {
 		return nil, err
 	}
 	return ReadEntry(vaultDir, path, identity)
+}
+
+// tagEntryForWeakPassword checks if the password in partialData is weak and
+// adds/removes the "weak-password" tag accordingly. Only acts when partialData
+// contains a "password" key, since other field changes don't affect password strength.
+func tagEntryForWeakPassword(entry *Entry, partialData map[string]any) {
+	pwd, ok := partialData["password"]
+	if !ok {
+		return
+	}
+	pwdStr, ok := pwd.(string)
+	if !ok || pwdStr == "" {
+		return
+	}
+	s := vaultcrypto.AssessPasswordStrength(pwdStr)
+	if s.Weak {
+		entry.AddTag("weak-password")
+	} else {
+		entry.RemoveTag("weak-password")
+	}
 }

--- a/internal/vaultsvc/service.go
+++ b/internal/vaultsvc/service.go
@@ -104,9 +104,9 @@ func (s *vaultService) setEntry(path string, data map[string]any) error {
 		}
 		if pwd, ok := data["password"]; ok {
 			if pwdStr, ok := pwd.(string); ok && pwdStr != "" {
-				s := cryptopkg.AssessPasswordStrength(pwdStr)
-				if s.Weak {
-					entry.AddTag("weak-password")
+				strength := cryptopkg.AssessPasswordStrength(pwdStr)
+				if strength.Weak {
+					entry.AddTag(vaultpkg.TagWeakPassword)
 				}
 			}
 		}

--- a/internal/vaultsvc/service.go
+++ b/internal/vaultsvc/service.go
@@ -10,6 +10,7 @@ import (
 
 	"filippo.io/age"
 
+	cryptopkg "github.com/danieljustus/OpenPass/internal/crypto"
 	errorspkg "github.com/danieljustus/OpenPass/internal/errors"
 	vaultpkg "github.com/danieljustus/OpenPass/internal/vault"
 )
@@ -100,6 +101,14 @@ func (s *vaultService) setEntry(path string, data map[string]any) error {
 				Updated: time.Now().UTC(),
 				Version: 0,
 			},
+		}
+		if pwd, ok := data["password"]; ok {
+			if pwdStr, ok := pwd.(string); ok && pwdStr != "" {
+				s := cryptopkg.AssessPasswordStrength(pwdStr)
+				if s.Weak {
+					entry.AddTag("weak-password")
+				}
+			}
 		}
 		if err := vaultpkg.WriteEntryWithRecipients(s.vault.Dir, path, entry, s.vault.Identity); err != nil {
 			return errorspkg.WriteFailed(err, "cannot create entry %s: %v", path, err)


### PR DESCRIPTION
## Summary

Replaces blocking `ValidatePasswordStrength` with non-blocking `AssessPasswordStrength` that warns and confirms in TTY mode instead of rejecting. Weak passwords are auto-tagged with `"weak-password"` in the entry metadata and detected by new doctor checks.

## Changes

- **New API**: `PasswordStrength` struct + `AssessPasswordStrength()` — non-blocking assessment
- **CLI confirmation**: Weak passwords trigger a confirmation prompt in interactive TTY mode; `--force` bypasses
- **TUI form**: Shows inline warning, allows submission
- **Auto-tagging**: Service layer tags entries with `"weak-password"` when password is weak, removes tag when strengthened
- **Doctor checks**: `password.strength` (weak password detection) and `password.reuse` (SHA-256 based reuse detection), both tagged `"slow"`
- **MCP**: `set_entry_field` gains optional `force` parameter
- **Import**: Automatic weak-password tagging via service-layer injection

## Testing

- `go test ./...` passes (all packages green)
- New tests for `AssessPasswordStrength` (6 test cases)
- Existing `ValidatePasswordStrength` tests unchanged
- Doctor registration verified via existing test framework

Fixes #35