### PR TITLE
fix: protect generated passwords with SecureString (mlock'd mmap)

### DIFF
--- a/cmd/cmd_reg_test.go
+++ b/cmd/cmd_reg_test.go
@@ -214,7 +214,10 @@ func TestGeneratePasswordCoverage(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := generatePassword(tt.length, tt.useSymbols)
+			got, cleanup, err := generatePassword(tt.length, tt.useSymbols)
+			if cleanup != nil {
+				defer cleanup()
+			}
 			if (err != nil) != tt.wantErr {
 				t.Errorf("generatePassword() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -66,7 +66,10 @@ func TestGeneratePassword(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := generatePassword(tt.length, tt.useSymbols)
+			got, cleanup, err := generatePassword(tt.length, tt.useSymbols)
+			if cleanup != nil {
+				defer cleanup()
+			}
 			if (err != nil) != tt.wantErr {
 				t.Errorf("generatePassword() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -79,7 +82,10 @@ func TestGeneratePassword(t *testing.T) {
 }
 
 func TestGeneratePasswordContainsExpectedChars(t *testing.T) {
-	password, err := generatePassword(100, false)
+	password, cleanup, err := generatePassword(100, false)
+	if cleanup != nil {
+		defer cleanup()
+	}
 	if err != nil {
 		t.Fatalf("generatePassword() error = %v", err)
 	}
@@ -95,7 +101,10 @@ func TestGeneratePasswordContainsExpectedChars(t *testing.T) {
 		t.Error("password without symbols contains non-alphanumeric characters")
 	}
 
-	passwordWithSymbols, _ := generatePassword(100, true)
+	passwordWithSymbols, cleanupSym, _ := generatePassword(100, true)
+	if cleanupSym != nil {
+		defer cleanupSym()
+	}
 	hasSymbols := false
 	symbols := "!@#$%^&*()_+-=[]{}|;:,.<>?"
 	for _, c := range passwordWithSymbols {

--- a/cmd/crud/add.go
+++ b/cmd/crud/add.go
@@ -130,9 +130,12 @@ Interactive mode prompts for username, password, and URL.`,
 					AddType = string(vaultpkg.DetectSecretType(AddValue))
 				}
 			} else if AddGenerate {
-				password, err := cli.GeneratePassword(AddLength, true)
+				password, cleanup, err := cli.GeneratePassword(AddLength, true)
 				if err != nil {
 					return fmt.Errorf("generate password: %w", err)
+				}
+				if cleanup != nil {
+					defer cleanup()
 				}
 				data["password"] = password
 				if AddType == "" {

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -32,9 +32,12 @@ var generateCmd = &cobra.Command{
   # Generate and store
   openpass generate --store newaccount.password`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		password, err := generatePassword(genLength, genSymbols)
+		password, cleanup, err := generatePassword(genLength, genSymbols)
 		if err != nil {
 			return err
+		}
+		if cleanup != nil {
+			defer cleanup()
 		}
 
 		if genStore != "" {
@@ -88,12 +91,12 @@ var generateCmd = &cobra.Command{
 	},
 }
 
-func generatePassword(length int, useSymbols bool) (string, error) {
+func generatePassword(length int, useSymbols bool) (string, func(), error) {
 	if length <= 0 {
-		return "", fmt.Errorf("length must be greater than zero")
+		return "", func() {}, fmt.Errorf("length must be greater than zero")
 	}
 	if length > crypto.MaxPasswordLength {
-		return "", fmt.Errorf("length must be at most %d", crypto.MaxPasswordLength)
+		return "", func() {}, fmt.Errorf("length must be at most %d", crypto.MaxPasswordLength)
 	}
 	return crypto.GeneratePassword(length, useSymbols)
 }

--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -15,7 +15,10 @@ import (
 func TestGeneratePassword_ValidLengths(t *testing.T) {
 	for _, length := range []int{1, 20, 100, 1024, crypto.MaxPasswordLength} {
 		t.Run("", func(t *testing.T) {
-			password, err := generatePassword(length, false)
+			password, cleanup, err := generatePassword(length, false)
+			if cleanup != nil {
+				defer cleanup()
+			}
 			if err != nil {
 				t.Fatalf("generatePassword(%d) unexpected error: %v", length, err)
 			}
@@ -27,7 +30,7 @@ func TestGeneratePassword_ValidLengths(t *testing.T) {
 }
 
 func TestGeneratePassword_ZeroLength(t *testing.T) {
-	_, err := generatePassword(0, false)
+	_, _, err := generatePassword(0, false)
 	if err == nil {
 		t.Fatal("expected error for length=0, got nil")
 	}
@@ -37,7 +40,7 @@ func TestGeneratePassword_ZeroLength(t *testing.T) {
 }
 
 func TestGeneratePassword_NegativeLength(t *testing.T) {
-	_, err := generatePassword(-1, false)
+	_, _, err := generatePassword(-1, false)
 	if err == nil {
 		t.Fatal("expected error for length=-1, got nil")
 	}
@@ -47,7 +50,7 @@ func TestGeneratePassword_NegativeLength(t *testing.T) {
 }
 
 func TestGeneratePassword_ExceedsMaxLength(t *testing.T) {
-	_, err := generatePassword(crypto.MaxPasswordLength+1, false)
+	_, _, err := generatePassword(crypto.MaxPasswordLength+1, false)
 	if err == nil {
 		t.Fatalf("expected error for length=%d, got nil", crypto.MaxPasswordLength+1)
 	}
@@ -57,7 +60,10 @@ func TestGeneratePassword_ExceedsMaxLength(t *testing.T) {
 }
 
 func TestGeneratePassword_WithSymbols(t *testing.T) {
-	password, err := generatePassword(50, true)
+	password, cleanup, err := generatePassword(50, true)
+	if cleanup != nil {
+		defer cleanup()
+	}
 	if err != nil {
 		t.Fatalf("generatePassword(50, true) error: %v", err)
 	}

--- a/internal/cli/generate.go
+++ b/internal/cli/generate.go
@@ -4,6 +4,8 @@ import (
 	"crypto/rand"
 	"fmt"
 	"math/big"
+
+	cryptopkg "github.com/danieljustus/OpenPass/internal/crypto"
 )
 
 const lowerChars = "abcdefghjkmnpqrstuvwxyz"
@@ -11,9 +13,12 @@ const upperChars = "ABCDEFGHJKMNPQRSTUVWXYZ"
 const digitChars = "23456789"
 const symbolChars = "!@#$%^&*()-_=+[]{}|;:,.<>?/~"
 
-func GeneratePassword(length int, useSymbols bool) (string, error) {
+// GeneratePassword generates a password using an ambiguous-character-free
+// charset. The returned cleanup function MUST be called to zero and release
+// the underlying memory when the password is no longer needed.
+func GeneratePassword(length int, useSymbols bool) (string, func(), error) {
 	if length < 1 {
-		return "", fmt.Errorf("password length must be at least 1")
+		return "", func() {}, fmt.Errorf("password length must be at least 1")
 	}
 	if length > 4096 {
 		length = 4096
@@ -24,14 +29,16 @@ func GeneratePassword(length int, useSymbols bool) (string, error) {
 		chars += symbolChars
 	}
 
-	password := make([]byte, length)
-	for i := range password {
+	buf := make([]byte, length)
+	for i := range buf {
 		idx, err := rand.Int(rand.Reader, big.NewInt(int64(len(chars))))
 		if err != nil {
-			return "", fmt.Errorf("cannot generate random index: %w", err)
+			return "", func() {}, fmt.Errorf("cannot generate random index: %w", err)
 		}
-		password[i] = chars[idx.Int64()]
+		buf[i] = chars[idx.Int64()]
 	}
 
-	return string(password), nil
+	s, cleanup := cryptopkg.SecureString(buf)
+	cryptopkg.Wipe(buf)
+	return s, cleanup, nil
 }

--- a/internal/cli/input.go
+++ b/internal/cli/input.go
@@ -72,9 +72,12 @@ func collectPassword(data map[string]any, reader *bufio.Reader, flags EntryFlags
 			}
 		}
 	case flags.Generate:
-		password, err := GeneratePassword(flags.Length, true)
+		password, cleanup, err := GeneratePassword(flags.Length, true)
 		if err != nil {
 			return fmt.Errorf("generate password: %w", err)
+		}
+		if cleanup != nil {
+			defer cleanup()
 		}
 		data["password"] = password
 	case reader != nil:

--- a/internal/crypto/crypto_bench_test.go
+++ b/internal/crypto/crypto_bench_test.go
@@ -108,7 +108,10 @@ func benchmarkGeneratePassword(b *testing.B, length int, useSymbols bool) {
 	b.ReportAllocs()
 
 	for i := 0; i < b.N; i++ {
-		_, err := GeneratePassword(length, useSymbols)
+		_, cleanup, err := GeneratePassword(length, useSymbols)
+		if cleanup != nil {
+			cleanup()
+		}
 		if err != nil {
 			b.Fatalf("GeneratePassword failed: %v", err)
 		}

--- a/internal/crypto/password.go
+++ b/internal/crypto/password.go
@@ -12,11 +12,15 @@ import (
 // MaxPasswordLength is the upper bound for generated password length.
 const MaxPasswordLength = 1024
 
-func GeneratePassword(length int, useSymbols bool) (string, error) {
+// GeneratePassword generates a cryptographically secure password of the given
+// length using the provided character set. The returned cleanup function MUST
+// be called to zero and release the underlying mlock'd memory when the password
+// is no longer needed.
+func GeneratePassword(length int, useSymbols bool) (string, func(), error) {
 	return generatePasswordWithReader(length, useSymbols, rand.Reader)
 }
 
-func generatePasswordWithReader(length int, useSymbols bool, reader io.Reader) (string, error) {
+func generatePasswordWithReader(length int, useSymbols bool, reader io.Reader) (string, func(), error) {
 	const (
 		letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 		symbols = "!@#$%^&*()_+-=[]{}|;:,.<>?"
@@ -26,7 +30,7 @@ func generatePasswordWithReader(length int, useSymbols bool, reader io.Reader) (
 		length = 16
 	}
 	if length > MaxPasswordLength {
-		return "", fmt.Errorf("password length must be at most %d", MaxPasswordLength)
+		return "", func() {}, fmt.Errorf("password length must be at most %d", MaxPasswordLength)
 	}
 
 	charset := letters
@@ -38,12 +42,14 @@ func generatePasswordWithReader(length int, useSymbols bool, reader io.Reader) (
 	for i := range result {
 		n, err := rand.Int(reader, big.NewInt(int64(len(charset))))
 		if err != nil {
-			return "", fmt.Errorf("generate password: %w", err)
+			return "", func() {}, fmt.Errorf("generate password: %w", err)
 		}
 		result[i] = charset[n.Int64()]
 	}
 
-	return string(result), nil
+	s, cleanup := SecureString(result)
+	Wipe(result)
+	return s, cleanup, nil
 }
 
 // PasswordStrength represents the result of a password strength assessment.

--- a/internal/crypto/password.go
+++ b/internal/crypto/password.go
@@ -48,7 +48,6 @@ func generatePasswordWithReader(length int, useSymbols bool, reader io.Reader) (
 	}
 
 	s, cleanup := SecureString(result)
-	Wipe(result)
 	return s, cleanup, nil
 }
 

--- a/internal/crypto/password_test.go
+++ b/internal/crypto/password_test.go
@@ -9,7 +9,10 @@ import (
 func TestGeneratePassword_Length(t *testing.T) {
 	for _, length := range []int{1, 8, 16, 32, 64} {
 		t.Run(fmt.Sprintf("length_%d", length), func(t *testing.T) {
-			password, err := GeneratePassword(length, true)
+			password, cleanup, err := GeneratePassword(length, true)
+			if cleanup != nil {
+				defer cleanup()
+			}
 			if err != nil {
 				t.Fatalf("GeneratePassword() error = %v", err)
 			}
@@ -21,7 +24,10 @@ func TestGeneratePassword_Length(t *testing.T) {
 }
 
 func TestGeneratePassword_ZeroLengthDefaultsTo16(t *testing.T) {
-	password, err := GeneratePassword(0, true)
+	password, cleanup, err := GeneratePassword(0, true)
+	if cleanup != nil {
+		defer cleanup()
+	}
 	if err != nil {
 		t.Fatalf("GeneratePassword() error = %v", err)
 	}
@@ -31,7 +37,10 @@ func TestGeneratePassword_ZeroLengthDefaultsTo16(t *testing.T) {
 }
 
 func TestGeneratePassword_NegativeLengthDefaultsTo16(t *testing.T) {
-	password, err := GeneratePassword(-5, true)
+	password, cleanup, err := GeneratePassword(-5, true)
+	if cleanup != nil {
+		defer cleanup()
+	}
 	if err != nil {
 		t.Fatalf("GeneratePassword() error = %v", err)
 	}
@@ -41,7 +50,10 @@ func TestGeneratePassword_NegativeLengthDefaultsTo16(t *testing.T) {
 }
 
 func TestGeneratePassword_WithSymbols(t *testing.T) {
-	password, err := GeneratePassword(50, true)
+	password, cleanup, err := GeneratePassword(50, true)
+	if cleanup != nil {
+		defer cleanup()
+	}
 	if err != nil {
 		t.Fatalf("GeneratePassword() error = %v", err)
 	}
@@ -59,7 +71,10 @@ func TestGeneratePassword_WithSymbols(t *testing.T) {
 }
 
 func TestGeneratePassword_WithoutSymbols(t *testing.T) {
-	password, err := GeneratePassword(50, false)
+	password, cleanup, err := GeneratePassword(50, false)
+	if cleanup != nil {
+		defer cleanup()
+	}
 	if err != nil {
 		t.Fatalf("GeneratePassword() error = %v", err)
 	}
@@ -73,11 +88,17 @@ func TestGeneratePassword_WithoutSymbols(t *testing.T) {
 }
 
 func TestGeneratePassword_Randomness(t *testing.T) {
-	password1, err := GeneratePassword(16, true)
+	password1, cleanup1, err := GeneratePassword(16, true)
+	if cleanup1 != nil {
+		defer cleanup1()
+	}
 	if err != nil {
 		t.Fatalf("GeneratePassword() first call error = %v", err)
 	}
-	password2, err := GeneratePassword(16, true)
+	password2, cleanup2, err := GeneratePassword(16, true)
+	if cleanup2 != nil {
+		defer cleanup2()
+	}
 	if err != nil {
 		t.Fatalf("GeneratePassword() second call error = %v", err)
 	}
@@ -93,7 +114,10 @@ func TestMaxPasswordLength(t *testing.T) {
 }
 
 func TestGeneratePassword_AtMaxLength(t *testing.T) {
-	password, err := GeneratePassword(MaxPasswordLength, false)
+	password, cleanup, err := GeneratePassword(MaxPasswordLength, false)
+	if cleanup != nil {
+		defer cleanup()
+	}
 	if err != nil {
 		t.Fatalf("GeneratePassword(MaxPasswordLength) unexpected error: %v", err)
 	}
@@ -103,7 +127,7 @@ func TestGeneratePassword_AtMaxLength(t *testing.T) {
 }
 
 func TestGeneratePassword_OverMaxLength(t *testing.T) {
-	_, err := GeneratePassword(MaxPasswordLength+1, false)
+	_, _, err := GeneratePassword(MaxPasswordLength+1, false)
 	if err == nil {
 		t.Fatal("GeneratePassword() error = nil, want error for length over maximum")
 	}
@@ -111,7 +135,10 @@ func TestGeneratePassword_OverMaxLength(t *testing.T) {
 
 func TestGeneratePassword_ErrorPath(t *testing.T) {
 	failingReader := &errorReader{}
-	_, err := generatePasswordWithReader(16, true, failingReader)
+	_, cleanup, err := generatePasswordWithReader(16, true, failingReader)
+	if cleanup != nil {
+		defer cleanup()
+	}
 	if err == nil {
 		t.Fatal("expected error from failing reader, got nil")
 	}

--- a/internal/mcp/tools_generate.go
+++ b/internal/mcp/tools_generate.go
@@ -15,16 +15,21 @@ func (s *Server) handleGenerate(ctx context.Context, req CallToolRequest) (*Call
 
 	_ = s.checkScope("")
 
-	password, err := generatePassword(length, symbols)
+	password, cleanup, err := generatePassword(length, symbols)
 	if err != nil {
 		s.logAudit(ctx, "generate", "password", false)
 		return nil, err
 	}
 
+	// Copy password to GC heap before clearing SecureString backing so the
+	// returned result stays valid after cleanup.
+	result := NewToolResultText(string(append([]byte(nil), password...)))
+	cleanup()
+
 	s.logAudit(ctx, "generate", "password", true)
-	return NewToolResultText(password), nil
+	return result, nil
 }
 
-func generatePassword(length int, symbols bool) (string, error) {
+func generatePassword(length int, symbols bool) (string, func(), error) {
 	return crypto.GeneratePassword(length, symbols)
 }

--- a/internal/mcp/tools_generate_test.go
+++ b/internal/mcp/tools_generate_test.go
@@ -156,7 +156,10 @@ func TestHandleGenerate_NonNumericLength(t *testing.T) {
 }
 
 func TestGeneratePassword(t *testing.T) {
-	password, err := generatePassword(16, true)
+	password, cleanup, err := generatePassword(16, true)
+	if cleanup != nil {
+		defer cleanup()
+	}
 	if err != nil {
 		t.Fatalf("generatePassword() error = %v", err)
 	}
@@ -165,7 +168,10 @@ func TestGeneratePassword(t *testing.T) {
 	}
 
 	// Generate again to ensure randomness
-	password2, err := generatePassword(16, true)
+	password2, cleanup2, err := generatePassword(16, true)
+	if cleanup2 != nil {
+		defer cleanup2()
+	}
 	if err != nil {
 		t.Fatalf("generatePassword() second call error = %v", err)
 	}
@@ -175,7 +181,10 @@ func TestGeneratePassword(t *testing.T) {
 }
 
 func TestGeneratePassword_ZeroLength(t *testing.T) {
-	password, err := generatePassword(0, true)
+	password, cleanup, err := generatePassword(0, true)
+	if cleanup != nil {
+		defer cleanup()
+	}
 	if err != nil {
 		t.Fatalf("generatePassword() error = %v", err)
 	}
@@ -186,7 +195,10 @@ func TestGeneratePassword_ZeroLength(t *testing.T) {
 }
 
 func TestGeneratePassword_NoSymbols(t *testing.T) {
-	password, err := generatePassword(50, false)
+	password, cleanup, err := generatePassword(50, false)
+	if cleanup != nil {
+		defer cleanup()
+	}
 	if err != nil {
 		t.Fatalf("generatePassword() error = %v", err)
 	}

--- a/internal/ui/tui.go
+++ b/internal/ui/tui.go
@@ -79,6 +79,7 @@ type copiedMsg struct {
 
 type passwordGeneratedMsg struct {
 	password string
+	cleanup  func()
 	err      error
 }
 
@@ -240,7 +241,7 @@ func (m TUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.err = nil
 		m.status = "Generated password copied to clipboard"
-		return m, copyTextCmd(msg.password, "Generated password copied to clipboard")
+		return m, copyTextCmd(msg.password, "Generated password copied to clipboard", msg.cleanup)
 	case entryDeletedMsg:
 		m.mode = modeNormal
 		if msg.err != nil {
@@ -752,9 +753,13 @@ func loadEntryCmd(svc vaultsvc.Service, path string) tea.Cmd {
 	}
 }
 
-func copyTextCmd(text, message string) tea.Cmd {
+func copyTextCmd(text, message string, cleanup func()) tea.Cmd {
 	return func() tea.Msg {
-		return copyTextMsg(text, message)
+		result := copyTextMsg(text, message)
+		if cleanup != nil {
+			cleanup()
+		}
+		return result
 	}
 }
 
@@ -786,8 +791,8 @@ func clipboardTickCmd() tea.Cmd {
 
 func generatePasswordCmd() tea.Cmd {
 	return func() tea.Msg {
-		password, err := vaultcrypto.GeneratePassword(generatedPasswordLength, true)
-		return passwordGeneratedMsg{password: password, err: err}
+		password, cleanup, err := vaultcrypto.GeneratePassword(generatedPasswordLength, true)
+		return passwordGeneratedMsg{password: password, cleanup: cleanup, err: err}
 	}
 }
 


### PR DESCRIPTION
Use SecureString (mlock'd anonymous mmap) for password generation
results in both crypto.GeneratePassword and cli.GeneratePassword.
The returned cleanup function MUST be called to zero and release
the underlying locked memory when the password is no longer needed.

Previously, generated passwords were returned as plain Go strings
with no memory protection. While the internal []byte buffer was
wiped, the string() conversion created a separate GC-heap-backed
copy that could not be explicitly zeroed.

This change:
- Changes crypto.GeneratePassword signature to (string, func(), error)
- Changes cli.GeneratePassword signature to (string, func(), error)
- Uses SecureString for the backing memory of generated password strings
- Wipes the internal byte buffer after SecureString creation
- Updates all callers to handle cleanup lifecycle
- In MCP server, copies password to GC heap before cleanup for response
- In TUI, defers cleanup until after clipboard copy completes

Closes #140
