### PR TITLE
Ignore io.WriteString results in Format

### DIFF
--- a/cmd/passlint/testdata/src/taint/taint.go
+++ b/cmd/passlint/testdata/src/taint/taint.go
@@ -43,5 +43,5 @@ func (u Untrusted) Tags() map[string]string {
 }
 
 func (u Untrusted) Format(f fmt.State, verb rune) {
-	io.WriteString(f, "<untrusted:source>")
+	_, _ = io.WriteString(f, "<untrusted:source>")
 }


### PR DESCRIPTION
Assign io.WriteString's return values to blank identifiers in Untrusted.Format to explicitly ignore them. This silences linters/tools (e.g., errcheck) that flag unchecked return values when writing the fixed string.

## What

Describe the change in a few sentences.

## Why

Explain the problem, user need, or maintenance reason.

## Testing

- [ ] `make fmt`
- [ ] `make vet`
- [ ] `make lint`
- [ ] `GOWORK=off go test ./...`
- [ ] Added or updated tests where needed

## Safety

- [ ] I did not include passwords, tokens, private keys, vault contents, or personal data
- [ ] Documentation was updated where behavior changed
