### PR TITLE
Security: wipe TOTP secret string backing array after storage

### DIFF
--- a/internal/cli/input.go
+++ b/internal/cli/input.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"unsafe"
 
 	cryptopkg "github.com/danieljustus/OpenPass/internal/crypto"
 )
@@ -164,12 +165,21 @@ func collectTOTP(data map[string]any, reader *bufio.Reader, flags EntryFlags) er
 		return nil
 	}
 
-	totpSecret := []byte(totpLine)
-	defer cryptopkg.Wipe(totpSecret)
+	// Make a copy so the original string's backing array can be wiped.
+	secretCopy := string([]byte(totpLine))
 
 	totpData := map[string]any{
-		"secret": totpLine,
+		"secret": secretCopy,
 	}
+
+	// Wipe the original string's backing array to prevent the TOTP secret
+	// from persisting in process memory after the function returns.
+	// #nosec G103 — intentional: unsafe.StringData/Slice create a byte slice
+	// over the original string's backing array so Wipe() clears the only
+	// in-memory copy that is not stored in the vault data map.
+	ptr := unsafe.StringData(totpLine)
+	buf := unsafe.Slice(ptr, len(totpLine))
+	cryptopkg.Wipe(buf)
 
 	if !flags.SkipTOTPDetails {
 		fmt.Fprint(os.Stderr, "TOTP Issuer (optional): ")


### PR DESCRIPTION
Apply unsafe+wipe pattern to the TOTP secret string before storing it in the vault data map.

## Problem
The `[]byte` copy of the TOTP secret (from `totpLine`) was wiped with `defer cryptopkg.Wipe(totpSecret)`, but this only wiped the copy — the original `totpLine` string continued to exist in process memory because it was stored in the vault data map as a Go string.

## Fix
1. Make an explicit string copy for the data map: `secretCopy := string([]byte(totpLine))`
2. Store the copy in the map instead of the original
3. Use `unsafe.StringData` + `unsafe.Slice` to alias the original string's backing array and call `cryptopkg.Wipe` to clear it

This follows the existing unsafe+wipe convention used throughout the crypto package (see `age.go`, `keygen.go`, `secstring_*.go`).

Closes #148