### PR TITLE
fix: wipe OPENPASS_PASSPHRASE env var backing array after reading

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+	"unsafe"
 
 	"filippo.io/age"
 	"github.com/spf13/cobra"
@@ -375,7 +376,13 @@ func resolveUnlockPassphrase(vaultDir string, interactive bool, cfg *configpkg.C
 		}
 		if len(passphrase) == 0 {
 			if envPass := os.Getenv("OPENPASS_PASSPHRASE"); envPass != "" {
-				passphrase = []byte(envPass)
+				// Use unsafe.Slice to alias the string backing array without a heap copy.
+				// This way the deferred Wipe(passphrase) at the call site clears the only
+				// copy of the passphrase in memory, and the os.Unsetenv does not leave a
+				// lingering string on the heap.
+				// #nosec G103 — intentional: unsafe.Slice avoids heap-copying the passphrase
+				// so that the subsequent Wipe clears the only copy in memory.
+				passphrase = unsafe.Slice(unsafe.StringData(envPass), len(envPass))
 				passphraseFromEnv = true
 			}
 			_ = os.Unsetenv("OPENPASS_PASSPHRASE")


### PR DESCRIPTION
## Description

Apply the existing `unsafe.Slice` + `Wipe` pattern (modeled on `internal/crypto/age.go`) to zero the string backing array after conversion, so the passphrase does not survive in process memory after `os.Unsetenv()`.

## Problem

`os.Unsetenv()` removes the env var from the process, but `envPass` is a Go `string` — it lives on the heap with no guarantee of being overwritten. The passphrase content remained in process memory until GC collected it. The `defer cryptopkg.Wipe(passphrase)` wiped the `[]byte` copy but not the original `envPass` string backing array.

## Fix

Replace `passphrase = []byte(envPass)` (which heap-copies the string) with `passphrase = unsafe.Slice(unsafe.StringData(envPass), len(envPass))` (which aliases the backing array directly). Now the existing `Wipe(passphrase)` clears the only copy.

## Changes

- `internal/cli/cli.go`: Replace `[]byte(envPass)` with `unsafe.Slice(unsafe.StringData(envPass), len(envPass))` to avoid heap-copying the passphrase

Closes #138