### PR TITLE
feat: audit hardening — per-tool redactFields, registry hash, tool-chain anomaly, import quarantine (#91-94)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Worktrees
+.worktrees/
+
 # Binaries
 openpass
 OpenPass

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -1,11 +1,13 @@
 package cmd
 
 import (
+	"crypto/rand"
 	"errors"
 	"fmt"
 	"os"
 	"path"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -21,6 +23,7 @@ var (
 	importSkipExisting bool
 	importOverwrite    bool
 	importMapping      string
+	importQuarantine   bool
 )
 
 var importCmd = &cobra.Command{
@@ -46,12 +49,22 @@ var importCmd = &cobra.Command{
 			return errorspkg.NewCLIError(errorspkg.ExitGeneralError, "--skip-existing and --overwrite cannot be used together", nil)
 		}
 
+		if importQuarantine && importPrefix != "" {
+			return errorspkg.NewCLIError(errorspkg.ExitGeneralError, "--quarantine and --prefix cannot be used together", nil)
+		}
+
 		options := importer.ImportOptions{
 			DryRun:       importDryRun,
 			Prefix:       strings.Trim(importPrefix, "/"),
 			SkipExisting: importSkipExisting,
 			Overwrite:    importOverwrite,
 			Mapping:      importMapping,
+		}
+
+		if importQuarantine {
+			importID := generateImportID()
+			options.Prefix = "quarantine/" + importID
+			printQuietAware("Quarantine import ID: %s\n", importID)
 		}
 
 		if _, err := importer.ParseMapping(options.Mapping); err != nil {
@@ -136,6 +149,7 @@ func init() {
 	importCmd.Flags().BoolVar(&importSkipExisting, "skip-existing", false, "Skip entries that already exist")
 	importCmd.Flags().BoolVar(&importOverwrite, "overwrite", false, "Delete existing entries before writing")
 	importCmd.Flags().StringVar(&importMapping, "mapping", "", "CSV column mapping (format: title=col1,username=col2,...)")
+	importCmd.Flags().BoolVar(&importQuarantine, "quarantine", false, "Import entries into quarantine/<import-id>/ for human review before agent access")
 	rootCmd.AddCommand(importCmd)
 }
 
@@ -164,6 +178,14 @@ func importEntryPath(prefix, entryPath string) string {
 		return prefix
 	}
 	return path.Join(prefix, entryPath)
+}
+
+func generateImportID() string {
+	buf := make([]byte, 4)
+	if _, err := rand.Read(buf); err != nil {
+		return fmt.Sprintf("import-%s-%x", time.Now().UTC().Format("20060102"), time.Now().UnixNano())
+	}
+	return fmt.Sprintf("import-%s-%x", time.Now().UTC().Format("20060102"), buf)
 }
 
 func importEntryExists(svc vaultsvc.Service, entryPath string) (bool, error) {

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"sort"
 	"strings"
 	"time"
 
@@ -230,8 +231,13 @@ var importReviewListCmd = &cobra.Command{
 				printQuietAware("No quarantined imports found.\n")
 				return nil
 			}
-			for id, count := range batches {
-				printQuietAware("%s  (%d entries)\n", id, count)
+			ids := make([]string, 0, len(batches))
+			for id := range batches {
+				ids = append(ids, id)
+			}
+			sort.Strings(ids)
+			for _, id := range ids {
+				printQuietAware("%s  (%d entries)\n", id, batches[id])
 			}
 			return nil
 		})

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -200,3 +200,107 @@ func importEntryExists(svc vaultsvc.Service, entryPath string) (bool, error) {
 	}
 	return false, err
 }
+
+var reviewPromoteOverwrite bool
+
+var importReviewCmd = &cobra.Command{
+	Use:   "review",
+	Short: "Review and manage quarantined imports",
+}
+
+var importReviewListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List quarantined import batches",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return withVault(func(svc vaultsvc.Service) error {
+			entries, err := svc.List("quarantine/")
+			if err != nil {
+				return fmt.Errorf("list quarantine: %w", err)
+			}
+			// Group by import-id (path format: quarantine/<import-id>/<rest>)
+			batches := make(map[string]int)
+			for _, e := range entries {
+				parts := strings.SplitN(strings.TrimPrefix(e, "quarantine/"), "/", 2)
+				if len(parts) > 0 && parts[0] != "" {
+					batches[parts[0]]++
+				}
+			}
+			if len(batches) == 0 {
+				printQuietAware("No quarantined imports found.\n")
+				return nil
+			}
+			for id, count := range batches {
+				printQuietAware("%s  (%d entries)\n", id, count)
+			}
+			return nil
+		})
+	},
+}
+
+var importReviewPromoteCmd = &cobra.Command{
+	Use:   "promote <import-id>",
+	Short: "Promote quarantined entries to their final vault paths",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		importID := args[0]
+		quarantinePrefix := "quarantine/" + importID + "/"
+		return withVault(func(svc vaultsvc.Service) error {
+			entries, err := svc.List(quarantinePrefix)
+			if err != nil {
+				return fmt.Errorf("list quarantine batch: %w", err)
+			}
+			if len(entries) == 0 {
+				return fmt.Errorf("no quarantined entries found for import-id %q", importID)
+			}
+			hadError := false
+			for _, entryPath := range entries {
+				destPath := strings.TrimPrefix(entryPath, quarantinePrefix)
+				if destPath == "" {
+					continue
+				}
+				// Check if destination already exists
+				exists, existsErr := importEntryExists(svc, destPath)
+				if existsErr != nil {
+					printQuietAware("Warning: cannot check destination %s: %v\n", destPath, existsErr)
+					hadError = true
+					continue
+				}
+				if exists && !reviewPromoteOverwrite {
+					printQuietAware("Warning: skipping %s — destination already exists (use --overwrite)\n", destPath)
+					hadError = true
+					continue
+				}
+				// Read source entry
+				entry, readErr := svc.GetEntry(entryPath)
+				if readErr != nil {
+					printQuietAware("Warning: failed to read %s: %v\n", entryPath, readErr)
+					hadError = true
+					continue
+				}
+				// Write to destination
+				if writeErr := svc.WriteEntry(destPath, entry); writeErr != nil {
+					printQuietAware("Warning: failed to write %s: %v\n", destPath, writeErr)
+					hadError = true
+					continue
+				}
+				if deleteErr := svc.Delete(entryPath); deleteErr != nil {
+					printQuietAware("Warning: failed to delete quarantine entry %s: %v\n", entryPath, deleteErr)
+					// Don't set hadError — promote succeeded
+				}
+				printQuietAware("Promoted: %s\n", destPath)
+			}
+			if hadError {
+				return fmt.Errorf("some entries could not be promoted")
+			}
+			return nil
+		})
+	},
+}
+
+func init() {
+	importReviewPromoteCmd.Flags().BoolVar(&reviewPromoteOverwrite, "overwrite", false, "Overwrite existing entries at destination")
+	importReviewCmd.AddCommand(importReviewListCmd)
+	importReviewCmd.AddCommand(importReviewPromoteCmd)
+	importCmd.AddCommand(importReviewCmd)
+}

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -183,7 +183,7 @@ func importEntryPath(prefix, entryPath string) string {
 func generateImportID() string {
 	buf := make([]byte, 4)
 	if _, err := rand.Read(buf); err != nil {
-		return fmt.Sprintf("import-%s-%x", time.Now().UTC().Format("20060102"), time.Now().UnixNano())
+		return fmt.Sprintf("import-%s-%08x", time.Now().UTC().Format("20060102"), uint32(time.Now().UnixNano()))
 	}
 	return fmt.Sprintf("import-%s-%x", time.Now().UTC().Format("20060102"), buf)
 }

--- a/cmd/import_test.go
+++ b/cmd/import_test.go
@@ -264,6 +264,175 @@ func TestImportQuarantinePath(t *testing.T) {
 	}
 }
 
+func TestImportReviewListEmpty(t *testing.T) {
+	vaultDir, passphrase := initVault(t)
+	setPassEnv(t, string(passphrase))
+	defer setupVaultFlag(t, vaultDir)()
+
+	if err := os.Setenv("OPENPASS_PASSPHRASE", string(passphrase)); err != nil {
+		t.Fatalf("set passphrase env: %v", err)
+	}
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "import", "review", "list"})
+	defer rootCmd.SetArgs(nil)
+
+	var execErr error
+	output := captureStdout(func() {
+		execErr = rootCmd.Execute()
+	})
+	if execErr != nil {
+		t.Fatalf("import review list failed: %v", execErr)
+	}
+	if !strings.Contains(output, "No quarantined imports found.") {
+		t.Errorf("expected empty message, got: %s", output)
+	}
+}
+
+func TestImportReviewList(t *testing.T) {
+	vaultDir, passphrase := initVault(t)
+	setPassEnv(t, string(passphrase))
+	defer setupVaultFlag(t, vaultDir)()
+
+	// First do a quarantine import to create an import batch
+	if err := os.Setenv("OPENPASS_PASSPHRASE", string(passphrase)); err != nil {
+		t.Fatalf("set passphrase env: %v", err)
+	}
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "import", "csv", csvImportFixture(t), "--quarantine"})
+	var importOutput string
+	var importErr error
+	importOutput = captureStdout(func() {
+		importErr = rootCmd.Execute()
+	})
+	rootCmd.SetArgs(nil)
+	if importErr != nil {
+		t.Fatalf("quarantine import failed: %v", importErr)
+	}
+
+	// Extract the import-id from the output
+	var importID string
+	for _, line := range strings.Split(importOutput, "\n") {
+		if strings.HasPrefix(line, "Quarantine import ID: ") {
+			importID = strings.TrimSpace(strings.TrimPrefix(line, "Quarantine import ID: "))
+		}
+	}
+	if importID == "" {
+		t.Fatalf("could not extract import-id from output: %s", importOutput)
+	}
+
+	// Re-set passphrase (unlockVault unsets it after each use)
+	if err := os.Setenv("OPENPASS_PASSPHRASE", string(passphrase)); err != nil {
+		t.Fatalf("set passphrase env: %v", err)
+	}
+
+	// Now run review list
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "import", "review", "list"})
+	var listErr error
+	listOutput := captureStdout(func() {
+		listErr = rootCmd.Execute()
+	})
+	rootCmd.SetArgs(nil)
+	if listErr != nil {
+		t.Fatalf("import review list failed: %v", listErr)
+	}
+	if !strings.Contains(listOutput, importID) {
+		t.Errorf("review list missing import-id %q: %s", importID, listOutput)
+	}
+	if !strings.Contains(listOutput, "(3 entries)") {
+		t.Errorf("review list missing entry count: %s", listOutput)
+	}
+}
+
+func TestImportReviewPromote(t *testing.T) {
+	vaultDir, passphrase := initVault(t)
+	setPassEnv(t, string(passphrase))
+	defer setupVaultFlag(t, vaultDir)()
+
+	// Quarantine import
+	if err := os.Setenv("OPENPASS_PASSPHRASE", string(passphrase)); err != nil {
+		t.Fatalf("set passphrase env: %v", err)
+	}
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "import", "csv", csvImportFixture(t), "--quarantine"})
+	var importOutput string
+	var importErr error
+	importOutput = captureStdout(func() {
+		importErr = rootCmd.Execute()
+	})
+	rootCmd.SetArgs(nil)
+	if importErr != nil {
+		t.Fatalf("quarantine import failed: %v", importErr)
+	}
+
+	// Extract the import-id
+	var importID string
+	for _, line := range strings.Split(importOutput, "\n") {
+		if strings.HasPrefix(line, "Quarantine import ID: ") {
+			importID = strings.TrimSpace(strings.TrimPrefix(line, "Quarantine import ID: "))
+		}
+	}
+	if importID == "" {
+		t.Fatalf("could not extract import-id from output: %s", importOutput)
+	}
+
+	// Re-set passphrase (unlockVault unsets it after each use)
+	if err := os.Setenv("OPENPASS_PASSPHRASE", string(passphrase)); err != nil {
+		t.Fatalf("set passphrase env: %v", err)
+	}
+
+	// Promote
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "import", "review", "promote", importID})
+	var promoteErr error
+	promoteOutput := captureStdout(func() {
+		promoteErr = rootCmd.Execute()
+	})
+	rootCmd.SetArgs(nil)
+	if promoteErr != nil {
+		t.Fatalf("import review promote failed: %v", promoteErr)
+	}
+
+	// All 3 CSV entries should be promoted
+	for _, p := range expectedCSVImportPaths {
+		if !strings.Contains(promoteOutput, "Promoted: "+p) {
+			t.Errorf("promote output missing %q: %s", p, promoteOutput)
+		}
+	}
+
+	// Verify entries now exist at final paths
+	svc := importTestVaultService(t, vaultDir, string(passphrase))
+	assertCSVImportedEntries(t, svc, "")
+
+	// Quarantine prefix should be empty
+	quarantined, err := svc.List("quarantine/")
+	if err != nil {
+		t.Fatalf("list quarantine: %v", err)
+	}
+	if len(quarantined) != 0 {
+		t.Errorf("quarantine not cleaned up: %v", quarantined)
+	}
+}
+
+func TestImportReviewPromoteNotFound(t *testing.T) {
+	vaultDir, passphrase := initVault(t)
+	setPassEnv(t, string(passphrase))
+	defer setupVaultFlag(t, vaultDir)()
+
+	if err := os.Setenv("OPENPASS_PASSPHRASE", string(passphrase)); err != nil {
+		t.Fatalf("set passphrase env: %v", err)
+	}
+
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "import", "review", "promote", "import-00000000-deadbeef"})
+	defer rootCmd.SetArgs(nil)
+
+	var execErr error
+	captureStdout(func() {
+		execErr = rootCmd.Execute()
+	})
+	if execErr == nil {
+		t.Fatal("expected error for unknown import-id, got nil")
+	}
+	if !strings.Contains(execErr.Error(), "no quarantined entries found") {
+		t.Errorf("unexpected error message: %v", execErr)
+	}
+}
+
 func snapshotImportEntries(t *testing.T, svc vaultsvc.Service, paths []string) map[string]*vaultpkg.Entry {
 	t.Helper()
 	snapshot := make(map[string]*vaultpkg.Entry, len(paths))

--- a/cmd/import_test.go
+++ b/cmd/import_test.go
@@ -409,6 +409,151 @@ func TestImportReviewPromote(t *testing.T) {
 	}
 }
 
+func TestImportReviewPromoteSkipsExisting(t *testing.T) {
+	vaultDir, passphrase := initVault(t)
+	setPassEnv(t, string(passphrase))
+	defer setupVaultFlag(t, vaultDir)()
+
+	// Quarantine import
+	if err := os.Setenv("OPENPASS_PASSPHRASE", string(passphrase)); err != nil {
+		t.Fatalf("set passphrase env: %v", err)
+	}
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "import", "csv", csvImportFixture(t), "--quarantine"})
+	var importOutput string
+	var importErr error
+	importOutput = captureStdout(func() {
+		importErr = rootCmd.Execute()
+	})
+	rootCmd.SetArgs(nil)
+	if importErr != nil {
+		t.Fatalf("quarantine import failed: %v", importErr)
+	}
+
+	// Extract the import-id
+	var importID string
+	for _, line := range strings.Split(importOutput, "\n") {
+		if strings.HasPrefix(line, "Quarantine import ID: ") {
+			importID = strings.TrimSpace(strings.TrimPrefix(line, "Quarantine import ID: "))
+		}
+	}
+	if importID == "" {
+		t.Fatalf("could not extract import-id from output: %s", importOutput)
+	}
+
+	// Create a conflicting destination entry
+	svc := importTestVaultService(t, vaultDir, string(passphrase))
+	if err := svc.SetFields("GitHub,-Personal", map[string]any{
+		"username": "existing@example.com",
+	}); err != nil {
+		t.Fatalf("create conflicting destination entry: %v", err)
+	}
+
+	// Re-set passphrase
+	if err := os.Setenv("OPENPASS_PASSPHRASE", string(passphrase)); err != nil {
+		t.Fatalf("set passphrase env: %v", err)
+	}
+
+	// Promote WITHOUT --overwrite — should fail
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "import", "review", "promote", importID})
+	var promoteErr error
+	promoteOutput := captureStdout(func() {
+		promoteErr = rootCmd.Execute()
+	})
+	rootCmd.SetArgs(nil)
+	if promoteErr == nil {
+		t.Fatal("expected error when destination already exists without --overwrite, got nil")
+	}
+
+	// Warning output should mention "already exists"
+	if !strings.Contains(promoteOutput, "already exists") {
+		t.Errorf("promote output missing 'already exists' warning: %s", promoteOutput)
+	}
+
+	// Quarantine entry should still exist (not deleted)
+	quarantined, err := svc.List("quarantine/")
+	if err != nil {
+		t.Fatalf("list quarantine: %v", err)
+	}
+	if len(quarantined) == 0 {
+		t.Error("quarantine was cleaned up despite promote failure")
+	}
+}
+
+func TestImportReviewPromoteOverwrite(t *testing.T) {
+	vaultDir, passphrase := initVault(t)
+	setPassEnv(t, string(passphrase))
+	defer setupVaultFlag(t, vaultDir)()
+
+	// Quarantine import
+	if err := os.Setenv("OPENPASS_PASSPHRASE", string(passphrase)); err != nil {
+		t.Fatalf("set passphrase env: %v", err)
+	}
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "import", "csv", csvImportFixture(t), "--quarantine"})
+	var importOutput string
+	var importErr error
+	importOutput = captureStdout(func() {
+		importErr = rootCmd.Execute()
+	})
+	rootCmd.SetArgs(nil)
+	if importErr != nil {
+		t.Fatalf("quarantine import failed: %v", importErr)
+	}
+
+	// Extract the import-id
+	var importID string
+	for _, line := range strings.Split(importOutput, "\n") {
+		if strings.HasPrefix(line, "Quarantine import ID: ") {
+			importID = strings.TrimSpace(strings.TrimPrefix(line, "Quarantine import ID: "))
+		}
+	}
+	if importID == "" {
+		t.Fatalf("could not extract import-id from output: %s", importOutput)
+	}
+
+	// Create a conflicting destination entry with stale data
+	svc := importTestVaultService(t, vaultDir, string(passphrase))
+	if err := svc.SetFields("GitHub,-Personal", map[string]any{
+		"username": "stale@example.com",
+		"extra":    "stale-field",
+	}); err != nil {
+		t.Fatalf("create conflicting destination entry: %v", err)
+	}
+
+	// Re-set passphrase
+	if err := os.Setenv("OPENPASS_PASSPHRASE", string(passphrase)); err != nil {
+		t.Fatalf("set passphrase env: %v", err)
+	}
+
+	// Promote WITH --overwrite — should succeed
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "import", "review", "promote", importID, "--overwrite"})
+	var promoteErr error
+	captureStdout(func() {
+		promoteErr = rootCmd.Execute()
+	})
+	rootCmd.SetArgs(nil)
+	if promoteErr != nil {
+		t.Fatalf("import review promote --overwrite failed: %v", promoteErr)
+	}
+
+	// Destination entry should have been updated with imported data
+	entry, err := svc.GetEntry("GitHub,-Personal")
+	if err != nil {
+		t.Fatalf("get overwritten entry: %v", err)
+	}
+	if entry.Data["username"] != "user@example.com" {
+		t.Errorf("username was not overwritten, got %#v", entry.Data["username"])
+	}
+
+	// Quarantine should be empty
+	quarantined, err := svc.List("quarantine/")
+	if err != nil {
+		t.Fatalf("list quarantine: %v", err)
+	}
+	if len(quarantined) != 0 {
+		t.Errorf("quarantine not cleaned up after --overwrite promote: %v", quarantined)
+	}
+}
+
 func TestImportReviewPromoteNotFound(t *testing.T) {
 	vaultDir, passphrase := initVault(t)
 	setPassEnv(t, string(passphrase))

--- a/cmd/import_test.go
+++ b/cmd/import_test.go
@@ -196,6 +196,74 @@ func assertCSVImportedEntries(t *testing.T, svc vaultsvc.Service, prefix string)
 	}
 }
 
+func TestImportQuarantineMutualExclusion(t *testing.T) {
+	vaultDir, passphrase := initVault(t)
+	setPassEnv(t, string(passphrase))
+	defer setupVaultFlag(t, vaultDir)()
+
+	if err := os.Setenv("OPENPASS_PASSPHRASE", string(passphrase)); err != nil {
+		t.Fatalf("set passphrase env: %v", err)
+	}
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "import", "csv", csvImportFixture(t), "--quarantine", "--prefix", "myprefix/"})
+	defer rootCmd.SetArgs(nil)
+
+	var execErr error
+	captureStdout(func() {
+		execErr = rootCmd.Execute()
+	})
+	if execErr == nil {
+		t.Fatal("expected error combining --quarantine and --prefix, got nil")
+	}
+	if !strings.Contains(execErr.Error(), "--quarantine and --prefix cannot be used together") {
+		t.Errorf("unexpected error message: %v", execErr)
+	}
+}
+
+func TestImportQuarantinePath(t *testing.T) {
+	vaultDir, passphrase := initVault(t)
+	setPassEnv(t, string(passphrase))
+	defer setupVaultFlag(t, vaultDir)()
+
+	if err := os.Setenv("OPENPASS_PASSPHRASE", string(passphrase)); err != nil {
+		t.Fatalf("set passphrase env: %v", err)
+	}
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "import", "csv", csvImportFixture(t), "--quarantine"})
+	defer rootCmd.SetArgs(nil)
+
+	var execErr error
+	output := captureStdout(func() {
+		execErr = rootCmd.Execute()
+	})
+	if execErr != nil {
+		t.Fatalf("import --quarantine failed: %v", execErr)
+	}
+
+	// Output should contain the quarantine import ID line
+	if !strings.Contains(output, "Quarantine import ID: import-") {
+		t.Errorf("output missing quarantine import ID: %s", output)
+	}
+
+	// Verify entries are stored under quarantine/<import-id>/
+	svc := importTestVaultService(t, vaultDir, string(passphrase))
+	quarantined, err := svc.List("quarantine/")
+	if err != nil {
+		t.Fatalf("list quarantine entries: %v", err)
+	}
+	if len(quarantined) == 0 {
+		t.Fatal("no entries imported under quarantine/ prefix")
+	}
+	// All quarantined entries must be under quarantine/import-YYYYMMDD-<hex>/
+	for _, e := range quarantined {
+		if !strings.HasPrefix(e, "quarantine/import-") {
+			t.Errorf("entry %q not under quarantine/import-* prefix", e)
+		}
+	}
+	// Verify that exactly the 3 CSV entries are present
+	if len(quarantined) != 3 {
+		t.Errorf("expected 3 quarantined entries, got %d: %v", len(quarantined), quarantined)
+	}
+}
+
 func snapshotImportEntries(t *testing.T, svc vaultsvc.Service, paths []string) map[string]*vaultpkg.Entry {
 	t.Helper()
 	snapshot := make(map[string]*vaultpkg.Entry, len(paths))

--- a/internal/anomaly/detector.go
+++ b/internal/anomaly/detector.go
@@ -47,6 +47,7 @@ const (
 	AlertRateAnomaly  AlertType = "rate_anomaly"
 	AlertOffHours     AlertType = "off_hours"
 	AlertCanaryAccess AlertType = "canary_access"
+	AlertToolChain    AlertType = "tool_chain"
 )
 
 // AnomalyAlert represents a single anomaly detection event.
@@ -63,14 +64,15 @@ type AnomalyAlert struct {
 
 // ToolCallEvent represents a single tool call to be analyzed by the detector.
 type ToolCallEvent struct {
-	Timestamp time.Time
-	Agent     string
-	Tool      string
-	Path      string
-	Duration  time.Duration
-	OK        bool
-	IsCanary  bool
-	RequestID string
+	Timestamp   time.Time
+	Agent       string
+	Tool        string
+	Path        string
+	Duration    time.Duration
+	OK          bool
+	IsCanary    bool
+	RequestID   string
+	FieldLength int // byte length of raw value before redaction; 0 for non-read tools
 }
 
 // Option configures an AnomalyDetector.
@@ -133,6 +135,17 @@ func WithStaleThreshold(days int) Option {
 	}
 }
 
+// WithToolChainWindow sets the time window for tool-chain detection.
+func WithToolChainWindow(dur time.Duration) Option {
+	return func(d *AnomalyDetector) { d.toolChainWindow = dur }
+}
+
+// WithToolChainFieldThreshold sets the minimum field length (in bytes) that
+// triggers tool-chain detection when followed by a command execution tool.
+func WithToolChainFieldThreshold(n int) Option {
+	return func(d *AnomalyDetector) { d.toolChainThreshold = n }
+}
+
 // WithAlertHook registers a callback invoked for every detected anomaly.
 // The hook receives a copy of the alert and runs in the same goroutine as Check.
 // Hooks must not block; they are called synchronously during Check.
@@ -152,6 +165,12 @@ const (
 	defaultOffHoursStart = 22 // 10 PM
 	defaultOffHoursEnd   = 6  // 6 AM
 	defaultStaleDays     = 90
+
+	defaultToolChainWindow = 30 * time.Second
+	// 500 bytes: passwords/tokens are typically <200 bytes; notes fields used
+	// for prompt-injection attacks are typically multi-paragraph (500-5000 bytes).
+	// Tunable via WithToolChainFieldThreshold for vaults with legitimately long fields.
+	defaultToolChainThreshold = 500
 )
 
 // AnomalyDetector maintains a sliding window of tool call events and applies
@@ -169,19 +188,24 @@ type AnomalyDetector struct {
 	offHoursEnd    int
 	staleDays      int
 	alertHooks     []func(AnomalyAlert)
+
+	toolChainWindow    time.Duration
+	toolChainThreshold int
 }
 
 // New creates a new AnomalyDetector with the given options.
 func New(opts ...Option) *AnomalyDetector {
 	d := &AnomalyDetector{
-		maxEvents:      defaultMaxEvents,
-		sweepWindow:    defaultSweepWindow,
-		sweepThreshold: defaultSweepThresh,
-		rateWindow:     defaultRateWindow,
-		rateLimit:      defaultRateLimit,
-		offHoursStart:  defaultOffHoursStart,
-		offHoursEnd:    defaultOffHoursEnd,
-		staleDays:      defaultStaleDays,
+		maxEvents:          defaultMaxEvents,
+		sweepWindow:        defaultSweepWindow,
+		sweepThreshold:     defaultSweepThresh,
+		rateWindow:         defaultRateWindow,
+		rateLimit:          defaultRateLimit,
+		offHoursStart:      defaultOffHoursStart,
+		offHoursEnd:        defaultOffHoursEnd,
+		staleDays:          defaultStaleDays,
+		toolChainWindow:    defaultToolChainWindow,
+		toolChainThreshold: defaultToolChainThreshold,
 	}
 	for _, opt := range opts {
 		opt(d)
@@ -241,6 +265,9 @@ func (d *AnomalyDetector) evaluate(event ToolCallEvent) []AnomalyAlert {
 		alerts = append(alerts, *alert)
 	}
 	if alert := d.detectRateAnomaly(event); alert != nil {
+		alerts = append(alerts, *alert)
+	}
+	if alert := d.detectToolChain(event); alert != nil {
 		alerts = append(alerts, *alert)
 	}
 

--- a/internal/anomaly/detector_test.go
+++ b/internal/anomaly/detector_test.go
@@ -447,6 +447,86 @@ func TestConcurrentAccess(t *testing.T) {
 	}
 }
 
+func TestDetectToolChain_FiresOnNotesRunCommand(t *testing.T) {
+	d := New(WithToolChainWindow(30*time.Second), WithToolChainFieldThreshold(500))
+	now := time.Now()
+	agentName := "claude"
+
+	e1 := ToolCallEvent{
+		Timestamp:   now,
+		Agent:       agentName,
+		Tool:        "get_entry_value",
+		Path:        "prod/db",
+		FieldLength: 600,
+		OK:          true,
+	}
+	if alert := d.Check(context.Background(), e1); alert != nil {
+		t.Errorf("unexpected alert on read event: %v", alert)
+	}
+
+	e2 := ToolCallEvent{
+		Timestamp: now.Add(5 * time.Second),
+		Agent:     agentName,
+		Tool:      "run_command",
+		OK:        true,
+	}
+	alert := d.Check(context.Background(), e2)
+	if alert == nil {
+		t.Fatal("expected tool-chain alert, got nil")
+	}
+	if alert.Type != AlertToolChain {
+		t.Errorf("alert type = %q, want %q", alert.Type, AlertToolChain)
+	}
+	if alert.Severity != SeverityHigh {
+		t.Errorf("severity = %v, want High", alert.Severity)
+	}
+}
+
+func TestDetectToolChain_NoFireBelowThreshold(t *testing.T) {
+	d := New(WithToolChainWindow(30*time.Second), WithToolChainFieldThreshold(500))
+	now := time.Now()
+
+	d.Check(context.Background(), ToolCallEvent{
+		Timestamp: now, Agent: "agent", Tool: "get_entry_value", FieldLength: 200, OK: true,
+	})
+	alert := d.Check(context.Background(), ToolCallEvent{
+		Timestamp: now.Add(2 * time.Second), Agent: "agent", Tool: "run_command", OK: true,
+	})
+	if alert != nil && alert.Type == AlertToolChain {
+		t.Error("should not alert when FieldLength < threshold")
+	}
+}
+
+func TestDetectToolChain_NoFireOutsideWindow(t *testing.T) {
+	d := New(WithToolChainWindow(30*time.Second), WithToolChainFieldThreshold(500))
+	now := time.Now()
+
+	d.Check(context.Background(), ToolCallEvent{
+		Timestamp: now, Agent: "agent", Tool: "get_entry_value", FieldLength: 800, OK: true,
+	})
+	alert := d.Check(context.Background(), ToolCallEvent{
+		Timestamp: now.Add(60 * time.Second), Agent: "agent", Tool: "run_command", OK: true,
+	})
+	if alert != nil && alert.Type == AlertToolChain {
+		t.Error("should not alert when read is outside tool-chain window")
+	}
+}
+
+func TestDetectToolChain_DifferentAgents(t *testing.T) {
+	d := New(WithToolChainWindow(30*time.Second), WithToolChainFieldThreshold(500))
+	now := time.Now()
+
+	d.Check(context.Background(), ToolCallEvent{
+		Timestamp: now, Agent: "agentA", Tool: "get_entry_value", FieldLength: 800, OK: true,
+	})
+	alert := d.Check(context.Background(), ToolCallEvent{
+		Timestamp: now.Add(2 * time.Second), Agent: "agentB", Tool: "run_command", OK: true,
+	})
+	if alert != nil && alert.Type == AlertToolChain {
+		t.Error("should not alert for different agents")
+	}
+}
+
 func TestStaleAccessRuleNotYetImplemented(t *testing.T) {
 	// Stale access detection requires entry metadata (created/updated timestamps).
 	// The detector currently uses ToolCallEvent which doesn't carry this info.

--- a/internal/anomaly/rules.go
+++ b/internal/anomaly/rules.go
@@ -112,6 +112,39 @@ func (d *AnomalyDetector) detectRateAnomaly(event ToolCallEvent) *AnomalyAlert {
 	return nil
 }
 
+// detectToolChain flags a tool-call chain where an agent reads a large field
+// (likely notes containing injected content) then immediately invokes a
+// command execution tool. This is the canonical prompt-injection exfiltration chain.
+func (d *AnomalyDetector) detectToolChain(event ToolCallEvent) *AnomalyAlert {
+	if event.Tool != "run_command" && event.Tool != "execute_with_secret" {
+		return nil
+	}
+	cutoff := event.Timestamp.Add(-d.toolChainWindow)
+	for i := len(d.events) - 1; i >= 0; i-- {
+		e := d.events[i]
+		if e.Timestamp.Before(cutoff) {
+			break
+		}
+		if e.Agent != event.Agent {
+			continue
+		}
+		if (e.Tool == "get_entry" || e.Tool == "get_entry_value") && e.FieldLength >= d.toolChainThreshold {
+			return &AnomalyAlert{
+				Type:     AlertToolChain,
+				Severity: SeverityHigh,
+				Description: "Tool-chain: agent " + event.Agent +
+					" read a large field (" + itoa(e.FieldLength) + " bytes) then invoked " + event.Tool,
+				Timestamp: event.Timestamp,
+				Agent:     event.Agent,
+				Path:      event.Path,
+				Tool:      event.Tool,
+				RequestID: event.RequestID,
+			}
+		}
+	}
+	return nil
+}
+
 // itoa is a fast integer to string conversion without importing strconv
 // in the hot path.
 func itoa(n int) string {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -311,6 +311,8 @@ func Load(path string) (*Config, error) {
 			if profile.RedactFields != nil {
 				current.RedactFields = append([]string(nil), profile.RedactFields...)
 			}
+			// PerToolRedactFields uses append semantics (unlike the scalar RedactFields replace)
+			// so that stacked profile overrides can each add per-tool patterns additively.
 			if profile.PerToolRedactFields != nil {
 				if current.PerToolRedactFields == nil {
 					current.PerToolRedactFields = make(map[string][]string, len(profile.PerToolRedactFields))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -80,6 +80,7 @@ type AgentProfile struct {
 	ApprovalMode        string              `yaml:"approvalMode"`
 	AllowedPaths        []string            `yaml:"allowedPaths"`
 	RedactFields        []string            `yaml:"redactFields,omitempty"`
+	PerToolRedactFields map[string][]string `yaml:"perToolRedactFields,omitempty"`
 	CanWrite            bool                `yaml:"canWrite"`
 	CanRunCommands      bool                `yaml:"canRunCommands,omitempty"`
 	CanManageConfig     bool                `yaml:"canManageConfig,omitempty"`
@@ -117,6 +118,7 @@ type fileAgentProfile struct {
 	ApprovalMode        *string             `yaml:"approvalMode,omitempty"`
 	AllowedPaths        []string            `yaml:"allowedPaths,omitempty"`
 	RedactFields        []string            `yaml:"redactFields,omitempty"`
+	PerToolRedactFields map[string][]string `yaml:"perToolRedactFields,omitempty"`
 	AllowedTools        []string            `yaml:"allowed_tools,omitempty"`
 	MaxReadsPerHour     *int                `yaml:"max_reads_per_hour,omitempty"`
 	MaxReadsPerDay      *int                `yaml:"max_reads_per_day,omitempty"`
@@ -131,6 +133,36 @@ type fileAgentProfile struct {
 
 type fileProfile struct {
 	VaultPath string `yaml:"vault,omitempty"`
+}
+
+// EffectiveRedactFields returns the merged, deduplicated list of redact field
+// patterns for toolName: global RedactFields always included, followed by any
+// per-tool additions from PerToolRedactFields[toolName].
+func (p *AgentProfile) EffectiveRedactFields(toolName string) []string {
+	if p == nil {
+		return nil
+	}
+	if len(p.RedactFields) == 0 && len(p.PerToolRedactFields[toolName]) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(p.RedactFields)+len(p.PerToolRedactFields[toolName]))
+	result := make([]string, 0, len(p.RedactFields)+len(p.PerToolRedactFields[toolName]))
+	for _, f := range p.RedactFields {
+		if _, ok := seen[f]; !ok {
+			seen[f] = struct{}{}
+			result = append(result, f)
+		}
+	}
+	for _, f := range p.PerToolRedactFields[toolName] {
+		if _, ok := seen[f]; !ok {
+			seen[f] = struct{}{}
+			result = append(result, f)
+		}
+	}
+	if len(result) == 0 {
+		return nil
+	}
+	return result
 }
 
 func Default() *Config {
@@ -278,6 +310,12 @@ func Load(path string) (*Config, error) {
 			}
 			if profile.RedactFields != nil {
 				current.RedactFields = append([]string(nil), profile.RedactFields...)
+			}
+			if profile.PerToolRedactFields != nil {
+				current.PerToolRedactFields = make(map[string][]string, len(profile.PerToolRedactFields))
+				for tool, fields := range profile.PerToolRedactFields {
+					current.PerToolRedactFields[tool] = append([]string(nil), fields...)
+				}
 			}
 			if profile.AllowedTools != nil {
 				current.AllowedTools = append([]string(nil), profile.AllowedTools...)
@@ -587,6 +625,12 @@ func buildFileAgents(agents map[string]AgentProfile) map[string]fileAgentProfile
 		}
 		if profile.RedactFields != nil {
 			fap.RedactFields = append([]string(nil), profile.RedactFields...)
+		}
+		if profile.PerToolRedactFields != nil {
+			fap.PerToolRedactFields = make(map[string][]string, len(profile.PerToolRedactFields))
+			for tool, fields := range profile.PerToolRedactFields {
+				fap.PerToolRedactFields[tool] = append([]string(nil), fields...)
+			}
 		}
 		if profile.AllowedTools != nil {
 			fap.AllowedTools = append([]string(nil), profile.AllowedTools...)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -312,9 +312,11 @@ func Load(path string) (*Config, error) {
 				current.RedactFields = append([]string(nil), profile.RedactFields...)
 			}
 			if profile.PerToolRedactFields != nil {
-				current.PerToolRedactFields = make(map[string][]string, len(profile.PerToolRedactFields))
+				if current.PerToolRedactFields == nil {
+					current.PerToolRedactFields = make(map[string][]string, len(profile.PerToolRedactFields))
+				}
 				for tool, fields := range profile.PerToolRedactFields {
-					current.PerToolRedactFields[tool] = append([]string(nil), fields...)
+					current.PerToolRedactFields[tool] = append(current.PerToolRedactFields[tool], fields...)
 				}
 			}
 			if profile.AllowedTools != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2362,56 +2362,39 @@ func TestLoadParsesPerToolRedactFields(t *testing.T) {
 }
 
 func TestPerToolRedactFieldsDeepMerge(t *testing.T) {
-	// Verify that the merge loop appends per-tool patterns rather than replacing
-	// the entire map. We exercise the exact branch in Load by setting up a YAML
-	// file whose agent name matches a builtin, then manually seeding that builtin
-	// with existing PerToolRedactFields before calling into the merge path.
-	//
-	// Because Load() starts from Default() (builtins have nil PerToolRedactFields),
-	// we replicate the merge logic directly here using the same code path to prove
-	// append semantics: if current already has patterns for a tool key, incoming
-	// patterns for that same key must be appended, not used to replace the map.
+	// Verify that loading a YAML with per-tool patterns actually works end-to-end,
+	// and that EffectiveRedactFields returns the combined union correctly after Load.
+	dir := t.TempDir()
+	content := `agents:
+  test:
+    allowedPaths: ["*"]
+    redactFields:
+      - totp.*
+    perToolRedactFields:
+      get_entry_value:
+        - password
+        - api_key
+`
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	agent := cfg.Agents["test"]
 
-	// Simulate: current agent already has a pattern for "get_entry_value".
-	current := AgentProfile{
-		Name: "test",
-		PerToolRedactFields: map[string][]string{
-			"get_entry_value": {"totp.*"},
-		},
+	// EffectiveRedactFields("get_entry_value") should return totp.*, password, api_key
+	got := agent.EffectiveRedactFields("get_entry_value")
+	if len(got) != 3 {
+		t.Fatalf("want 3 patterns, got %v", got)
 	}
 
-	// Incoming profile adds a second pattern for the same tool key plus a new key.
-	incoming := fileAgentProfile{
-		PerToolRedactFields: map[string][]string{
-			"get_entry_value": {"password"},
-			"get_entry":       {"api_key"},
-		},
-	}
-
-	// Apply the merge (mirrors the fixed code in Load).
-	if incoming.PerToolRedactFields != nil {
-		if current.PerToolRedactFields == nil {
-			current.PerToolRedactFields = make(map[string][]string, len(incoming.PerToolRedactFields))
-		}
-		for tool, fields := range incoming.PerToolRedactFields {
-			current.PerToolRedactFields[tool] = append(current.PerToolRedactFields[tool], fields...)
-		}
-	}
-
-	// "get_entry_value" must contain both the pre-existing "totp.*" AND the new "password".
-	got := current.PerToolRedactFields["get_entry_value"]
-	if len(got) != 2 {
-		t.Errorf("get_entry_value: want 2 patterns after merge, got %v", got)
-	} else {
-		if got[0] != "totp.*" || got[1] != "password" {
-			t.Errorf("get_entry_value: want [totp.* password], got %v", got)
-		}
-	}
-
-	// "get_entry" was not present before; it should be set from the incoming profile.
-	got = current.PerToolRedactFields["get_entry"]
-	if len(got) != 1 || got[0] != "api_key" {
-		t.Errorf("get_entry: want [api_key], got %v", got)
+	// EffectiveRedactFields("list_entries") should return only the global pattern
+	global := agent.EffectiveRedactFields("list_entries")
+	if len(global) != 1 || global[0] != "totp.*" {
+		t.Errorf("list_entries: want [totp.*], got %v", global)
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2279,3 +2279,111 @@ func TestLoad_ExposeValueToolsExplicitOverridesTier(t *testing.T) {
 		t.Error("ExposeValueTools should be true (explicit override of standard preset)")
 	}
 }
+
+func TestEffectiveRedactFields(t *testing.T) {
+	p := AgentProfile{
+		RedactFields: []string{"totp.*"},
+		PerToolRedactFields: map[string][]string{
+			"get_entry_value": {"password"},
+		},
+	}
+
+	// Global patterns always included
+	got := p.EffectiveRedactFields("get_entry_value")
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2; got %v", len(got), got)
+	}
+
+	// Tool with no per-tool config — only global
+	got = p.EffectiveRedactFields("list_entries")
+	if len(got) != 1 || got[0] != "totp.*" {
+		t.Errorf("list_entries = %v, want [totp.*]", got)
+	}
+
+	// Dedup: same pattern in both global and per-tool
+	p2 := AgentProfile{
+		RedactFields: []string{"password"},
+		PerToolRedactFields: map[string][]string{
+			"get_entry_value": {"password", "api_key"},
+		},
+	}
+	got = p2.EffectiveRedactFields("get_entry_value")
+	// Should be ["password", "api_key"] — no duplicate password
+	if len(got) != 2 {
+		t.Errorf("dedup: len = %d, want 2; got %v", len(got), got)
+	}
+
+	// Nil profile — nil result
+	var nilProfile *AgentProfile
+	if nilProfile.EffectiveRedactFields("x") != nil {
+		t.Error("nil profile should return nil")
+	}
+
+	// Empty profile — nil result
+	empty := AgentProfile{}
+	if empty.EffectiveRedactFields("x") != nil {
+		t.Error("empty profile should return nil")
+	}
+}
+
+func TestLoadParsesPerToolRedactFields(t *testing.T) {
+	dir := t.TempDir()
+	content := `agents:
+  restricted:
+    allowedPaths: ["*"]
+    canWrite: false
+    redactFields:
+      - totp.*
+    perToolRedactFields:
+      get_entry_value:
+        - password
+      get_entry:
+        - password
+        - api_key
+`
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	agent := cfg.Agents["restricted"]
+	if len(agent.PerToolRedactFields) != 2 {
+		t.Fatalf("PerToolRedactFields len = %d, want 2", len(agent.PerToolRedactFields))
+	}
+	if len(agent.PerToolRedactFields["get_entry_value"]) != 1 || agent.PerToolRedactFields["get_entry_value"][0] != "password" {
+		t.Errorf("get_entry_value = %v", agent.PerToolRedactFields["get_entry_value"])
+	}
+	if len(agent.PerToolRedactFields["get_entry"]) != 2 {
+		t.Errorf("get_entry = %v", agent.PerToolRedactFields["get_entry"])
+	}
+}
+
+func TestSaveRoundTripsPerToolRedactFields(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	cfg := &Config{
+		VaultDir: dir,
+		Agents: map[string]AgentProfile{
+			"test": {
+				AllowedPaths: []string{"*"},
+				PerToolRedactFields: map[string][]string{
+					"get_entry_value": {"password"},
+				},
+			},
+		},
+	}
+	if err := cfg.SaveTo(path); err != nil {
+		t.Fatalf("SaveTo: %v", err)
+	}
+	loaded, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	got := loaded.Agents["test"].PerToolRedactFields["get_entry_value"]
+	if len(got) != 1 || got[0] != "password" {
+		t.Errorf("round-trip: got %v", got)
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2361,6 +2361,60 @@ func TestLoadParsesPerToolRedactFields(t *testing.T) {
 	}
 }
 
+func TestPerToolRedactFieldsDeepMerge(t *testing.T) {
+	// Verify that the merge loop appends per-tool patterns rather than replacing
+	// the entire map. We exercise the exact branch in Load by setting up a YAML
+	// file whose agent name matches a builtin, then manually seeding that builtin
+	// with existing PerToolRedactFields before calling into the merge path.
+	//
+	// Because Load() starts from Default() (builtins have nil PerToolRedactFields),
+	// we replicate the merge logic directly here using the same code path to prove
+	// append semantics: if current already has patterns for a tool key, incoming
+	// patterns for that same key must be appended, not used to replace the map.
+
+	// Simulate: current agent already has a pattern for "get_entry_value".
+	current := AgentProfile{
+		Name: "test",
+		PerToolRedactFields: map[string][]string{
+			"get_entry_value": {"totp.*"},
+		},
+	}
+
+	// Incoming profile adds a second pattern for the same tool key plus a new key.
+	incoming := fileAgentProfile{
+		PerToolRedactFields: map[string][]string{
+			"get_entry_value": {"password"},
+			"get_entry":       {"api_key"},
+		},
+	}
+
+	// Apply the merge (mirrors the fixed code in Load).
+	if incoming.PerToolRedactFields != nil {
+		if current.PerToolRedactFields == nil {
+			current.PerToolRedactFields = make(map[string][]string, len(incoming.PerToolRedactFields))
+		}
+		for tool, fields := range incoming.PerToolRedactFields {
+			current.PerToolRedactFields[tool] = append(current.PerToolRedactFields[tool], fields...)
+		}
+	}
+
+	// "get_entry_value" must contain both the pre-existing "totp.*" AND the new "password".
+	got := current.PerToolRedactFields["get_entry_value"]
+	if len(got) != 2 {
+		t.Errorf("get_entry_value: want 2 patterns after merge, got %v", got)
+	} else {
+		if got[0] != "totp.*" || got[1] != "password" {
+			t.Errorf("get_entry_value: want [totp.* password], got %v", got)
+		}
+	}
+
+	// "get_entry" was not present before; it should be set from the incoming profile.
+	got = current.PerToolRedactFields["get_entry"]
+	if len(got) != 1 || got[0] != "api_key" {
+		t.Errorf("get_entry: want [api_key], got %v", got)
+	}
+}
+
 func TestSaveRoundTripsPerToolRedactFields(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.yaml")

--- a/internal/mcp/server_authorize.go
+++ b/internal/mcp/server_authorize.go
@@ -270,6 +270,8 @@ func (s *Server) requiresApproval() bool {
 	}
 }
 
+// shouldRedactField checks global redactFields only. Per-tool redaction is
+// applied post-dispatch in the tool handlers via EffectiveRedactFields.
 func (s *Server) shouldRedactField(field string) bool {
 	if s == nil || s.agent == nil || s.agent.RedactFields == nil {
 		return false

--- a/internal/mcp/server_dispatch.go
+++ b/internal/mcp/server_dispatch.go
@@ -114,6 +114,22 @@ func (s *Server) executeTool(ctx context.Context, name string, args json.RawMess
 		token.UpdateLastUsed()
 	}
 
+	// Registry drift check: reject if binary was updated since this token was issued.
+	// Returns a user-visible tool error (not a protocol error) so the agent sees
+	// a descriptive message. Pattern: return callToolResultPayload(...), nil
+	// (contrast with the scope check above which returns nil, fmt.Errorf — a protocol error).
+	if token, ok := TokenFromContext(ctx); ok && token != nil {
+		if token.IsToolRegistryDriftDetected() {
+			span.SetStatus(codes.Error, "tool registry drift")
+			metrics.RecordMCPRequest(name, agentName, "error", time.Since(start))
+			s.logAudit(ctx, "tool_registry_drift", name, false)
+			return callToolResultPayload(toolError(
+				"tool registry has changed since this token was issued — " +
+					"re-issue the token with 'openpass mcp token create'",
+			)), nil
+		}
+	}
+
 	// Evaluate declarative policies before tool execution
 	if entryPath != "" {
 		if policyErr := s.checkPolicy(ctx, entryPath, toolActionType(name)); policyErr != nil {

--- a/internal/mcp/server_dispatch.go
+++ b/internal/mcp/server_dispatch.go
@@ -173,7 +173,7 @@ func (s *Server) executeTool(ctx context.Context, name string, args json.RawMess
 		span.SetAttributes(attribute.String("status", "error"))
 		metrics.RecordMCPRequest(name, agentName, "error", duration)
 		// Fire-and-forget anomaly detection (non-blocking)
-		s.detectAnomalyAsync(ctx, name, entryPath, reqID, agentName, duration, false)
+		s.detectAnomalyAsync(ctx, name, entryPath, reqID, agentName, duration, false, 0)
 		return nil, err
 	}
 
@@ -185,8 +185,14 @@ func (s *Server) executeTool(ctx context.Context, name string, args json.RawMess
 	span.SetAttributes(attribute.String("status", status))
 	metrics.RecordMCPRequest(name, agentName, status, duration)
 
+	// Compute field length for anomaly detection (read tools only)
+	fieldLength := 0
+	if !result.IsError && (name == "get_entry" || name == "get_entry_value") {
+		fieldLength = len(result.Text)
+	}
+
 	// Fire-and-forget anomaly detection (non-blocking)
-	s.detectAnomalyAsync(ctx, name, entryPath, reqID, agentName, duration, true)
+	s.detectAnomalyAsync(ctx, name, entryPath, reqID, agentName, duration, true, fieldLength)
 
 	return callToolResultPayload(result), nil
 }
@@ -194,7 +200,7 @@ func (s *Server) executeTool(ctx context.Context, name string, args json.RawMess
 // detectAnomalyAsync runs anomaly detection in a separate goroutine so it
 // NEVER blocks tool execution. It checks all detection patterns and handles
 // any alerts that are generated (logging, notifications, cache invalidation).
-func (s *Server) detectAnomalyAsync(_ context.Context, toolName, entryPath, reqID, agentName string, duration time.Duration, ok bool) {
+func (s *Server) detectAnomalyAsync(_ context.Context, toolName, entryPath, reqID, agentName string, duration time.Duration, ok bool, fieldLength int) {
 	if s == nil || s.anomalyDetector == nil {
 		return
 	}
@@ -204,14 +210,15 @@ func (s *Server) detectAnomalyAsync(_ context.Context, toolName, entryPath, reqI
 
 	go func() {
 		event := anomaly.ToolCallEvent{
-			Timestamp: time.Now(),
-			Agent:     agentName,
-			Tool:      toolName,
-			Path:      entryPath,
-			Duration:  duration,
-			OK:        ok,
-			IsCanary:  entryPath != "" && vault.IsCanaryPath(entryPath),
-			RequestID: reqID,
+			Timestamp:   time.Now(),
+			Agent:       agentName,
+			Tool:        toolName,
+			Path:        entryPath,
+			Duration:    duration,
+			OK:          ok,
+			IsCanary:    entryPath != "" && vault.IsCanaryPath(entryPath),
+			RequestID:   reqID,
+			FieldLength: fieldLength,
 		}
 
 		alert := s.anomalyDetector.Check(context.Background(), event)

--- a/internal/mcp/token.go
+++ b/internal/mcp/token.go
@@ -32,6 +32,7 @@ type TokenRegistryEntry struct {
 	Hash             string     `json:"hash"`
 	Prefix           string     `json:"prefix"`
 	AllowedTools     []string   `json:"allowed_tools"`
+	ToolRegistryHash string     `json:"tool_registry_hash,omitempty"`
 	AgentName        string     `json:"agent_name,omitempty"`
 	CreatedAt        time.Time  `json:"created_at"`
 	ExpiresAt        *time.Time `json:"expires_at,omitempty"`
@@ -50,6 +51,7 @@ type ScopedToken struct {
 	Hash             string     `json:"hash"`
 	Prefix           string     `json:"prefix"`
 	AllowedTools     []string   `json:"allowed_tools"`
+	ToolRegistryHash string     `json:"tool_registry_hash,omitempty"`
 	AgentName        string     `json:"agent_name,omitempty"`
 	CreatedAt        time.Time  `json:"created_at"`
 	ExpiresAt        *time.Time `json:"expires_at,omitempty"`
@@ -104,6 +106,16 @@ func (t *ScopedToken) IsToolAllowed(toolName string) bool {
 	return false
 }
 
+// IsToolRegistryDriftDetected returns true if the token was issued against a
+// tool registry that no longer matches the current binary. Returns false for
+// legacy tokens (empty hash) to preserve backward compatibility.
+func (t *ScopedToken) IsToolRegistryDriftDetected() bool {
+	if t == nil || t.ToolRegistryHash == "" {
+		return false
+	}
+	return t.ToolRegistryHash != ComputeToolRegistryHash()
+}
+
 // UpdateLastUsed sets the LastUsedAt timestamp to the current time.
 func (t *ScopedToken) UpdateLastUsed() {
 	if t == nil {
@@ -127,6 +139,7 @@ func (t *ScopedToken) toEntry() TokenRegistryEntry {
 		Hash:             t.Hash,
 		Prefix:           t.Prefix,
 		AllowedTools:     t.AllowedTools,
+		ToolRegistryHash: t.ToolRegistryHash,
 		AgentName:        t.AgentName,
 		CreatedAt:        t.CreatedAt,
 		ExpiresAt:        t.ExpiresAt,
@@ -150,6 +163,7 @@ func entryToScopedToken(e TokenRegistryEntry) *ScopedToken {
 		Hash:             e.Hash,
 		Prefix:           e.Prefix,
 		AllowedTools:     allowed,
+		ToolRegistryHash: e.ToolRegistryHash,
 		AgentName:        e.AgentName,
 		CreatedAt:        e.CreatedAt,
 		ExpiresAt:        e.ExpiresAt,
@@ -260,14 +274,15 @@ func (r *TokenRegistry) Create(label string, allowedTools []string, agentName st
 
 	createdAt := time.Now().UTC()
 	t := &ScopedToken{
-		ID:           id,
-		Label:        label,
-		Hash:         hash,
-		Prefix:       prefix,
-		AllowedTools: allowedTools,
-		AgentName:    agentName,
-		CreatedAt:    createdAt,
-		ExpiresAt:    expiresAt,
+		ID:               id,
+		Label:            label,
+		Hash:             hash,
+		Prefix:           prefix,
+		AllowedTools:     allowedTools,
+		ToolRegistryHash: ComputeToolRegistryHash(),
+		AgentName:        agentName,
+		CreatedAt:        createdAt,
+		ExpiresAt:        expiresAt,
 	}
 
 	r.mu.Lock()
@@ -377,6 +392,7 @@ func (r *TokenRegistry) CreateWithRefresh(label string, allowedTools []string, a
 		Hash:             accessHash,
 		Prefix:           prefix,
 		AllowedTools:     allowedTools,
+		ToolRegistryHash: ComputeToolRegistryHash(),
 		AgentName:        agentName,
 		CreatedAt:        createdAt,
 		ExpiresAt:        expiresAt,

--- a/internal/mcp/token_test.go
+++ b/internal/mcp/token_test.go
@@ -1247,3 +1247,62 @@ func TestTokenRegistry_FileWatcherHandlesMissingFile(t *testing.T) {
 		t.Error("file watcher should have loaded tokens after file creation")
 	}
 }
+
+func TestComputeToolRegistryHashStable(t *testing.T) {
+	h1 := ComputeToolRegistryHash()
+	h2 := ComputeToolRegistryHash()
+	if h1 != h2 {
+		t.Errorf("hash not stable: %q vs %q", h1, h2)
+	}
+	if len(h1) != 64 { // SHA-256 hex = 64 chars
+		t.Errorf("unexpected hash length: %d", len(h1))
+	}
+}
+
+func TestTokenRegistryHashStoredOnCreate(t *testing.T) {
+	dir := t.TempDir()
+	reg := NewTokenRegistry(filepath.Join(dir, "tokens.json"))
+	tok, _, err := reg.Create("test", []string{"*"}, "agent", 0)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if tok.ToolRegistryHash == "" {
+		t.Error("ToolRegistryHash should be set on created token")
+	}
+	if tok.ToolRegistryHash != ComputeToolRegistryHash() {
+		t.Errorf("hash mismatch: token=%q, current=%q", tok.ToolRegistryHash, ComputeToolRegistryHash())
+	}
+}
+
+func TestTokenRegistryHashStoredOnCreateWithRefresh(t *testing.T) {
+	dir := t.TempDir()
+	reg := NewTokenRegistry(filepath.Join(dir, "tokens.json"))
+	tok, _, _, err := reg.CreateWithRefresh("test", []string{"*"}, "agent", time.Hour, time.Hour)
+	if err != nil {
+		t.Fatalf("CreateWithRefresh: %v", err)
+	}
+	if tok.ToolRegistryHash != ComputeToolRegistryHash() {
+		t.Errorf("hash not set on CreateWithRefresh token")
+	}
+}
+
+func TestTokenLegacyNoHashSkipsCheck(t *testing.T) {
+	tok := &ScopedToken{
+		ID:               "tok-test",
+		Hash:             "abc",
+		AllowedTools:     []string{"*"},
+		ToolRegistryHash: "", // legacy token
+	}
+	if tok.IsToolRegistryDriftDetected() {
+		t.Error("legacy token (no hash) should not report drift")
+	}
+}
+
+func TestTokenDriftDetected(t *testing.T) {
+	tok := &ScopedToken{
+		ToolRegistryHash: "stale-hash-does-not-match",
+	}
+	if !tok.IsToolRegistryDriftDetected() {
+		t.Error("stale hash should report drift")
+	}
+}

--- a/internal/mcp/token_test.go
+++ b/internal/mcp/token_test.go
@@ -1306,3 +1306,10 @@ func TestTokenDriftDetected(t *testing.T) {
 		t.Error("stale hash should report drift")
 	}
 }
+
+func TestIsToolRegistryDriftDetectedNilSafe(t *testing.T) {
+	var tok *ScopedToken
+	if tok.IsToolRegistryDriftDetected() {
+		t.Error("nil token should not report drift")
+	}
+}

--- a/internal/mcp/tool_registry.go
+++ b/internal/mcp/tool_registry.go
@@ -2,7 +2,11 @@ package mcp
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
+	"fmt"
+	"sort"
 
 	"github.com/danieljustus/OpenPass/internal/config"
 )
@@ -453,6 +457,20 @@ func decodeToolRequest(args json.RawMessage) (CallToolRequest, error) {
 		req.Arguments = map[string]any{}
 	}
 	return req, nil
+}
+
+// ComputeToolRegistryHash returns a SHA-256 hex digest of the full static tool
+// registry (all entries from toolDefinitions(), sorted by name). Covers name,
+// description, and input schema so any injection-relevant change is detected.
+func ComputeToolRegistryHash() string {
+	defs := toolDefinitions()
+	sort.Slice(defs, func(i, j int) bool { return defs[i].Name < defs[j].Name })
+	h := sha256.New()
+	for _, def := range defs {
+		schemaJSON, _ := json.Marshal(def.InputSchema) // stable: encoding/json sorts map keys
+		_, _ = fmt.Fprintf(h, "%s|%s|%s\n", def.Name, def.Description, schemaJSON)
+	}
+	return hex.EncodeToString(h.Sum(nil))
 }
 
 // resolveToolAlias looks up a tool by name and returns its canonical name if

--- a/internal/mcp/tool_registry.go
+++ b/internal/mcp/tool_registry.go
@@ -467,7 +467,11 @@ func ComputeToolRegistryHash() string {
 	sort.Slice(defs, func(i, j int) bool { return defs[i].Name < defs[j].Name })
 	h := sha256.New()
 	for _, def := range defs {
-		schemaJSON, _ := json.Marshal(def.InputSchema) // stable: encoding/json sorts map keys
+		schemaJSON, err := json.Marshal(def.InputSchema) // stable: encoding/json sorts map keys
+		if err != nil {
+			// unreachable: InputSchema is always a plain map[string]any from static definitions
+			schemaJSON = []byte("{}")
+		}
 		_, _ = fmt.Fprintf(h, "%s|%s|%s\n", def.Name, def.Description, schemaJSON)
 	}
 	return hex.EncodeToString(h.Sum(nil))

--- a/internal/mcp/tools_find.go
+++ b/internal/mcp/tools_find.go
@@ -50,9 +50,9 @@ func (s *Server) findEntries(ctx context.Context, query string) ([]vault.Match, 
 		workers = s.vault.Config.Vault.SearchWorkers
 	}
 
-	redactPatterns := []string{}
-	if s.agent != nil && s.agent.RedactFields != nil {
-		redactPatterns = s.agent.RedactFields
+	var redactPatterns []string
+	if s.agent != nil {
+		redactPatterns = s.agent.EffectiveRedactFields("find_entries")
 	}
 
 	return svc.Find(query, vault.FindOptions{

--- a/internal/mcp/tools_find_test.go
+++ b/internal/mcp/tools_find_test.go
@@ -219,6 +219,110 @@ func TestFindEntries_ListFails(t *testing.T) {
 	}
 }
 
+// TestFindPerToolRedact verifies that PerToolRedactFields["find_entries"]
+// is applied when handleFind is called. A query matching a redacted field
+// must not surface that field in Match.Fields, while non-redacted fields
+// that match continue to appear normally.
+func TestFindPerToolRedact(t *testing.T) {
+	vaultDir, identity := mockVault(t)
+
+	// Override the github entry with a password value we can search for
+	entry := &vault.Entry{
+		Data: map[string]any{
+			"password": "s3cr3tpass",
+			"username": "alice",
+		},
+	}
+	if err := vault.WriteEntry(vaultDir, "github", entry, identity); err != nil {
+		t.Fatalf("WriteEntry: %v", err)
+	}
+
+	srv := &Server{
+		vault: &vault.Vault{
+			Dir:      vaultDir,
+			Identity: identity,
+		},
+		agent: &config.AgentProfile{
+			Name:         "restricted",
+			AllowedPaths: []string{"*"},
+			CanWrite:     false,
+			ApprovalMode: "none",
+			PerToolRedactFields: map[string][]string{
+				"find_entries": {"password"},
+			},
+		},
+		hookRegistry: NewHookRegistry(),
+	}
+
+	// Query that matches the password value — should not appear in Fields
+	req := CallToolRequest{
+		Arguments: map[string]any{"query": "s3cr3tpass"},
+	}
+
+	result, err := srv.handleFind(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleFind() error = %v", err)
+	}
+	if result == nil {
+		t.Fatal("handleFind() returned nil result")
+	}
+	if result.IsError {
+		t.Fatalf("handleFind() returned error: %s", result.Text)
+	}
+
+	var matches []vault.Match
+	if parseErr := json.Unmarshal([]byte(result.Text), &matches); parseErr != nil {
+		t.Fatalf("parse result: %v", parseErr)
+	}
+
+	// The password value matches the query but password is redacted — no match
+	// should be returned for the github entry via that field.
+	for _, m := range matches {
+		if m.Path == "github" {
+			for _, f := range m.Fields {
+				if f == "password" {
+					t.Errorf("password field should be redacted from find_entries results, but got field %q", f)
+				}
+			}
+		}
+	}
+
+	// Now query for a value in the non-redacted username field — must appear
+	req2 := CallToolRequest{
+		Arguments: map[string]any{"query": "alice"},
+	}
+
+	result2, err := srv.handleFind(context.Background(), req2)
+	if err != nil {
+		t.Fatalf("handleFind() second call error = %v", err)
+	}
+	if result2 == nil {
+		t.Fatal("handleFind() second call returned nil result")
+	}
+	if result2.IsError {
+		t.Fatalf("handleFind() second call returned error: %s", result2.Text)
+	}
+
+	var matches2 []vault.Match
+	if parseErr := json.Unmarshal([]byte(result2.Text), &matches2); parseErr != nil {
+		t.Fatalf("parse second result: %v", parseErr)
+	}
+
+	found := false
+	for _, m := range matches2 {
+		if m.Path == "github" {
+			for _, f := range m.Fields {
+				if f == "username" {
+					found = true
+				}
+			}
+		}
+	}
+	if !found {
+		t.Error("username field should NOT be redacted and should appear in find_entries results")
+	}
+}
+
 func TestCollectFieldMatches(t *testing.T) {
 	tests := []struct {
 		data     map[string]any

--- a/internal/mcp/tools_get.go
+++ b/internal/mcp/tools_get.go
@@ -130,8 +130,10 @@ func (s *Server) handleGetValue(ctx context.Context, req CallToolRequest) (*Call
 		return vaultServiceErrorResult(err)
 	}
 
-	if s.agent != nil && s.agent.RedactFields != nil && len(s.agent.RedactFields) > 0 {
-		entry = redactEntry(entry, s.agent.RedactFields)
+	if s.agent != nil {
+		if patterns := s.agent.EffectiveRedactFields("get_entry_value"); len(patterns) > 0 {
+			entry = redactEntry(entry, patterns)
+		}
 	}
 
 	// Sanitize tags to prevent prompt injection via tag metadata.

--- a/internal/mcp/tools_get.go
+++ b/internal/mcp/tools_get.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	gopath "path"
+	"strings"
 	"time"
 
 	errorspkg "github.com/danieljustus/OpenPass/internal/errors"
@@ -108,6 +110,17 @@ func (s *Server) handleGetValue(ctx context.Context, req CallToolRequest) (*Call
 		s.logAudit(ctx, "get_value", path, false)
 		metrics.RecordAuthDenial("scope_denied", s.agent.Name)
 		return nil, fmt.Errorf("access denied: path %q outside allowed scope", path)
+	}
+
+	// Block value access for quarantined entries. Normalize path first to prevent
+	// traversal bypasses (e.g., "quarantine/../secrets/foo" normalizes to
+	// "secrets/foo", correctly bypassing the check — that path is not quarantined).
+	{
+		cleanedPath := gopath.Clean(path)
+		if cleanedPath == "quarantine" || strings.HasPrefix(cleanedPath, "quarantine/") {
+			s.logAudit(ctx, "quarantine_block", path, false)
+			return NewToolResultError("entry is in quarantine — run 'openpass import review promote' to make it accessible"), nil
+		}
 	}
 
 	if !s.canReadValues() {

--- a/internal/mcp/tools_get_test.go
+++ b/internal/mcp/tools_get_test.go
@@ -770,11 +770,11 @@ func TestGetValuePerToolRedact(t *testing.T) {
 			Identity: identity,
 		},
 		agent: &config.AgentProfile{
-			Name:         "restricted",
-			AllowedPaths: []string{"*"},
+			Name:          "restricted",
+			AllowedPaths:  []string{"*"},
 			CanReadValues: true,
-			ApprovalMode: "none",
-			AutoUnseal:   true,
+			ApprovalMode:  "none",
+			AutoUnseal:    true,
 			PerToolRedactFields: map[string][]string{
 				"get_entry_value": {"password"},
 			},

--- a/internal/mcp/tools_get_test.go
+++ b/internal/mcp/tools_get_test.go
@@ -812,6 +812,58 @@ func TestGetValuePerToolRedact(t *testing.T) {
 	}
 }
 
+// TestGetValueBlocksQuarantinedPath verifies that handleGetValue returns an
+// error for any path inside the "quarantine/" namespace, preventing agents
+// from reading raw secret values of imported-but-unreviewed entries.
+func TestGetValueBlocksQuarantinedPath(t *testing.T) {
+	vaultDir, identity := mockVault(t)
+
+	// Write an entry under quarantine/ so the vault lookup would succeed
+	// if the quarantine check were not in place.
+	qEntry := &vault.Entry{
+		Data: map[string]any{
+			"password": "s3cr3t",
+		},
+	}
+	quarantinePath := "quarantine/import-20260517-ab12cd34/github.com"
+	if err := vault.WriteEntry(vaultDir, quarantinePath, qEntry, identity); err != nil {
+		t.Fatalf("WriteEntry quarantine: %v", err)
+	}
+
+	srv := &Server{
+		vault: &vault.Vault{
+			Dir:      vaultDir,
+			Identity: identity,
+		},
+		agent: &config.AgentProfile{
+			Name:          "test",
+			AllowedPaths:  []string{"*"},
+			CanReadValues: true,
+			ApprovalMode:  "none",
+			AutoUnseal:    true,
+		},
+		hookRegistry: NewHookRegistry(),
+	}
+
+	req := CallToolRequest{
+		Arguments: map[string]any{"path": quarantinePath},
+	}
+
+	result, err := srv.handleGetValue(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleGetValue() unexpected hard error = %v", err)
+	}
+	if result == nil {
+		t.Fatal("handleGetValue() returned nil result")
+	}
+	if !result.IsError {
+		t.Fatalf("handleGetValue() expected error result for quarantined path, got success: %s", result.Text)
+	}
+	if !strings.Contains(result.Text, "quarantine") {
+		t.Errorf("error text should mention 'quarantine', got: %q", result.Text)
+	}
+}
+
 // F-1: buildSecretMetadataResponse must expose tags and route each tag
 // through the MCP sanitizer. Tags are user-controlled vault metadata
 // that become part of the JSON returned to the LLM by get_entry and

--- a/internal/mcp/tools_get_test.go
+++ b/internal/mcp/tools_get_test.go
@@ -729,6 +729,89 @@ func hasField(slice []any, targetName string) bool {
 	return false
 }
 
+// TestEffectiveRedactFieldsIntegration verifies that EffectiveRedactFields
+// integrates correctly with the config layer — per-tool patterns are returned
+// for the named tool and nil is returned when no patterns are configured.
+func TestEffectiveRedactFieldsIntegration(t *testing.T) {
+	profile := &config.AgentProfile{
+		PerToolRedactFields: map[string][]string{
+			"get_entry_value": {"password"},
+		},
+	}
+	got := profile.EffectiveRedactFields("get_entry_value")
+	if len(got) != 1 || got[0] != "password" {
+		t.Errorf("want [password], got %v", got)
+	}
+	// For list_entries (no per-tool), should return nil
+	if profile.EffectiveRedactFields("list_entries") != nil {
+		t.Error("expected nil for tool with no patterns")
+	}
+}
+
+// TestGetValuePerToolRedact verifies that PerToolRedactFields["get_entry_value"]
+// is applied when handleGetValue is called, redacting the configured field.
+func TestGetValuePerToolRedact(t *testing.T) {
+	vaultDir, identity := mockVault(t)
+
+	// Write a vault entry with password + username
+	entry := &vault.Entry{
+		Data: map[string]any{
+			"password": "s3cr3t",
+			"username": "alice",
+		},
+	}
+	if err := vault.WriteEntry(vaultDir, "github", entry, identity); err != nil {
+		t.Fatalf("WriteEntry: %v", err)
+	}
+
+	srv := &Server{
+		vault: &vault.Vault{
+			Dir:      vaultDir,
+			Identity: identity,
+		},
+		agent: &config.AgentProfile{
+			Name:         "restricted",
+			AllowedPaths: []string{"*"},
+			CanReadValues: true,
+			ApprovalMode: "none",
+			AutoUnseal:   true,
+			PerToolRedactFields: map[string][]string{
+				"get_entry_value": {"password"},
+			},
+		},
+		hookRegistry: NewHookRegistry(),
+	}
+
+	req := CallToolRequest{
+		Arguments: map[string]any{"path": "github"},
+	}
+
+	result, err := srv.handleGetValue(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleGetValue() error = %v", err)
+	}
+	if result == nil {
+		t.Fatal("handleGetValue() returned nil result")
+	}
+	if result.IsError {
+		t.Fatalf("handleGetValue() returned error: %s", result.Text)
+	}
+
+	var resp vault.Entry
+	if parseErr := json.Unmarshal([]byte(result.Text), &resp); parseErr != nil {
+		t.Fatalf("parse result: %v", parseErr)
+	}
+
+	pwVal, _ := resp.Data["password"].(string)
+	if !strings.Contains(pwVal, "[REDACTED]") {
+		t.Errorf("password should be redacted, got %q", pwVal)
+	}
+	usernameVal, _ := resp.Data["username"].(string)
+	if strings.Contains(usernameVal, "[REDACTED]") {
+		t.Errorf("username should NOT be redacted, got %q", usernameVal)
+	}
+}
+
 // F-1: buildSecretMetadataResponse must expose tags and route each tag
 // through the MCP sanitizer. Tags are user-controlled vault metadata
 // that become part of the JSON returned to the LLM by get_entry and


### PR DESCRIPTION
## Summary

Four independent audit hardening features from the backlog, plus closing one won't-implement.

- **#91 — Per-tool redactFields**: Added `PerToolRedactFields map[string][]string` to `AgentProfile` and `EffectiveRedactFields(toolName)` method returning the additive union of global + per-tool patterns. Updated `handleGetValue`, `handleFind`, and related call sites. Config deep-merges per-tool pattern slices across profile overrides.

- **#94 — Tool-registry integrity hash**: `ComputeToolRegistryHash()` computes a SHA-256 over all tool definitions (name + description + inputSchema, sorted). Hash is stored in `ScopedToken` at creation. `executeTool` checks `IsToolRegistryDriftDetected()` before dispatch and returns a descriptive tool-level error if the binary has been updated since the token was issued. Legacy tokens (no hash) are unaffected.

- **#92 — Tool-chain anomaly rule**: `detectToolChain` fires when an agent reads a large field (≥ 500 bytes, tunable) and then invokes `run_command` or `execute_with_secret` within 30 seconds. Guards the classic prompt-injection exfiltration chain. `FieldLength` added to `ToolCallEvent`; populated from `result.Text` length in the MCP dispatch path.

- **#93 — Import quarantine**: `openpass import <fmt> <file> --quarantine` routes entries to `quarantine/<import-id>/` vault prefix. `openpass import review list` shows pending batches. `openpass import review promote <id>` moves entries to their final paths with `--overwrite` support and best-effort partial failure handling. `get_entry_value` in the MCP server blocks quarantined paths (metadata access via `get_entry`/`list_entries` is unaffected).

- **#78 — Two-tier daemon**: Closed as won't implement. Single-user local tool; same-OS-user attacker already has socket access.

## Test plan

- [ ] `go test ./internal/config/...` — EffectiveRedactFields, deep-merge, round-trip (4 new tests)
- [ ] `go test ./internal/mcp/...` — per-tool redact, registry hash stability, drift detection, quarantine block (8 new tests)
- [ ] `go test ./internal/anomaly/...` — tool-chain fires, threshold, window, agent isolation (4 new tests)
- [ ] `go test ./cmd/... -run TestImport` — quarantine flag, review list/promote, overwrite (8 new tests)
- [ ] `go build ./...` — clean build
- [ ] `go vet ./...` — clean vet
- [ ] `internal/audit` timeout is pre-existing macOS keyring issue, unrelated to this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)