### PR TITLE
fix: wipe OPENPASS_MCP_TOKEN memory backing after Getenv

### DIFF
--- a/internal/mcp/token.go
+++ b/internal/mcp/token.go
@@ -12,7 +12,9 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unsafe"
 
+	"github.com/danieljustus/OpenPass/internal/crypto"
 	"github.com/danieljustus/OpenPass/internal/fileutil"
 )
 
@@ -700,6 +702,9 @@ func LoadOrCreateToken(path string) (string, error) {
 			if envToken := os.Getenv("OPENPASS_MCP_TOKEN"); envToken != "" {
 				fmt.Fprintf(os.Stderr, "Warning: OPENPASS_MCP_TOKEN is set but file token exists at %s; using file token\n", path)
 				_ = os.Unsetenv("OPENPASS_MCP_TOKEN")
+				// #nosec G103 — intentional: unsafe.StringData aliases the Getenv
+				// backing array so Wipe can zero the only copy in memory.
+				crypto.Wipe(unsafe.Slice(unsafe.StringData(envToken), len(envToken)))
 			}
 			return token, nil
 		}
@@ -707,7 +712,12 @@ func LoadOrCreateToken(path string) (string, error) {
 
 	if envToken := os.Getenv("OPENPASS_MCP_TOKEN"); envToken != "" {
 		_ = os.Unsetenv("OPENPASS_MCP_TOKEN")
-		return envToken, nil
+		// Clone the string so we can safely wipe Getenv's backing array.
+		token := string([]byte(envToken))
+		// #nosec G103 — intentional: unsafe.StringData aliases the Getenv
+		// backing array so Wipe can zero the only copy in memory.
+		crypto.Wipe(unsafe.Slice(unsafe.StringData(envToken), len(envToken)))
+		return token, nil
 	}
 
 	buf := make([]byte, 32)


### PR DESCRIPTION
## Changes

Zero the backing array of the `OPENPASS_MCP_TOKEN` env var value after reading, using the existing `unsafe.StringData` + `crypto.Wipe` pattern from `internal/crypto/age.go`.

- **Warning path** (file token exists, env var ignored): envToken backing array is wiped immediately since the value is not returned.
- **Return path** (no file token, env var used): the string is cloned first, the original backing array is wiped, and the clone is returned.

## Verification
- `go build ./internal/mcp/...`: clean
- `go test ./internal/mcp/...`: all pass
- `go vet ./internal/mcp/...`: no issues
- `golangci-lint run ./internal/mcp/...`: 0 issues

Closes #139