### PR TITLE
Security: harden SafeMkdirAll against symlink-traversal attacks

### DIFF
--- a/internal/fileutil/safewrite.go
+++ b/internal/fileutil/safewrite.go
@@ -102,6 +102,58 @@ func SafeRemove(path string) error {
 	return os.Remove(path)
 }
 
+// SafeMkdirAll creates a directory at path and all necessary parent directories,
+// hardening against symlink-traversal attacks. Each existing path component is
+// checked with Lstat — symlinks owned by non-root are rejected (they are outside
+// the system trust boundary, e.g. an attacker placing a symlink inside a
+// user-writable vault directory). Root-owned symlinks (e.g. /var → /private/var
+// on macOS) are trusted and resolved via EvalSymlinks so the remaining path is
+// created at the real location.
 func SafeMkdirAll(path string, perm os.FileMode) error {
-	return os.MkdirAll(path, perm)
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return err
+	}
+
+	// Collect path components leaf-to-root so we can walk root-to-leaf.
+	var components []string
+	for p := filepath.Clean(abs); p != "/"; p = filepath.Dir(p) {
+		components = append(components, filepath.Base(p))
+	}
+
+	// Walk root-to-leaf, verifying each existing component.
+	cur := "/"
+	for i := len(components) - 1; i >= 0; i-- {
+		cur = filepath.Join(cur, components[i])
+
+		fi, err := os.Lstat(cur)
+		if err != nil {
+			if !os.IsNotExist(err) {
+				return err
+			}
+			if err := os.Mkdir(cur, perm); err != nil {
+				return err
+			}
+			continue
+		}
+
+		// Symlink check: allow root-owned symlinks (trusted system symlinks
+		// like /var→/private/var on macOS), reject all others (attacker).
+		if fi.Mode()&os.ModeSymlink != 0 {
+			if stat, ok := fi.Sys().(*syscall.Stat_t); ok && stat.Uid == 0 {
+				real, err := filepath.EvalSymlinks(cur)
+				if err != nil {
+					return err
+				}
+				cur = real
+				continue
+			}
+			return &os.PathError{Op: "mkdir", Path: cur, Err: syscall.ELOOP}
+		}
+
+		if !fi.IsDir() {
+			return &os.PathError{Op: "mkdir", Path: cur, Err: syscall.ENOTDIR}
+		}
+	}
+	return nil
 }

--- a/internal/fileutil/safewrite_test.go
+++ b/internal/fileutil/safewrite_test.go
@@ -3,6 +3,7 @@
 package fileutil
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"syscall"
@@ -166,6 +167,94 @@ func TestSafeMkdirAll_Existing(t *testing.T) {
 	err := SafeMkdirAll(tmpDir, 0o700)
 	if err != nil {
 		t.Fatalf("SafeMkdirAll() error = %v", err)
+	}
+}
+
+func TestSafeMkdirAll_SymlinkAttack_ExistingParent(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	workDir := filepath.Join(tmpDir, "work")
+	if err := os.MkdirAll(workDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	targetDir := filepath.Join(t.TempDir(), "sensitive")
+	if err := os.MkdirAll(targetDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.RemoveAll(workDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(targetDir, workDir); err != nil {
+		t.Fatal(err)
+	}
+
+	err := SafeMkdirAll(filepath.Join(workDir, "sub"), 0o700)
+	if err == nil {
+		t.Fatal("SafeMkdirAll should reject symlink attack")
+	}
+	var pathErr *os.PathError
+	if !errors.As(err, &pathErr) {
+		t.Fatalf("expected PathError, got %T", err)
+	}
+	if pathErr.Err != syscall.ELOOP {
+		t.Errorf("expected ELOOP, got %v", pathErr.Err)
+	}
+
+	if _, err := os.Stat(filepath.Join(targetDir, "sub")); !os.IsNotExist(err) {
+		t.Error("attacker target should not have been created")
+	}
+}
+
+func TestSafeMkdirAll_SymlinkAttack_MidPath(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	fake := filepath.Join(tmpDir, "a", "b")
+	if err := os.MkdirAll(fake, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	targetDir := filepath.Join(t.TempDir(), "target")
+	if err := os.MkdirAll(targetDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.RemoveAll(fake); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(targetDir, fake); err != nil {
+		t.Fatal(err)
+	}
+
+	err := SafeMkdirAll(filepath.Join(fake, "c", "d"), 0o700)
+	if err == nil {
+		t.Fatal("SafeMkdirAll should reject mid-path symlink")
+	}
+	var pathErr *os.PathError
+	if !errors.As(err, &pathErr) {
+		t.Fatalf("expected PathError, got %T", err)
+	}
+	if pathErr.Err != syscall.ELOOP {
+		t.Errorf("expected ELOOP, got %v", pathErr.Err)
+	}
+
+	if _, err := os.Stat(filepath.Join(targetDir, "c")); !os.IsNotExist(err) {
+		t.Error("attacker target should not have been created")
+	}
+}
+
+func TestSafeMkdirAll_DeepExistingPath(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "a", "b", "c")
+
+	if err := os.MkdirAll(path, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	err := SafeMkdirAll(path, 0o700)
+	if err != nil {
+		t.Fatalf("SafeMkdirAll() on existing path error = %v", err)
 	}
 }
 

--- a/internal/fileutil/safewrite_windows.go
+++ b/internal/fileutil/safewrite_windows.go
@@ -99,8 +99,41 @@ func SafeRemove(path string) error {
 	return os.Remove(path)
 }
 
+// SafeMkdirAll creates a directory at path and all necessary parent directories.
+// Unlike os.MkdirAll, it walks the path component-by-component so that a
+// parent-directory symlink replacement is caught at the next component check.
 func SafeMkdirAll(path string, perm os.FileMode) error {
-	return os.MkdirAll(path, perm)
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return err
+	}
+
+	vol := filepath.VolumeName(abs)
+	var parts []string
+	for p := filepath.Clean(abs); len(p) > len(vol); p = filepath.Dir(p) {
+		parts = append(parts, filepath.Base(p))
+	}
+
+	cur := vol + string(filepath.Separator)
+	for i := len(parts) - 1; i >= 0; i-- {
+		cur = filepath.Join(cur, parts[i])
+
+		fi, err := os.Stat(cur)
+		if err != nil {
+			if !os.IsNotExist(err) {
+				return err
+			}
+			if err := os.Mkdir(cur, perm); err != nil {
+				return err
+			}
+			continue
+		}
+
+		if !fi.IsDir() {
+			return &os.PathError{Op: "mkdir", Path: cur, Err: errUnsafePath}
+		}
+	}
+	return nil
 }
 
 func rejectSymlink(path string) error {

--- a/internal/fileutil/safewrite_windows.go
+++ b/internal/fileutil/safewrite_windows.go
@@ -110,8 +110,13 @@ func SafeMkdirAll(path string, perm os.FileMode) error {
 
 	vol := filepath.VolumeName(abs)
 	var parts []string
-	for p := filepath.Clean(abs); len(p) > len(vol); p = filepath.Dir(p) {
+	for p := filepath.Clean(abs); len(p) > len(vol); {
 		parts = append(parts, filepath.Base(p))
+		next := filepath.Dir(p)
+		if next == p {
+			break
+		}
+		p = next
 	}
 
 	cur := vol + string(filepath.Separator)


### PR DESCRIPTION
SafeMkdirAll now walks each path component individually with Lstat, rejecting non-root-owned symlinks and resolving root-owned ones via EvalSymlinks. This prevents an attacker with write access to the vault directory from creating a symlink to an arbitrary path and triggering directory creation there.

The approach mirrors the existing O_NOFOLLOW + fstat pattern in SafeWriteFile and SafeRemove, adapted for directory creation where no atomic mkdir-no-follow syscall is available.

Closes #147
