### PR TITLE
Session 2026-05-20: batch issue fixes

### DIFF
--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -350,13 +351,9 @@ func (l *Logger) EnforceRetention() error {
 	}
 
 	// Sort by modification time, oldest first
-	for i := 0; i < len(rotatedFiles)-1; i++ {
-		for j := i + 1; j < len(rotatedFiles); j++ {
-			if rotatedFiles[i].ModTime().After(rotatedFiles[j].ModTime()) {
-				rotatedFiles[i], rotatedFiles[j] = rotatedFiles[j], rotatedFiles[i]
-			}
-		}
-	}
+	sort.Slice(rotatedFiles, func(i, j int) bool {
+		return rotatedFiles[i].ModTime().Before(rotatedFiles[j].ModTime())
+	})
 
 	// Check max backups policy - keep at most MaxBackups files
 	backupsToDelete := len(rotatedFiles) - config.MaxBackups

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -469,31 +469,68 @@ func (l *Logger) lastNEntries(n int) ([]LogEntry, error) {
 		return nil, nil
 	}
 
-	// Read file content into memory for parsing (avoids bad file descriptor with O_APPEND)
-	data, err := os.ReadFile(l.path)
+	f, err := os.Open(l.path)
 	if err != nil {
 		return nil, err
 	}
+	defer f.Close()
 
+	readSize := int64(4096)
 	var entries []LogEntry
-	scanner := bufio.NewScanner(bytes.NewReader(data))
-	scanner.Split(scanLines)
+	for {
+		if readSize > fileSize {
+			readSize = fileSize
+		}
+		start := fileSize - readSize
 
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
+		buf := make([]byte, readSize)
+		if _, err := f.ReadAt(buf, start); err != nil {
+			return nil, err
+		}
+
+		entries = parseTailEntries(buf, start == 0)
+		if len(entries) >= n || readSize >= fileSize {
+			if len(entries) > n {
+				entries = entries[len(entries)-n:]
+			}
+			return entries, nil
+		}
+		readSize *= 2
+	}
+}
+
+// parseTailEntries extracts complete JSON log entries from the tail of a JSONL file.
+// data may start in the middle of a line if atStart is false. Only complete lines
+// (terminated by \n) are parsed. Malformed lines are skipped.
+func parseTailEntries(data []byte, atStart bool) []LogEntry {
+	idx := 0
+	if !atStart && len(data) > 0 && data[0] != '\n' {
+		if nl := bytes.IndexByte(data, '\n'); nl >= 0 {
+			idx = nl + 1
+		} else {
+			return nil
+		}
+	}
+	for idx < len(data) && data[idx] == '\n' {
+		idx++
+	}
+	if idx >= len(data) {
+		return nil
+	}
+
+	lines := strings.Split(string(data[idx:]), "\n")
+	var entries []LogEntry
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
 		if line == "" {
 			continue
 		}
 		var entry LogEntry
 		if err := json.Unmarshal([]byte(line), &entry); err == nil {
 			entries = append(entries, entry)
-			if len(entries) > n {
-				entries = entries[len(entries)-n:]
-			}
 		}
 	}
-
-	return entries, nil
+	return entries
 }
 
 func scanLines(data []byte, atEOF bool) (advance int, token []byte, err error) {
@@ -554,19 +591,58 @@ func (l *Logger) readLastHMAC() ([]byte, error) {
 	if err != nil {
 		return nil, nil
 	}
-	if info.Size() == 0 {
+	fileSize := info.Size()
+	if fileSize == 0 {
 		return nil, nil
 	}
 
-	data, err := os.ReadFile(l.path)
+	f, err := os.Open(l.path)
 	if err != nil {
 		return nil, nil
 	}
+	defer f.Close()
 
-	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
-	lastLine := lines[len(lines)-1]
-	if lastLine == "" && len(lines) > 1 {
-		lastLine = lines[len(lines)-2]
+	readSize := int64(4096)
+	var lastLine string
+
+	for {
+		if readSize > fileSize {
+			readSize = fileSize
+		}
+		start := fileSize - readSize
+
+		buf := make([]byte, readSize)
+		if _, err := f.ReadAt(buf, start); err != nil {
+			return nil, nil
+		}
+
+		idx := 0
+		if start > 0 {
+			nl := bytes.IndexByte(buf, '\n')
+			if nl >= 0 {
+				idx = nl + 1
+			} else {
+				if readSize >= fileSize {
+					return nil, nil
+				}
+				readSize *= 2
+				continue
+			}
+		}
+
+		text := string(buf[idx:])
+		lines := strings.Split(text, "\n")
+		for i := len(lines) - 1; i >= 0; i-- {
+			if strings.TrimSpace(lines[i]) != "" {
+				lastLine = lines[i]
+				break
+			}
+		}
+		break
+	}
+
+	if lastLine == "" {
+		return nil, nil
 	}
 
 	var lastEntry LogEntry

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -470,7 +470,7 @@ func (l *Logger) lastNEntries(n int) ([]LogEntry, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	readSize := int64(4096)
 	var entries []LogEntry
@@ -530,6 +530,7 @@ func parseTailEntries(data []byte, atStart bool) []LogEntry {
 	return entries
 }
 
+//nolint:unparam // signature required by bufio.SplitFunc
 func scanLines(data []byte, atEOF bool) (advance int, token []byte, err error) {
 	if atEOF && len(data) == 0 {
 		return 0, nil, nil
@@ -597,7 +598,7 @@ func (l *Logger) readLastHMAC() ([]byte, error) {
 	if err != nil {
 		return nil, nil
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	readSize := int64(4096)
 	var lastLine string

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -149,9 +149,14 @@ var ThemePreset string
 var RootCmd = &cobra.Command{
 	Use:   "openpass",
 	Short: "OpenPass is a Go CLI password manager",
-	Long: `OpenPass is a Go CLI password manager with an interactive TUI, multi-device
+	Long: `Quick Start:
+  openpass init            create a vault and identity
+  openpass add <name>      add a credential
+  openpass get <name>      retrieve a credential
+
+OpenPass is a Go CLI password manager with an interactive TUI, multi-device
 sync via Git, and an MCP server for AI-agent integration.
- 
+
 First-time setup:
    1. openpass init         create a vault and identity (non-interactive)
    2. openpass setup        same, plus guided wizard for sync/agents (TTY only)

--- a/internal/vault/entry.go
+++ b/internal/vault/entry.go
@@ -258,13 +258,13 @@ func ReadEntry(vaultDir, path string, identity *age.X25519Identity) (*Entry, err
 		span.SetStatus(codes.Error, err.Error())
 		return nil, err
 	}
-	defer vaultcrypto.Wipe(plaintext)
-
 	var entry Entry
 	if err := json.Unmarshal(plaintext, &entry); err != nil {
+		vaultcrypto.Wipe(plaintext)
 		span.SetStatus(codes.Error, err.Error())
 		return nil, err
 	}
+	vaultcrypto.Wipe(plaintext)
 	if entry.Data == nil {
 		entry.Data = map[string]any{}
 	}

--- a/internal/vault/search.go
+++ b/internal/vault/search.go
@@ -327,12 +327,13 @@ func listPseudonymized(vaultDir, prefix string) ([]string, error) {
 		if decryptErr != nil {
 			return nil
 		}
-		defer vaultcrypto.Wipe(plaintext)
 
 		var entry Entry
 		if jsonErr := json.Unmarshal(plaintext, &entry); jsonErr != nil {
+			vaultcrypto.Wipe(plaintext)
 			return nil
 		}
+		vaultcrypto.Wipe(plaintext)
 
 		entryPath := entry.Path
 		if entryPath == "" {


### PR DESCRIPTION
Aggregated session PR opened by 03-gh-go.

This PR will close the following issues on merge:

<!-- closes-list-start -->
- Closes #141 [Performance] lastNEntries reads entire audit log into memory
- Closes #142 [Architecture] Audit retention uses O(n²) bubble sort
- Closes #145 [Performance] Concurrent search deferred wipes accumulate plaintext in memory
- Closes #146 [UX/DX] --help may not surface vault init/setup clearly for new users
<!-- closes-list-end -->