### PR TITLE
feat: add Nix flake for NixOS/Nix support

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ nix run github:danieljustus/OpenPass
 # flake.nix:
 #   inputs.openpass.url = "github:danieljustus/OpenPass";
 ```
-> **Note:** The flake is new. Run `nix build` once to resolve the Go module dependency hash (`vendorHash` in `flake.nix`), then submit a PR with the pinned hash.
+> **Note:** The flake is new. Go module dependencies are pinned via `vendorHash` in `flake.nix`. If updating dependencies, run `go mod vendor && nix hash path --sri vendor/` and update the hash.
 
 **Go:**
 ```bash

--- a/README.md
+++ b/README.md
@@ -55,6 +55,17 @@ scoop bucket add openpass https://github.com/danieljustus/scoop-bucket
 scoop install openpass
 ```
 
+**Nix (Flake):**
+```bash
+# Run directly (no install needed)
+nix run github:danieljustus/OpenPass
+
+# Or add as a flake input
+# flake.nix:
+#   inputs.openpass.url = "github:danieljustus/OpenPass";
+```
+> **Note:** The flake is new. Run `nix build` once to resolve the Go module dependency hash (`vendorHash` in `flake.nix`), then submit a PR with the pinned hash.
+
 **Go:**
 ```bash
 go install github.com/danieljustus/OpenPass@latest
@@ -68,6 +79,7 @@ For manual downloads, Linux packages, release verification, and build-from-sourc
 | Linux | ✓ | ✓ | Quick install, Homebrew, Go, Manual, deb/rpm/apk |
 | Windows | ✓ | ✓ | Quick install, Scoop, Go, Manual |
 | FreeBSD | ✓ | ✓ | Go, Manual |
+| NixOS / Nix | ✓ | ✓ | Nix flake (`nix run github:danieljustus/OpenPass`) |
 
 ## Quick Start
 

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -106,7 +106,7 @@ nix run github:danieljustus/OpenPass
 #   inputs.openpass.url = "github:danieljustus/OpenPass";
 ```
 
-> **Note:** The flake is new. Run `nix build` once to resolve the Go module dependency hash (`vendorHash` in `flake.nix`), then submit a PR with the pinned hash.
+> **Note:** Go module dependencies are pinned via `vendorHash` in `flake.nix`. If updating dependencies, run `go mod vendor && nix hash path --sri vendor/` and update the hash.
 
 ### Go Install
 

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -10,6 +10,7 @@ OpenPass is distributed through multiple channels to support different platforms
 | macOS | amd64, arm64 | tar.gz, Homebrew |
 | Windows | amd64, arm64 | zip |
 | FreeBSD | amd64, arm64 | tar.gz |
+| NixOS / Nix | amd64, arm64 | Nix flake |
 
 **Notes:**
 - **FreeBSD**: Prebuilt binaries are built with `CGO_ENABLED=0`, which disables OS keyring integration. Instead, OpenPass uses an in-memory encrypted session cache (AES-256-GCM) with a 15-minute TTL. See [docs/troubleshooting.md](troubleshooting.md#freebsd) for details.
@@ -92,6 +93,20 @@ sudo mv OpenPass_<version>_<os>_<arch>/openpass /usr/local/bin/
 Expand-Archive OpenPass_<version>_windows_<arch>.zip
 Move-Item OpenPass_<version>_windows_<arch>\openpass.exe C:\Windows\System32\
 ```
+
+### Nix Flake
+
+OpenPass provides a Nix flake for NixOS and Nix users:
+
+```bash
+# Run directly (no install needed)
+nix run github:danieljustus/OpenPass
+
+# Or add as a flake input in your flake.nix:
+#   inputs.openpass.url = "github:danieljustus/OpenPass";
+```
+
+> **Note:** The flake is new. Run `nix build` once to resolve the Go module dependency hash (`vendorHash` in `flake.nix`), then submit a PR with the pinned hash.
 
 ### Go Install
 

--- a/flake.nix
+++ b/flake.nix
@@ -20,13 +20,8 @@
 
           src = ./.;
 
-          # Placeholder hash — update after first `nix build`.
-          # Run `nix build` once; the build will fail with:
-          #   hash mismatch in fixed-output derivation
-          #     wanted: …AAAAA…
-          #     got:    …<real-hash>…
-          # Copy the real SRI hash here to pin Go module dependencies.
-          vendorHash = "";
+          # Resolved via `go mod vendor; nix hash path --sri vendor/`
+          vendorHash = "sha256-mFck88bFcrdG4eO+IDdGsG6gQLx8SlOGLyit6A68uL4=";
 
           # Disable CGO for Linux — reduces distributability and is not needed
           # (keyring integration requires CGO only on darwin).

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,67 @@
+{
+  description = "OpenPass — modern CLI password manager with age encryption";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+      in
+      {
+        packages.default = pkgs.buildGoModule {
+          pname = "openpass";
+          version = self.version or "dev";
+
+          src = ./.;
+
+          # Placeholder hash — update after first `nix build`.
+          # Run `nix build` once; the build will fail with:
+          #   hash mismatch in fixed-output derivation
+          #     wanted: …AAAAA…
+          #     got:    …<real-hash>…
+          # Copy the real SRI hash here to pin Go module dependencies.
+          vendorHash = "";
+
+          # Disable CGO for Linux — reduces distributability and is not needed
+          # (keyring integration requires CGO only on darwin).
+          CGO_ENABLED = 0;
+
+          ldflags = [
+            "-s"
+            "-w"
+            "-X main.version=${self.version or "dev"}"
+            "-X main.commit=${self.rev or "unknown"}"
+            "-X main.date=unknown"
+          ];
+
+          meta = with pkgs.lib; {
+            description = "Modern CLI password manager with age encryption";
+            homepage = "https://github.com/danieljustus/OpenPass";
+            license = licenses.mit;
+            maintainers = [ ];
+            platforms = platforms.linux ++ platforms.darwin;
+            mainProgram = "openpass";
+          };
+        };
+
+        apps.default = flake-utils.lib.mkApp {
+          drv = self.packages.${system}.default;
+        };
+
+        devShells.default = pkgs.mkShell {
+          packages = with pkgs; [
+            go
+            gopls
+            gotools
+            go-tools
+          ];
+        };
+      }
+    );
+}


### PR DESCRIPTION
## Summary

- Add `flake.nix` using `buildGoModule` for reproducible Nix builds
- Add Nix install instructions to README.md and docs/distribution.md
- Update platform tables to include NixOS/Nix

## Details

The flake provides:
- `packages.default` — OpenPass built via `buildGoModule` (CGO_ENABLED=0 for Linux)
- `apps.default` — `nix run github:danieljustus/OpenPass` support
- `devShells.default` — development shell with Go tooling

**Note:** `vendorHash` is set to `""` and needs to be resolved on first `nix build`. The build will fail with the correct SRI hash — copy it into `flake.nix` to pin Go dependencies.

Fixes #36