### PR TITLE
feat: add agent profile tier presets + ExposeValueTools filter

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -62,6 +62,7 @@ type fileConfig struct {
 
 type AgentProfile struct {
 	Name                string              `yaml:"-"`
+	Tier                string              `yaml:"tier,omitempty"`
 	ApprovalMode        string              `yaml:"approvalMode"`
 	AllowedPaths        []string            `yaml:"allowedPaths"`
 	RedactFields        []string            `yaml:"redactFields,omitempty"`
@@ -71,6 +72,7 @@ type AgentProfile struct {
 	CanUseClipboard     bool                `yaml:"canUseClipboard,omitempty"`
 	CanUseAutotype      bool                `yaml:"canUseAutotype,omitempty"`
 	CanReadValues       bool                `yaml:"canReadValues,omitempty"`
+	ExposeValueTools    bool                `yaml:"exposeValueTools,omitempty"`
 	RequireApproval     bool                `yaml:"requireApproval"`
 	ApprovalTimeout     time.Duration       `yaml:"approvalTimeout,omitempty"`
 	AllowedTools        []string            `yaml:"allowed_tools,omitempty"`
@@ -81,6 +83,8 @@ type AgentProfile struct {
 }
 
 type fileAgentProfile struct {
+	Tier                *string             `yaml:"tier,omitempty"`
+	ExposeValueTools    *bool               `yaml:"exposeValueTools,omitempty"`
 	ApprovalTimeout     *time.Duration      `yaml:"approvalTimeout,omitempty"`
 	CanWrite            *bool               `yaml:"canWrite,omitempty"`
 	CanRunCommands      *bool               `yaml:"canRunCommands,omitempty"`
@@ -188,6 +192,18 @@ func Load(path string) (*Config, error) {
 				current = newDefaultAgentProfile(name)
 			}
 			current.Name = name
+
+			// Apply tier preset before explicit YAML overrides
+			if profile.Tier != nil && *profile.Tier != "" {
+				ApplyTierPreset(&current, *profile.Tier)
+				current.Tier = *profile.Tier
+			}
+
+			// Backward compat: default ExposeValueTools to true when neither tier nor explicit value
+			if profile.Tier == nil || *profile.Tier == "" {
+				current.ExposeValueTools = true
+			}
+
 			if profile.AllowedPaths != nil {
 				current.AllowedPaths = append([]string(nil), profile.AllowedPaths...)
 			} else if current.AllowedPaths == nil {
@@ -240,6 +256,9 @@ func Load(path string) (*Config, error) {
 			}
 			if profile.MaxSecretsInSession != nil {
 				current.MaxSecretsInSession = *profile.MaxSecretsInSession
+			}
+			if profile.ExposeValueTools != nil {
+				current.ExposeValueTools = *profile.ExposeValueTools
 			}
 			if profile.DynamicProviders != nil {
 				current.DynamicProviders = make(map[string][]string, len(profile.DynamicProviders))
@@ -480,16 +499,22 @@ func buildFileAgents(agents map[string]AgentProfile) map[string]fileAgentProfile
 		canUseClipboard := profile.CanUseClipboard
 		canUseAutotype := profile.CanUseAutotype
 		canReadValues := profile.CanReadValues
+		exposeValueTools := profile.ExposeValueTools
 		requireApproval := profile.RequireApproval
 		fap := fileAgentProfile{
-			AllowedPaths:    allowed,
-			CanWrite:        &canWrite,
-			CanRunCommands:  &canRunCommands,
-			CanManageConfig: &canManageConfig,
-			CanUseClipboard: &canUseClipboard,
-			CanUseAutotype:  &canUseAutotype,
-			CanReadValues:   &canReadValues,
-			RequireApproval: &requireApproval,
+			AllowedPaths:     allowed,
+			CanWrite:         &canWrite,
+			CanRunCommands:   &canRunCommands,
+			CanManageConfig:  &canManageConfig,
+			CanUseClipboard:  &canUseClipboard,
+			CanUseAutotype:   &canUseAutotype,
+			CanReadValues:    &canReadValues,
+			ExposeValueTools: &exposeValueTools,
+			RequireApproval:  &requireApproval,
+		}
+		if profile.Tier != "" {
+			t := profile.Tier
+			fap.Tier = &t
 		}
 		if profile.ApprovalMode != "" {
 			am := profile.ApprovalMode
@@ -591,22 +616,23 @@ func (c *Config) SetAuthMethod(method string) error {
 
 func newDefaultAgentProfile(name string) AgentProfile {
 	return AgentProfile{
-		Name:           name,
-		AllowedPaths:   []string{},
-		CanWrite:       false,
-		CanRunCommands: false,
-		ApprovalMode:   "none",
+		Name:             name,
+		AllowedPaths:     []string{},
+		CanWrite:         false,
+		CanRunCommands:   false,
+		ApprovalMode:     "none",
+		ExposeValueTools: true,
 	}
 }
 
 func builtinAgentProfiles() map[string]AgentProfile {
 	return map[string]AgentProfile{
-		"default":     {Name: "default", AllowedPaths: []string{"*"}, CanWrite: false, CanRunCommands: false, ApprovalMode: "none"},
-		"claude-code": {Name: "claude-code", AllowedPaths: []string{"*"}, CanWrite: true, CanRunCommands: false, ApprovalMode: "none"},
-		"codex":       {Name: "codex", AllowedPaths: []string{"*"}, CanWrite: false, CanRunCommands: false, ApprovalMode: "none"},
-		"hermes":      {Name: "hermes", AllowedPaths: []string{"*"}, CanWrite: true, CanRunCommands: false, ApprovalMode: "none"},
-		"openclaw":    {Name: "openclaw", AllowedPaths: []string{"*"}, CanWrite: true, CanRunCommands: false, ApprovalMode: "none"},
-		"opencode":    {Name: "opencode", AllowedPaths: []string{"*"}, CanWrite: false, CanRunCommands: false, ApprovalMode: "none"},
+		"default":     {Name: "default", AllowedPaths: []string{"*"}, CanWrite: false, CanRunCommands: false, ApprovalMode: "none", ExposeValueTools: true},
+		"claude-code": {Name: "claude-code", AllowedPaths: []string{"*"}, CanWrite: true, CanRunCommands: false, ApprovalMode: "none", ExposeValueTools: true},
+		"codex":       {Name: "codex", AllowedPaths: []string{"*"}, CanWrite: false, CanRunCommands: false, ApprovalMode: "none", ExposeValueTools: true},
+		"hermes":      {Name: "hermes", AllowedPaths: []string{"*"}, CanWrite: true, CanRunCommands: false, ApprovalMode: "none", ExposeValueTools: true},
+		"openclaw":    {Name: "openclaw", AllowedPaths: []string{"*"}, CanWrite: true, CanRunCommands: false, ApprovalMode: "none", ExposeValueTools: true},
+		"opencode":    {Name: "opencode", AllowedPaths: []string{"*"}, CanWrite: false, CanRunCommands: false, ApprovalMode: "none", ExposeValueTools: true},
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -200,7 +200,7 @@ func Load(path string) (*Config, error) {
 			}
 
 			// Backward compat: default ExposeValueTools to true when neither tier nor explicit value
-			if profile.Tier == nil || *profile.Tier == "" {
+			if (profile.Tier == nil || *profile.Tier == "") && profile.ExposeValueTools == nil {
 				current.ExposeValueTools = true
 			}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -628,6 +628,9 @@ func TestSaveLoadRoundTrip_PreservesAllFields(t *testing.T) {
 	if len(agent.AllowedPaths) != len(cfg.Agents["test-agent"].AllowedPaths) {
 		t.Errorf("agent.AllowedPaths len = %d, want %d", len(agent.AllowedPaths), len(cfg.Agents["test-agent"].AllowedPaths))
 	}
+	if agent.ExposeValueTools != cfg.Agents["test-agent"].ExposeValueTools {
+		t.Errorf("agent.ExposeValueTools = %v, want %v", agent.ExposeValueTools, cfg.Agents["test-agent"].ExposeValueTools)
+	}
 	if agent.DynamicProviders == nil {
 		t.Fatal("agent.DynamicProviders should not be nil after round-trip")
 	}
@@ -1964,5 +1967,315 @@ func TestEffectiveAuthMethod_Default(t *testing.T) {
 	c := &Config{}
 	if got := c.EffectiveAuthMethod(); got != AuthMethodPassphrase {
 		t.Errorf("EffectiveAuthMethod = %q, want %q", got, AuthMethodPassphrase)
+	}
+}
+
+// --- Tier Preset Tests ---
+
+func TestPresets_ApplyTierPreset_ReadOnly(t *testing.T) {
+	t.Parallel()
+	p := &AgentProfile{Name: "test", AllowedPaths: []string{"*"}}
+	ok := ApplyTierPreset(p, "read-only")
+	if !ok {
+		t.Fatal("ApplyTierPreset returned false for known tier")
+	}
+	if p.CanWrite {
+		t.Error("CanWrite should be false for read-only")
+	}
+	if p.CanReadValues {
+		t.Error("CanReadValues should be false for read-only")
+	}
+	if p.ExposeValueTools {
+		t.Error("ExposeValueTools should be false for read-only")
+	}
+	if p.ApprovalMode != "none" {
+		t.Errorf("ApprovalMode = %q, want none", p.ApprovalMode)
+	}
+	// AllowedPaths should be preserved
+	if len(p.AllowedPaths) != 1 || p.AllowedPaths[0] != "*" {
+		t.Error("AllowedPaths should be preserved from original profile")
+	}
+}
+
+func TestPresets_ApplyTierPreset_Standard(t *testing.T) {
+	t.Parallel()
+	p := &AgentProfile{Name: "test", AllowedPaths: []string{"*"}}
+	ok := ApplyTierPreset(p, "standard")
+	if !ok {
+		t.Fatal("ApplyTierPreset returned false for known tier")
+	}
+	if p.CanWrite {
+		t.Error("CanWrite should be false for standard")
+	}
+	if !p.CanReadValues {
+		t.Error("CanReadValues should be true for standard")
+	}
+	if p.ExposeValueTools {
+		t.Error("ExposeValueTools should be false for standard")
+	}
+	if p.ApprovalMode != "prompt" {
+		t.Errorf("ApprovalMode = %q, want prompt", p.ApprovalMode)
+	}
+}
+
+func TestPresets_ApplyTierPreset_Admin(t *testing.T) {
+	t.Parallel()
+	p := &AgentProfile{Name: "test", AllowedPaths: []string{"*"}}
+	ok := ApplyTierPreset(p, "admin")
+	if !ok {
+		t.Fatal("ApplyTierPreset returned false for known tier")
+	}
+	if !p.CanWrite {
+		t.Error("CanWrite should be true for admin")
+	}
+	if !p.CanReadValues {
+		t.Error("CanReadValues should be true for admin")
+	}
+	if !p.ExposeValueTools {
+		t.Error("ExposeValueTools should be true for admin")
+	}
+	if !p.CanRunCommands {
+		t.Error("CanRunCommands should be true for admin")
+	}
+	if !p.CanManageConfig {
+		t.Error("CanManageConfig should be true for admin")
+	}
+	if !p.CanUseClipboard {
+		t.Error("CanUseClipboard should be true for admin")
+	}
+}
+
+func TestPresets_UnknownTier_Ignored(t *testing.T) {
+	t.Parallel()
+	p := &AgentProfile{Name: "test", AllowedPaths: []string{"*"}}
+	p.CanWrite = true
+	ok := ApplyTierPreset(p, "nonexistent")
+	if ok {
+		t.Fatal("ApplyTierPreset should return false for unknown tier")
+	}
+	if !p.CanWrite {
+		t.Error("CanWrite should not be changed by unknown tier")
+	}
+}
+
+// --- Tier Preset Load Tests ---
+
+func TestLoad_TierStandardPreset(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	yamlContent := `agents:
+  my-agent:
+    tier: standard
+`
+	path := writeTempFile(t, []byte(yamlContent))
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	agent, ok := cfg.Agents["my-agent"]
+	if !ok {
+		t.Fatal("my-agent should exist")
+	}
+	// Verify preset was applied
+	if agent.CanWrite {
+		t.Error("CanWrite should be false (standard preset)")
+	}
+	if !agent.CanReadValues {
+		t.Error("CanReadValues should be true (standard preset)")
+	}
+	if agent.ExposeValueTools {
+		t.Error("ExposeValueTools should be false (standard preset)")
+	}
+	if agent.Tier != "standard" {
+		t.Errorf("Tier = %q, want standard", agent.Tier)
+	}
+}
+
+func TestLoad_TierStandardWithExplicitOverride(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	yamlContent := `agents:
+  my-agent:
+    tier: standard
+    canWrite: true
+`
+	path := writeTempFile(t, []byte(yamlContent))
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	agent, ok := cfg.Agents["my-agent"]
+	if !ok {
+		t.Fatal("my-agent should exist")
+	}
+	// Preset sets CanWrite=false, but explicit YAML override should win
+	if !agent.CanWrite {
+		t.Error("CanWrite should be true (explicit YAML overrides preset)")
+	}
+	// Preset should still apply for non-overridden fields
+	if agent.ExposeValueTools {
+		t.Error("ExposeValueTools should be false (from preset, not overridden)")
+	}
+}
+
+func TestLoad_TierReadOnlyPreset(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	yamlContent := `agents:
+  my-agent:
+    tier: read-only
+`
+	path := writeTempFile(t, []byte(yamlContent))
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	agent, ok := cfg.Agents["my-agent"]
+	if !ok {
+		t.Fatal("my-agent should exist")
+	}
+	if agent.CanWrite {
+		t.Error("CanWrite should be false (read-only preset)")
+	}
+	if agent.CanReadValues {
+		t.Error("CanReadValues should be false (read-only preset)")
+	}
+	if agent.ExposeValueTools {
+		t.Error("ExposeValueTools should be false (read-only preset)")
+	}
+}
+
+func TestLoad_TierAdminPreset(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	yamlContent := `agents:
+  my-agent:
+    tier: admin
+`
+	path := writeTempFile(t, []byte(yamlContent))
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	agent, ok := cfg.Agents["my-agent"]
+	if !ok {
+		t.Fatal("my-agent should exist")
+	}
+	if !agent.CanWrite {
+		t.Error("CanWrite should be true (admin preset)")
+	}
+	if !agent.CanReadValues {
+		t.Error("CanReadValues should be true (admin preset)")
+	}
+	if !agent.ExposeValueTools {
+		t.Error("ExposeValueTools should be true (admin preset)")
+	}
+	if !agent.CanRunCommands {
+		t.Error("CanRunCommands should be true (admin preset)")
+	}
+}
+
+// --- ExposeValueTools Tests ---
+
+func TestLoad_ExposeValueToolsExplicitTrue(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	yamlContent := `agents:
+  my-agent:
+    exposeValueTools: true
+`
+	path := writeTempFile(t, []byte(yamlContent))
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	agent := cfg.Agents["my-agent"]
+	if !agent.ExposeValueTools {
+		t.Error("ExposeValueTools should be true (explicitly set)")
+	}
+}
+
+func TestLoad_ExposeValueToolsExplicitFalse(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	yamlContent := `agents:
+  my-agent:
+    exposeValueTools: false
+`
+	path := writeTempFile(t, []byte(yamlContent))
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	agent := cfg.Agents["my-agent"]
+	if agent.ExposeValueTools {
+		t.Error("ExposeValueTools should be false (explicitly set)")
+	}
+}
+
+func TestLoad_ExposeValueToolsBackwardCompat(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Config without tier and without exposeValueTools should default to true
+	yamlContent := `agents:
+  my-agent:
+    canWrite: true
+`
+	path := writeTempFile(t, []byte(yamlContent))
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	agent := cfg.Agents["my-agent"]
+	if !agent.ExposeValueTools {
+		t.Error("ExposeValueTools should default to true for backward compat")
+	}
+}
+
+func TestLoad_ExposeValueToolsTierOverridesDefault(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Config with tier=standard but no exposeValueTools - should be false from preset
+	yamlContent := `agents:
+  my-agent:
+    tier: standard
+`
+	path := writeTempFile(t, []byte(yamlContent))
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	agent := cfg.Agents["my-agent"]
+	if agent.ExposeValueTools {
+		t.Error("ExposeValueTools should be false (from standard preset)")
+	}
+}
+
+func TestLoad_ExposeValueToolsExplicitOverridesTier(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Config with tier=standard but explicit exposeValueTools: true - value should be true
+	yamlContent := `agents:
+  my-agent:
+    tier: standard
+    exposeValueTools: true
+`
+	path := writeTempFile(t, []byte(yamlContent))
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	agent := cfg.Agents["my-agent"]
+	if !agent.ExposeValueTools {
+		t.Error("ExposeValueTools should be true (explicit override of standard preset)")
 	}
 }

--- a/internal/config/presets.go
+++ b/internal/config/presets.go
@@ -1,0 +1,72 @@
+package config
+
+// TierPreset represents a named set of agent profile defaults.
+type TierPreset string
+
+const (
+	TierReadOnly TierPreset = "read-only"
+	TierStandard TierPreset = "standard"
+	TierAdmin    TierPreset = "admin"
+)
+
+// TierPresets maps tier names to their default agent profile values.
+// These are applied as a base when an AgentProfile specifies a Tier.
+// Explicit YAML fields for the same agent override the preset values.
+var TierPresets = map[TierPreset]AgentProfile{
+	TierReadOnly: {
+		CanWrite:         false,
+		CanRunCommands:   false,
+		CanManageConfig:  false,
+		CanUseClipboard:  false,
+		CanUseAutotype:   false,
+		CanReadValues:    false,
+		ExposeValueTools: false,
+		ApprovalMode:     "none",
+		RequireApproval:  false,
+		AllowedPaths:     []string{},
+	},
+	TierStandard: {
+		CanWrite:         false,
+		CanRunCommands:   false,
+		CanManageConfig:  false,
+		CanUseClipboard:  true,
+		CanUseAutotype:   true,
+		CanReadValues:    true,
+		ExposeValueTools: false,
+		ApprovalMode:     "prompt",
+		RequireApproval:  true,
+		AllowedPaths:     []string{},
+	},
+	TierAdmin: {
+		CanWrite:         true,
+		CanRunCommands:   true,
+		CanManageConfig:  true,
+		CanUseClipboard:  true,
+		CanUseAutotype:   true,
+		CanReadValues:    true,
+		ExposeValueTools: true,
+		ApprovalMode:     "prompt",
+		RequireApproval:  true,
+		AllowedPaths:     []string{},
+	},
+}
+
+// ApplyTierPreset applies the preset values for the given tier to target.
+// Only capability/approval fields are overwritten; Name and AllowedPaths are preserved.
+// Returns true if the tier was found and applied, false otherwise.
+func ApplyTierPreset(target *AgentProfile, tier string) bool {
+	preset, ok := TierPresets[TierPreset(tier)]
+	if !ok {
+		return false
+	}
+	target.CanWrite = preset.CanWrite
+	target.CanRunCommands = preset.CanRunCommands
+	target.CanManageConfig = preset.CanManageConfig
+	target.CanUseClipboard = preset.CanUseClipboard
+	target.CanUseAutotype = preset.CanUseAutotype
+	target.CanReadValues = preset.CanReadValues
+	target.ExposeValueTools = preset.ExposeValueTools
+	target.ApprovalMode = preset.ApprovalMode
+	target.RequireApproval = preset.RequireApproval
+	return true
+}

--- a/internal/mcp/server_dispatch.go
+++ b/internal/mcp/server_dispatch.go
@@ -83,6 +83,12 @@ func (s *Server) executeTool(ctx context.Context, name string, args json.RawMess
 		metrics.RecordMCPRequest(name, agentName, "error", time.Since(start))
 		return nil, fmt.Errorf("tool %q is not available in the current environment", name)
 	}
+	if isToolBlockedByAgent(s.agent, name) {
+		span.SetStatus(codes.Error, "tool not found")
+		metrics.RecordMCPRequest(name, agentName, "error", time.Since(start))
+		s.logAudit(ctx, "agent_tool_denied", name, false)
+		return nil, fmt.Errorf("unknown tool: %s", name)
+	}
 
 	// Check token tool scope
 	if token, ok := TokenFromContext(ctx); ok {

--- a/internal/mcp/tool_registry.go
+++ b/internal/mcp/tool_registry.go
@@ -324,10 +324,15 @@ func toolsListPayload(s *Server) []map[string]any {
 	definitions := availableToolDefinitions(s)
 	tools := make([]map[string]any, 0, len(definitions))
 	for _, def := range definitions {
+		inputSchema := def.InputSchema
+		if def.Name == "get_entry" && s != nil && s.agent != nil && !s.agent.ExposeValueTools {
+			inputSchema = withoutSchemaProperty(def.InputSchema, "include_value")
+		}
+
 		payload := map[string]any{
 			"name":        def.Name,
 			"description": def.Description,
-			"inputSchema": def.InputSchema,
+			"inputSchema": inputSchema,
 		}
 		if def.Deprecated {
 			payload["deprecated"] = true
@@ -338,6 +343,33 @@ func toolsListPayload(s *Server) []map[string]any {
 		tools = append(tools, payload)
 	}
 	return tools
+}
+
+func withoutSchemaProperty(schema map[string]any, property string) map[string]any {
+	if schema == nil {
+		return nil
+	}
+
+	cloned := make(map[string]any, len(schema))
+	for key, value := range schema {
+		cloned[key] = value
+	}
+
+	properties, ok := schema["properties"].(map[string]any)
+	if !ok {
+		return cloned
+	}
+
+	clonedProperties := make(map[string]any, len(properties))
+	for key, value := range properties {
+		if key == property {
+			continue
+		}
+		clonedProperties[key] = value
+	}
+	cloned["properties"] = clonedProperties
+
+	return cloned
 }
 
 func callToolResultPayload(result *CallToolResult) map[string]any {

--- a/internal/mcp/tool_registry.go
+++ b/internal/mcp/tool_registry.go
@@ -3,6 +3,8 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+
+	"github.com/danieljustus/OpenPass/internal/config"
 )
 
 type toolHandler func(*Server, context.Context, CallToolRequest) (*CallToolResult, error)
@@ -288,9 +290,25 @@ func availableToolDefinitions(s *Server) []toolDefinition {
 		if def.Available != nil && !def.Available(s) {
 			continue
 		}
+		if s != nil && isToolBlockedByAgent(s.agent, def.Name) {
+			continue
+		}
 		available = append(available, def)
 	}
 	return available
+}
+
+// isToolBlockedByAgent returns true when the tool should be hidden/unavailable
+// based on the agent's profile capabilities. This is used both at list-time
+// (availableToolDefinitions) and at call-time (executeTool) for defense-in-depth.
+func isToolBlockedByAgent(agent *config.AgentProfile, toolName string) bool {
+	if agent == nil {
+		return false
+	}
+	if !agent.ExposeValueTools && toolName == "get_entry_value" {
+		return true
+	}
+	return false
 }
 
 func findToolDefinition(name string) (toolDefinition, bool) {

--- a/internal/mcp/tool_registry_test.go
+++ b/internal/mcp/tool_registry_test.go
@@ -1,8 +1,13 @@
 package mcp
 
 import (
+	"context"
+	"encoding/json"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/danieljustus/OpenPass/internal/config"
 )
 
 func TestResolveToolAlias(t *testing.T) {
@@ -144,5 +149,74 @@ func TestIsToolAllowed(t *testing.T) {
 				t.Errorf("isToolAllowed(token=%v, toolName=%q) = %v, want %v", tt.token, tt.toolName, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestToolError(t *testing.T) {
+	result := toolError("test error")
+	if result == nil {
+		t.Fatal("toolError() returned nil")
+	}
+	if !result.IsError {
+		t.Error("toolError() expected IsError to be true")
+	}
+}
+
+func TestExecuteToolUnknownTool(t *testing.T) {
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:         "test",
+		AllowedPaths: []string{"*"},
+		CanWrite:     false,
+		ApprovalMode: "none",
+	}, "stdio", "")
+
+	args := json.RawMessage(`{}`)
+	_, err := srv.executeTool(context.Background(), "unknown_tool", args)
+	if err == nil {
+		t.Fatal("executeTool() expected error for unknown tool, got nil")
+	}
+	if !strings.Contains(err.Error(), "unknown tool") {
+		t.Fatalf("executeTool() error = %v, want 'unknown tool'", err)
+	}
+}
+
+func TestToolsListPayloadMatchesAvailableRegistry(t *testing.T) {
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:             "test",
+		AllowedPaths:     []string{"*"},
+		CanWrite:         true,
+		ApprovalMode:     "none",
+		ExposeValueTools: true,
+	}, "http", "")
+
+	tools := toolsListPayload(srv)
+	names := make(map[string]map[string]any, len(tools))
+	for _, tool := range tools {
+		name, _ := tool["name"].(string)
+		names[name] = tool
+	}
+
+	for _, def := range availableToolDefinitions(srv) {
+		if _, ok := names[def.Name]; !ok {
+			t.Fatalf("tools/list missing available tool %q", def.Name)
+		}
+	}
+
+	for _, name := range []string{"list_entries", "get_entry", "get_entry_value", "get_entry_metadata", "generate_password", "health", "delete_entry", "openpass_delete"} {
+		if _, ok := names[name]; !ok {
+			t.Fatalf("tools/list missing expected tool %q", name)
+		}
+	}
+
+	getEntrySchema, ok := names["get_entry"]["inputSchema"].(map[string]any)
+	if !ok {
+		t.Fatal("get_entry inputSchema has unexpected type")
+	}
+	properties, ok := getEntrySchema["properties"].(map[string]any)
+	if !ok {
+		t.Fatal("get_entry properties have unexpected type")
+	}
+	if _, ok := properties["include_value"]; !ok {
+		t.Fatal("get_entry schema missing include_value")
 	}
 }

--- a/internal/mcp/tools_get.go
+++ b/internal/mcp/tools_get.go
@@ -70,6 +70,16 @@ func (s *Server) handleGet(ctx context.Context, req CallToolRequest) (*CallToolR
 		return nil, fmt.Errorf("access denied: path %q outside allowed scope", path)
 	}
 
+	// Strip include_value when agent profile blocks value exposure
+	if s.agent != nil && !s.agent.ExposeValueTools {
+		if includeVal, ok := req.Arguments["include_value"]; ok {
+			if includeBool, ok := includeVal.(bool); ok && includeBool {
+				delete(req.Arguments, "include_value")
+				s.logAudit(ctx, "get_value_stripped", path, false)
+			}
+		}
+	}
+
 	svc := vaultsvc.New(slog.Default(), s.vault)
 	_, span := metrics.StartSpan(ctx, "vault.GetEntry")
 	entry, err := svc.GetEntry(path)

--- a/internal/mcp/tools_get.go
+++ b/internal/mcp/tools_get.go
@@ -70,16 +70,6 @@ func (s *Server) handleGet(ctx context.Context, req CallToolRequest) (*CallToolR
 		return nil, fmt.Errorf("access denied: path %q outside allowed scope", path)
 	}
 
-	// Strip include_value when agent profile blocks value exposure
-	if s.agent != nil && !s.agent.ExposeValueTools {
-		if includeVal, ok := req.Arguments["include_value"]; ok {
-			if includeBool, ok := includeVal.(bool); ok && includeBool {
-				delete(req.Arguments, "include_value")
-				s.logAudit(ctx, "get_value_stripped", path, false)
-			}
-		}
-	}
-
 	svc := vaultsvc.New(slog.Default(), s.vault)
 	_, span := metrics.StartSpan(ctx, "vault.GetEntry")
 	entry, err := svc.GetEntry(path)

--- a/internal/mcp/tools_test_helpers.go
+++ b/internal/mcp/tools_test_helpers.go
@@ -1,9 +1,6 @@
 package mcp
 
 import (
-	"context"
-	"encoding/json"
-	"strings"
 	"testing"
 
 	"filippo.io/age"
@@ -63,76 +60,4 @@ func mockVault(t *testing.T) (string, *age.X25519Identity) {
 	}
 
 	return dir, identity
-}
-
-func TestToolError(t *testing.T) {
-	result := toolError("test error")
-	if result == nil {
-		t.Fatal("toolError() returned nil")
-	}
-	if !result.IsError {
-		t.Error("toolError() expected IsError to be true")
-	}
-}
-
-func TestExecuteToolUnknownTool(t *testing.T) {
-	srv := newTestServerWithVault(t, config.AgentProfile{
-		Name:         "test",
-		AllowedPaths: []string{"*"},
-		CanWrite:     false,
-		ApprovalMode: "none",
-	}, "stdio", "")
-
-	// Use empty JSON object instead of nil to avoid parse error
-	args := json.RawMessage(`{}`)
-	_, err := srv.executeTool(context.Background(), "unknown_tool", args)
-	if err == nil {
-		t.Fatal("executeTool() expected error for unknown tool, got nil")
-	}
-	if !strings.Contains(err.Error(), "unknown tool") {
-		t.Fatalf("executeTool() error = %v, want 'unknown tool'", err)
-	}
-}
-
-func TestToolsListPayloadMatchesAvailableRegistry(t *testing.T) {
-	srv := newTestServerWithVault(t, config.AgentProfile{
-		Name:         "test",
-		AllowedPaths: []string{"*"},
-		CanWrite:     true,
-		ApprovalMode: "none",
-	}, "http", "")
-
-	tools := toolsListPayload(srv)
-	names := make(map[string]map[string]any, len(tools))
-	for _, tool := range tools {
-		name, _ := tool["name"].(string)
-		names[name] = tool
-	}
-
-	for _, def := range availableToolDefinitions(srv) {
-		if _, ok := names[def.Name]; !ok {
-			t.Fatalf("tools/list missing available tool %q", def.Name)
-		}
-	}
-
-	for _, name := range []string{"list_entries", "get_entry", "get_entry_value", "get_entry_metadata", "generate_password", "health", "delete_entry", "openpass_delete"} {
-		if _, ok := names[name]; !ok {
-			t.Fatalf("tools/list missing expected tool %q", name)
-		}
-	}
-	if _, ok := names["secure_input"]; ok {
-		t.Fatal("secure_input should not be listed for non-stdio transports")
-	}
-
-	getEntrySchema, ok := names["get_entry"]["inputSchema"].(map[string]any)
-	if !ok {
-		t.Fatal("get_entry inputSchema has unexpected type")
-	}
-	properties, ok := getEntrySchema["properties"].(map[string]any)
-	if !ok {
-		t.Fatal("get_entry properties have unexpected type")
-	}
-	if _, ok := properties["include_value"]; !ok {
-		t.Fatal("get_entry schema missing include_value")
-	}
 }

--- a/internal/mcp/tools_value_exposure_test.go
+++ b/internal/mcp/tools_value_exposure_test.go
@@ -33,6 +33,19 @@ func TestToolsList_FiltersGetEntryValue_WhenExposeValueToolsFalse(t *testing.T) 
 	if !names["list_entries"] {
 		t.Error("list_entries should still be in tools/list")
 	}
+
+	getEntry := findToolByName(t, tools, "get_entry")
+	inputSchema, ok := getEntry["inputSchema"].(map[string]any)
+	if !ok {
+		t.Fatal("get_entry inputSchema has unexpected type")
+	}
+	properties, ok := inputSchema["properties"].(map[string]any)
+	if !ok {
+		t.Fatal("get_entry properties have unexpected type")
+	}
+	if _, ok := properties["include_value"]; ok {
+		t.Error("get_entry schema should hide include_value when ExposeValueTools=false")
+	}
 }
 
 func TestToolsList_ShowsGetEntryValue_WhenExposeValueToolsTrue(t *testing.T) {
@@ -52,6 +65,19 @@ func TestToolsList_ShowsGetEntryValue_WhenExposeValueToolsTrue(t *testing.T) {
 
 	if !names["get_entry_value"] {
 		t.Error("get_entry_value should be in tools/list when ExposeValueTools=true")
+	}
+
+	getEntry := findToolByName(t, tools, "get_entry")
+	inputSchema, ok := getEntry["inputSchema"].(map[string]any)
+	if !ok {
+		t.Fatal("get_entry inputSchema has unexpected type")
+	}
+	properties, ok := inputSchema["properties"].(map[string]any)
+	if !ok {
+		t.Fatal("get_entry properties have unexpected type")
+	}
+	if _, ok := properties["include_value"]; !ok {
+		t.Error("get_entry schema should include include_value when ExposeValueTools=true")
 	}
 }
 
@@ -93,4 +119,17 @@ func TestAvailableToolDefinitions_FiltersGetEntryValue_WhenExposeValueToolsFalse
 	if !names["get_entry"] {
 		t.Error("get_entry should still be available when ExposeValueTools=false")
 	}
+}
+
+func findToolByName(t *testing.T, tools []map[string]any, name string) map[string]any {
+	t.Helper()
+
+	for _, tool := range tools {
+		if tool["name"] == name {
+			return tool
+		}
+	}
+
+	t.Fatalf("tool %q not found", name)
+	return nil
 }

--- a/internal/mcp/tools_value_exposure_test.go
+++ b/internal/mcp/tools_value_exposure_test.go
@@ -1,0 +1,96 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/danieljustus/OpenPass/internal/config"
+)
+
+func TestToolsList_FiltersGetEntryValue_WhenExposeValueToolsFalse(t *testing.T) {
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:             "test",
+		AllowedPaths:     []string{"*"},
+		CanReadValues:    true,
+		ExposeValueTools: false,
+		ApprovalMode:     "prompt",
+	}, "http", "")
+
+	tools := toolsListPayload(srv)
+	names := make(map[string]bool, len(tools))
+	for _, tool := range tools {
+		names[tool["name"].(string)] = true
+	}
+
+	if names["get_entry_value"] {
+		t.Error("get_entry_value should NOT be in tools/list when ExposeValueTools=false")
+	}
+	if !names["get_entry"] {
+		t.Error("get_entry should still be in tools/list when ExposeValueTools=false")
+	}
+	if !names["list_entries"] {
+		t.Error("list_entries should still be in tools/list")
+	}
+}
+
+func TestToolsList_ShowsGetEntryValue_WhenExposeValueToolsTrue(t *testing.T) {
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:             "test",
+		AllowedPaths:     []string{"*"},
+		CanReadValues:    true,
+		ExposeValueTools: true,
+		ApprovalMode:     "prompt",
+	}, "http", "")
+
+	tools := toolsListPayload(srv)
+	names := make(map[string]bool, len(tools))
+	for _, tool := range tools {
+		names[tool["name"].(string)] = true
+	}
+
+	if !names["get_entry_value"] {
+		t.Error("get_entry_value should be in tools/list when ExposeValueTools=true")
+	}
+}
+
+func TestExecuteTool_BlocksGetEntryValue_WhenExposeValueToolsFalse(t *testing.T) {
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:             "test",
+		AllowedPaths:     []string{"*"},
+		ExposeValueTools: false,
+		ApprovalMode:     "none",
+	}, "stdio", "")
+
+	args := json.RawMessage(`{"path": "test"}`)
+	_, err := srv.executeTool(context.Background(), "get_entry_value", args)
+	if err == nil {
+		t.Fatal("executeTool() expected error for get_entry_value when ExposeValueTools=false, got nil")
+	}
+	if !strings.Contains(err.Error(), "unknown tool") {
+		t.Fatalf("executeTool() error = %v, want 'unknown tool'", err)
+	}
+}
+
+func TestAvailableToolDefinitions_FiltersGetEntryValue_WhenExposeValueToolsFalse(t *testing.T) {
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:             "test",
+		AllowedPaths:     []string{"*"},
+		ExposeValueTools: false,
+		ApprovalMode:     "none",
+	}, "http", "")
+
+	defs := availableToolDefinitions(srv)
+	names := make(map[string]bool, len(defs))
+	for _, def := range defs {
+		names[def.Name] = true
+	}
+
+	if names["get_entry_value"] {
+		t.Error("get_entry_value should NOT be available when ExposeValueTools=false")
+	}
+	if !names["get_entry"] {
+		t.Error("get_entry should still be available when ExposeValueTools=false")
+	}
+}


### PR DESCRIPTION
Adds credential isolation foundation: tier presets (read-only, standard, admin) in internal/config/presets.go, ExposeValueTools field on AgentProfile, and tool registry filter that hides get_entry_value from tools/list and blocks it at dispatch when ExposeValueTools=false. Also strips include_value param from get_entry with audit logging.

Fixes #53

## What

Describe the change in a few sentences.

## Why

Explain the problem, user need, or maintenance reason.

## Testing

- [ ] `make fmt`
- [ ] `make vet`
- [ ] `make lint`
- [ ] `GOWORK=off go test ./...`
- [ ] Added or updated tests where needed

## Safety

- [ ] I did not include passwords, tokens, private keys, vault contents, or personal data
- [ ] Documentation was updated where behavior changed
