### PR TITLE
feat: harden generate_totp — default clipboard, return only with appr…

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -115,10 +115,12 @@ linters:
       - path: '(.+)_test\.go'
         linters:
           - gocritic
-      # Vendored third-party code under editors/node_modules
-      - path: 'editors/node_modules/.+'
+      # Vendored third-party Go code under editors/node_modules
+      - path: 'editors/node_modules/flatted/.+'
         linters:
-          - all
+          - gocyclo
+          - prealloc
+          - revive
 
 formatters:
   enable:

--- a/internal/mcp/tool_registry.go
+++ b/internal/mcp/tool_registry.go
@@ -171,11 +171,14 @@ func toolDefinitions() []toolDefinition {
 		},
 		{
 			Name:        "generate_totp",
-			Description: "Generate a TOTP code for an entry with TOTP configuration",
+			Description: "Generate a TOTP code for an entry with TOTP configuration. By default the code is copied to the clipboard without being returned in the response. Use destination=\"autotype\" to type the code directly, or destination=\"return\" with return_code=true to return the code in the response (requires approval).",
 			InputSchema: objectSchema([]string{"path"}, map[string]schemaProperty{
-				"path": {Type: "string", Description: "Entry path with TOTP configuration"},
+				"path":        {Type: "string", Description: "Entry path with TOTP configuration"},
+				"destination": {Type: "string", Description: "Where to send the code: \"clipboard\" (default, not returned), \"autotype\" (type directly), \"return\" (return in response, requires approval)"},
+				"return_code": {Type: "boolean", Description: "Must be true when destination=\"return\""},
 			}),
-			Handler: (*Server).handleGenerateTOTP,
+			Handler:   (*Server).handleGenerateTOTP,
+			Available: generateTOTPAvailable,
 		},
 		{
 			Name:        "health",

--- a/internal/mcp/tools_get_test.go
+++ b/internal/mcp/tools_get_test.go
@@ -378,7 +378,9 @@ func TestHandleGet_RedactedTOTPStillGeneratesCode(t *testing.T) {
 
 	totpReq := CallToolRequest{
 		Arguments: map[string]any{
-			"path": "github",
+			"path":        "github",
+			"destination": "return",
+			"return_code": true,
 		},
 	}
 	totpResult, err := srv.handleGenerateTOTP(context.Background(), totpReq)

--- a/internal/mcp/tools_totp.go
+++ b/internal/mcp/tools_totp.go
@@ -28,7 +28,7 @@ func (s *Server) handleGenerateTOTP(ctx context.Context, req CallToolRequest) (*
 		return nil, fmt.Errorf("access denied: path %q outside allowed scope", path)
 	}
 
-	destination := req.GetString("destination", "clipboard")
+	destination := req.GetString("destination", s.defaultTOTPDestination())
 	returnCode := req.GetBool("return_code", false)
 
 	svc := vaultsvc.New(slog.Default(), s.vault)
@@ -100,13 +100,13 @@ func (s *Server) totpClipboard(ctx context.Context, path string, code *crypto.TO
 	metrics.RecordVaultOperation("totp", "success")
 
 	result := map[string]any{
-		"success":     true,
-		"destination": "clipboard",
-		"expires_in":  autoClearDuration,
+		"success":             true,
+		"destination":         "clipboard",
+		"clipboard_clears_in": autoClearDuration,
 	}
 	resultJSON, err := json.Marshal(result)
 	if err != nil {
-		return NewToolResultError(fmt.Sprintf("failed to create response: %v", err)), nil
+		return nil, fmt.Errorf("marshal totp clipboard result: %w", err)
 	}
 	return NewToolResultText(string(resultJSON)), nil
 }
@@ -168,6 +168,16 @@ func (s *Server) totpReturn(ctx context.Context, path string, code *crypto.TOTPC
 		return nil, fmt.Errorf("marshal totp result: %w", err)
 	}
 	return NewToolResultText(string(resultJSON)), nil
+}
+
+func (s *Server) defaultTOTPDestination() string {
+	if s.canUseClipboard() {
+		return "clipboard"
+	}
+	if s.canUseAutotype() {
+		return "autotype"
+	}
+	return "return"
 }
 
 func generateTOTPAvailable(s *Server) bool {

--- a/internal/mcp/tools_totp.go
+++ b/internal/mcp/tools_totp.go
@@ -104,7 +104,10 @@ func (s *Server) totpClipboard(ctx context.Context, path string, code *crypto.TO
 		"destination": "clipboard",
 		"expires_in":  autoClearDuration,
 	}
-	resultJSON, _ := json.Marshal(result)
+	resultJSON, err := json.Marshal(result)
+	if err != nil {
+		return NewToolResultError(fmt.Sprintf("failed to create response: %v", err)), nil
+	}
 	return NewToolResultText(string(resultJSON)), nil
 }
 

--- a/internal/mcp/tools_totp.go
+++ b/internal/mcp/tools_totp.go
@@ -6,51 +6,170 @@ import (
 	"fmt"
 	"log/slog"
 
+	"github.com/danieljustus/OpenPass/internal/autotype"
+	"github.com/danieljustus/OpenPass/internal/clipboard"
 	"github.com/danieljustus/OpenPass/internal/crypto"
+	"github.com/danieljustus/OpenPass/internal/metrics"
 	"github.com/danieljustus/OpenPass/internal/vault"
 	"github.com/danieljustus/OpenPass/internal/vaultsvc"
 )
 
+const totpToolName = "generate_totp"
+
 func (s *Server) handleGenerateTOTP(ctx context.Context, req CallToolRequest) (*CallToolResult, error) {
 	path, err := req.RequireString("path")
 	if err != nil {
-		s.logAudit(ctx, "totp", "<invalid>", false)
+		s.logAudit(ctx, totpToolName, "<invalid>", false)
 		return NewToolResultError(err.Error()), nil
 	}
 
 	if !s.checkScope(path) {
-		s.logAudit(ctx, "totp", path, false)
+		s.logAudit(ctx, totpToolName, path, false)
 		return nil, fmt.Errorf("access denied: path %q outside allowed scope", path)
 	}
+
+	destination := req.GetString("destination", "clipboard")
+	returnCode := req.GetBool("return_code", false)
 
 	svc := vaultsvc.New(slog.Default(), s.vault)
 	entry, err := svc.GetEntry(path)
 	if err != nil {
-		s.logAudit(ctx, "totp", path, false)
+		s.logAudit(ctx, totpToolName, path, false)
 		return vaultServiceErrorResult(err)
 	}
 
 	secret, algorithm, digits, period, hasTOTP := vault.ExtractTOTP(entry.Data)
 	if !hasTOTP {
-		s.logAudit(ctx, "totp", path, false)
+		s.logAudit(ctx, totpToolName, path, false)
 		return nil, fmt.Errorf("entry %q does not have TOTP configuration", path)
 	}
 
 	totpCode, err := crypto.GenerateTOTP(secret, algorithm, digits, period)
 	if err != nil {
-		s.logAudit(ctx, "totp", path, false)
+		s.logAudit(ctx, totpToolName, path, false)
 		return nil, fmt.Errorf("failed to generate TOTP code: %w", err)
 	}
 
-	s.logAudit(ctx, "totp", path, true)
+	switch destination {
+	case "clipboard":
+		return s.totpClipboard(ctx, path, totpCode)
+	case "autotype":
+		return s.totpAutotype(ctx, path, totpCode)
+	case "return":
+		return s.totpReturn(ctx, path, totpCode, returnCode)
+	default:
+		return NewToolResultError(fmt.Sprintf("invalid destination %q: must be clipboard, autotype, or return", destination)), nil
+	}
+}
+
+func (s *Server) totpClipboard(ctx context.Context, path string, code *crypto.TOTPCode) (*CallToolResult, error) {
+	if !s.canUseClipboard() {
+		s.logAudit(ctx, totpToolName, path, false)
+		metrics.RecordAuthDenial("clipboard_denied", s.agent.Name)
+		return nil, fmt.Errorf("clipboard operations not permitted for this agent")
+	}
+
+	if s.requiresApproval() {
+		s.logAudit(ctx, totpToolName, path, false)
+		metrics.RecordApproval(s.agent.Name, "denied")
+		return nil, fmt.Errorf("generate_totp denied: approval required but clipboard mode does not support approval")
+	}
+
+	clip := clipboard.DefaultClipboard()
+	if clip == nil {
+		return NewToolResultError("clipboard not available"), nil
+	}
+
+	if err := clip.Copy(code.Code); err != nil {
+		s.logAudit(ctx, totpToolName, path, false)
+		return NewToolResultError(fmt.Sprintf("clipboard copy failed: %v", err)), nil
+	}
+
+	autoClearDuration := 30
+	if s.vault != nil && s.vault.Config != nil && s.vault.Config.Clipboard != nil {
+		autoClearDuration = s.vault.Config.Clipboard.AutoClearDuration
+	}
+
+	if autoClearDuration > 0 {
+		go clipboard.StartAutoClear(autoClearDuration, func() {
+			_ = clip.Copy("")
+		}, make(chan struct{}))
+	}
+
+	s.logAudit(ctx, totpToolName+".clipboard", path, true)
+	metrics.RecordVaultOperation("totp", "success")
+
 	result := map[string]any{
-		"code":       totpCode.Code,
-		"expires_at": totpCode.ExpiresAt,
-		"period":     totpCode.Period,
+		"success":     true,
+		"destination": "clipboard",
+		"expires_in":  autoClearDuration,
+	}
+	resultJSON, _ := json.Marshal(result)
+	return NewToolResultText(string(resultJSON)), nil
+}
+
+func (s *Server) totpAutotype(ctx context.Context, path string, code *crypto.TOTPCode) (*CallToolResult, error) {
+	if !s.canUseAutotype() {
+		s.logAudit(ctx, totpToolName, path, false)
+		metrics.RecordAuthDenial("autotype_denied", s.agent.Name)
+		return nil, fmt.Errorf("autotype operations not permitted for this agent")
+	}
+
+	if s.requiresApproval() {
+		s.logAudit(ctx, totpToolName, path, false)
+		metrics.RecordApproval(s.agent.Name, "denied")
+		return nil, fmt.Errorf("generate_totp denied: approval required but autotype mode does not support approval")
+	}
+
+	at := autotype.DefaultAutotype()
+	if at == nil {
+		return NewToolResultError("autotype not available on this platform"), nil
+	}
+
+	if err := at.Type(code.Code); err != nil {
+		s.logAudit(ctx, totpToolName, path, false)
+		return NewToolResultError(fmt.Sprintf("autotype failed: %v", err)), nil
+	}
+
+	s.logAudit(ctx, totpToolName+".autotype", path, true)
+	metrics.RecordVaultOperation("totp", "success")
+
+	return NewToolResultText(`{"success": true}`), nil
+}
+
+func (s *Server) totpReturn(ctx context.Context, path string, code *crypto.TOTPCode, returnCode bool) (*CallToolResult, error) {
+	if !returnCode {
+		return NewToolResultError("return_code must be true when destination is \"return\""), nil
+	}
+
+	if !s.canReadValues() {
+		if approvalErr := s.requireApproval(ctx, Intent{
+			Action:    "generate_totp_return",
+			EntryPath: path,
+			Summary:   RenderSummary("return TOTP code in response", path, ""),
+		}); approvalErr != nil {
+			return NewToolResultError(approvalErr.Error()), nil
+		}
+	}
+
+	s.logAudit(ctx, totpToolName+".return", path, true)
+	metrics.RecordVaultOperation("totp", "success")
+
+	result := map[string]any{
+		"code":       code.Code,
+		"expires_at": code.ExpiresAt,
+		"period":     code.Period,
 	}
 	resultJSON, err := json.Marshal(result)
 	if err != nil {
 		return nil, fmt.Errorf("marshal totp result: %w", err)
 	}
 	return NewToolResultText(string(resultJSON)), nil
+}
+
+func generateTOTPAvailable(s *Server) bool {
+	if s == nil || s.agent == nil {
+		return true // show when no profile context
+	}
+	return s.canUseClipboard() || s.canUseAutotype() || s.canReadValues()
 }

--- a/internal/mcp/tools_totp_test.go
+++ b/internal/mcp/tools_totp_test.go
@@ -157,6 +157,44 @@ func TestHandleGenerateTOTP_ClipboardDefault(t *testing.T) {
 	if clipResult["code"] != nil {
 		t.Error("code should not be present in clipboard response")
 	}
+	if clipResult["clipboard_clears_in"] == nil {
+		t.Error("expected clipboard_clears_in in clipboard result")
+	}
+	if clipResult["expires_in"] != nil {
+		t.Error("expires_in should not be present in clipboard response (use clipboard_clears_in)")
+	}
+}
+
+func TestHandleGenerateTOTP_DefaultsToReturnForCanReadValues(t *testing.T) {
+	// Agents with only CanReadValues (no clipboard, no autotype) should default
+	// destination to "return" rather than "clipboard" to avoid a confusing denial.
+	vaultDir, identity := mockVault(t)
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:          "test",
+		AllowedPaths:  []string{"*"},
+		CanWrite:      false,
+		CanReadValues: true,
+		ApprovalMode:  "none",
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+	writeTOTPEntry(t, vaultDir, identity)
+
+	// No destination specified — should default to "return" for this agent.
+	// Without return_code=true, totpReturn will return a tool-level error.
+	req := CallToolRequest{
+		Arguments: map[string]any{"path": "github"},
+	}
+
+	result, err := srv.handleGenerateTOTP(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleGenerateTOTP() error = %v", err)
+	}
+	if result == nil || !result.IsError {
+		t.Fatal("expected error result: return_code must be true (destination defaulted to return)")
+	}
+	if !strings.Contains(result.Text, "return_code must be true") {
+		t.Fatalf("error = %q, want 'return_code must be true'", result.Text)
+	}
 }
 
 func TestHandleGenerateTOTP_ClipboardExplicit(t *testing.T) {

--- a/internal/mcp/tools_totp_test.go
+++ b/internal/mcp/tools_totp_test.go
@@ -36,11 +36,11 @@ func writeTOTPEntry(t *testing.T, vaultDir string, identity *age.X25519Identity)
 func TestHandleGenerateTOTP_ReturnSuccess(t *testing.T) {
 	vaultDir, identity := mockVault(t)
 	srv := newTestServerWithVault(t, config.AgentProfile{
-		Name:         "test",
-		AllowedPaths: []string{"*"},
-		CanWrite:     false,
+		Name:          "test",
+		AllowedPaths:  []string{"*"},
+		CanWrite:      false,
 		CanReadValues: true,
-		ApprovalMode: "none",
+		ApprovalMode:  "none",
 	}, "stdio", vaultDir)
 	srv.vault.Identity = identity
 	writeTOTPEntry(t, vaultDir, identity)

--- a/internal/mcp/tools_totp_test.go
+++ b/internal/mcp/tools_totp_test.go
@@ -6,21 +6,16 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/danieljustus/OpenPass/internal/autotype"
+	"github.com/danieljustus/OpenPass/internal/clipboard"
 	"github.com/danieljustus/OpenPass/internal/config"
 	"github.com/danieljustus/OpenPass/internal/vault"
+
+	"filippo.io/age"
 )
 
-func TestHandleGenerateTOTP_Success(t *testing.T) {
-	vaultDir, identity := mockVault(t)
-	srv := newTestServerWithVault(t, config.AgentProfile{
-		Name:         "test",
-		AllowedPaths: []string{"*"},
-		CanWrite:     false,
-		ApprovalMode: "none",
-	}, "stdio", vaultDir)
-	srv.vault.Identity = identity
-
-	// Create entry with TOTP configuration
+func writeTOTPEntry(t *testing.T, vaultDir string, identity *age.X25519Identity) {
+	t.Helper()
 	entry := &vault.Entry{
 		Data: map[string]any{
 			"password": "testpass123",
@@ -35,6 +30,97 @@ func TestHandleGenerateTOTP_Success(t *testing.T) {
 	if err := vault.WriteEntry(vaultDir, "github", entry, identity); err != nil {
 		t.Fatalf("write entry: %v", err)
 	}
+}
+
+// Return destination with explicit return_code=true
+func TestHandleGenerateTOTP_ReturnSuccess(t *testing.T) {
+	vaultDir, identity := mockVault(t)
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:         "test",
+		AllowedPaths: []string{"*"},
+		CanWrite:     false,
+		CanReadValues: true,
+		ApprovalMode: "none",
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+	writeTOTPEntry(t, vaultDir, identity)
+
+	req := CallToolRequest{
+		Arguments: map[string]any{
+			"path":        "github",
+			"destination": "return",
+			"return_code": true,
+		},
+	}
+
+	result, err := srv.handleGenerateTOTP(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleGenerateTOTP() error = %v", err)
+	}
+	if result == nil || result.IsError {
+		t.Fatalf("handleGenerateTOTP() returned error: %v", result)
+	}
+
+	var totpResult map[string]any
+	if err := json.Unmarshal([]byte(result.Text), &totpResult); err != nil {
+		t.Fatalf("parse result: %v", err)
+	}
+	if totpResult["code"] == nil || totpResult["code"] == "" {
+		t.Error("expected TOTP code in return result")
+	}
+	if totpResult["expires_at"] == nil {
+		t.Error("expected expires_at in return result")
+	}
+	if totpResult["period"] == nil {
+		t.Error("expected period in return result")
+	}
+}
+
+func TestHandleGenerateTOTP_ReturnWithoutReturnCode(t *testing.T) {
+	vaultDir, identity := mockVault(t)
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:         "test",
+		AllowedPaths: []string{"*"},
+		CanWrite:     false,
+		ApprovalMode: "none",
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+	writeTOTPEntry(t, vaultDir, identity)
+
+	req := CallToolRequest{
+		Arguments: map[string]any{
+			"path":        "github",
+			"destination": "return",
+		},
+	}
+
+	result, err := srv.handleGenerateTOTP(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleGenerateTOTP() error = %v", err)
+	}
+	if result == nil || !result.IsError {
+		t.Fatal("expected error for return without return_code")
+	}
+	if !strings.Contains(result.Text, "return_code must be true") {
+		t.Fatalf("error = %q, want 'return_code must be true'", result.Text)
+	}
+}
+
+func TestHandleGenerateTOTP_ClipboardDefault(t *testing.T) {
+	vaultDir, identity := mockVault(t)
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:            "test",
+		AllowedPaths:    []string{"*"},
+		CanWrite:        false,
+		CanUseClipboard: true,
+		ApprovalMode:    "none",
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+	writeTOTPEntry(t, vaultDir, identity)
+
+	mockClip := &mockClipboard{}
+	clipboard.SetClipboard(mockClip)
+	defer clipboard.SetClipboard(nil)
 
 	req := CallToolRequest{
 		Arguments: map[string]any{"path": "github"},
@@ -44,26 +130,203 @@ func TestHandleGenerateTOTP_Success(t *testing.T) {
 	if err != nil {
 		t.Fatalf("handleGenerateTOTP() error = %v", err)
 	}
-	if result == nil {
-		t.Fatal("handleGenerateTOTP() returned nil result")
-	}
-	if result.IsError {
-		t.Fatalf("handleGenerateTOTP() returned error: %s", result.Text)
+	if result == nil || result.IsError {
+		t.Fatalf("handleGenerateTOTP() returned error: %v", result)
 	}
 
-	// Verify result contains expected fields
-	var totpResult map[string]any
-	if err := json.Unmarshal([]byte(result.Text), &totpResult); err != nil {
+	// Verify clipboard received the code
+	text, _ := mockClip.Read()
+	if text == "" {
+		t.Error("expected TOTP code in clipboard")
+	}
+	if len(text) != 6 {
+		t.Errorf("expected 6-digit TOTP code, got %q", text)
+	}
+
+	// Verify response has clipboard format (no code)
+	var clipResult map[string]any
+	if err := json.Unmarshal([]byte(result.Text), &clipResult); err != nil {
 		t.Fatalf("parse result: %v", err)
 	}
-	if totpResult["code"] == nil || totpResult["code"] == "" {
-		t.Error("expected TOTP code in result")
+	if clipResult["success"] != true {
+		t.Error("expected success=true in clipboard result")
 	}
-	if totpResult["expires_at"] == nil {
-		t.Error("expected expires_at in result")
+	if clipResult["destination"] != "clipboard" {
+		t.Error(`expected destination="clipboard" in clipboard result`)
 	}
-	if totpResult["period"] == nil {
-		t.Error("expected period in result")
+	if clipResult["code"] != nil {
+		t.Error("code should not be present in clipboard response")
+	}
+}
+
+func TestHandleGenerateTOTP_ClipboardExplicit(t *testing.T) {
+	vaultDir, identity := mockVault(t)
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:            "test",
+		AllowedPaths:    []string{"*"},
+		CanWrite:        false,
+		CanUseClipboard: true,
+		ApprovalMode:    "none",
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+	writeTOTPEntry(t, vaultDir, identity)
+
+	mockClip := &mockClipboard{}
+	clipboard.SetClipboard(mockClip)
+	defer clipboard.SetClipboard(nil)
+
+	req := CallToolRequest{
+		Arguments: map[string]any{
+			"path":        "github",
+			"destination": "clipboard",
+		},
+	}
+
+	result, err := srv.handleGenerateTOTP(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleGenerateTOTP() error = %v", err)
+	}
+	if result == nil || result.IsError {
+		t.Fatalf("handleGenerateTOTP() returned error: %v", result)
+	}
+
+	text, _ := mockClip.Read()
+	if text == "" {
+		t.Error("expected TOTP code in clipboard")
+	}
+}
+
+func TestHandleGenerateTOTP_ClipboardDenied(t *testing.T) {
+	vaultDir, identity := mockVault(t)
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:            "test",
+		AllowedPaths:    []string{"*"},
+		CanWrite:        false,
+		CanUseClipboard: false,
+		ApprovalMode:    "none",
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+	writeTOTPEntry(t, vaultDir, identity)
+
+	req := CallToolRequest{
+		Arguments: map[string]any{
+			"path":        "github",
+			"destination": "clipboard",
+		},
+	}
+
+	_, err := srv.handleGenerateTOTP(context.Background(), req)
+	if err == nil {
+		t.Fatal("expected error for clipboard denied")
+	}
+	if !strings.Contains(err.Error(), "clipboard operations not permitted") {
+		t.Fatalf("error = %q, want 'clipboard operations not permitted'", err.Error())
+	}
+}
+
+func TestHandleGenerateTOTP_AutotypeSuccess(t *testing.T) {
+	vaultDir, identity := mockVault(t)
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:           "test",
+		AllowedPaths:   []string{"*"},
+		CanWrite:       false,
+		CanUseAutotype: true,
+		ApprovalMode:   "none",
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+	writeTOTPEntry(t, vaultDir, identity)
+
+	mockAT := &mockAutotype{}
+	autotype.SetAutotype(mockAT)
+	defer autotype.SetAutotype(nil)
+
+	req := CallToolRequest{
+		Arguments: map[string]any{
+			"path":        "github",
+			"destination": "autotype",
+		},
+	}
+
+	result, err := srv.handleGenerateTOTP(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleGenerateTOTP() error = %v", err)
+	}
+	if result == nil || result.IsError {
+		t.Fatalf("handleGenerateTOTP() returned error: %v", result)
+	}
+
+	// Verify autotype received the code
+	mockAT.mu.Lock()
+	text := mockAT.text
+	mockAT.mu.Unlock()
+	if text == "" {
+		t.Error("expected TOTP code sent to autotype")
+	}
+	if len(text) != 6 {
+		t.Errorf("expected 6-digit TOTP code, got %q", text)
+	}
+
+	// Verify response
+	if !strings.Contains(result.Text, `"success": true`) {
+		t.Errorf("expected success response, got %q", result.Text)
+	}
+}
+
+func TestHandleGenerateTOTP_AutotypeDenied(t *testing.T) {
+	vaultDir, identity := mockVault(t)
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:           "test",
+		AllowedPaths:   []string{"*"},
+		CanWrite:       false,
+		CanUseAutotype: false,
+		ApprovalMode:   "none",
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+	writeTOTPEntry(t, vaultDir, identity)
+
+	req := CallToolRequest{
+		Arguments: map[string]any{
+			"path":        "github",
+			"destination": "autotype",
+		},
+	}
+
+	_, err := srv.handleGenerateTOTP(context.Background(), req)
+	if err == nil {
+		t.Fatal("expected error for autotype denied")
+	}
+	if !strings.Contains(err.Error(), "autotype operations not permitted") {
+		t.Fatalf("error = %q, want 'autotype operations not permitted'", err.Error())
+	}
+}
+
+func TestHandleGenerateTOTP_InvalidDestination(t *testing.T) {
+	vaultDir, identity := mockVault(t)
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:         "test",
+		AllowedPaths: []string{"*"},
+		CanWrite:     false,
+		ApprovalMode: "none",
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+	writeTOTPEntry(t, vaultDir, identity)
+
+	req := CallToolRequest{
+		Arguments: map[string]any{
+			"path":        "github",
+			"destination": "email",
+		},
+	}
+
+	result, err := srv.handleGenerateTOTP(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleGenerateTOTP() error = %v", err)
+	}
+	if result == nil || !result.IsError {
+		t.Fatal("expected error for invalid destination")
+	}
+	if !strings.Contains(result.Text, `invalid destination "email"`) {
+		t.Fatalf("error = %q, want 'invalid destination'", result.Text)
 	}
 }
 
@@ -77,7 +340,6 @@ func TestHandleGenerateTOTP_OutsideScope(t *testing.T) {
 	}, "stdio", vaultDir)
 	srv.vault.Identity = identity
 
-	// Create entry with TOTP configuration
 	entry := &vault.Entry{
 		Data: map[string]any{
 			"password": "testpass123",
@@ -162,7 +424,6 @@ func TestHandleGenerateTOTP_NoTOTPConfig(t *testing.T) {
 	}, "stdio", vaultDir)
 	srv.vault.Identity = identity
 
-	// Create entry WITHOUT TOTP configuration
 	entry := &vault.Entry{
 		Data: map[string]any{
 			"password": "testpass123",
@@ -195,7 +456,6 @@ func TestHandleGenerateTOTP_EmptySecret(t *testing.T) {
 	}, "stdio", vaultDir)
 	srv.vault.Identity = identity
 
-	// Create entry with empty TOTP secret
 	entry := &vault.Entry{
 		Data: map[string]any{
 			"password": "testpass123",
@@ -214,32 +474,63 @@ func TestHandleGenerateTOTP_EmptySecret(t *testing.T) {
 
 	_, err := srv.handleGenerateTOTP(context.Background(), req)
 	if err == nil {
-		t.Fatal("handleGenerateTOTP() expected error for entry with empty TOTP secret, got nil")
+		t.Fatal("handleGenerateTOTP() expected error for empty TOTP secret, got nil")
 	}
 }
 
-func TestExecuteTool_GenerateTOTP(t *testing.T) {
+func TestExecuteTool_GenerateTOTP_Return(t *testing.T) {
 	vaultDir, identity := mockVault(t)
 	srv := newTestServerWithVault(t, config.AgentProfile{
-		Name:         "test",
-		AllowedPaths: []string{"*"},
-		CanWrite:     false,
-		ApprovalMode: "none",
+		Name:          "test",
+		AllowedPaths:  []string{"*"},
+		CanWrite:      false,
+		CanReadValues: true,
+		ApprovalMode:  "none",
 	}, "stdio", vaultDir)
 	srv.vault.Identity = identity
+	writeTOTPEntry(t, vaultDir, identity)
 
-	// Create entry with TOTP configuration
-	entry := &vault.Entry{
-		Data: map[string]any{
-			"password": "testpass123",
-			"totp": map[string]any{
-				"secret": "JBSWY3DPEHPK3PXP",
-			},
-		},
+	args := json.RawMessage(`{"path": "github", "destination": "return", "return_code": true}`)
+	result, err := srv.executeTool(context.Background(), "generate_totp", args)
+	if err != nil {
+		t.Fatalf("executeTool() error = %v", err)
 	}
-	if err := vault.WriteEntry(vaultDir, "github", entry, identity); err != nil {
-		t.Fatalf("write entry: %v", err)
+
+	content, ok := result["content"].([]map[string]any)
+	if !ok {
+		t.Fatal("result content has unexpected type")
 	}
+	if len(content) == 0 {
+		t.Fatal("expected content in result")
+	}
+	if result["isError"] == true {
+		t.Errorf("expected no error, got isError=true: %s", content[0]["text"])
+	}
+
+	var totpResult map[string]any
+	if err := json.Unmarshal([]byte(content[0]["text"].(string)), &totpResult); err != nil {
+		t.Fatalf("parse result: %v", err)
+	}
+	if totpResult["code"] == nil {
+		t.Error("expected code in return result via executeTool")
+	}
+}
+
+func TestExecuteTool_GenerateTOTP_Clipboard(t *testing.T) {
+	vaultDir, identity := mockVault(t)
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:            "test",
+		AllowedPaths:    []string{"*"},
+		CanWrite:        false,
+		CanUseClipboard: true,
+		ApprovalMode:    "none",
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+	writeTOTPEntry(t, vaultDir, identity)
+
+	mockClip := &mockClipboard{}
+	clipboard.SetClipboard(mockClip)
+	defer clipboard.SetClipboard(nil)
 
 	args := json.RawMessage(`{"path": "github"}`)
 	result, err := srv.executeTool(context.Background(), "generate_totp", args)
@@ -256,5 +547,93 @@ func TestExecuteTool_GenerateTOTP(t *testing.T) {
 	}
 	if result["isError"] == true {
 		t.Errorf("expected no error, got isError=true: %s", content[0]["text"])
+	}
+
+	// Verify clipboard received the code
+	text, _ := mockClip.Read()
+	if text == "" {
+		t.Error("expected TOTP code in clipboard via executeTool")
+	}
+}
+
+func TestGenerateTOTPAvailable_ClipboardOnly(t *testing.T) {
+	srv := &Server{agent: &config.AgentProfile{CanUseClipboard: true, CanUseAutotype: false, CanReadValues: false}}
+	if !generateTOTPAvailable(srv) {
+		t.Error("expected TOTP available when clipboard is allowed")
+	}
+}
+
+func TestGenerateTOTPAvailable_AutotypeOnly(t *testing.T) {
+	srv := &Server{agent: &config.AgentProfile{CanUseClipboard: false, CanUseAutotype: true, CanReadValues: false}}
+	if !generateTOTPAvailable(srv) {
+		t.Error("expected TOTP available when autotype is allowed")
+	}
+}
+
+func TestGenerateTOTPAvailable_CanReadValuesOnly(t *testing.T) {
+	srv := &Server{agent: &config.AgentProfile{CanUseClipboard: false, CanUseAutotype: false, CanReadValues: true}}
+	if !generateTOTPAvailable(srv) {
+		t.Error("expected TOTP available when canReadValues")
+	}
+}
+
+func TestGenerateTOTPAvailable_AllDenied(t *testing.T) {
+	srv := &Server{agent: &config.AgentProfile{CanUseClipboard: false, CanUseAutotype: false, CanReadValues: false}}
+	if generateTOTPAvailable(srv) {
+		t.Error("expected TOTP not available when all denied")
+	}
+}
+
+func TestGenerateTOTPAvailable_NilServer(t *testing.T) {
+	if !generateTOTPAvailable(nil) {
+		t.Error("expected TOTP available for nil server (no profile context)")
+	}
+}
+
+func TestGenerateTOTPAvailable_NilAgent(t *testing.T) {
+	srv := &Server{agent: nil}
+	if !generateTOTPAvailable(srv) {
+		t.Error("expected TOTP available for nil agent (no profile context)")
+	}
+}
+
+func TestToolsList_GenerateTOTP_Filtered(t *testing.T) {
+	// Profile with no usable capabilities → generate_totp should be filtered out
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:            "test",
+		AllowedPaths:    []string{"*"},
+		CanUseClipboard: false,
+		CanUseAutotype:  false,
+		CanReadValues:   false,
+		CanWrite:        false,
+	}, "stdio", "")
+
+	tools := toolsListPayload(srv)
+	for _, tool := range tools {
+		if tool["name"] == "generate_totp" {
+			t.Fatal("generate_totp should not be in tools/list when no TOTP destination available")
+		}
+	}
+}
+
+func TestToolsList_GenerateTOTP_Visible(t *testing.T) {
+	// Profile with clipboard capability → generate_totp should be visible
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:            "test",
+		AllowedPaths:    []string{"*"},
+		CanUseClipboard: true,
+		CanWrite:        false,
+	}, "stdio", "")
+
+	tools := toolsListPayload(srv)
+	found := false
+	for _, tool := range tools {
+		if tool["name"] == "generate_totp" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("generate_totp should be visible when clipboard is allowed")
 	}
 }


### PR DESCRIPTION
…oval

Changes generate_totp to use clipboard as the default destination instead of returning the TOTP code in the response. Adds three destination modes:
- clipboard (default): copies code to clipboard with auto-clear
- autotype: types the code directly via existing autotype infra
- return: returns code in response but requires return_code=true and triggers approval unless agent has CanReadValues=true

Agent profiles without clipboard/autotype/canReadValues will have the generate_totp tool filtered from tools/list entirely.

Fixes #54

## What

Describe the change in a few sentences.

## Why

Explain the problem, user need, or maintenance reason.

## Testing

- [ ] `make fmt`
- [ ] `make vet`
- [ ] `make lint`
- [ ] `GOWORK=off go test ./...`
- [ ] Added or updated tests where needed

## Safety

- [ ] I did not include passwords, tokens, private keys, vault contents, or personal data
- [ ] Documentation was updated where behavior changed
