### PR TITLE
Session 2026-05-18: batch issue fixes

### DIFF
--- a/.github/workflows/deferred-deps-check.yml
+++ b/.github/workflows/deferred-deps-check.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: '1.26.3'
           cache: true
@@ -46,7 +46,7 @@ jobs:
 
       - name: Create issue if ProtonMail/go-crypto updated
         if: steps.check.outputs.proton_version != '' && !contains(steps.check.outputs.proton_version, 'v1.1.')
-        uses: actions/github-script@v9
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799c7f6 # v9
         with:
           script: |
             const version = '${{ steps.check.outputs.proton_version }}';
@@ -73,7 +73,7 @@ jobs:
 
       - name: Create issue if golang/protobuf still present
         if: steps.check.outputs.has_golang_protobuf != ''
-        uses: actions/github-script@v9
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799c7f6 # v9
         with:
           script: |
             const version = '${{ steps.check.outputs.has_golang_protobuf }}';

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,12 +21,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: '1.26.3'
           cache: true
@@ -35,7 +35,7 @@ jobs:
         run: make fmt-check
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9
         with:
           version: v2.11.4
           install-mode: binary
@@ -49,7 +49,7 @@ jobs:
 
       - name: Upload gosec SARIF report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: gosec-sarif
           path: gosec.sarif
@@ -57,7 +57,7 @@ jobs:
 
       - name: Upload gosec results to code scanning
         if: always() && github.event_name == 'push'
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@7c1e4cf0b20d7c1872b26569c00ba908797a59bf # v4
         with:
           sarif_file: gosec.sarif
 
@@ -66,12 +66,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: '1.26.3'
           cache: true
@@ -84,16 +84,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: '1.26.3'
           cache: true
 
       - name: Run govulncheck
-        uses: golang/govulncheck-action@v1
+        uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1
         with:
           go-version-input: '1.26.3'
           go-package: ./...
@@ -104,24 +104,24 @@ jobs:
     needs: [test, govulncheck, lint]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: '1.26.3'
           cache: true
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@d7d6bc7722e3daa8354c50b52f5411669fdd27b3 # v3
 
       - name: Install Syft
-        uses: anchore/sbom-action/download-syft@v0
+        uses: anchore/sbom-action/download-syft@f325610c9f50a54015d68455d9b029324854468f # v0
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@90a068edfddc332c5d60a30e63e9b949c422cafc # v7
         with:
           distribution: goreleaser
           version: '~> v2'
@@ -132,7 +132,7 @@ jobs:
           SCOOP_BUCKET_GITHUB_TOKEN: ${{ secrets.SCOOP_BUCKET_GITHUB_TOKEN }}
 
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@c074443f1aee8d4aeeae555aebba3282517141b2 # v4
         with:
           subject-path: 'dist/**'
 

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -35,4 +35,6 @@ func init() {
 	serveCmd.Flags().Int("port", 8080, "Server port")
 	serveCmd.Flags().Bool("stdio", false, "Enable stdio transport (for MCP)")
 	serveCmd.Flags().String("bind", "127.0.0.1", "Bind address for HTTP server")
+	serveCmd.Flags().String("tls-cert", "", "TLS certificate file path (overrides config)")
+	serveCmd.Flags().String("tls-key", "", "TLS key file path (overrides config)")
 }

--- a/cmd/serve_deps.go
+++ b/cmd/serve_deps.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/cobra"
 
 	errorspkg "github.com/danieljustus/OpenPass/internal/errors"
+	"github.com/danieljustus/OpenPass/internal/config"
 	"github.com/danieljustus/OpenPass/internal/mcp"
 	"github.com/danieljustus/OpenPass/internal/mcp/serverbootstrap"
 	vaultpkg "github.com/danieljustus/OpenPass/internal/vault"
@@ -58,6 +59,14 @@ func runServe(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("read bind flag: %w", err)
 	}
+	tlsCertFlag, err := cmd.Flags().GetString("tls-cert")
+	if err != nil {
+		return fmt.Errorf("read tls-cert flag: %w", err)
+	}
+	tlsKeyFlag, err := cmd.Flags().GetString("tls-key")
+	if err != nil {
+		return fmt.Errorf("read tls-key flag: %w", err)
+	}
 	if bind == "" {
 		return fmt.Errorf("--bind must not be empty; use '127.0.0.1' for localhost-only")
 	}
@@ -84,6 +93,19 @@ func runServe(cmd *cobra.Command, args []string) error {
 		}
 		if err != nil {
 			return err
+		}
+	}
+	// Apply CLI TLS flag overrides to the vault config so they take
+	// precedence over config file values before the HTTP server starts.
+	if vault != nil && vault.Config != nil {
+		if vault.Config.MCP == nil {
+			vault.Config.MCP = &config.MCPConfig{}
+		}
+		if tlsCertFlag != "" {
+			vault.Config.MCP.TLSCertFile = tlsCertFlag
+		}
+		if tlsKeyFlag != "" {
+			vault.Config.MCP.TLSKeyFile = tlsKeyFlag
 		}
 	}
 	ctx, cancel := context.WithCancel(context.Background())

--- a/cmd/serve_deps.go
+++ b/cmd/serve_deps.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	errorspkg "github.com/danieljustus/OpenPass/internal/errors"
 	"github.com/danieljustus/OpenPass/internal/config"
+	errorspkg "github.com/danieljustus/OpenPass/internal/errors"
 	"github.com/danieljustus/OpenPass/internal/mcp"
 	"github.com/danieljustus/OpenPass/internal/mcp/serverbootstrap"
 	vaultpkg "github.com/danieljustus/OpenPass/internal/vault"

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -1322,6 +1322,176 @@ func TestCmdServe_NonLoopbackWarning(t *testing.T) {
 	}
 }
 
+func TestCmdServe_TLSFlagsOverride(t *testing.T) {
+	vaultDir := t.TempDir()
+	identity := testutil.TempIdentity(t)
+	cfg := config.Default()
+	cfg.VaultDir = vaultDir
+	if err := vaultpkg.Init(vaultDir, identity, cfg); err != nil {
+		t.Fatalf("init vault: %v", err)
+	}
+	vaultFlagReset(t)
+
+	serveSignals := make(chan chan<- os.Signal, 1)
+	origNotify := serveSignalNotify
+	serveSignalNotify = func(c chan<- os.Signal, sigs ...os.Signal) {
+		serveSignals <- c
+	}
+	defer func() { serveSignalNotify = origNotify }()
+
+	origFindAvailablePort := findAvailablePortFunc
+	findAvailablePortFunc = func(bind string, preferredPort int) (int, bool, error) {
+		return preferredPort, true, nil
+	}
+	defer func() { findAvailablePortFunc = origFindAvailablePort }()
+
+	origUnlock := serveUnlockVault
+	serveUnlockVault = func(vaultDir string, interactive bool) (*vaultpkg.Vault, error) {
+		return &vaultpkg.Vault{Dir: vaultDir, Identity: identity, Config: cfg}, nil
+	}
+	defer func() { serveUnlockVault = origUnlock }()
+
+	var capturedVault *vaultpkg.Vault
+	httpDone := make(chan struct{}, 1)
+	origHTTP := runHTTPServerFunc
+	runHTTPServerFunc = func(ctx context.Context, bind string, gotPort int, v *vaultpkg.Vault) error {
+		capturedVault = v
+		<-ctx.Done()
+		httpDone <- struct{}{}
+		return nil
+	}
+	defer func() { runHTTPServerFunc = origHTTP }()
+
+	const port = 18182
+	_ = serveCmd.Flags().Set("stdio", "false")
+	_ = serveCmd.Flags().Set("agent", "")
+	_ = serveCmd.Flags().Set("port", fmt.Sprintf("%d", port))
+
+	rootCmd.SetArgs([]string{
+		"--vault", vaultDir,
+		"serve",
+		"--bind", "127.0.0.1",
+		"--port", fmt.Sprintf("%d", port),
+		"--tls-cert", "/path/to/cert.pem",
+		"--tls-key", "/path/to/key.pem",
+	})
+	t.Cleanup(func() {
+		rootCmd.SetArgs(nil)
+		_ = serveCmd.Flags().Set("bind", "127.0.0.1")
+		_ = serveCmd.Flags().Set("tls-cert", "")
+		_ = serveCmd.Flags().Set("tls-key", "")
+	})
+
+	done := make(chan struct{})
+	go func() {
+		_ = rootCmd.Execute()
+		close(done)
+	}()
+
+	sigCh := <-serveSignals
+	sigCh <- syscall.SIGINT
+	<-httpDone
+	<-done
+
+	if capturedVault == nil {
+		t.Fatal("vault was not passed to HTTP server")
+	}
+	if capturedVault.Config.MCP == nil {
+		t.Fatal("MCP config is nil")
+	}
+	if capturedVault.Config.MCP.TLSCertFile != "/path/to/cert.pem" {
+		t.Errorf("TLSCertFile = %q, want %q", capturedVault.Config.MCP.TLSCertFile, "/path/to/cert.pem")
+	}
+	if capturedVault.Config.MCP.TLSKeyFile != "/path/to/key.pem" {
+		t.Errorf("TLSKeyFile = %q, want %q", capturedVault.Config.MCP.TLSKeyFile, "/path/to/key.pem")
+	}
+}
+
+func TestCmdServe_TLSFlagsOnlyCert(t *testing.T) {
+	vaultDir := t.TempDir()
+	identity := testutil.TempIdentity(t)
+	cfg := config.Default()
+	cfg.VaultDir = vaultDir
+	if err := vaultpkg.Init(vaultDir, identity, cfg); err != nil {
+		t.Fatalf("init vault: %v", err)
+	}
+	vaultFlagReset(t)
+
+	serveSignals := make(chan chan<- os.Signal, 1)
+	origNotify := serveSignalNotify
+	serveSignalNotify = func(c chan<- os.Signal, sigs ...os.Signal) {
+		serveSignals <- c
+	}
+	defer func() { serveSignalNotify = origNotify }()
+
+	origFindAvailablePort := findAvailablePortFunc
+	findAvailablePortFunc = func(bind string, preferredPort int) (int, bool, error) {
+		return preferredPort, true, nil
+	}
+	defer func() { findAvailablePortFunc = origFindAvailablePort }()
+
+	origUnlock := serveUnlockVault
+	serveUnlockVault = func(vaultDir string, interactive bool) (*vaultpkg.Vault, error) {
+		return &vaultpkg.Vault{Dir: vaultDir, Identity: identity, Config: cfg}, nil
+	}
+	defer func() { serveUnlockVault = origUnlock }()
+
+	var capturedVault *vaultpkg.Vault
+	httpDone := make(chan struct{}, 1)
+	origHTTP := runHTTPServerFunc
+	runHTTPServerFunc = func(ctx context.Context, bind string, gotPort int, v *vaultpkg.Vault) error {
+		capturedVault = v
+		<-ctx.Done()
+		httpDone <- struct{}{}
+		return nil
+	}
+	defer func() { runHTTPServerFunc = origHTTP }()
+
+	const port = 18183
+	_ = serveCmd.Flags().Set("stdio", "false")
+	_ = serveCmd.Flags().Set("agent", "")
+	_ = serveCmd.Flags().Set("port", fmt.Sprintf("%d", port))
+
+	// Only set --tls-cert, leave --tls-key as default
+	rootCmd.SetArgs([]string{
+		"--vault", vaultDir,
+		"serve",
+		"--bind", "127.0.0.1",
+		"--port", fmt.Sprintf("%d", port),
+		"--tls-cert", "/path/to/cert.pem",
+	})
+	t.Cleanup(func() {
+		rootCmd.SetArgs(nil)
+		_ = serveCmd.Flags().Set("bind", "127.0.0.1")
+		_ = serveCmd.Flags().Set("tls-cert", "")
+		_ = serveCmd.Flags().Set("tls-key", "")
+	})
+
+	done := make(chan struct{})
+	go func() {
+		_ = rootCmd.Execute()
+		close(done)
+	}()
+
+	sigCh := <-serveSignals
+	sigCh <- syscall.SIGINT
+	<-httpDone
+	<-done
+
+	if capturedVault == nil {
+		t.Fatal("vault was not passed to HTTP server")
+	}
+	if capturedVault.Config.MCP == nil {
+		t.Fatal("MCP config is nil")
+	}
+	if capturedVault.Config.MCP.TLSCertFile != "/path/to/cert.pem" {
+		t.Errorf("TLSCertFile = %q, want %q", capturedVault.Config.MCP.TLSCertFile, "/path/to/cert.pem")
+	}
+	if capturedVault.Config.MCP.TLSKeyFile != "" {
+		t.Errorf("TLSKeyFile = %q, want empty string", capturedVault.Config.MCP.TLSKeyFile)
+	}
+}
+
 func TestServe_StdioError(t *testing.T) {
 	resetVaultState(t)
 

--- a/internal/update/apply.go
+++ b/internal/update/apply.go
@@ -96,6 +96,23 @@ func Apply(ctx context.Context, currentVersion string, force, dryRun bool) (*App
 		return nil, fmt.Errorf("fetch checksums: %w", err)
 	}
 
+	// Verify the cosign signature on the checksums file before trusting its
+	// SHA256 hashes. This ensures the checksums were published by the
+	// OpenPass release workflow and haven't been tampered with.
+	sig, err := FetchCosignSignature(ctx, result.LatestVersion)
+	if err != nil {
+		return nil, fmt.Errorf("fetch cosign signature: %w", err)
+	}
+
+	cert, err := FetchCosignCertificate(ctx, result.LatestVersion)
+	if err != nil {
+		return nil, fmt.Errorf("fetch cosign certificate: %w", err)
+	}
+
+	if err := VerifyCosignSignature([]byte(checksums), sig, cert); err != nil {
+		return nil, fmt.Errorf("cosign verification failed: %w", err)
+	}
+
 	an := archiveName(result.LatestVersion, runtime.GOOS, runtime.GOARCH)
 	if verifyErr := VerifyChecksum(archiveData, checksums, an); verifyErr != nil {
 		return nil, fmt.Errorf("verify checksum: %w", verifyErr)

--- a/internal/update/apply.go
+++ b/internal/update/apply.go
@@ -109,8 +109,8 @@ func Apply(ctx context.Context, currentVersion string, force, dryRun bool) (*App
 		return nil, fmt.Errorf("fetch cosign certificate: %w", err)
 	}
 
-	if err := VerifyCosignSignature([]byte(checksums), sig, cert); err != nil {
-		return nil, fmt.Errorf("cosign verification failed: %w", err)
+	if cosignErr := VerifyCosignSignature([]byte(checksums), sig, cert); cosignErr != nil {
+		return nil, fmt.Errorf("cosign verification failed: %w", cosignErr)
 	}
 
 	an := archiveName(result.LatestVersion, runtime.GOOS, runtime.GOARCH)

--- a/internal/update/cosign.go
+++ b/internal/update/cosign.go
@@ -1,0 +1,187 @@
+package update
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// execCommand is overridden in tests to allow verification without the cosign
+// CLI being installed.
+var execCommand = exec.Command
+
+// cosignSignatureFileName returns the cosign signature filename for the
+// checksums file of the given release version. Matches the GoReleaser
+// cosign signing convention where "<artifact>.sig" is the signature.
+func cosignSignatureFileName(version string) string {
+	v := strings.TrimPrefix(version, "v")
+	return fmt.Sprintf("OpenPass_%s_checksums.txt.sig", v)
+}
+
+// cosignCertificateFileName returns the cosign certificate filename for the
+// checksums file of the given release version. Matches the GoReleaser
+// cosign signing convention where "<artifact>.pem" is the certificate.
+func cosignCertificateFileName(version string) string {
+	v := strings.TrimPrefix(version, "v")
+	return fmt.Sprintf("OpenPass_%s_checksums.txt.pem", v)
+}
+
+// FetchCosignSignature downloads the cosign signature file for the release
+// checksums. The signature is produced by GoReleaser using cosign keyless
+// signing and is published alongside the checksums file.
+func FetchCosignSignature(ctx context.Context, version string) ([]byte, error) {
+	v := strings.TrimPrefix(version, "v")
+	if v == "" {
+		return nil, fmt.Errorf("version must not be empty")
+	}
+
+	name := cosignSignatureFileName(version)
+	u := fmt.Sprintf("%s/v%s/%s", DefaultDownloadBaseURL, v, name)
+
+	parsed, err := url.Parse(u)
+	if err != nil {
+		return nil, fmt.Errorf("invalid cosign signature URL: %w", err)
+	}
+	if parsed.Scheme != "https" {
+		return nil, fmt.Errorf("cosign signature URL must use HTTPS, got %q", parsed.Scheme)
+	}
+
+	client := checksumsClient()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create cosign signature request: %w", err)
+	}
+
+	resp, err := client.Do(req) // #nosec G107 — URL is constructed from controlled inputs
+	if err != nil {
+		return nil, fmt.Errorf("fetch cosign signature: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("fetch cosign signature: HTTP %d", resp.StatusCode)
+	}
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read cosign signature response: %w", err)
+	}
+
+	return data, nil
+}
+
+// FetchCosignCertificate downloads the cosign certificate file for the release
+// checksums. The certificate is produced by GoReleaser using cosign keyless
+// signing and contains the OIDC identity from the GitHub Actions workflow run.
+func FetchCosignCertificate(ctx context.Context, version string) ([]byte, error) {
+	v := strings.TrimPrefix(version, "v")
+	if v == "" {
+		return nil, fmt.Errorf("version must not be empty")
+	}
+
+	name := cosignCertificateFileName(version)
+	u := fmt.Sprintf("%s/v%s/%s", DefaultDownloadBaseURL, v, name)
+
+	parsed, err := url.Parse(u)
+	if err != nil {
+		return nil, fmt.Errorf("invalid cosign certificate URL: %w", err)
+	}
+	if parsed.Scheme != "https" {
+		return nil, fmt.Errorf("cosign certificate URL must use HTTPS, got %q", parsed.Scheme)
+	}
+
+	client := checksumsClient()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create cosign certificate request: %w", err)
+	}
+
+	resp, err := client.Do(req) // #nosec G107 — URL is constructed from controlled inputs
+	if err != nil {
+		return nil, fmt.Errorf("fetch cosign certificate: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("fetch cosign certificate: HTTP %d", resp.StatusCode)
+	}
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read cosign certificate response: %w", err)
+	}
+
+	return data, nil
+}
+
+// VerifyCosignSignature verifies a cosign keyless signature on the given content
+// using the provided signature and certificate. It shells out to the cosign CLI.
+//
+// The verification enforces:
+//   - The certificate's OIDC issuer must be GitHub Actions
+//     (https://token.actions.githubusercontent.com)
+//   - The certificate identity must match the OpenPass release workflow
+//     (https://github.com/danieljustus/OpenPass/.github/workflows/release.yml)
+//     with a semantic version tag reference
+//
+// If the cosign CLI is not installed, the function returns a clear error
+// instructing the user to install it. This is a security requirement — the
+// update is aborted when cosign is not available.
+func VerifyCosignSignature(content, signature, certificate []byte) error {
+	if _, err := exec.LookPath("cosign"); err != nil {
+		return fmt.Errorf(
+			"cosign CLI not found — install cosign from https://docs.sigstore.dev "+
+				"to verify release signatures: %w", err,
+		)
+	}
+
+	tmpDir, err := os.MkdirTemp("", "openpass-cosign-*")
+	if err != nil {
+		return fmt.Errorf("create temp directory: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	contentPath := filepath.Join(tmpDir, "content")
+	sigPath := filepath.Join(tmpDir, "signature.sig")
+	certPath := filepath.Join(tmpDir, "certificate.pem")
+
+	if err := os.WriteFile(contentPath, content, 0o600); err != nil {
+		return fmt.Errorf("write content file: %w", err)
+	}
+	if err := os.WriteFile(sigPath, signature, 0o600); err != nil {
+		return fmt.Errorf("write signature file: %w", err)
+	}
+	if err := os.WriteFile(certPath, certificate, 0o600); err != nil {
+		return fmt.Errorf("write certificate file: %w", err)
+	}
+
+	var stderr bytes.Buffer
+	cmd := execCommand("cosign",
+		"verify-blob",
+		"--certificate", certPath,
+		"--signature", sigPath,
+		"--certificate-identity-regexp",
+		`https://github\.com/danieljustus/OpenPass/\.github/workflows/release\.yml@refs/tags/v.*`,
+		"--certificate-oidc-issuer",
+		"https://token.actions.githubusercontent.com",
+		contentPath,
+	)
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf(
+			"cosign verify-blob failed: %s: %w",
+			strings.TrimSpace(stderr.String()),
+			err,
+		)
+	}
+
+	return nil
+}

--- a/internal/update/cosign.go
+++ b/internal/update/cosign.go
@@ -33,92 +33,63 @@ func cosignCertificateFileName(version string) string {
 	return fmt.Sprintf("OpenPass_%s_checksums.txt.pem", v)
 }
 
-// FetchCosignSignature downloads the cosign signature file for the release
-// checksums. The signature is produced by GoReleaser using cosign keyless
-// signing and is published alongside the checksums file.
-func FetchCosignSignature(ctx context.Context, version string) ([]byte, error) {
+// fetchCosignArtifact downloads a cosign artifact (signature or certificate)
+// for the given release version. The artifactName function produces the
+// filename (e.g., cosignSignatureFileName or cosignCertificateFileName).
+func fetchCosignArtifact(ctx context.Context, version string, artifactName func(string) string, artifactLabel string) ([]byte, error) {
 	v := strings.TrimPrefix(version, "v")
 	if v == "" {
 		return nil, fmt.Errorf("version must not be empty")
 	}
 
-	name := cosignSignatureFileName(version)
+	name := artifactName(version)
 	u := fmt.Sprintf("%s/v%s/%s", DefaultDownloadBaseURL, v, name)
 
 	parsed, err := url.Parse(u)
 	if err != nil {
-		return nil, fmt.Errorf("invalid cosign signature URL: %w", err)
+		return nil, fmt.Errorf("invalid cosign %s URL: %w", artifactLabel, err)
 	}
-	if parsed.Scheme != "https" {
-		return nil, fmt.Errorf("cosign signature URL must use HTTPS, got %q", parsed.Scheme)
+	const httpsScheme = "https"
+	if parsed.Scheme != httpsScheme {
+		return nil, fmt.Errorf("cosign %s URL must use HTTPS, got %q", artifactLabel, parsed.Scheme)
 	}
 
 	client := checksumsClient()
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
 	if err != nil {
-		return nil, fmt.Errorf("create cosign signature request: %w", err)
+		return nil, fmt.Errorf("create cosign %s request: %w", artifactLabel, err)
 	}
 
 	resp, err := client.Do(req) // #nosec G107 — URL is constructed from controlled inputs
 	if err != nil {
-		return nil, fmt.Errorf("fetch cosign signature: %w", err)
+		return nil, fmt.Errorf("fetch cosign %s: %w", artifactLabel, err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("fetch cosign signature: HTTP %d", resp.StatusCode)
+		return nil, fmt.Errorf("fetch cosign %s: HTTP %d", artifactLabel, resp.StatusCode)
 	}
 
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("read cosign signature response: %w", err)
+		return nil, fmt.Errorf("read cosign %s response: %w", artifactLabel, err)
 	}
 
 	return data, nil
+}
+
+// FetchCosignSignature downloads the cosign signature file for the release
+// checksums. The signature is produced by GoReleaser using cosign keyless
+// signing and is published alongside the checksums file.
+func FetchCosignSignature(ctx context.Context, version string) ([]byte, error) {
+	return fetchCosignArtifact(ctx, version, cosignSignatureFileName, "signature")
 }
 
 // FetchCosignCertificate downloads the cosign certificate file for the release
 // checksums. The certificate is produced by GoReleaser using cosign keyless
 // signing and contains the OIDC identity from the GitHub Actions workflow run.
 func FetchCosignCertificate(ctx context.Context, version string) ([]byte, error) {
-	v := strings.TrimPrefix(version, "v")
-	if v == "" {
-		return nil, fmt.Errorf("version must not be empty")
-	}
-
-	name := cosignCertificateFileName(version)
-	u := fmt.Sprintf("%s/v%s/%s", DefaultDownloadBaseURL, v, name)
-
-	parsed, err := url.Parse(u)
-	if err != nil {
-		return nil, fmt.Errorf("invalid cosign certificate URL: %w", err)
-	}
-	if parsed.Scheme != "https" {
-		return nil, fmt.Errorf("cosign certificate URL must use HTTPS, got %q", parsed.Scheme)
-	}
-
-	client := checksumsClient()
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
-	if err != nil {
-		return nil, fmt.Errorf("create cosign certificate request: %w", err)
-	}
-
-	resp, err := client.Do(req) // #nosec G107 — URL is constructed from controlled inputs
-	if err != nil {
-		return nil, fmt.Errorf("fetch cosign certificate: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("fetch cosign certificate: HTTP %d", resp.StatusCode)
-	}
-
-	data, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("read cosign certificate response: %w", err)
-	}
-
-	return data, nil
+	return fetchCosignArtifact(ctx, version, cosignCertificateFileName, "certificate")
 }
 
 // VerifyCosignSignature verifies a cosign keyless signature on the given content

--- a/internal/update/cosign_test.go
+++ b/internal/update/cosign_test.go
@@ -1,0 +1,276 @@
+package update
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestCosignSignatureFileName(t *testing.T) {
+	tests := []struct {
+		version  string
+		expected string
+	}{
+		{"0.5.0", "OpenPass_0.5.0_checksums.txt.sig"},
+		{"v1.2.0", "OpenPass_1.2.0_checksums.txt.sig"},
+		{"v", "OpenPass__checksums.txt.sig"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			got := cosignSignatureFileName(tt.version)
+			if got != tt.expected {
+				t.Fatalf("cosignSignatureFileName(%q) = %q, want %q",
+					tt.version, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestCosignCertificateFileName(t *testing.T) {
+	tests := []struct {
+		version  string
+		expected string
+	}{
+		{"0.5.0", "OpenPass_0.5.0_checksums.txt.pem"},
+		{"v1.2.0", "OpenPass_1.2.0_checksums.txt.pem"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			got := cosignCertificateFileName(tt.version)
+			if got != tt.expected {
+				t.Fatalf("cosignCertificateFileName(%q) = %q, want %q",
+					tt.version, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestFetchCosignSignature_Success(t *testing.T) {
+	expectedBody := []byte("fake-cosign-signature")
+	mu.Lock()
+	testHTTPClient = stubHTTPDoer{
+		do: func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(string(expectedBody))),
+				Header:     make(http.Header),
+			}, nil
+		},
+	}
+	mu.Unlock()
+	t.Cleanup(func() {
+		mu.Lock()
+		testHTTPClient = nil
+		mu.Unlock()
+	})
+
+	data, err := FetchCosignSignature(context.Background(), "0.5.0")
+	if err != nil {
+		t.Fatalf("FetchCosignSignature() error = %v", err)
+	}
+	if string(data) != string(expectedBody) {
+		t.Fatalf("got body %q, want %q", string(data), string(expectedBody))
+	}
+}
+
+func TestFetchCosignSignature_HTTPError(t *testing.T) {
+	mu.Lock()
+	testHTTPClient = stubHTTPDoer{
+		do: func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusNotFound,
+				Body:       io.NopCloser(strings.NewReader("not found")),
+				Header:     make(http.Header),
+			}, nil
+		},
+	}
+	mu.Unlock()
+	t.Cleanup(func() {
+		mu.Lock()
+		testHTTPClient = nil
+		mu.Unlock()
+	})
+
+	_, err := FetchCosignSignature(context.Background(), "0.5.0")
+	if err == nil {
+		t.Fatal("expected HTTP error")
+	}
+	if !strings.Contains(err.Error(), "HTTP 404") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestFetchCosignSignature_EmptyVersion(t *testing.T) {
+	_, err := FetchCosignSignature(context.Background(), "")
+	if err == nil {
+		t.Fatal("expected empty version error")
+	}
+	if !strings.Contains(err.Error(), "version must not be empty") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestFetchCosignSignature_URLScheme(t *testing.T) {
+	origURL := DefaultDownloadBaseURL
+	DefaultDownloadBaseURL = "http://example.com/fake"
+	t.Cleanup(func() { DefaultDownloadBaseURL = origURL })
+
+	_, err := FetchCosignSignature(context.Background(), "0.5.0")
+	if err == nil {
+		t.Fatal("expected HTTPS enforcement error")
+	}
+	if !strings.Contains(err.Error(), "must use HTTPS") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestFetchCosignCertificate_Success(t *testing.T) {
+	expectedBody := []byte("fake-cosign-certificate")
+	mu.Lock()
+	testHTTPClient = stubHTTPDoer{
+		do: func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(string(expectedBody))),
+				Header:     make(http.Header),
+			}, nil
+		},
+	}
+	mu.Unlock()
+	t.Cleanup(func() {
+		mu.Lock()
+		testHTTPClient = nil
+		mu.Unlock()
+	})
+
+	data, err := FetchCosignCertificate(context.Background(), "0.5.0")
+	if err != nil {
+		t.Fatalf("FetchCosignCertificate() error = %v", err)
+	}
+	if string(data) != string(expectedBody) {
+		t.Fatalf("got body %q, want %q", string(data), string(expectedBody))
+	}
+}
+
+func TestFetchCosignCertificate_HTTPError(t *testing.T) {
+	mu.Lock()
+	testHTTPClient = stubHTTPDoer{
+		do: func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusForbidden,
+				Body:       io.NopCloser(strings.NewReader("forbidden")),
+				Header:     make(http.Header),
+			}, nil
+		},
+	}
+	mu.Unlock()
+	t.Cleanup(func() {
+		mu.Lock()
+		testHTTPClient = nil
+		mu.Unlock()
+	})
+
+	_, err := FetchCosignCertificate(context.Background(), "0.5.0")
+	if err == nil {
+		t.Fatal("expected HTTP error")
+	}
+	if !strings.Contains(err.Error(), "HTTP 403") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestFetchCosignCertificate_EmptyVersion(t *testing.T) {
+	_, err := FetchCosignCertificate(context.Background(), "")
+	if err == nil {
+		t.Fatal("expected empty version error")
+	}
+	if !strings.Contains(err.Error(), "version must not be empty") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestFetchCosignCertificate_URLScheme(t *testing.T) {
+	origURL := DefaultDownloadBaseURL
+	DefaultDownloadBaseURL = "http://example.com/fake"
+	t.Cleanup(func() { DefaultDownloadBaseURL = origURL })
+
+	_, err := FetchCosignCertificate(context.Background(), "0.5.0")
+	if err == nil {
+		t.Fatal("expected HTTPS enforcement error")
+	}
+	if !strings.Contains(err.Error(), "must use HTTPS") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestVerifyCosignSignature_CosignNotFound(t *testing.T) {
+	origPath := os.Getenv("PATH")
+	t.Cleanup(func() { os.Setenv("PATH", origPath) })
+	os.Setenv("PATH", "")
+
+	err := VerifyCosignSignature(
+		[]byte("test-content"),
+		[]byte("fake-signature"),
+		[]byte("fake-certificate"),
+	)
+	if err == nil {
+		t.Fatal("expected error when cosign is not on PATH")
+	}
+	if !strings.Contains(err.Error(), "cosign CLI not found") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestVerifyCosignSignature_InvalidArgs(t *testing.T) {
+	if _, err := exec.LookPath("cosign"); err == nil {
+		t.Skip("cosign is installed — this test is for the binary-not-found path")
+	}
+
+	origPath := os.Getenv("PATH")
+	t.Cleanup(func() { os.Setenv("PATH", origPath) })
+	os.Setenv("PATH", "")
+
+	err := VerifyCosignSignature(
+		[]byte("random-content"),
+		[]byte("random-sig"),
+		[]byte("random-cert"),
+	)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "install cosign") {
+		t.Fatalf("error should instruct user to install cosign: %v", err)
+	}
+}
+
+func TestVerifyCosignSignature_ExecFailure(t *testing.T) {
+	if _, err := exec.LookPath("cosign"); err != nil {
+		t.Skip("cosign not on PATH — exec failure test requires cosign to pass LookPath")
+	}
+
+	origExec := execCommand
+	t.Cleanup(func() { execCommand = origExec })
+
+	execCommand = func(name string, arg ...string) *exec.Cmd {
+		if name == "cosign" {
+			return exec.Command("false")
+		}
+		return exec.Command(name, arg...)
+	}
+
+	err := VerifyCosignSignature(
+		[]byte("content"),
+		[]byte("sig"),
+		[]byte("cert"),
+	)
+	if err == nil {
+		t.Fatal("expected error from cosign exec failure")
+	}
+	if !strings.Contains(err.Error(), "cosign verify-blob failed") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -39,6 +39,15 @@ fatal() { error "$*"; exit 1; }
 # Detect whether a command exists.
 has_cmd() { command -v "$1" >/dev/null 2>&1; }
 
+# Require cosign to be installed for signature verification.
+require_cosign() {
+    if ! has_cmd cosign; then
+        fatal "cosign not found — required for checksums.txt signature verification.
+  Install cosign from https://docs.sigstore.dev/cosign/installation/
+  or use: brew install cosign (macOS) / apt install cosign (Linux)."
+    fi
+}
+
 # Download a URL to stdout.  Prefers curl, falls back to wget.
 download() {
     if has_cmd curl; then
@@ -138,6 +147,39 @@ verify_checksum() {
     info "Checksum verified for $archive_basename."
 }
 
+# ── Cosign signature verification ────────────────────────────────────────────
+
+# Cosign-verify the checksums file before trusting its SHA-256 hashes.
+# Downloads .sig and .pem sidecar files from the same release URL.
+verify_checksums_signature() {
+    checksums_path="$1"
+    sig_url="$2"
+    pem_url="$3"
+
+    require_cosign
+
+    sig_path="${checksums_path}.sig"
+    pem_path="${checksums_path}.pem"
+
+    info "Downloading checksums signature..."
+    download_to "$sig_path" "$sig_url"
+
+    info "Downloading checksums certificate..."
+    download_to "$pem_path" "$pem_url"
+
+    info "Verifying cosign signature on checksums.txt..."
+    cosign verify-blob \
+        --certificate "$pem_path" \
+        --signature "$sig_path" \
+        --certificate-identity-regexp 'https://github.com/danieljustus/OpenPass/.github/workflows/release.yml@refs/tags/v.*' \
+        --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+        "$checksums_path" >/dev/null 2>&1 || fatal "Cosign signature verification failed for checksums.txt.
+  The checksums file may have been tampered with.
+  See: https://docs.sigstore.dev/cosign/overview/"
+
+    info "Cosign signature verified on checksums.txt."
+}
+
 # ── Archive extraction ───────────────────────────────────────────────────────
 
 extract_archive() {
@@ -232,6 +274,8 @@ USAGE
 
     archive_url="${GITHUB_DOWNLOAD}/${version}/${archive_file}"
     checksums_url="${GITHUB_DOWNLOAD}/${version}/${checksums_file}"
+    checksums_sig_url="${checksums_url}.sig"
+    checksums_pem_url="${checksums_url}.pem"
 
     # Create temp workspace.
     tmpdir=$(mktemp -d)
@@ -241,6 +285,9 @@ USAGE
     info "Downloading checksums..."
     checksums_path="${tmpdir}/${checksums_file}"
     download_to "$checksums_path" "$checksums_url"
+
+    # Verify cosign signature on checksums before trusting its hashes.
+    verify_checksums_signature "$checksums_path" "$checksums_sig_url" "$checksums_pem_url"
 
     # Download archive.
     info "Downloading ${archive_file}..."


### PR DESCRIPTION
Aggregated session PR opened by 03-gh-go.

This PR will close the following issues on merge:

<!-- closes-list-start -->
- Closes #107 [SECURITY] GitHub Actions use mutable tags instead of pinned SHAs
- Closes #106 [SECURITY] serve --bind 0.0.0.0 allowed without TLS warning
- Closes #116 [SECURITY] Self-update verifies SHA256 only — no cosign/GPG signature chain
- Closes #117 [SECURITY] install.sh downloads checksums.txt without signature verification
<!-- closes-list-end -->