### PR TITLE
refactor: replace init() functions with package-level initialization

### DIFF
--- a/internal/crypto/argon2id.go
+++ b/internal/crypto/argon2id.go
@@ -32,17 +32,15 @@ func DefaultArgon2idParams() Argon2idParams {
 	}
 }
 
-var testArgon2idParams atomic.Value
-
-// init populates testArgon2idParams with default params so that
-// atomic.Value.Store is never called with nil (which would panic).
-func init() {
-	testArgon2idParams.Store(&Argon2idParams{
+var testArgon2idParams = func() atomic.Value {
+	var v atomic.Value
+	v.Store(&Argon2idParams{
 		Time:    DefaultArgon2idTime,
 		Memory:  DefaultArgon2idMemory,
 		Threads: DefaultArgon2idThreads,
 	})
-}
+	return v
+}()
 
 func SetTestArgon2idParams(p Argon2idParams) (restore func()) {
 	prev := testArgon2idParams.Load()

--- a/internal/vault/entry.go
+++ b/internal/vault/entry.go
@@ -165,18 +165,16 @@ func validateLegacyEntryPath(vaultDir, path string) error {
 // configCache memoizes parsed vault configs per vaultDir, keyed by the
 // config file's mtime. It avoids re-parsing config.yaml on every entry
 // read during a search — the hot path for large vaults.
-var configCache struct {
+var configCache = struct {
 	mu    sync.RWMutex
 	items map[string]configCacheEntry
+}{
+	items: make(map[string]configCacheEntry),
 }
 
 type configCacheEntry struct {
 	cfg   *vaultconfig.Config
 	mtime time.Time
-}
-
-func init() {
-	configCache.items = make(map[string]configCacheEntry)
 }
 
 // InvalidateConfigCache drops the cached config for vaultDir. Callers should
@@ -867,13 +865,11 @@ func (e *Entry) IsCanary() bool {
 // canaryPaths is an in-memory set of known canary entry paths.
 // Maintained separately from encrypted entries to enable O(1) canary checks
 // without requiring decryption.
-var canaryPaths struct {
+var canaryPaths = struct {
 	mu    sync.RWMutex
 	paths map[string]bool
-}
-
-func init() {
-	canaryPaths.paths = make(map[string]bool)
+}{
+	paths: make(map[string]bool),
 }
 
 // MarkCanaryPath adds a path to the in-memory canary set.


### PR DESCRIPTION
Replace three init() functions that set mutable global state with
package-level initialization patterns:
- configCache and canaryPaths use struct composite literals
- testArgon2idParams uses an anonymous init function for atomic.Value

No behavioral changes; all existing tests pass.
- go test ./internal/vault/... ./internal/crypto/... -race -short: ok
- No init() functions remain in either file

Closes #151
