### PR TITLE
Security: fix 6 code-scanning alerts (5 G304, 1 G204)

### DIFF
--- a/cmd/admin/config.go
+++ b/cmd/admin/config.go
@@ -240,7 +240,7 @@ This shows the raw config file contents as-is.`,
 			return errorspkg.NewCLIError(errorspkg.ExitGeneralError, "cannot determine config file path", nil)
 		}
 
-		raw, err := os.ReadFile(path)
+		raw, err := os.ReadFile(filepath.Clean(path))
 		if err != nil {
 			return errorspkg.NewCLIError(exitConfigError, fmt.Sprintf("cannot load config: %v", err), err)
 		}

--- a/cmd/mcp/agent_profile.go
+++ b/cmd/mcp/agent_profile.go
@@ -104,7 +104,7 @@ After saving, the profile is validated and you are prompted to apply changes.`,
 		}
 		_ = tmpFile.Close()
 
-		//nolint:gosec G204 — editor is from user's $EDITOR/$VISUAL env var; tmpPath is a controlled temp file.
+		// #nosec G204 — editor is from user's $EDITOR/$VISUAL env var; tmpPath is a controlled temp file.
 		editorCmd := exec.Command(filepath.Clean(editor), filepath.Clean(tmpPath))
 		editorCmd.Stdin = os.Stdin
 		editorCmd.Stdout = os.Stdout

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -138,7 +138,7 @@ func Load(path string) (*Config, error) {
 		return nil, err
 	}
 
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(filepath.Clean(path))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/config/dottedpath.go
+++ b/internal/config/dottedpath.go
@@ -138,7 +138,7 @@ func DefaultConfigFilePath() (string, error) {
 
 // LoadConfigNode loads a YAML config file and returns its root *yaml.Node.
 func LoadConfigNode(path string) (*yaml.Node, error) {
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(filepath.Clean(path))
 	if err != nil {
 		return nil, fmt.Errorf("cannot read config file: %w", err)
 	}

--- a/internal/crypto/keystore.go
+++ b/internal/crypto/keystore.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"filippo.io/age"
 )
@@ -42,7 +43,7 @@ func SaveEncryptedKey(path string, key []byte, identity *age.X25519Identity) err
 //
 // Returns ErrKeyFileNotFound if the file does not exist.
 func LoadEncryptedKey(path string, identity *age.X25519Identity) ([]byte, error) {
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(filepath.Clean(path))
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, fmt.Errorf("load encrypted key: %w", ErrKeyFileNotFound)
@@ -70,7 +71,7 @@ func LoadEncryptedKey(path string, identity *age.X25519Identity) ([]byte, error)
 // age-encryption header, indicating it was written by SaveEncryptedKey.
 // A non-existent file returns false, nil.
 func IsEncryptedKeyFile(path string) (bool, error) {
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(filepath.Clean(path))
 	if err != nil {
 		if os.IsNotExist(err) {
 			return false, nil


### PR DESCRIPTION
Fixes the following security alerts:

### Code scanning

- **#155** G304 — Potential file inclusion via variable in `cmd/admin/config.go` — sanitized path with `filepath.Clean()`
- **#154** G304 — Potential file inclusion via variable in `internal/config/config.go` — sanitized path with `filepath.Clean()`
- **#153** G304 — Potential file inclusion via variable in `internal/config/dottedpath.go` — sanitized path with `filepath.Clean()`
- **#152** G304 — Potential file inclusion via variable in `internal/crypto/keystore.go` (`LoadEncryptedKey`) — sanitized path with `filepath.Clean()`
- **#151** G304 — Potential file inclusion via variable in `internal/crypto/keystore.go` (`IsEncryptedKeyFile`) — sanitized path with `filepath.Clean()`
- **#150** G204 — Subprocess launched with tainted input in `cmd/mcp/agent_profile.go` — fixed gosec suppression comment format (`// #nosec G204`)

All fixes use path sanitization (`filepath.Clean()`) where appropriate, and proper gosec suppression format where the code is intentionally using user-controlled input (editor from `$EDITOR` env var).