### PR TITLE
feat: warn when OPENPASS_PASSPHRASE is used

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -751,3 +751,40 @@ func TestWarnPipeRead_OnceAndSilenced(t *testing.T) {
 	// Already emitted → second call is silent (idempotent).
 	cli.WarnPipeRead("Passphrase")
 }
+
+func TestWarnEnvPassphrase_OnceAndSilenced(t *testing.T) {
+	oldEmitted := cli.EnvPassphraseWarningEmitted
+	oldQuiet := cli.QuietMode
+	defer func() {
+		cli.EnvPassphraseWarningEmitted = oldEmitted
+		cli.QuietMode = oldQuiet
+	}()
+
+	// Suppressed in quiet mode.
+	cli.EnvPassphraseWarningEmitted = false
+	cli.QuietMode = true
+	cli.WarnEnvPassphrase()
+	if cli.EnvPassphraseWarningEmitted {
+		t.Errorf("warning fired despite --quiet")
+	}
+	cli.QuietMode = false
+
+	// Suppressed when OPENPASS_NO_ENV_WARNING is set.
+	cli.EnvPassphraseWarningEmitted = false
+	t.Setenv("OPENPASS_NO_ENV_WARNING", "1")
+	cli.WarnEnvPassphrase()
+	if cli.EnvPassphraseWarningEmitted {
+		t.Errorf("warning fired despite OPENPASS_NO_ENV_WARNING")
+	}
+	t.Setenv("OPENPASS_NO_ENV_WARNING", "0")
+
+	// Fires once when not suppressed.
+	cli.EnvPassphraseWarningEmitted = false
+	cli.WarnEnvPassphrase()
+	if !cli.EnvPassphraseWarningEmitted {
+		t.Errorf("warning did not fire when expected")
+	}
+
+	// Already emitted → second call is silent (idempotent).
+	cli.WarnEnvPassphrase()
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -44,6 +44,23 @@ var IsTerminalFunc func(int) bool = term.IsTerminal
 // printed in this process so we only nag once per invocation.
 var PipeWarningEmitted bool
 
+// EnvPassphraseWarningEmitted tracks whether the OPENPASS_PASSPHRASE env-var
+// warning has already been printed in this process.
+var EnvPassphraseWarningEmitted bool
+
+// WarnEnvPassphrase prints a one-shot warning that OPENPASS_PASSPHRASE is set,
+// which makes the passphrase visible in /proc/PID/environ and process listings.
+func WarnEnvPassphrase() {
+	if EnvPassphraseWarningEmitted || QuietMode {
+		return
+	}
+	if v := os.Getenv("OPENPASS_NO_ENV_WARNING"); v != "" && v != "0" {
+		return
+	}
+	EnvPassphraseWarningEmitted = true
+	cliout.Warnf("OPENPASS_PASSPHRASE is set — the passphrase is visible in /proc/PID/environ and may be exposed in process listings and crash dumps.")
+}
+
 // WarnPipeRead prints a one-shot warning that hidden input is being read from
 // a non-TTY (pipe/redirect).
 func WarnPipeRead(label string) {
@@ -384,6 +401,7 @@ func resolveUnlockPassphrase(vaultDir string, interactive bool, cfg *configpkg.C
 				// so that the subsequent Wipe clears the only copy in memory.
 				passphrase = unsafe.Slice(unsafe.StringData(envPass), len(envPass))
 				passphraseFromEnv = true
+				WarnEnvPassphrase()
 			}
 			_ = os.Unsetenv("OPENPASS_PASSPHRASE")
 		}


### PR DESCRIPTION
## Summary

Add a one-shot warning when the vault passphrase is supplied via `OPENPASS_PASSPHRASE` environment variable, alerting users that the passphrase is visible in `/proc/PID/environ`, process listings, and crash dumps.

## Changes

- **internal/cli/cli.go**: Added `EnvPassphraseWarningEmitted` flag and `WarnEnvPassphrase()` function following the same one-shot pattern as `WarnPipeRead()`. Called from `resolveUnlockPassphrase()` when the passphrase originates from `OPENPASS_PASSPHRASE`.
- **cmd/root_test.go**: Added `TestWarnEnvPassphrase_OnceAndSilenced` verifying suppression via `--quiet`, `OPENPASS_NO_ENV_WARNING`, and the one-shot idempotency guarantee.

## Suppression

The warning can be suppressed via:
- `--quiet` flag
- `OPENPASS_NO_ENV_WARNING=1` environment variable

This follows the exact same pattern as the existing `WarnPipeRead` / `OPENPASS_NO_PIPE_WARNING` mechanism.

Closes #149