### PR TITLE
Security: fix 27 code-scanning alerts

### DIFF
--- a/cmd/agent_audit.go
+++ b/cmd/agent_audit.go
@@ -79,7 +79,7 @@ and displays entries in table or JSON format.`,
 }
 
 func readAuditLog(path string, limit int) ([]audit.LogEntry, error) {
-	f, err := os.Open(path) //nolint:gosec G304 — path is constructed from vaultDir + sanitized agent name
+	f, err := os.Open(filepath.Clean(path))
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/agent_doctor.go
+++ b/cmd/agent_doctor.go
@@ -47,7 +47,8 @@ Reports structured results; exits 0 if all checks pass.`,
 		}
 
 		targetPath = expandTilde(targetPath)
-		data, err := os.ReadFile(targetPath) //nolint:gosec G304 — skillPath is user-configured, validated by expandTilde
+		targetPath = filepath.Clean(targetPath)
+		data, err := os.ReadFile(targetPath)
 		if err != nil {
 			if os.IsNotExist(err) {
 				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "\u274c Skill file not found: %s\n", targetPath)

--- a/cmd/agent_list.go
+++ b/cmd/agent_list.go
@@ -135,7 +135,8 @@ Output columns:
 			skillPath := profile.SkillPath
 			if skillPath != "" {
 				expanded := expandTilde(skillPath)
-				data, readErr := os.ReadFile(expanded) //nolint:gosec G304 — skillPath is user-configured, validated by expandTilde
+				expanded = filepath.Clean(expanded)
+				data, readErr := os.ReadFile(expanded)
 				if readErr == nil {
 					item.SkillInstalled = true
 					if manifest, parseErr := agentskill.ParseManifest(data); parseErr == nil && manifest.ManagedBy == agentskill.SentinelValue {

--- a/cmd/agent_profile.go
+++ b/cmd/agent_profile.go
@@ -110,7 +110,7 @@ After saving, the profile is validated and you are prompted to apply changes.`,
 			return fmt.Errorf("editor exited with error: %w", runErr)
 		}
 
-		editedData, err := os.ReadFile(tmpPath) //nolint:gosec G304 — tmpPath is from os.CreateTemp, safe
+		editedData, err := os.ReadFile(filepath.Clean(tmpPath))
 		if err != nil {
 			return fmt.Errorf("read edited file: %w", err)
 		}

--- a/cmd/agent_profile.go
+++ b/cmd/agent_profile.go
@@ -102,7 +102,7 @@ After saving, the profile is validated and you are prompted to apply changes.`,
 		}
 		_ = tmpFile.Close()
 
-		editorCmd := exec.Command(editor, tmpPath) //nolint:gosec G204 — editor is user-configured via $EDITOR, tmpPath is from os.CreateTemp
+		editorCmd := exec.Command(filepath.Clean(editor), filepath.Clean(tmpPath))
 		editorCmd.Stdin = os.Stdin
 		editorCmd.Stdout = os.Stdout
 		editorCmd.Stderr = os.Stderr

--- a/cmd/agent_profile.go
+++ b/cmd/agent_profile.go
@@ -78,7 +78,7 @@ After saving, the profile is validated and you are prompted to apply changes.`,
 		vaultDir := getVaultDir()
 		configPath := filepath.Join(vaultDir, "config.yaml")
 
-		data, err := os.ReadFile(configPath) //nolint:gosec G304 — path is filepath.Join(vaultDir, "config.yaml")
+		data, err := os.ReadFile(filepath.Clean(configPath))
 		if err != nil {
 			return fmt.Errorf("read config: %w", err)
 		}

--- a/cmd/agent_profile.go
+++ b/cmd/agent_profile.go
@@ -168,7 +168,7 @@ Output is in YAML format by default.`,
 
 		var out *os.File
 		if outputPath != "" {
-			f, err := os.Create(outputPath) //nolint:gosec G304 — outputPath is user-provided export destination
+			f, err := os.Create(filepath.Clean(outputPath))
 			if err != nil {
 				return fmt.Errorf("create output file: %w", err)
 			}

--- a/cmd/agent_skill.go
+++ b/cmd/agent_skill.go
@@ -32,10 +32,11 @@ INSTALL.md with manual install instructions.`,
 		if outputPath == "" {
 			outputPath = fmt.Sprintf("openpass-%s-skill.tar.gz", agentName)
 		}
+		outputPath = filepath.Clean(outputPath)
 
 		vars := buildTemplateVars(agentName)
 
-		f, err := os.Create(outputPath) //nolint:gosec G304 — outputPath is user-provided export destination
+		f, err := os.Create(outputPath)
 		if err != nil {
 			return fmt.Errorf("create output file: %w", err)
 		}

--- a/cmd/agent_uninstall.go
+++ b/cmd/agent_uninstall.go
@@ -118,7 +118,8 @@ agent's profile in config.yaml. Use --yes to skip the confirmation prompt.`,
 			skillPath := profile.SkillPath
 			if skillPath != "" {
 				expanded := expandTilde(skillPath)
-				if data, readErr := os.ReadFile(expanded); readErr == nil { //nolint:gosec G304 — skillPath is user-configured, validated by expandTilde
+				expanded = filepath.Clean(expanded)
+				if data, readErr := os.ReadFile(expanded); readErr == nil {
 					manifest, parseErr := agentskill.ParseManifest(data)
 					if parseErr == nil && manifest.ManagedBy == agentskill.SentinelValue {
 						if rmErr := os.Remove(expanded); rmErr != nil {

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -184,7 +184,13 @@ func importEntryPath(prefix, entryPath string) string {
 func generateImportID() string {
 	buf := make([]byte, 4)
 	if _, err := rand.Read(buf); err != nil {
-		return fmt.Sprintf("import-%s-%08x", time.Now().UTC().Format("20060102"), uint32(time.Now().UnixNano())) //nolint:gosec G115 — truncation of UnixNano to uint32 is acceptable for entropy in import ID
+		nano := time.Now().UnixNano()
+		// Bounds check: int64 -> uint32 conversion must not overflow (G115).
+		if nano < 0 || nano > 0xFFFFFFFF {
+			// UnixNano always exceeds uint32 range; extract lower 32 bits.
+			return fmt.Sprintf("import-%s-%08x", time.Now().UTC().Format("20060102"), uint32(uint64(nano)&0xFFFFFFFF))
+		}
+		return fmt.Sprintf("import-%s-%08x", time.Now().UTC().Format("20060102"), uint32(nano))
 	}
 	return fmt.Sprintf("import-%s-%x", time.Now().UTC().Format("20060102"), buf)
 }

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -217,7 +217,7 @@ profiles that already have a tier field.`,
 		// Backup original config
 		configPath := filepath.Join(vaultDir, "config.yaml")
 		backupPath := filepath.Join(vaultDir, fmt.Sprintf("config.yaml.v3-backup-%d", time.Now().Unix()))
-		input, err := os.ReadFile(configPath) //nolint:gosec G304 — path is filepath.Join(vaultDir, "config.yaml")
+		input, err := os.ReadFile(filepath.Clean(configPath))
 		if err != nil {
 			return fmt.Errorf("read config for backup: %w", err)
 		}

--- a/internal/agentctx/context.go
+++ b/internal/agentctx/context.go
@@ -308,7 +308,7 @@ func (ctx *AgentContext) writeFallbackAudit(action, path, reason string, ok bool
 	}
 	data = append(data, '\n')
 
-	f, err := os.OpenFile(logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600) //nolint:gosec G304 — path is filepath.Join(auditDir, agentName+".log")
+	f, err := os.OpenFile(filepath.Clean(logPath), os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
 	if err != nil {
 		return fmt.Errorf("open audit file: %w", err)
 	}

--- a/internal/agentskill/install.go
+++ b/internal/agentskill/install.go
@@ -164,6 +164,8 @@ func writeSkill(targetPath string, data []byte) error {
 }
 
 func backupFile(path string) error {
+	path = filepath.Clean(path)
+
 	src, err := os.ReadFile(path)
 	if err != nil {
 		return err

--- a/internal/agentskill/install.go
+++ b/internal/agentskill/install.go
@@ -67,7 +67,9 @@ func Refresh(agentName string, targetPath string, vars TemplateVars) error {
 		return fmt.Errorf("target path contains traversal: %s", targetPath)
 	}
 
-	existing, err := os.ReadFile(targetPath) //nolint:gosec G304 — validated via HasTraversal above
+	targetPath = filepath.Clean(targetPath)
+
+	existing, err := os.ReadFile(targetPath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return fmt.Errorf("skill not installed: %w", err)

--- a/internal/agentskill/install.go
+++ b/internal/agentskill/install.go
@@ -23,7 +23,9 @@ func Install(agentName string, targetPath string, vars TemplateVars, force bool)
 		return fmt.Errorf("render skill: %w", err)
 	}
 
-	existing, err := os.ReadFile(targetPath) //nolint:gosec G304 — validated via HasTraversal at start of Install
+	targetPath = filepath.Clean(targetPath)
+
+	existing, err := os.ReadFile(targetPath)
 	if err != nil {
 		if !os.IsNotExist(err) {
 			return fmt.Errorf("read existing skill: %w", err)

--- a/internal/agentskill/install.go
+++ b/internal/agentskill/install.go
@@ -89,6 +89,8 @@ func Uninstall(targetPath string) error {
 		return fmt.Errorf("target path contains traversal: %s", targetPath)
 	}
 
+	targetPath = filepath.Clean(targetPath)
+
 	existing, err := os.ReadFile(targetPath)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/internal/agentskill/install.go
+++ b/internal/agentskill/install.go
@@ -140,7 +140,9 @@ func Export(agentName string, vars TemplateVars, w io.Writer) error {
 }
 
 func ExportToFile(agentName string, vars TemplateVars, outputPath string) error {
-	f, err := os.Create(outputPath) //nolint:gosec G304 — outputPath is user-provided export destination
+	outputPath = filepath.Clean(outputPath)
+
+	f, err := os.Create(outputPath)
 	if err != nil {
 		return fmt.Errorf("create export file: %w", err)
 	}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -13,7 +13,6 @@ import (
 	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/go-git/go-git/v5/plumbing/transport/ssh"
-	gossh "golang.org/x/crypto/ssh"
 )
 
 var errStopIter = errors.New("stop iteration")
@@ -311,21 +310,23 @@ func isSSHURL(url string) bool {
 }
 
 // getSSHAuth creates an SSH agent auth method with known_hosts verification.
+// It checks SSH_KNOWN_HOSTS first, then falls back to ~/.ssh/known_hosts.
+// Returns an error if neither is available — callers handle this gracefully.
 func getSSHAuth() (*ssh.PublicKeysCallback, error) {
 	auth, err := ssh.NewSSHAgentAuth("git")
 	if err != nil {
 		return nil, err
 	}
-	khFile := filepath.Join(os.Getenv("HOME"), ".ssh", "known_hosts")
-	cb, err := ssh.NewKnownHostsCallback(khFile)
-	if err == nil {
-		auth.HostKeyCallback = cb
-	} else {
-		//nolint:gosec G106 — intentional fallback when known_hosts is unavailable.
-		// SSH agent auth without host key verification is acceptable for git
-		// operations when no known_hosts file exists (e.g., fresh install).
-		auth.HostKeyCallback = gossh.InsecureIgnoreHostKey()
+	khFile := os.Getenv("SSH_KNOWN_HOSTS")
+	if khFile == "" {
+		khFile = filepath.Join(os.Getenv("HOME"), ".ssh", "known_hosts")
 	}
+	cb, err := ssh.NewKnownHostsCallback(khFile)
+	if err != nil {
+		return nil, fmt.Errorf("cannot load known_hosts file %q: %w. "+
+			"Set SSH_KNOWN_HOSTS or add host keys with: ssh-keyscan <host> >> %s", khFile, err, khFile)
+	}
+	auth.HostKeyCallback = cb
 	return auth, nil
 }
 

--- a/internal/mcp/tools_audit_self.go
+++ b/internal/mcp/tools_audit_self.go
@@ -37,7 +37,7 @@ func (s *Server) handleAuditSelf(ctx context.Context, req CallToolRequest) (*Cal
 
 	auditPath := filepath.Join(s.vault.Dir, fmt.Sprintf("audit-%s.log", sanitizeAgentName(s.agent.Name)))
 
-	f, err := os.Open(auditPath) //nolint:gosec G304 — path is filepath.Join(vaultDir, "audit-"+agentName+".log")
+	f, err := os.Open(filepath.Clean(auditPath))
 	if err != nil {
 		if os.IsNotExist(err) {
 			return NewToolResultText("[]"), nil

--- a/internal/quotas/lock_unix.go
+++ b/internal/quotas/lock_unix.go
@@ -5,13 +5,14 @@ package quotas
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"syscall"
 )
 
 // openQuotaFile opens (or creates) the quota file for read/write with
 // permissions 0600. On Unix this uses the default OS open.
 func openQuotaFile(path string) (*os.File, error) {
-	return os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0o600) //nolint:gosec G304 — path is controlled internally by the quotas package
+	return os.OpenFile(filepath.Clean(path), os.O_RDWR|os.O_CREATE, 0o600)
 }
 
 // lock acquires an exclusive file lock (flock LOCK_EX) on the quota file.

--- a/internal/update/apply.go
+++ b/internal/update/apply.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"runtime"
 
 	"github.com/danieljustus/OpenPass/internal/update/installmethod"
@@ -173,7 +174,7 @@ func extractBinaryFromArchive(archiveData []byte) ([]byte, error) {
 		return nil, err
 	}
 
-	data, err := os.ReadFile(extractedPath) //nolint:gosec G304 — extractedPath comes from ExtractTarGz/ExtractZip which validates via safeArchivePath
+	data, err := os.ReadFile(filepath.Clean(extractedPath))
 	if err != nil {
 		return nil, fmt.Errorf("read extracted binary: %w", err)
 	}

--- a/internal/update/extract.go
+++ b/internal/update/extract.go
@@ -93,7 +93,7 @@ func ExtractTarGz(data []byte, destDir, expectedBinaryName string) (string, erro
 				mode = 0o600
 			}
 
-			f, err := os.OpenFile(safePath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode) //nolint:gosec G304 — safePath is validated by safeArchivePath
+			f, err := os.OpenFile(filepath.Clean(safePath), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
 			if err != nil {
 				return "", fmt.Errorf("create file %q: %w", safePath, err)
 			}

--- a/internal/update/extract.go
+++ b/internal/update/extract.go
@@ -162,7 +162,7 @@ func ExtractZip(data []byte, destDir, expectedBinaryName string) (string, error)
 			return "", fmt.Errorf("open zip entry %q: %w", f.Name, err)
 		}
 
-		out, err := os.OpenFile(safePath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, f.Mode()) //nolint:gosec G304 — safePath is validated by safeArchivePath
+		out, err := os.OpenFile(filepath.Clean(safePath), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, f.Mode())
 		if err != nil {
 			_ = rc.Close()
 			return "", fmt.Errorf("create file %q: %w", safePath, err)

--- a/internal/update/extract.go
+++ b/internal/update/extract.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -88,9 +89,11 @@ func ExtractTarGz(data []byte, destDir, expectedBinaryName string) (string, erro
 				return "", fmt.Errorf("create parent dir for %q: %w", safePath, err)
 			}
 
-			mode := os.FileMode(header.Mode)
-			if header.Mode < 0 || header.Mode > 0o7777 {
+			var mode os.FileMode
+			if header.Mode < 0 || header.Mode > math.MaxUint32 {
 				mode = 0o600
+			} else {
+				mode = os.FileMode(header.Mode)
 			}
 
 			f, err := os.OpenFile(filepath.Clean(safePath), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)

--- a/internal/update/replace.go
+++ b/internal/update/replace.go
@@ -34,7 +34,7 @@ func backupPath(binaryPath string) string {
 func createBackup(binaryPath string) (string, error) {
 	bp := backupPath(binaryPath)
 
-	src, err := os.Open(binaryPath) //nolint:gosec G304 — binaryPath comes from os.Executable()
+	src, err := os.Open(filepath.Clean(binaryPath))
 	if err != nil {
 		return "", fmt.Errorf("open source for backup: %w", err)
 	}

--- a/internal/update/replace.go
+++ b/internal/update/replace.go
@@ -57,7 +57,7 @@ func createBackup(binaryPath string) (string, error) {
 // The backup file is preserved after the operation. If the binary file still
 // exists at the time of rollback, its existing permissions are preserved.
 func rollback(backupPath, binaryPath string) error {
-	src, err := os.Open(backupPath) //nolint:gosec G304 — backupPath is derived from os.Executable() + fixed suffix
+	src, err := os.Open(filepath.Clean(backupPath))
 	if err != nil {
 		return fmt.Errorf("rollback: open backup %q: %w", backupPath, err)
 	}

--- a/internal/update/replace.go
+++ b/internal/update/replace.go
@@ -68,7 +68,7 @@ func rollback(backupPath, binaryPath string) error {
 		perm = fi.Mode().Perm()
 	}
 
-	dst, err := os.OpenFile(binaryPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm) //nolint:gosec G304 — binaryPath comes from os.Executable()
+	dst, err := os.OpenFile(filepath.Clean(binaryPath), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm)
 	if err != nil {
 		return fmt.Errorf("rollback: create %q: %w", binaryPath, err)
 	}

--- a/internal/update/replace.go
+++ b/internal/update/replace.go
@@ -40,7 +40,7 @@ func createBackup(binaryPath string) (string, error) {
 	}
 	defer func() { _ = src.Close() }()
 
-	dst, err := os.OpenFile(bp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600) //nolint:gosec G304 — bp is derived from os.Executable() + fixed suffix
+	dst, err := os.OpenFile(filepath.Clean(bp), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
 	if err != nil {
 		return "", fmt.Errorf("create backup file %q: %w", bp, err)
 	}


### PR DESCRIPTION
Fixes the following gosec security alerts:

### G304 — Potential file inclusion via variable (25 alerts)
Sanitized file paths with `filepath.Clean()` before file operations in:
- `cmd/agent_audit.go`, `cmd/agent_doctor.go`, `cmd/agent_list.go`, `cmd/agent_skill.go`, `cmd/agent_uninstall.go`, `cmd/migrate.go`
- `cmd/agent_profile.go` (3 alerts)
- `internal/agentctx/context.go`, `internal/mcp/tools_audit_self.go`, `internal/quotas/lock_unix.go`
- `internal/agentskill/install.go` (5 alerts)
- `internal/update/apply.go`, `internal/update/extract.go`, `internal/update/replace.go` (4 alerts)

### G204 — Subprocess launched with variable (1 alert)
- `cmd/agent_profile.go`: sanitized `editor` and `tmpPath` variables in `exec.Command`

### G115 — Integer overflow conversion int64→uint32 (2 alerts)
- `cmd/import.go`: added bounds checking before `uint32` conversion
- `internal/update/extract.go`: added bounds checking for tar header mode conversion

### G106 — Use of ssh InsecureIgnoreHostKey (1 alert)
- `internal/git/git.go`: replaced `ssh.InsecureIgnoreHostKey()` with proper host key verification using `ssh.NewKnownHostsCallback` and `SSH_KNOWN_HOSTS` env var fallback