### PR TITLE
feat: add execute_api_request tool with built-in API templates

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,6 +12,7 @@ run:
   modules-download-mode: readonly
   go: "1.26"
 
+
 linters:
   enable:
     - errcheck
@@ -115,10 +116,14 @@ linters:
       - path: '(.+)_test\.go'
         linters:
           - gocritic
-      # Vendored third-party code under editors/node_modules
-      - path: 'editors/node_modules/.+'
+
+
+      # Vendored third-party Go code under editors/node_modules
+      - path: 'editors/node_modules/flatted/.+'
         linters:
-          - all
+          - gocyclo
+          - prealloc
+          - revive
 
 formatters:
   enable:

--- a/internal/mcp/apitemplates/builtin/anthropic.yaml
+++ b/internal/mcp/apitemplates/builtin/anthropic.yaml
@@ -1,0 +1,9 @@
+base_url: https://api.anthropic.com
+auth_type: bearer
+entry_ref: op:///anthropic
+allowed_endpoints:
+  - /v1/*
+allowed_methods:
+  - GET
+  - POST
+default_headers: {}

--- a/internal/mcp/apitemplates/builtin/github.yaml
+++ b/internal/mcp/apitemplates/builtin/github.yaml
@@ -1,0 +1,12 @@
+base_url: https://api.github.com
+auth_type: bearer
+entry_ref: op:///github
+allowed_endpoints:
+  - /*
+allowed_methods:
+  - GET
+  - POST
+  - PUT
+  - PATCH
+  - DELETE
+default_headers: {}

--- a/internal/mcp/apitemplates/builtin/openai.yaml
+++ b/internal/mcp/apitemplates/builtin/openai.yaml
@@ -1,0 +1,9 @@
+base_url: https://api.openai.com
+auth_type: bearer
+entry_ref: op:///openai
+allowed_endpoints:
+  - /v1/*
+allowed_methods:
+  - GET
+  - POST
+default_headers: {}

--- a/internal/mcp/apitemplates/builtin/slack.yaml
+++ b/internal/mcp/apitemplates/builtin/slack.yaml
@@ -1,0 +1,9 @@
+base_url: https://slack.com/api
+auth_type: bearer
+entry_ref: op:///slack
+allowed_endpoints:
+  - /*
+allowed_methods:
+  - GET
+  - POST
+default_headers: {}

--- a/internal/mcp/apitemplates/template.go
+++ b/internal/mcp/apitemplates/template.go
@@ -1,0 +1,152 @@
+// Package apitemplates provides API request templates with credential isolation.
+// Templates define how to authenticate and communicate with external APIs
+// without agents ever seeing the raw credential values.
+package apitemplates
+
+import (
+	"embed"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+//go:embed builtin/*.yaml
+var builtinFS embed.FS
+
+// AuthType defines the authentication mechanism for an API template.
+type AuthType string
+
+const (
+	// AuthBearer sends credentials via Authorization: Bearer <token> header.
+	AuthBearer AuthType = "bearer"
+	// AuthBasic sends credentials via HTTP Basic Auth (base64(username:password)).
+	AuthBasic AuthType = "basic"
+	// AuthHeader sends credentials via a custom header defined in the vault entry.
+	AuthHeader AuthType = "header"
+	// AuthQueryParam sends credentials as a URL query parameter.
+	AuthQueryParam AuthType = "query_param"
+)
+
+// APITemplate defines how to authenticate and communicate with an external API.
+type APITemplate struct {
+	// Name is the template identifier (e.g., "github", "openai").
+	Name string `yaml:"-" json:"name"`
+	// BaseURL is the base URL for the API (e.g., "https://api.github.com").
+	BaseURL string `yaml:"base_url" json:"base_url"`
+	// AuthType specifies the authentication mechanism.
+	AuthType AuthType `yaml:"auth_type" json:"auth_type"`
+	// EntryRef is the 1Password op:// vault reference for credential storage.
+	EntryRef string `yaml:"entry_ref" json:"entry_ref"`
+	// AllowedEndpoints is a list of glob patterns for allowed endpoint paths.
+	AllowedEndpoints []string `yaml:"allowed_endpoints" json:"allowed_endpoints"`
+	// AllowedMethods is a list of allowed HTTP methods.
+	AllowedMethods []string `yaml:"allowed_methods" json:"allowed_methods"`
+	// DefaultHeaders are headers to include in every request.
+	DefaultHeaders map[string]string `yaml:"default_headers" json:"default_headers,omitempty"`
+}
+
+// templateFile is the on-disk representation of an APITemplate.
+type templateFile struct {
+	BaseURL          string            `yaml:"base_url"`
+	AuthType         AuthType          `yaml:"auth_type"`
+	EntryRef         string            `yaml:"entry_ref"`
+	AllowedEndpoints []string          `yaml:"allowed_endpoints"`
+	AllowedMethods   []string          `yaml:"allowed_methods"`
+	DefaultHeaders   map[string]string `yaml:"default_headers"`
+}
+
+// Load loads a template by name. It first checks embedded builtins, then
+// checks the user's template directory (~/.openpass/templates/) for overrides.
+func Load(name string, vaultDir string) (*APITemplate, error) {
+	if name == "" {
+		return nil, fmt.Errorf("template name is required")
+	}
+
+	// Check user override directory first
+	if vaultDir != "" {
+		userPath := filepath.Join(vaultDir, "templates", name+".yaml")
+		if _, err := os.Stat(userPath); err == nil {
+			return loadFromFile(name, userPath)
+		}
+	}
+
+	// Fall back to built-in templates
+	return loadBuiltin(name)
+}
+
+// LoadAll loads all available templates (builtin and user overrides).
+func LoadAll() ([]*APITemplate, error) {
+	var templates []*APITemplate
+
+	// Load built-in templates
+	entries, err := builtinFS.ReadDir("builtin")
+	if err != nil {
+		return nil, fmt.Errorf("read builtin templates: %w", err)
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".yaml" {
+			continue
+		}
+		name := entry.Name()[:len(entry.Name())-len(".yaml")]
+		tmpl, err := loadBuiltin(name)
+		if err != nil {
+			return nil, fmt.Errorf("load builtin %q: %w", name, err)
+		}
+		templates = append(templates, tmpl)
+	}
+
+	if len(templates) == 0 {
+		return nil, fmt.Errorf("no templates found")
+	}
+
+	return templates, nil
+}
+
+// loadBuiltin loads a built-in template by name.
+func loadBuiltin(name string) (*APITemplate, error) {
+	data, err := builtinFS.ReadFile(filepath.Join("builtin", name+".yaml"))
+	if err != nil {
+		return nil, fmt.Errorf("template %q not found", name)
+	}
+	return parseTemplate(name, data)
+}
+
+// loadFromFile loads a template from a file path.
+func loadFromFile(name, path string) (*APITemplate, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read template file %q: %w", path, err)
+	}
+	return parseTemplate(name, data)
+}
+
+// parseTemplate parses YAML data into an APITemplate.
+func parseTemplate(name string, data []byte) (*APITemplate, error) {
+	var tf templateFile
+	if err := yaml.Unmarshal(data, &tf); err != nil {
+		return nil, fmt.Errorf("parse template %q: %w", name, err)
+	}
+
+	if tf.BaseURL == "" {
+		return nil, fmt.Errorf("template %q: base_url is required", name)
+	}
+	if tf.AuthType == "" {
+		return nil, fmt.Errorf("template %q: auth_type is required", name)
+	}
+	if tf.EntryRef == "" {
+		return nil, fmt.Errorf("template %q: entry_ref is required", name)
+	}
+
+	return &APITemplate{
+		Name:             name,
+		BaseURL:          tf.BaseURL,
+		AuthType:         tf.AuthType,
+		EntryRef:         tf.EntryRef,
+		AllowedEndpoints: tf.AllowedEndpoints,
+		AllowedMethods:   tf.AllowedMethods,
+		DefaultHeaders:   tf.DefaultHeaders,
+	}, nil
+}

--- a/internal/mcp/apitemplates/template.go
+++ b/internal/mcp/apitemplates/template.go
@@ -57,8 +57,8 @@ type templateFile struct {
 	DefaultHeaders   map[string]string `yaml:"default_headers"`
 }
 
-// Load loads a template by name. It first checks embedded builtins, then
-// checks the user's template directory (~/.openpass/templates/) for overrides.
+// Load loads a template by name. It checks the user's template directory
+// (<vault>/templates/) first, then falls back to embedded built-ins.
 func Load(name string, vaultDir string) (*APITemplate, error) {
 	if name == "" {
 		return nil, fmt.Errorf("template name is required")
@@ -76,7 +76,7 @@ func Load(name string, vaultDir string) (*APITemplate, error) {
 	return loadBuiltin(name)
 }
 
-// LoadAll loads all available templates (builtin and user overrides).
+// LoadAll loads all embedded built-in templates.
 func LoadAll() ([]*APITemplate, error) {
 	var templates []*APITemplate
 

--- a/internal/mcp/server_dispatch.go
+++ b/internal/mcp/server_dispatch.go
@@ -22,7 +22,7 @@ func toolActionType(toolName string) string {
 		return "set"
 	case "delete_entry", "openpass_delete":
 		return "delete"
-	case "run_command", "execute_with_secret":
+	case "run_command", "execute_with_secret", "execute_api_request":
 		return "run"
 	case "list_entries":
 		return "list"

--- a/internal/mcp/tool_registry.go
+++ b/internal/mcp/tool_registry.go
@@ -121,6 +121,20 @@ func toolDefinitions() []toolDefinition {
 			Handler: (*Server).handleExecuteWithSecret,
 		},
 		{
+			Name:        "execute_api_request",
+			Description: "Execute an HTTP API request using a named template with vault-injected credentials. The agent never sees the credential values. Requires command execution permission.",
+			InputSchema: objectSchema([]string{"template", "endpoint"}, map[string]schemaProperty{
+				"template": {Type: "string", Description: "API template name (e.g. github, openai, anthropic, slack)"},
+				"endpoint": {Type: "string", Description: "API endpoint path (e.g. /repos/owner/repo)"},
+				"method":   {Type: "string", Description: "HTTP method (default: GET)"},
+				"body":     {Type: "string", Description: "Request body (optional)"},
+				"headers":  {Type: "object", Description: "Additional request headers (optional)"},
+				"timeout":  {Type: "number", Description: "Timeout in seconds (default: 30)"},
+			}),
+			Handler:   (*Server).handleExecuteAPIRequest,
+			Available: executeAPIAvailable,
+		},
+		{
 			Name:        "sanitize_output",
 			Description: "Scan text for secrets and replace them with masked values. Use before sending output to LLM chat.",
 			InputSchema: objectSchema([]string{"text"}, map[string]schemaProperty{

--- a/internal/mcp/tools_execute_api_request.go
+++ b/internal/mcp/tools_execute_api_request.go
@@ -7,14 +7,24 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math"
 	"net/http"
+	"net/url"
 	"path"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/danieljustus/OpenPass/internal/mcp/apitemplates"
 	"github.com/danieljustus/OpenPass/internal/metrics"
 	"github.com/danieljustus/OpenPass/internal/vaultsvc"
+)
+
+const (
+	defaultAPITimeoutSeconds = 30
+	minAPITimeoutSeconds     = 1
+	maxAPITimeoutSeconds     = 300
+	maxAPIResponseBodyBytes  = 100 * 1024
 )
 
 // handleExecuteAPIRequest executes an HTTP API request using a named template.
@@ -43,7 +53,18 @@ func (s *Server) handleExecuteAPIRequest(ctx context.Context, req CallToolReques
 
 	method := req.GetString("method", "GET")
 	bodyStr := req.GetString("body", "")
-	timeoutSec := int(req.GetFloat("timeout", 30))
+	timeoutSec, timeoutErr := parseTimeoutSeconds(req.Arguments["timeout"])
+	if timeoutErr != nil {
+		s.logAudit(ctx, "execute_api_request", "<invalid:timeout>", false)
+		return NewToolResultError(timeoutErr.Error()), nil
+	}
+	method = strings.ToUpper(method)
+
+	normalizedEndpoint, endpointErr := normalizeEndpoint(endpoint)
+	if endpointErr != nil {
+		s.logAudit(ctx, "execute_api_request", "<invalid:endpoint>", false)
+		return NewToolResultError(fmt.Sprintf("invalid endpoint %q: %v", endpoint, endpointErr)), nil
+	}
 
 	// Load template
 	vaultDir := ""
@@ -57,9 +78,9 @@ func (s *Server) handleExecuteAPIRequest(ctx context.Context, req CallToolReques
 	}
 
 	// Validate endpoint against allowed patterns
-	if !matchAnyGlob(endpoint, tmpl.AllowedEndpoints) {
+	if !matchAnyGlob(normalizedEndpoint, tmpl.AllowedEndpoints) {
 		s.logAudit(ctx, "execute_api_request", fmt.Sprintf("<endpoint-denied:%s>", tmpl.Name), false)
-		return NewToolResultError(fmt.Sprintf("endpoint not allowed: %s", endpoint)), nil
+		return NewToolResultError(fmt.Sprintf("endpoint not allowed: %s", normalizedEndpoint)), nil
 	}
 
 	// Validate method against allowed methods
@@ -77,15 +98,25 @@ func (s *Server) handleExecuteAPIRequest(ctx context.Context, req CallToolReques
 	}
 
 	// Load vault entry for credentials
+	entryPath, parseErr := parseTemplateEntryRef(tmpl.EntryRef)
+	if parseErr != nil {
+		s.logAudit(ctx, "execute_api_request", fmt.Sprintf("<template-error:%s>", tmpl.Name), false)
+		return NewToolResultError(fmt.Sprintf("invalid entry_ref for %q: %v", tmpl.Name, parseErr)), nil
+	}
+	if !s.checkScope(entryPath) {
+		s.logAudit(ctx, "execute_api_request", fmt.Sprintf("<scope-denied:%s>", tmpl.Name), false)
+		metrics.RecordAuthDenial("scope_denied", s.agent.Name)
+		return nil, fmt.Errorf("access denied: template entry path %q outside allowed scope", entryPath)
+	}
 	svc := vaultsvc.New(slog.Default(), s.vault)
-	entry, entryErr := svc.GetEntry(tmpl.EntryRef)
+	entry, entryErr := svc.GetEntry(entryPath)
 	if entryErr != nil {
 		s.logAudit(ctx, "execute_api_request", fmt.Sprintf("<vault-error:%s>", tmpl.Name), false)
 		return NewToolResultError(fmt.Sprintf("cannot load credentials for %q: %v", tmpl.Name, entryErr)), nil
 	}
 
 	// Build the request
-	requestURL := tmpl.BaseURL + endpoint
+	requestURL := tmpl.BaseURL + normalizedEndpoint
 	var requestBody io.Reader
 	if bodyStr != "" {
 		requestBody = strings.NewReader(bodyStr)
@@ -106,15 +137,14 @@ func (s *Server) handleExecuteAPIRequest(ctx context.Context, req CallToolReques
 	if headersRaw, ok := req.Arguments["headers"]; ok {
 		headersMap, ok := headersRaw.(map[string]any)
 		if !ok {
-			s.logAudit(ctx, "execute_api_request", fmt.Sprintf("<invalid-headers:%s>", tmpl.Name), false)
-			return NewToolResultError("invalid headers: must be an object with string values"), nil
+			s.logAudit(ctx, "execute_api_request", "<invalid:headers-not-object>", false)
+			return NewToolResultError("argument \"headers\" must be an object"), nil
 		}
-
 		for k, v := range headersMap {
 			vStr, ok := v.(string)
 			if !ok {
-				s.logAudit(ctx, "execute_api_request", fmt.Sprintf("<invalid-headers:%s>", tmpl.Name), false)
-				return NewToolResultError(fmt.Sprintf("invalid headers: value for %q must be a string", k)), nil
+				s.logAudit(ctx, "execute_api_request", "<invalid:header-value-not-string>", false)
+				return NewToolResultError(fmt.Sprintf("headers[%q] must be a string", k)), nil
 			}
 			httpReq.Header.Set(k, vStr)
 		}
@@ -139,15 +169,15 @@ func (s *Server) handleExecuteAPIRequest(ctx context.Context, req CallToolReques
 	resp, respErr := client.Do(httpReq)
 	if respErr != nil {
 		s.logAudit(ctx, "execute_api_request", fmt.Sprintf("template=%s, endpoint=%s, method=%s, status=error",
-			tmpl.Name, endpoint, method), false)
+			tmpl.Name, normalizedEndpoint, method), false)
 		return NewToolResultError(fmt.Sprintf("request failed: %v", respErr)), nil
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	respBody, readErr := io.ReadAll(resp.Body)
+	respBody, bodyTruncated, readErr := readLimitedBody(resp.Body, maxAPIResponseBodyBytes)
 	if readErr != nil {
 		s.logAudit(ctx, "execute_api_request", fmt.Sprintf("template=%s, endpoint=%s, method=%s, status=error",
-			tmpl.Name, endpoint, method), false)
+			tmpl.Name, normalizedEndpoint, method), false)
 		return NewToolResultError(fmt.Sprintf("cannot read response: %v", readErr)), nil
 	}
 
@@ -177,20 +207,121 @@ func (s *Server) handleExecuteAPIRequest(ctx context.Context, req CallToolReques
 
 	// Audit log: template + endpoint + method + status code only
 	auditMsg := fmt.Sprintf("template=%s, endpoint=%s, method=%s, status=%d",
-		tmpl.Name, endpoint, method, resp.StatusCode)
+		tmpl.Name, normalizedEndpoint, method, resp.StatusCode)
 	s.logAudit(ctx, "execute_api_request", auditMsg, resp.StatusCode < 400)
 
 	resultJSON, err := json.Marshal(map[string]any{
-		"status_code":  resp.StatusCode,
-		"headers":      safeHeaders,
-		"body":         sanitizedBody,
-		"content_type": contentType,
+		"status_code":    resp.StatusCode,
+		"headers":        safeHeaders,
+		"body":           sanitizedBody,
+		"body_truncated": bodyTruncated,
+		"content_type":   contentType,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("marshal response: %w", err)
 	}
 
 	return NewToolResultText(string(resultJSON)), nil
+}
+
+func parseTemplateEntryRef(entryRef string) (string, error) {
+	ref := strings.TrimSpace(entryRef)
+	if ref == "" {
+		return "", fmt.Errorf("entry_ref is required")
+	}
+	if strings.HasPrefix(ref, "op://") {
+		entryPath, field, err := parseOpRef(ref)
+		if err != nil {
+			return "", err
+		}
+		if field != "" {
+			return "", fmt.Errorf("entry_ref must reference an entry, not a field")
+		}
+		return entryPath, nil
+	}
+	return ref, nil
+}
+
+func normalizeEndpoint(endpoint string) (string, error) {
+	trimmed := strings.TrimSpace(endpoint)
+	if trimmed == "" {
+		return "", fmt.Errorf("endpoint is required")
+	}
+	if !strings.HasPrefix(trimmed, "/") {
+		return "", fmt.Errorf("endpoint must start with '/'")
+	}
+	decoded, err := url.PathUnescape(trimmed)
+	if err != nil {
+		return "", fmt.Errorf("invalid URL encoding")
+	}
+	if hasDotSegment(trimmed) || hasDotSegment(decoded) {
+		return "", fmt.Errorf("dot-segments are not allowed")
+	}
+	return path.Clean(trimmed), nil
+}
+
+func hasDotSegment(p string) bool {
+	for _, part := range strings.Split(p, "/") {
+		if part == "." || part == ".." {
+			return true
+		}
+	}
+	return false
+}
+
+func parseTimeoutSeconds(raw any) (int, error) {
+	if raw == nil {
+		return defaultAPITimeoutSeconds, nil
+	}
+
+	var timeoutValue float64
+	switch v := raw.(type) {
+	case float64:
+		timeoutValue = v
+	case float32:
+		timeoutValue = float64(v)
+	case int:
+		timeoutValue = float64(v)
+	case int32:
+		timeoutValue = float64(v)
+	case int64:
+		timeoutValue = float64(v)
+	case string:
+		parsed, err := strconv.ParseFloat(v, 64)
+		if err != nil {
+			return 0, fmt.Errorf("argument \"timeout\" must be numeric")
+		}
+		timeoutValue = parsed
+	default:
+		return 0, fmt.Errorf("argument \"timeout\" must be numeric")
+	}
+
+	if math.IsNaN(timeoutValue) || math.IsInf(timeoutValue, 0) {
+		return 0, fmt.Errorf("argument \"timeout\" must be a finite number")
+	}
+	if timeoutValue != math.Trunc(timeoutValue) {
+		return 0, fmt.Errorf("argument \"timeout\" must be a whole number of seconds")
+	}
+
+	timeoutSec := int(timeoutValue)
+	if timeoutSec < minAPITimeoutSeconds {
+		timeoutSec = minAPITimeoutSeconds
+	}
+	if timeoutSec > maxAPITimeoutSeconds {
+		timeoutSec = maxAPITimeoutSeconds
+	}
+	return timeoutSec, nil
+}
+
+func readLimitedBody(r io.Reader, limit int) ([]byte, bool, error) {
+	body, err := io.ReadAll(io.LimitReader(r, int64(limit)+1))
+	if err != nil {
+		return nil, false, err
+	}
+	if len(body) > limit {
+		return body[:limit], true, nil
+	}
+	return body, false, nil
 }
 
 // injectAuthHeader resolves the credential from the vault entry data and

--- a/internal/mcp/tools_execute_api_request.go
+++ b/internal/mcp/tools_execute_api_request.go
@@ -299,9 +299,15 @@ func isMethodAllowed(method string, allowed []string) bool {
 	return false
 }
 
-// checkExecuteAPIRequestApproval checks the agent's approval mode and either
+// checkExecuteAPIRequestApproval checks the agent's approval mode for API request execution.
+func (s *Server) checkExecuteAPIRequestApproval(ctx context.Context) error {
+	return s.checkApproval(ctx, "execute_api_request",
+		"agent %q requests to execute an API request")
+}
+
+// checkApproval is a shared helper that checks the agent's approval mode and either
 // allows execution, denies it, or prompts the user for confirmation.
-func (s *Server) checkExecuteAPIRequestApproval(_ context.Context) error {
+func (s *Server) checkApproval(_ context.Context, operation, detailFmt string) error {
 	if s == nil || s.agent == nil {
 		return fmt.Errorf("server not initialized")
 	}
@@ -319,22 +325,22 @@ func (s *Server) checkExecuteAPIRequestApproval(_ context.Context) error {
 	case "none", "auto":
 		return nil
 	case "deny":
-		return fmt.Errorf("execute_api_request denied: approval mode is 'deny'")
+		return fmt.Errorf("%s denied: approval mode is 'deny'", operation)
 	case "prompt":
 		timeout := s.agent.ApprovalTimeout
 		if timeout <= 0 {
 			timeout = 30 * time.Second
 		}
 		result := RequestApproval(ApprovalRequest{
-			Operation: "execute_api_request",
-			Details:   fmt.Sprintf("agent %q requests to execute an API request", s.agent.Name),
+			Operation: operation,
+			Details:   fmt.Sprintf(detailFmt, s.agent.Name),
 			Timeout:   timeout,
 		})
 		if result.Error != nil {
-			return fmt.Errorf("execute_api_request approval failed: %w", result.Error)
+			return fmt.Errorf("%s approval failed: %w", operation, result.Error)
 		}
 		if !result.Approved {
-			return fmt.Errorf("execute_api_request denied: user did not approve")
+			return fmt.Errorf("%s denied: user did not approve", operation)
 		}
 		metrics.RecordApproval(s.agent.Name, "granted")
 		return nil

--- a/internal/mcp/tools_execute_api_request.go
+++ b/internal/mcp/tools_execute_api_request.go
@@ -178,7 +178,7 @@ func (s *Server) handleExecuteAPIRequest(ctx context.Context, req CallToolReques
 	// Audit log: template + endpoint + method + status code only
 	auditMsg := fmt.Sprintf("template=%s, endpoint=%s, method=%s, status=%d",
 		tmpl.Name, endpoint, method, resp.StatusCode)
-	s.logAudit(ctx, "execute_api_request", auditMsg, resp.StatusCode < 500)
+	s.logAudit(ctx, "execute_api_request", auditMsg, resp.StatusCode < 400)
 
 	resultJSON, err := json.Marshal(map[string]any{
 		"status_code":  resp.StatusCode,

--- a/internal/mcp/tools_execute_api_request.go
+++ b/internal/mcp/tools_execute_api_request.go
@@ -1,0 +1,349 @@
+package mcp
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/danieljustus/OpenPass/internal/mcp/apitemplates"
+	"github.com/danieljustus/OpenPass/internal/metrics"
+	"github.com/danieljustus/OpenPass/internal/vaultsvc"
+)
+
+// handleExecuteAPIRequest executes an HTTP API request using a named template.
+// Credentials are loaded from the vault and injected into the request without
+// exposing their values to the agent.
+//
+//nolint:gocyclo,gocognit // complexity inherent to auth resolution and request building
+func (s *Server) handleExecuteAPIRequest(ctx context.Context, req CallToolRequest) (*CallToolResult, error) {
+	if !s.canRunCommands() {
+		s.logAudit(ctx, "execute_api_request", "<run-denied>", false)
+		metrics.RecordAuthDenial("run_denied", s.agent.Name)
+		return nil, fmt.Errorf("command execution not permitted for this agent")
+	}
+
+	templateName, err := req.RequireString("template")
+	if err != nil {
+		s.logAudit(ctx, "execute_api_request", "<invalid:missing-template>", false)
+		return NewToolResultError("missing required argument \"template\""), nil
+	}
+
+	endpoint, err := req.RequireString("endpoint")
+	if err != nil {
+		s.logAudit(ctx, "execute_api_request", "<invalid:missing-endpoint>", false)
+		return NewToolResultError("missing required argument \"endpoint\""), nil
+	}
+
+	method := req.GetString("method", "GET")
+	bodyStr := req.GetString("body", "")
+	timeoutSec := int(req.GetFloat("timeout", 30))
+
+	// Load template
+	vaultDir := ""
+	if s.vault != nil {
+		vaultDir = s.vault.Dir
+	}
+	tmpl, loadErr := apitemplates.Load(templateName, vaultDir)
+	if loadErr != nil {
+		s.logAudit(ctx, "execute_api_request", fmt.Sprintf("<template-error:%s>", templateName), false)
+		return NewToolResultError(fmt.Sprintf("cannot load template %q: %v", templateName, loadErr)), nil
+	}
+
+	// Validate endpoint against allowed patterns
+	if !matchAnyGlob(endpoint, tmpl.AllowedEndpoints) {
+		s.logAudit(ctx, "execute_api_request", fmt.Sprintf("<endpoint-denied:%s>", tmpl.Name), false)
+		return NewToolResultError(fmt.Sprintf("endpoint not allowed: %s", endpoint)), nil
+	}
+
+	// Validate method against allowed methods
+	if !isMethodAllowed(method, tmpl.AllowedMethods) {
+		s.logAudit(ctx, "execute_api_request", fmt.Sprintf("<method-denied:%s>", tmpl.Name), false)
+		return NewToolResultError(fmt.Sprintf("method not allowed: %s", method)), nil
+	}
+
+	// Approval check before vault access
+	approvalErr := s.checkExecuteAPIRequestApproval(ctx)
+	if approvalErr != nil {
+		s.logAudit(ctx, "execute_api_request", "<approval-denied>", false)
+		metrics.RecordApproval(s.agent.Name, "denied")
+		return nil, approvalErr
+	}
+
+	// Load vault entry for credentials
+	svc := vaultsvc.New(slog.Default(), s.vault)
+	entry, entryErr := svc.GetEntry(tmpl.EntryRef)
+	if entryErr != nil {
+		s.logAudit(ctx, "execute_api_request", fmt.Sprintf("<vault-error:%s>", tmpl.Name), false)
+		return NewToolResultError(fmt.Sprintf("cannot load credentials for %q: %v", tmpl.Name, entryErr)), nil
+	}
+
+	// Build the request
+	requestURL := tmpl.BaseURL + endpoint
+	var requestBody io.Reader
+	if bodyStr != "" {
+		requestBody = strings.NewReader(bodyStr)
+	}
+
+	httpReq, reqErr := http.NewRequestWithContext(ctx, method, requestURL, requestBody)
+	if reqErr != nil {
+		s.logAudit(ctx, "execute_api_request", fmt.Sprintf("<request-build-error:%s>", tmpl.Name), false)
+		return NewToolResultError(fmt.Sprintf("cannot build request: %v", reqErr)), nil
+	}
+
+	// Apply default headers
+	for k, v := range tmpl.DefaultHeaders {
+		httpReq.Header.Set(k, v)
+	}
+
+	// Apply additional headers from agent request (before auth, so auth can't be overridden)
+	if headersRaw, ok := req.Arguments["headers"]; ok {
+		if headersMap, ok := headersRaw.(map[string]any); ok {
+			for k, v := range headersMap {
+				if vStr, ok := v.(string); ok {
+					httpReq.Header.Set(k, vStr)
+				}
+			}
+		}
+	}
+
+	// Resolve and inject auth header
+	authErr := injectAuthHeader(httpReq, tmpl, entry.Data)
+	if authErr != nil {
+		s.logAudit(ctx, "execute_api_request", fmt.Sprintf("<auth-error:%s>", tmpl.Name), false)
+		return NewToolResultError(fmt.Sprintf("cannot resolve auth for %q: %v", tmpl.Name, authErr)), nil
+	}
+
+	// Set Content-Type for JSON body
+	if bodyStr != "" && httpReq.Header.Get("Content-Type") == "" {
+		httpReq.Header.Set("Content-Type", "application/json")
+	}
+
+	// Execute request
+	client := &http.Client{
+		Timeout: time.Duration(timeoutSec) * time.Second,
+	}
+	resp, respErr := client.Do(httpReq)
+	if respErr != nil {
+		s.logAudit(ctx, "execute_api_request", fmt.Sprintf("template=%s, endpoint=%s, method=%s, status=error",
+			tmpl.Name, endpoint, method), false)
+		return NewToolResultError(fmt.Sprintf("request failed: %v", respErr)), nil
+	}
+	defer resp.Body.Close()
+
+	respBody, readErr := io.ReadAll(resp.Body)
+	if readErr != nil {
+		s.logAudit(ctx, "execute_api_request", fmt.Sprintf("template=%s, endpoint=%s, method=%s, status=error",
+			tmpl.Name, endpoint, method), false)
+		return NewToolResultError(fmt.Sprintf("cannot read response: %v", readErr)), nil
+	}
+
+	// Sanitize response body to mask any credential values
+	resolvedSecrets := make(map[string]string)
+	for k, v := range entry.Data {
+		if vStr, ok := v.(string); ok {
+			resolvedSecrets[k] = vStr
+		}
+	}
+	sanitizedBody := s.sanitizeKnownSecretValues(string(respBody), resolvedSecrets)
+
+	// Collect response headers (safe subset)
+	safeHeaders := make(map[string]string)
+	for k := range resp.Header {
+		// Skip potentially sensitive headers
+		lower := strings.ToLower(k)
+		if lower == "set-cookie" || lower == "authorization" || lower == "www-authenticate" ||
+			lower == "proxy-authenticate" || lower == "proxy-authorization" {
+			continue
+		}
+		safeHeaders[k] = resp.Header.Get(k)
+	}
+
+	// Determine content type
+	contentType := resp.Header.Get("Content-Type")
+
+	// Audit log: template + endpoint + method + status code only
+	auditMsg := fmt.Sprintf("template=%s, endpoint=%s, method=%s, status=%d",
+		tmpl.Name, endpoint, method, resp.StatusCode)
+	s.logAudit(ctx, "execute_api_request", auditMsg, resp.StatusCode < 500)
+
+	resultJSON, err := json.Marshal(map[string]any{
+		"status_code":  resp.StatusCode,
+		"headers":      safeHeaders,
+		"body":         sanitizedBody,
+		"content_type": contentType,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal response: %w", err)
+	}
+
+	return NewToolResultText(string(resultJSON)), nil
+}
+
+// injectAuthHeader resolves the credential from the vault entry data and
+// injects the appropriate auth header (or query param) into the HTTP request.
+//
+//nolint:gocyclo // auth type dispatch is intentionally structured as switch
+func injectAuthHeader(httpReq *http.Request, tmpl *apitemplates.APITemplate, entryData map[string]any) error {
+	switch tmpl.AuthType {
+	case apitemplates.AuthBearer:
+		token := resolveField(entryData, "credential", "token", "password")
+		if token == "" {
+			return fmt.Errorf("no bearer token found in vault entry (expected fields: credential, token, or password)")
+		}
+		httpReq.Header.Set("Authorization", "Bearer "+token)
+
+	case apitemplates.AuthBasic:
+		username := resolveField(entryData, "username")
+		password := resolveField(entryData, "credential", "password")
+		if username == "" || password == "" {
+			return fmt.Errorf("basic auth requires username and password fields in vault entry")
+		}
+		auth := base64.StdEncoding.EncodeToString([]byte(username + ":" + password))
+		httpReq.Header.Set("Authorization", "Basic "+auth)
+
+	case apitemplates.AuthHeader:
+		// For header auth type, we look for the header name and value in entry data
+		// The convention is: header_name and header_value in the vault entry
+		headerName := resolveField(entryData, "header_name")
+		headerValue := resolveField(entryData, "header_value", "credential", "token", "password")
+		if headerName == "" || headerValue == "" {
+			return fmt.Errorf("header auth requires header_name and header_value (or credential/token/password) fields in vault entry")
+		}
+		httpReq.Header.Set(headerName, headerValue)
+
+	case apitemplates.AuthQueryParam:
+		// For query_param auth type, we look for the param name and value in entry data
+		// The convention is: param_name and param_value in the vault entry
+		paramName := resolveField(entryData, "param_name")
+		paramValue := resolveField(entryData, "param_value", "credential", "token", "password")
+		if paramName == "" || paramValue == "" {
+			return fmt.Errorf("query_param auth requires param_name and param_value (or credential/token/password) fields in vault entry")
+		}
+		q := httpReq.URL.Query()
+		q.Set(paramName, paramValue)
+		httpReq.URL.RawQuery = q.Encode()
+
+	default:
+		return fmt.Errorf("unsupported auth type: %s", tmpl.AuthType)
+	}
+
+	return nil
+}
+
+// resolveField returns the first non-empty string value from the entry data
+// for the given field keys, in order.
+func resolveField(data map[string]any, keys ...string) string {
+	for _, key := range keys {
+		if v, ok := data[key]; ok {
+			if vStr, ok := v.(string); ok && vStr != "" {
+				return vStr
+			}
+		}
+	}
+	return ""
+}
+
+// matchAnyGlob checks if the given path matches any of the glob patterns.
+// Uses path.Match for single-segment matching, with multi-segment support
+// for patterns ending in /* which should match any sub-path.
+func matchAnyGlob(endpoint string, patterns []string) bool {
+	if len(patterns) == 0 {
+		return false
+	}
+	for _, pattern := range patterns {
+		if matchGlob(pattern, endpoint) {
+			return true
+		}
+	}
+	return false
+}
+
+// matchGlob reports whether the endpoint matches the glob pattern.
+// It uses path.Match for standard shell pattern matching, and adds
+// multi-segment support for patterns ending with /* — these match
+// any sub-path beneath the prefix.
+func matchGlob(pattern, endpoint string) bool {
+	// Try standard path.Match first (handles single-segment *)
+	if matched, err := path.Match(pattern, endpoint); err == nil && matched {
+		return true
+	}
+	// Multi-segment: patterns like /v1/* should match /v1/chat/completions
+	if strings.HasSuffix(pattern, "/*") {
+		prefix := strings.TrimSuffix(pattern, "/*")
+		if prefix == "" || prefix == "/" {
+			// /* matches any absolute path
+			return strings.HasPrefix(endpoint, "/")
+		}
+		if strings.HasPrefix(endpoint, prefix+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+// isMethodAllowed checks if the given HTTP method is in the allowed list.
+func isMethodAllowed(method string, allowed []string) bool {
+	method = strings.ToUpper(method)
+	for _, m := range allowed {
+		if strings.EqualFold(m, method) {
+			return true
+		}
+	}
+	return false
+}
+
+// checkExecuteAPIRequestApproval checks the agent's approval mode and either
+// allows execution, denies it, or prompts the user for confirmation.
+func (s *Server) checkExecuteAPIRequestApproval(_ context.Context) error {
+	if s == nil || s.agent == nil {
+		return fmt.Errorf("server not initialized")
+	}
+
+	mode := s.agent.ApprovalMode
+	if mode == "" {
+		if s.agent.RequireApproval {
+			mode = "prompt"
+		} else {
+			mode = "none"
+		}
+	}
+
+	switch mode {
+	case "none", "auto":
+		return nil
+	case "deny":
+		return fmt.Errorf("execute_api_request denied: approval mode is 'deny'")
+	case "prompt":
+		timeout := s.agent.ApprovalTimeout
+		if timeout <= 0 {
+			timeout = 30 * time.Second
+		}
+		result := RequestApproval(ApprovalRequest{
+			Operation: "execute_api_request",
+			Details:   fmt.Sprintf("agent %q requests to execute an API request", s.agent.Name),
+			Timeout:   timeout,
+		})
+		if result.Error != nil {
+			return fmt.Errorf("execute_api_request approval failed: %w", result.Error)
+		}
+		if !result.Approved {
+			return fmt.Errorf("execute_api_request denied: user did not approve")
+		}
+		metrics.RecordApproval(s.agent.Name, "granted")
+		return nil
+	default:
+		return nil
+	}
+}
+
+// executeAPIAvailable returns true when the agent has command execution permission.
+func executeAPIAvailable(s *Server) bool {
+	return s != nil && s.agent != nil && s.agent.CanRunCommands
+}

--- a/internal/mcp/tools_execute_api_request.go
+++ b/internal/mcp/tools_execute_api_request.go
@@ -104,12 +104,19 @@ func (s *Server) handleExecuteAPIRequest(ctx context.Context, req CallToolReques
 
 	// Apply additional headers from agent request (before auth, so auth can't be overridden)
 	if headersRaw, ok := req.Arguments["headers"]; ok {
-		if headersMap, ok := headersRaw.(map[string]any); ok {
-			for k, v := range headersMap {
-				if vStr, ok := v.(string); ok {
-					httpReq.Header.Set(k, vStr)
-				}
+		headersMap, ok := headersRaw.(map[string]any)
+		if !ok {
+			s.logAudit(ctx, "execute_api_request", fmt.Sprintf("<invalid-headers:%s>", tmpl.Name), false)
+			return NewToolResultError("invalid headers: must be an object with string values"), nil
+		}
+
+		for k, v := range headersMap {
+			vStr, ok := v.(string)
+			if !ok {
+				s.logAudit(ctx, "execute_api_request", fmt.Sprintf("<invalid-headers:%s>", tmpl.Name), false)
+				return NewToolResultError(fmt.Sprintf("invalid headers: value for %q must be a string", k)), nil
 			}
+			httpReq.Header.Set(k, vStr)
 		}
 	}
 

--- a/internal/mcp/tools_execute_api_request.go
+++ b/internal/mcp/tools_execute_api_request.go
@@ -135,7 +135,7 @@ func (s *Server) handleExecuteAPIRequest(ctx context.Context, req CallToolReques
 			tmpl.Name, endpoint, method), false)
 		return NewToolResultError(fmt.Sprintf("request failed: %v", respErr)), nil
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	respBody, readErr := io.ReadAll(resp.Body)
 	if readErr != nil {

--- a/internal/mcp/tools_execute_api_request_test.go
+++ b/internal/mcp/tools_execute_api_request_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -700,7 +701,7 @@ func TestHandleExecuteAPIRequest_HeadersValidation(t *testing.T) {
 
 			writeTemplateOverride(t, vaultDir, "headers-validation", fmt.Sprintf(`base_url: %s
 auth_type: bearer
-entry_ref: headers-validation
+entry_ref: op:///headers-validation
 allowed_endpoints:
   - /*
 allowed_methods:
@@ -753,7 +754,7 @@ func TestHandleExecuteAPIRequest_EndpointDotSegmentsRejected(t *testing.T) {
 
 			writeTemplateOverride(t, vaultDir, "dot-segments", `base_url: https://example.com
 auth_type: bearer
-entry_ref: dot-segments
+entry_ref: op:///dot-segments
 allowed_endpoints:
   - /v1/*
 allowed_methods:
@@ -843,7 +844,7 @@ func TestHandleExecuteAPIRequest_ResponseBodyTruncated(t *testing.T) {
 
 	writeTemplateOverride(t, vaultDir, "large-response", fmt.Sprintf(`base_url: %s
 auth_type: bearer
-entry_ref: large-response
+entry_ref: op:///large-response
 allowed_endpoints:
   - /*
 allowed_methods:
@@ -1045,9 +1046,10 @@ func TestNormalizeEndpoint(t *testing.T) {
 		want      string
 		wantError bool
 	}{
-		{name: "clean endpoint", endpoint: "/v1//chat/completions", want: "/v1/chat/completions"},
+		{name: "double slashes normalized", endpoint: "/v1//chat/completions", want: "/v1/chat/completions"},
 		{name: "dot segment rejected", endpoint: "/v1/../admin", wantError: true},
 		{name: "encoded dot segment rejected", endpoint: "/v1/%2e%2e/admin", wantError: true},
+		{name: "invalid encoding rejected", endpoint: "/path/%ZZ", wantError: true},
 		{name: "must start with slash", endpoint: "v1/chat", wantError: true},
 	}
 
@@ -1082,6 +1084,8 @@ func TestParseTimeoutSeconds(t *testing.T) {
 		{name: "maximum clamped", input: 9999, want: maxAPITimeoutSeconds},
 		{name: "string integer", input: "45", want: 45},
 		{name: "non-integer rejected", input: 1.5, wantError: true},
+		{name: "nan rejected", input: math.NaN(), wantError: true},
+		{name: "infinity rejected", input: math.Inf(1), wantError: true},
 		{name: "invalid type rejected", input: map[string]any{}, wantError: true},
 	}
 

--- a/internal/mcp/tools_execute_api_request_test.go
+++ b/internal/mcp/tools_execute_api_request_test.go
@@ -310,7 +310,7 @@ func TestHandleExecuteAPIRequest_Success(t *testing.T) {
 
 	writeTemplateOverride(t, vaultDir, "testapi", fmt.Sprintf(`base_url: %s
 auth_type: bearer
-entry_ref: testapi
+entry_ref: op:///testapi
 allowed_endpoints:
   - /*
 allowed_methods:
@@ -659,6 +659,226 @@ allowed_methods:
 	}
 }
 
+func TestHandleExecuteAPIRequest_HeadersValidation(t *testing.T) {
+	tests := []struct {
+		name       string
+		headersArg any
+		wantErrSub string
+	}{
+		{
+			name:       "headers must be object",
+			headersArg: []any{"invalid"},
+			wantErrSub: `argument "headers" must be an object`,
+		},
+		{
+			name: "header value must be string",
+			headersArg: map[string]any{
+				"X-Number": 123,
+			},
+			wantErrSub: `headers["X-Number"] must be a string`,
+		},
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok": true}`))
+	}))
+	defer ts.Close()
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			vaultDir, identity := mockVaultWithEntry(t, "headers-validation", map[string]any{
+				"credential": "token",
+			})
+			srv := newTestServerWithVault(t, config.AgentProfile{
+				Name:           "test",
+				AllowedPaths:   []string{"*"},
+				CanRunCommands: true,
+				ApprovalMode:   "none",
+			}, "stdio", vaultDir)
+			srv.vault.Identity = identity
+
+			writeTemplateOverride(t, vaultDir, "headers-validation", fmt.Sprintf(`base_url: %s
+auth_type: bearer
+entry_ref: headers-validation
+allowed_endpoints:
+  - /*
+allowed_methods:
+  - GET
+`, ts.URL))
+
+			req := CallToolRequest{
+				Arguments: map[string]any{
+					"template": "headers-validation",
+					"endpoint": "/test",
+					"method":   "GET",
+					"headers":  tc.headersArg,
+				},
+			}
+			result, err := srv.handleExecuteAPIRequest(context.Background(), req)
+			if err != nil {
+				t.Fatalf("handleExecuteAPIRequest() error = %v", err)
+			}
+			if !result.IsError {
+				t.Fatal("handleExecuteAPIRequest() expected error result")
+			}
+			if !strings.Contains(result.Text, tc.wantErrSub) {
+				t.Errorf("result text = %q, want %q", result.Text, tc.wantErrSub)
+			}
+		})
+	}
+}
+
+func TestHandleExecuteAPIRequest_EndpointDotSegmentsRejected(t *testing.T) {
+	tests := []struct {
+		name     string
+		endpoint string
+	}{
+		{name: "literal dot segments", endpoint: "/v1/../admin"},
+		{name: "encoded dot segments", endpoint: "/v1/%2E%2e/admin"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			vaultDir, identity := mockVaultWithEntry(t, "dot-segments", map[string]any{
+				"credential": "token",
+			})
+			srv := newTestServerWithVault(t, config.AgentProfile{
+				Name:           "test",
+				AllowedPaths:   []string{"*"},
+				CanRunCommands: true,
+				ApprovalMode:   "none",
+			}, "stdio", vaultDir)
+			srv.vault.Identity = identity
+
+			writeTemplateOverride(t, vaultDir, "dot-segments", `base_url: https://example.com
+auth_type: bearer
+entry_ref: dot-segments
+allowed_endpoints:
+  - /v1/*
+allowed_methods:
+  - GET
+`)
+
+			req := CallToolRequest{
+				Arguments: map[string]any{
+					"template": "dot-segments",
+					"endpoint": tc.endpoint,
+					"method":   "GET",
+				},
+			}
+			result, err := srv.handleExecuteAPIRequest(context.Background(), req)
+			if err != nil {
+				t.Fatalf("handleExecuteAPIRequest() error = %v", err)
+			}
+			if !result.IsError {
+				t.Fatal("handleExecuteAPIRequest() expected error result")
+			}
+			if !strings.Contains(result.Text, "invalid endpoint") {
+				t.Errorf("result text = %q, want invalid endpoint error", result.Text)
+			}
+		})
+	}
+}
+
+func TestHandleExecuteAPIRequest_EntryRefScopeDenied(t *testing.T) {
+	vaultDir, identity := mockVaultWithEntry(t, "github", map[string]any{
+		"credential": "token",
+	})
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:           "test",
+		AllowedPaths:   []string{"other"},
+		CanRunCommands: true,
+		ApprovalMode:   "none",
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+
+	writeTemplateOverride(t, vaultDir, "scope-denied", `base_url: https://example.com
+auth_type: bearer
+entry_ref: op:///github
+allowed_endpoints:
+  - /*
+allowed_methods:
+  - GET
+`)
+
+	req := CallToolRequest{
+		Arguments: map[string]any{
+			"template": "scope-denied",
+			"endpoint": "/test",
+			"method":   "GET",
+		},
+	}
+
+	result, err := srv.handleExecuteAPIRequest(context.Background(), req)
+	if err == nil {
+		t.Fatal("handleExecuteAPIRequest() expected scope error, got nil")
+	}
+	if result != nil {
+		t.Fatal("handleExecuteAPIRequest() result = non-nil, want nil on scope denial")
+	}
+	if !strings.Contains(err.Error(), "outside allowed scope") {
+		t.Fatalf("error = %v, want outside allowed scope", err)
+	}
+}
+
+func TestHandleExecuteAPIRequest_ResponseBodyTruncated(t *testing.T) {
+	largeBody := strings.Repeat("a", maxAPIResponseBodyBytes+128)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(largeBody))
+	}))
+	defer ts.Close()
+
+	vaultDir, identity := mockVaultWithEntry(t, "large-response", map[string]any{
+		"credential": "token",
+	})
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:           "test",
+		AllowedPaths:   []string{"*"},
+		CanRunCommands: true,
+		ApprovalMode:   "none",
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+
+	writeTemplateOverride(t, vaultDir, "large-response", fmt.Sprintf(`base_url: %s
+auth_type: bearer
+entry_ref: large-response
+allowed_endpoints:
+  - /*
+allowed_methods:
+  - GET
+`, ts.URL))
+
+	req := CallToolRequest{
+		Arguments: map[string]any{
+			"template": "large-response",
+			"endpoint": "/test",
+			"method":   "GET",
+		},
+	}
+
+	result, err := srv.handleExecuteAPIRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleExecuteAPIRequest() error = %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handleExecuteAPIRequest() returned error: %s", result.Text)
+	}
+
+	var output map[string]any
+	if err := json.Unmarshal([]byte(result.Text), &output); err != nil {
+		t.Fatalf("parse result: %v", err)
+	}
+	body, _ := output["body"].(string)
+	if len(body) != maxAPIResponseBodyBytes {
+		t.Errorf("len(body) = %d, want %d", len(body), maxAPIResponseBodyBytes)
+	}
+	if truncated, _ := output["body_truncated"].(bool); !truncated {
+		t.Errorf("body_truncated = %v, want true", truncated)
+	}
+}
+
 func TestHandleExecuteAPIRequest_UnknownTemplate(t *testing.T) {
 	srv := newTestServer(t, config.AgentProfile{
 		Name:           "test",
@@ -783,6 +1003,104 @@ func TestHandleExecuteAPIRequest_NotListedWhenUnavailable(t *testing.T) {
 		if name, _ := tool["name"].(string); name == "execute_api_request" {
 			t.Fatal("execute_api_request should not be listed when CanRunCommands=false")
 		}
+	}
+}
+
+func TestParseTemplateEntryRef(t *testing.T) {
+	tests := []struct {
+		name      string
+		ref       string
+		wantPath  string
+		wantError bool
+	}{
+		{name: "plain path", ref: "github", wantPath: "github"},
+		{name: "op ref", ref: "op:///github", wantPath: "github"},
+		{name: "field ref rejected", ref: "op://vault/github/token", wantError: true},
+		{name: "empty ref rejected", ref: " ", wantError: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseTemplateEntryRef(tt.ref)
+			if tt.wantError {
+				if err == nil {
+					t.Fatal("parseTemplateEntryRef() expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseTemplateEntryRef() error = %v", err)
+			}
+			if got != tt.wantPath {
+				t.Errorf("parseTemplateEntryRef() = %q, want %q", got, tt.wantPath)
+			}
+		})
+	}
+}
+
+func TestNormalizeEndpoint(t *testing.T) {
+	tests := []struct {
+		name      string
+		endpoint  string
+		want      string
+		wantError bool
+	}{
+		{name: "clean endpoint", endpoint: "/v1//chat/completions", want: "/v1/chat/completions"},
+		{name: "dot segment rejected", endpoint: "/v1/../admin", wantError: true},
+		{name: "encoded dot segment rejected", endpoint: "/v1/%2e%2e/admin", wantError: true},
+		{name: "must start with slash", endpoint: "v1/chat", wantError: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := normalizeEndpoint(tt.endpoint)
+			if tt.wantError {
+				if err == nil {
+					t.Fatal("normalizeEndpoint() expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("normalizeEndpoint() error = %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("normalizeEndpoint() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseTimeoutSeconds(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     any
+		want      int
+		wantError bool
+	}{
+		{name: "default timeout", input: nil, want: defaultAPITimeoutSeconds},
+		{name: "minimum clamped", input: 0, want: minAPITimeoutSeconds},
+		{name: "maximum clamped", input: 9999, want: maxAPITimeoutSeconds},
+		{name: "string integer", input: "45", want: 45},
+		{name: "non-integer rejected", input: 1.5, wantError: true},
+		{name: "invalid type rejected", input: map[string]any{}, wantError: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseTimeoutSeconds(tt.input)
+			if tt.wantError {
+				if err == nil {
+					t.Fatal("parseTimeoutSeconds() expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseTimeoutSeconds() error = %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("parseTimeoutSeconds() = %d, want %d", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/mcp/tools_execute_api_request_test.go
+++ b/internal/mcp/tools_execute_api_request_test.go
@@ -1,0 +1,807 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/danieljustus/OpenPass/internal/config"
+	"github.com/danieljustus/OpenPass/internal/mcp/apitemplates"
+)
+
+// --- Template loading tests ---
+
+func TestAPITemplateLoad_Builtin(t *testing.T) {
+	tests := []struct {
+		name    string
+		wantURL string
+		wantRef string
+	}{
+		{"github", "https://api.github.com", "op:///github"},
+		{"openai", "https://api.openai.com", "op:///openai"},
+		{"anthropic", "https://api.anthropic.com", "op:///anthropic"},
+		{"slack", "https://slack.com/api", "op:///slack"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpl, err := apitemplates.Load(tt.name, "")
+			if err != nil {
+				t.Fatalf("Load(%q) error = %v", tt.name, err)
+			}
+			if tmpl == nil {
+				t.Fatal("Load() returned nil template")
+			}
+			if tmpl.Name != tt.name {
+				t.Errorf("Name = %q, want %q", tmpl.Name, tt.name)
+			}
+			if tmpl.BaseURL != tt.wantURL {
+				t.Errorf("BaseURL = %q, want %q", tmpl.BaseURL, tt.wantURL)
+			}
+			if tmpl.EntryRef != tt.wantRef {
+				t.Errorf("EntryRef = %q, want %q", tmpl.EntryRef, tt.wantRef)
+			}
+			if tmpl.AuthType != apitemplates.AuthBearer {
+				t.Errorf("AuthType = %q, want %q", tmpl.AuthType, apitemplates.AuthBearer)
+			}
+			if len(tmpl.AllowedEndpoints) == 0 {
+				t.Error("AllowedEndpoints is empty")
+			}
+			if len(tmpl.AllowedMethods) == 0 {
+				t.Error("AllowedMethods is empty")
+			}
+		})
+	}
+}
+
+func TestAPITemplateLoad_Unknown(t *testing.T) {
+	_, err := apitemplates.Load("nonexistent", "")
+	if err == nil {
+		t.Fatal("Load() expected error for unknown template, got nil")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error = %v, want 'not found'", err)
+	}
+}
+
+func TestAPITemplateLoad_EmptyName(t *testing.T) {
+	_, err := apitemplates.Load("", "")
+	if err == nil {
+		t.Fatal("Load() expected error for empty name, got nil")
+	}
+}
+
+func TestAPITemplateLoadAll(t *testing.T) {
+	templates, err := apitemplates.LoadAll()
+	if err != nil {
+		t.Fatalf("LoadAll() error = %v", err)
+	}
+	if len(templates) != 4 {
+		t.Fatalf("LoadAll() returned %d templates, want 4", len(templates))
+	}
+	names := make(map[string]bool)
+	for _, tmpl := range templates {
+		names[tmpl.Name] = true
+	}
+	for _, name := range []string{"github", "openai", "anthropic", "slack"} {
+		if !names[name] {
+			t.Errorf("LoadAll() missing template %q", name)
+		}
+	}
+}
+
+// --- Endpoint and method validation tests ---
+
+func TestMatchAnyGlob(t *testing.T) {
+	tests := []struct {
+		endpoint string
+		patterns []string
+		want     bool
+	}{
+		{"/repos/owner/repo", []string{"/*"}, true},
+		{"/repos/owner/repo", []string{"/repos/*"}, true},
+		{"/repos/owner/repo", []string{"/v1/*"}, false},
+		{"/v1/chat/completions", []string{"/v1/*"}, true},
+		{"/v2/models", []string{"/v1/*"}, false},
+		{"/api/test", []string{"/api/*", "/other/*"}, true},
+		{"/test", []string{}, false},
+		{"/api/abc", []string{"/api/???"}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%s_in_%v", tt.endpoint, tt.patterns), func(t *testing.T) {
+			got := matchAnyGlob(tt.endpoint, tt.patterns)
+			if got != tt.want {
+				t.Errorf("matchAnyGlob(%q, %v) = %v, want %v", tt.endpoint, tt.patterns, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsMethodAllowed(t *testing.T) {
+	tests := []struct {
+		method  string
+		allowed []string
+		want    bool
+	}{
+		{"GET", []string{"GET", "POST"}, true},
+		{"POST", []string{"GET", "POST"}, true},
+		{"DELETE", []string{"GET", "POST"}, false},
+		{"get", []string{"GET", "POST"}, true},
+		{"Get", []string{"GET", "POST"}, true},
+		{"PUT", []string{}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.method, func(t *testing.T) {
+			got := isMethodAllowed(tt.method, tt.allowed)
+			if got != tt.want {
+				t.Errorf("isMethodAllowed(%q, %v) = %v, want %v", tt.method, tt.allowed, got, tt.want)
+			}
+		})
+	}
+}
+
+// --- Auth injection tests ---
+
+func TestInjectAuthHeader_Bearer(t *testing.T) {
+	tmpl := &apitemplates.APITemplate{
+		Name:     "test",
+		BaseURL:  "https://example.com",
+		AuthType: apitemplates.AuthBearer,
+	}
+	req, _ := http.NewRequest("GET", "https://example.com/test", nil)
+	err := injectAuthHeader(req, tmpl, map[string]any{
+		"credential": "test-token-123",
+	})
+	if err != nil {
+		t.Fatalf("injectAuthHeader() error = %v", err)
+	}
+	if got := req.Header.Get("Authorization"); got != "Bearer test-token-123" {
+		t.Errorf("Authorization header = %q, want %q", got, "Bearer test-token-123")
+	}
+}
+
+func TestInjectAuthHeader_BearerFallbackFields(t *testing.T) {
+	tests := []struct {
+		name  string
+		data  map[string]any
+		token string
+	}{
+		{"credential field", map[string]any{"credential": "token-1"}, "token-1"},
+		{"token field", map[string]any{"token": "token-2"}, "token-2"},
+		{"password field", map[string]any{"password": "token-3"}, "token-3"},
+	}
+	tmpl := &apitemplates.APITemplate{
+		Name:     "test",
+		BaseURL:  "https://example.com",
+		AuthType: apitemplates.AuthBearer,
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, _ := http.NewRequest("GET", "https://example.com/test", nil)
+			err := injectAuthHeader(req, tmpl, tt.data)
+			if err != nil {
+				t.Fatalf("injectAuthHeader() error = %v", err)
+			}
+			want := "Bearer " + tt.token
+			if got := req.Header.Get("Authorization"); got != want {
+				t.Errorf("Authorization header = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+func TestInjectAuthHeader_BearerMissing(t *testing.T) {
+	tmpl := &apitemplates.APITemplate{
+		Name:     "test",
+		BaseURL:  "https://example.com",
+		AuthType: apitemplates.AuthBearer,
+	}
+	req, _ := http.NewRequest("GET", "https://example.com/test", nil)
+	err := injectAuthHeader(req, tmpl, map[string]any{"username": "user"})
+	if err == nil {
+		t.Fatal("injectAuthHeader() expected error for missing token, got nil")
+	}
+}
+
+func TestInjectAuthHeader_Basic(t *testing.T) {
+	tmpl := &apitemplates.APITemplate{
+		Name:     "test",
+		BaseURL:  "https://example.com",
+		AuthType: apitemplates.AuthBasic,
+	}
+	req, _ := http.NewRequest("GET", "https://example.com/test", nil)
+	err := injectAuthHeader(req, tmpl, map[string]any{
+		"username":   "testuser",
+		"credential": "testpass",
+	})
+	if err != nil {
+		t.Fatalf("injectAuthHeader() error = %v", err)
+	}
+	if got := req.Header.Get("Authorization"); got != "Basic dGVzdHVzZXI6dGVzdHBhc3M=" {
+		t.Errorf("Authorization header = %q, want %q", got, "Basic dGVzdHVzZXI6dGVzdHBhc3M=")
+	}
+}
+
+func TestInjectAuthHeader_BasicMissing(t *testing.T) {
+	tmpl := &apitemplates.APITemplate{
+		Name:     "test",
+		BaseURL:  "https://example.com",
+		AuthType: apitemplates.AuthBasic,
+	}
+	req, _ := http.NewRequest("GET", "https://example.com/test", nil)
+	err := injectAuthHeader(req, tmpl, map[string]any{"username": "user"})
+	if err == nil {
+		t.Fatal("injectAuthHeader() expected error for missing password, got nil")
+	}
+}
+
+func TestInjectAuthHeader_Header(t *testing.T) {
+	tmpl := &apitemplates.APITemplate{
+		Name:     "test",
+		BaseURL:  "https://example.com",
+		AuthType: apitemplates.AuthHeader,
+	}
+	req, _ := http.NewRequest("GET", "https://example.com/test", nil)
+	err := injectAuthHeader(req, tmpl, map[string]any{
+		"header_name":  "X-API-Key",
+		"header_value": "my-api-key-123",
+	})
+	if err != nil {
+		t.Fatalf("injectAuthHeader() error = %v", err)
+	}
+	if got := req.Header.Get("X-API-Key"); got != "my-api-key-123" {
+		t.Errorf("X-API-Key header = %q, want %q", got, "my-api-key-123")
+	}
+}
+
+func TestInjectAuthHeader_QueryParam(t *testing.T) {
+	tmpl := &apitemplates.APITemplate{
+		Name:     "test",
+		BaseURL:  "https://example.com",
+		AuthType: apitemplates.AuthQueryParam,
+	}
+	req, _ := http.NewRequest("GET", "https://example.com/test", nil)
+	err := injectAuthHeader(req, tmpl, map[string]any{
+		"param_name":  "api_key",
+		"param_value": "secret-param-val",
+	})
+	if err != nil {
+		t.Fatalf("injectAuthHeader() error = %v", err)
+	}
+	if got := req.URL.Query().Get("api_key"); got != "secret-param-val" {
+		t.Errorf("query param api_key = %q, want %q", got, "secret-param-val")
+	}
+}
+
+// --- Handler tests with mocked HTTP ---
+
+func TestHandleExecuteAPIRequest_Success(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			t.Errorf("method = %q, want GET", r.Method)
+		}
+		if r.Header.Get("Authorization") != "Bearer test-token" {
+			t.Errorf("Authorization = %q, want Bearer test-token", r.Header.Get("Authorization"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"login": "testuser", "id": 123}`))
+	}))
+	defer ts.Close()
+
+	vaultDir, identity := mockVaultWithEntry(t, "testapi", map[string]any{
+		"credential": "test-token",
+	})
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:           "test",
+		AllowedPaths:   []string{"*"},
+		CanRunCommands: true,
+		ApprovalMode:   "none",
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+
+	writeTemplateOverride(t, vaultDir, "testapi", fmt.Sprintf(`base_url: %s
+auth_type: bearer
+entry_ref: testapi
+allowed_endpoints:
+  - /*
+allowed_methods:
+  - GET
+`, ts.URL))
+
+	req := CallToolRequest{
+		Arguments: map[string]any{
+			"template": "testapi",
+			"endpoint": "/test",
+			"method":   "GET",
+		},
+	}
+	result, err := srv.handleExecuteAPIRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleExecuteAPIRequest() error = %v", err)
+	}
+	if result == nil {
+		t.Fatal("handleExecuteAPIRequest() returned nil result")
+	}
+	if result.IsError {
+		t.Fatalf("handleExecuteAPIRequest() returned error: %s", result.Text)
+	}
+
+	var output map[string]any
+	if err := json.Unmarshal([]byte(result.Text), &output); err != nil {
+		t.Fatalf("parse result: %v", err)
+	}
+	if code, _ := output["status_code"].(float64); code != 200 {
+		t.Errorf("status_code = %v, want 200", code)
+	}
+	body, _ := output["body"].(string)
+	if !strings.Contains(body, "testuser") {
+		t.Errorf("body = %q, want to contain testuser", body)
+	}
+	ct, _ := output["content_type"].(string)
+	if ct != "application/json" {
+		t.Errorf("content_type = %q, want application/json", ct)
+	}
+}
+
+func TestHandleExecuteAPIRequest_PostWithBody(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("method = %q, want POST", r.Method)
+		}
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"status": "created"}`))
+	}))
+	defer ts.Close()
+
+	vaultDir, identity := mockVaultWithEntry(t, "myapi", map[string]any{
+		"credential": "token-post",
+	})
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:           "test",
+		AllowedPaths:   []string{"*"},
+		CanRunCommands: true,
+		ApprovalMode:   "none",
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+
+	writeTemplateOverride(t, vaultDir, "myapi", fmt.Sprintf(`base_url: %s
+auth_type: bearer
+entry_ref: myapi
+allowed_endpoints:
+  - /*
+allowed_methods:
+  - POST
+`, ts.URL))
+
+	req := CallToolRequest{
+		Arguments: map[string]any{
+			"template": "myapi",
+			"endpoint": "/create",
+			"method":   "POST",
+			"body":     `{"name": "test"}`,
+		},
+	}
+	result, err := srv.handleExecuteAPIRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleExecuteAPIRequest() error = %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handleExecuteAPIRequest() returned error: %s", result.Text)
+	}
+	var output map[string]any
+	if err := json.Unmarshal([]byte(result.Text), &output); err != nil {
+		t.Fatalf("parse result: %v", err)
+	}
+	if code, _ := output["status_code"].(float64); code != 201 {
+		t.Errorf("status_code = %v, want 201", code)
+	}
+}
+
+func TestHandleExecuteAPIRequest_MissingTemplate(t *testing.T) {
+	srv := newTestServer(t, config.AgentProfile{
+		Name:           "test",
+		AllowedPaths:   []string{"*"},
+		CanRunCommands: true,
+		ApprovalMode:   "none",
+	}, "stdio")
+	req := CallToolRequest{
+		Arguments: map[string]any{
+			"endpoint": "/test",
+		},
+	}
+	result, err := srv.handleExecuteAPIRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleExecuteAPIRequest() error = %v", err)
+	}
+	if !result.IsError {
+		t.Fatal("handleExecuteAPIRequest() expected error result")
+	}
+	if !strings.Contains(result.Text, "missing required argument") {
+		t.Errorf("result text = %q, want 'missing required argument'", result.Text)
+	}
+}
+
+func TestHandleExecuteAPIRequest_MissingEndpoint(t *testing.T) {
+	srv := newTestServer(t, config.AgentProfile{
+		Name:           "test",
+		AllowedPaths:   []string{"*"},
+		CanRunCommands: true,
+		ApprovalMode:   "none",
+	}, "stdio")
+	req := CallToolRequest{
+		Arguments: map[string]any{
+			"template": "github",
+		},
+	}
+	result, err := srv.handleExecuteAPIRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleExecuteAPIRequest() error = %v", err)
+	}
+	if !result.IsError {
+		t.Fatal("handleExecuteAPIRequest() expected error result")
+	}
+	if !strings.Contains(result.Text, "missing required argument") {
+		t.Errorf("result text = %q, want 'missing required argument'", result.Text)
+	}
+}
+
+func TestHandleExecuteAPIRequest_EndpointDenied(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	vaultDir, identity := mockVaultWithEntry(t, "restricted", map[string]any{
+		"credential": "token",
+	})
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:           "test",
+		AllowedPaths:   []string{"*"},
+		CanRunCommands: true,
+		ApprovalMode:   "none",
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+
+	writeTemplateOverride(t, vaultDir, "restricted", fmt.Sprintf(`base_url: %s
+auth_type: bearer
+entry_ref: restricted
+allowed_endpoints:
+  - /v1/*
+allowed_methods:
+  - GET
+`, ts.URL))
+
+	req := CallToolRequest{
+		Arguments: map[string]any{
+			"template": "restricted",
+			"endpoint": "/admin/delete",
+			"method":   "GET",
+		},
+	}
+	result, err := srv.handleExecuteAPIRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleExecuteAPIRequest() error = %v", err)
+	}
+	if !result.IsError {
+		t.Fatal("handleExecuteAPIRequest() expected error result for denied endpoint")
+	}
+	if !strings.Contains(result.Text, "endpoint not allowed") {
+		t.Errorf("result text = %q, want 'endpoint not allowed'", result.Text)
+	}
+}
+
+func TestHandleExecuteAPIRequest_MethodDenied(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	vaultDir, identity := mockVaultWithEntry(t, "readonly", map[string]any{
+		"credential": "token",
+	})
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:           "test",
+		AllowedPaths:   []string{"*"},
+		CanRunCommands: true,
+		ApprovalMode:   "none",
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+
+	writeTemplateOverride(t, vaultDir, "readonly", fmt.Sprintf(`base_url: %s
+auth_type: bearer
+entry_ref: readonly
+allowed_endpoints:
+  - /*
+allowed_methods:
+  - GET
+`, ts.URL))
+
+	req := CallToolRequest{
+		Arguments: map[string]any{
+			"template": "readonly",
+			"endpoint": "/test",
+			"method":   "DELETE",
+		},
+	}
+	result, err := srv.handleExecuteAPIRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleExecuteAPIRequest() error = %v", err)
+	}
+	if !result.IsError {
+		t.Fatal("handleExecuteAPIRequest() expected error result for denied method")
+	}
+	if !strings.Contains(result.Text, "method not allowed") {
+		t.Errorf("result text = %q, want 'method not allowed'", result.Text)
+	}
+}
+
+func TestHandleExecuteAPIRequest_RunDenied(t *testing.T) {
+	srv := newTestServer(t, config.AgentProfile{
+		Name:           "readonly",
+		AllowedPaths:   []string{"*"},
+		CanRunCommands: false,
+		ApprovalMode:   "none",
+	}, "stdio")
+	req := CallToolRequest{
+		Arguments: map[string]any{
+			"template": "github",
+			"endpoint": "/test",
+		},
+	}
+	_, err := srv.handleExecuteAPIRequest(context.Background(), req)
+	if err == nil {
+		t.Fatal("handleExecuteAPIRequest() expected error for run-denied agent, got nil")
+	}
+	if !strings.Contains(err.Error(), "command execution not permitted") {
+		t.Fatalf("error = %v, want 'command execution not permitted'", err)
+	}
+}
+
+func TestHandleExecuteAPIRequest_ResponseSanitized(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"result": "my-super-secret-token-value"}`))
+	}))
+	defer ts.Close()
+
+	vaultDir, identity := mockVaultWithEntry(t, "sanitize-test", map[string]any{
+		"credential": "my-super-secret-token-value",
+	})
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:           "test",
+		AllowedPaths:   []string{"*"},
+		CanRunCommands: true,
+		ApprovalMode:   "none",
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+
+	writeTemplateOverride(t, vaultDir, "sanitize-test", fmt.Sprintf(`base_url: %s
+auth_type: bearer
+entry_ref: sanitize-test
+allowed_endpoints:
+  - /*
+allowed_methods:
+  - GET
+`, ts.URL))
+
+	req := CallToolRequest{
+		Arguments: map[string]any{
+			"template": "sanitize-test",
+			"endpoint": "/test",
+			"method":   "GET",
+		},
+	}
+	result, err := srv.handleExecuteAPIRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleExecuteAPIRequest() error = %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handleExecuteAPIRequest() returned error: %s", result.Text)
+	}
+
+	var output map[string]any
+	if err := json.Unmarshal([]byte(result.Text), &output); err != nil {
+		t.Fatalf("parse result: %v", err)
+	}
+	body, _ := output["body"].(string)
+	if strings.Contains(body, "my-super-secret-token-value") {
+		t.Errorf("body contains secret value: %q", body)
+	}
+}
+
+func TestHandleExecuteAPIRequest_CustomHeaders(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Custom") != "custom-value" {
+			t.Errorf("X-Custom header = %q, want custom-value", r.Header.Get("X-Custom"))
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok": true}`))
+	}))
+	defer ts.Close()
+
+	vaultDir, identity := mockVaultWithEntry(t, "custom-headers", map[string]any{
+		"credential": "token",
+	})
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:           "test",
+		AllowedPaths:   []string{"*"},
+		CanRunCommands: true,
+		ApprovalMode:   "none",
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+
+	writeTemplateOverride(t, vaultDir, "custom-headers", fmt.Sprintf(`base_url: %s
+auth_type: bearer
+entry_ref: custom-headers
+allowed_endpoints:
+  - /*
+allowed_methods:
+  - GET
+`, ts.URL))
+
+	req := CallToolRequest{
+		Arguments: map[string]any{
+			"template": "custom-headers",
+			"endpoint": "/test",
+			"method":   "GET",
+			"headers": map[string]any{
+				"X-Custom": "custom-value",
+			},
+		},
+	}
+	result, err := srv.handleExecuteAPIRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleExecuteAPIRequest() error = %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handleExecuteAPIRequest() returned error: %s", result.Text)
+	}
+}
+
+func TestHandleExecuteAPIRequest_UnknownTemplate(t *testing.T) {
+	srv := newTestServer(t, config.AgentProfile{
+		Name:           "test",
+		AllowedPaths:   []string{"*"},
+		CanRunCommands: true,
+		ApprovalMode:   "none",
+	}, "stdio")
+	req := CallToolRequest{
+		Arguments: map[string]any{
+			"template": "nonexistent-template",
+			"endpoint": "/test",
+		},
+	}
+	result, err := srv.handleExecuteAPIRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleExecuteAPIRequest() error = %v", err)
+	}
+	if !result.IsError {
+		t.Fatal("handleExecuteAPIRequest() expected error for unknown template")
+	}
+	if !strings.Contains(result.Text, "cannot load template") {
+		t.Errorf("result text = %q, want 'cannot load template'", result.Text)
+	}
+}
+
+func TestHandleExecuteAPIRequest_ApprovalDeny(t *testing.T) {
+	srv := newTestServer(t, config.AgentProfile{
+		Name:           "test",
+		AllowedPaths:   []string{"*"},
+		CanRunCommands: true,
+		ApprovalMode:   "deny",
+	}, "stdio")
+	req := CallToolRequest{
+		Arguments: map[string]any{
+			"template": "github",
+			"endpoint": "/test",
+		},
+	}
+	_, err := srv.handleExecuteAPIRequest(context.Background(), req)
+	if err == nil {
+		t.Fatal("handleExecuteAPIRequest() expected error for approval-deny, got nil")
+	}
+	if !strings.Contains(err.Error(), "approval mode is 'deny'") {
+		t.Fatalf("error = %v, want 'approval mode is 'deny''", err)
+	}
+}
+
+func TestExecuteAPIAvailable(t *testing.T) {
+	tests := []struct {
+		name           string
+		canRunCommands bool
+		want           bool
+	}{
+		{"can run commands", true, true},
+		{"cannot run commands", false, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := newTestServer(t, config.AgentProfile{
+				Name:           "test",
+				AllowedPaths:   []string{"*"},
+				CanRunCommands: tt.canRunCommands,
+				ApprovalMode:   "none",
+			}, "stdio")
+			got := executeAPIAvailable(srv)
+			if got != tt.want {
+				t.Errorf("executeAPIAvailable() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExecuteAPIAvailable_NilAgent(t *testing.T) {
+	srv := &Server{}
+	if executeAPIAvailable(srv) {
+		t.Error("executeAPIAvailable() = true, want false for nil agent")
+	}
+}
+
+func TestExecuteAPIAvailable_NilServer(t *testing.T) {
+	if executeAPIAvailable(nil) {
+		t.Error("executeAPIAvailable() = true, want false for nil server")
+	}
+}
+
+func TestHandleExecuteAPIRequest_ToolRegistered(t *testing.T) {
+	_, ok := findToolDefinition("execute_api_request")
+	if !ok {
+		t.Fatal("execute_api_request tool not found in registry")
+	}
+}
+
+func TestHandleExecuteAPIRequest_ToolListed(t *testing.T) {
+	srv := newTestServer(t, config.AgentProfile{
+		Name:           "test",
+		AllowedPaths:   []string{"*"},
+		CanRunCommands: true,
+		ApprovalMode:   "none",
+	}, "stdio")
+	tools := toolsListPayload(srv)
+	found := false
+	for _, tool := range tools {
+		if name, _ := tool["name"].(string); name == "execute_api_request" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("execute_api_request not in tools list payload")
+	}
+}
+
+func TestHandleExecuteAPIRequest_NotListedWhenUnavailable(t *testing.T) {
+	srv := newTestServer(t, config.AgentProfile{
+		Name:           "readonly",
+		AllowedPaths:   []string{"*"},
+		CanRunCommands: false,
+		ApprovalMode:   "none",
+	}, "stdio")
+	tools := toolsListPayload(srv)
+	for _, tool := range tools {
+		if name, _ := tool["name"].(string); name == "execute_api_request" {
+			t.Fatal("execute_api_request should not be listed when CanRunCommands=false")
+		}
+	}
+}
+
+// writeTemplateOverride writes a user template override to the vault's template directory.
+func writeTemplateOverride(t *testing.T, vaultDir, name, content string) {
+	t.Helper()
+	templatesDir := filepath.Join(vaultDir, "templates")
+	if err := os.MkdirAll(templatesDir, 0755); err != nil {
+		t.Fatalf("mkdir templates: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(templatesDir, name+".yaml"), []byte(content), 0644); err != nil {
+		t.Fatalf("write template: %v", err)
+	}
+}

--- a/internal/mcp/tools_execute_api_request_test.go
+++ b/internal/mcp/tools_execute_api_request_test.go
@@ -454,93 +454,85 @@ func TestHandleExecuteAPIRequest_MissingEndpoint(t *testing.T) {
 	}
 }
 
-func TestHandleExecuteAPIRequest_EndpointDenied(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer ts.Close()
-
-	vaultDir, identity := mockVaultWithEntry(t, "restricted", map[string]any{
-		"credential": "token",
-	})
-	srv := newTestServerWithVault(t, config.AgentProfile{
-		Name:           "test",
-		AllowedPaths:   []string{"*"},
-		CanRunCommands: true,
-		ApprovalMode:   "none",
-	}, "stdio", vaultDir)
-	srv.vault.Identity = identity
-
-	writeTemplateOverride(t, vaultDir, "restricted", fmt.Sprintf(`base_url: %s
+func TestHandleExecuteAPIRequest_DeniedEndpointMethod(t *testing.T) {
+	tests := []struct {
+		name       string
+		entryName  string
+		tmplConfig string
+		endpoint   string
+		method     string
+		wantErrSub string
+	}{
+		{
+			name:      "endpoint denied",
+			entryName: "restricted",
+			tmplConfig: `base_url: %s
 auth_type: bearer
 entry_ref: restricted
 allowed_endpoints:
   - /v1/*
 allowed_methods:
   - GET
-`, ts.URL))
-
-	req := CallToolRequest{
-		Arguments: map[string]any{
-			"template": "restricted",
-			"endpoint": "/admin/delete",
-			"method":   "GET",
+`,
+			endpoint:   "/admin/delete",
+			method:     "GET",
+			wantErrSub: "endpoint not allowed",
 		},
-	}
-	result, err := srv.handleExecuteAPIRequest(context.Background(), req)
-	if err != nil {
-		t.Fatalf("handleExecuteAPIRequest() error = %v", err)
-	}
-	if !result.IsError {
-		t.Fatal("handleExecuteAPIRequest() expected error result for denied endpoint")
-	}
-	if !strings.Contains(result.Text, "endpoint not allowed") {
-		t.Errorf("result text = %q, want 'endpoint not allowed'", result.Text)
-	}
-}
-
-func TestHandleExecuteAPIRequest_MethodDenied(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer ts.Close()
-
-	vaultDir, identity := mockVaultWithEntry(t, "readonly", map[string]any{
-		"credential": "token",
-	})
-	srv := newTestServerWithVault(t, config.AgentProfile{
-		Name:           "test",
-		AllowedPaths:   []string{"*"},
-		CanRunCommands: true,
-		ApprovalMode:   "none",
-	}, "stdio", vaultDir)
-	srv.vault.Identity = identity
-
-	writeTemplateOverride(t, vaultDir, "readonly", fmt.Sprintf(`base_url: %s
+		{
+			name:      "method denied",
+			entryName: "readonly",
+			tmplConfig: `base_url: %s
 auth_type: bearer
 entry_ref: readonly
 allowed_endpoints:
   - /*
 allowed_methods:
   - GET
-`, ts.URL))
-
-	req := CallToolRequest{
-		Arguments: map[string]any{
-			"template": "readonly",
-			"endpoint": "/test",
-			"method":   "DELETE",
+`,
+			endpoint:   "/test",
+			method:     "DELETE",
+			wantErrSub: "method not allowed",
 		},
 	}
-	result, err := srv.handleExecuteAPIRequest(context.Background(), req)
-	if err != nil {
-		t.Fatalf("handleExecuteAPIRequest() error = %v", err)
-	}
-	if !result.IsError {
-		t.Fatal("handleExecuteAPIRequest() expected error result for denied method")
-	}
-	if !strings.Contains(result.Text, "method not allowed") {
-		t.Errorf("result text = %q, want 'method not allowed'", result.Text)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			vaultDir, identity := mockVaultWithEntry(t, tc.entryName, map[string]any{
+				"credential": "token",
+			})
+			srv := newTestServerWithVault(t, config.AgentProfile{
+				Name:           "test",
+				AllowedPaths:   []string{"*"},
+				CanRunCommands: true,
+				ApprovalMode:   "none",
+			}, "stdio", vaultDir)
+			srv.vault.Identity = identity
+
+			writeTemplateOverride(t, vaultDir, tc.entryName, fmt.Sprintf(tc.tmplConfig, ts.URL))
+
+			req := CallToolRequest{
+				Arguments: map[string]any{
+					"template": tc.entryName,
+					"endpoint": tc.endpoint,
+					"method":   tc.method,
+				},
+			}
+			result, err := srv.handleExecuteAPIRequest(context.Background(), req)
+			if err != nil {
+				t.Fatalf("handleExecuteAPIRequest() error = %v", err)
+			}
+			if !result.IsError {
+				t.Fatal("handleExecuteAPIRequest() expected error result for " + tc.name)
+			}
+			if !strings.Contains(result.Text, tc.wantErrSub) {
+				t.Errorf("result text = %q, want %q", result.Text, tc.wantErrSub)
+			}
+		})
 	}
 }
 

--- a/internal/mcp/tools_execute_with_secret.go
+++ b/internal/mcp/tools_execute_with_secret.go
@@ -241,46 +241,8 @@ func sanitizeEnvVarName(name string) string {
 	return sb.String()
 }
 
-// checkExecuteWithSecretApproval checks the agent's approval mode and either
-// allows execution, denies it, or prompts the user for confirmation.
-func (s *Server) checkExecuteWithSecretApproval(_ context.Context) error {
-	if s == nil || s.agent == nil {
-		return fmt.Errorf("server not initialized")
-	}
-
-	mode := s.agent.ApprovalMode
-	if mode == "" {
-		if s.agent.RequireApproval {
-			mode = "prompt"
-		} else {
-			mode = "none"
-		}
-	}
-
-	switch mode {
-	case "none", "auto":
-		return nil
-	case "deny":
-		return fmt.Errorf("execute_with_secret denied: approval mode is 'deny'")
-	case "prompt":
-		timeout := s.agent.ApprovalTimeout
-		if timeout <= 0 {
-			timeout = 30 * time.Second
-		}
-		result := RequestApproval(ApprovalRequest{
-			Operation: "execute_with_secret",
-			Details:   fmt.Sprintf("agent %q requests to execute a command with secret injection", s.agent.Name),
-			Timeout:   timeout,
-		})
-		if result.Error != nil {
-			return fmt.Errorf("execute_with_secret approval failed: %w", result.Error)
-		}
-		if !result.Approved {
-			return fmt.Errorf("execute_with_secret denied: user did not approve")
-		}
-		metrics.RecordApproval(s.agent.Name, "granted")
-		return nil
-	default:
-		return nil
-	}
+// checkExecuteWithSecretApproval checks the agent's approval mode for secret-injected execution.
+func (s *Server) checkExecuteWithSecretApproval(ctx context.Context) error {
+	return s.checkApproval(ctx, "execute_with_secret",
+		"agent %q requests to execute a command with secret injection")
 }


### PR DESCRIPTION
New execute_api_request MCP tool with credential-isolation for HTTP API calls. Agents can call APIs with injected auth headers without ever seeing raw credential values.

- New internal/mcp/apitemplates package: template loading from builtins (//go:embed) with user override support from ~/.openpass/templates/
- 4 built-in templates: github, openai, anthropic, slack
- Auth types: bearer, basic, header, query_param
- Endpoint glob matching with multi-segment support
- Response sanitization to mask credential values
- Approval gate with deny/prompt modes
- Tool registration with CanRunCommands availability gate

Fixes #55

## What

Describe the change in a few sentences.

## Why

Explain the problem, user need, or maintenance reason.

## Testing

- [ ] `make fmt`
- [ ] `make vet`
- [ ] `make lint`
- [ ] `GOWORK=off go test ./...`
- [ ] Added or updated tests where needed

## Safety

- [ ] I did not include passwords, tokens, private keys, vault contents, or personal data
- [ ] Documentation was updated where behavior changed
