### PR TITLE
refactor(session): replace unsafe.StringData with []byte for passphrase wiping

### DIFF
--- a/internal/session/memory_keyring.go
+++ b/internal/session/memory_keyring.go
@@ -47,18 +47,18 @@ func (m *memoryKeyring) Set(service, account, value string) error {
 		return fmt.Errorf("unmarshal session: %w", err)
 	}
 
-	if sess.Passphrase != "" {
+	if len(sess.Passphrase) > 0 {
 		key, err := m.encryptionKeyForStore(service)
 		if err != nil {
 			return fmt.Errorf("encryption key: %w", err)
 		}
-		enc, nonce, err := encryptPassphrase([]byte(sess.Passphrase), key)
+		enc, nonce, err := encryptPassphrase(sess.Passphrase, key)
 		if err != nil {
 			return fmt.Errorf("encrypt passphrase: %w", err)
 		}
 		sess.EncryptedPassphrase = enc
 		sess.Nonce = nonce
-		sess.Passphrase = ""
+		sess.Passphrase = nil
 	}
 
 	payload, err := json.Marshal(sess)
@@ -144,7 +144,7 @@ func (m *memoryKeyring) Get(service, account string) (string, error) {
 			return "", fmt.Errorf("not found")
 		}
 		zeroBytes(plain)
-	} else if sess.Passphrase == "" {
+	} else if len(sess.Passphrase) == 0 {
 		delete(m.store, key)
 		return "", fmt.Errorf("not found")
 	}

--- a/internal/session/memory_keyring_test.go
+++ b/internal/session/memory_keyring_test.go
@@ -54,7 +54,7 @@ func TestMemoryKeyring_Set_EncryptsPlaintextPassphrase(t *testing.T) {
 
 	now := time.Now().UTC()
 	sess := storedSession{
-		Passphrase: passphrase,
+		Passphrase: passphraseBytes([]byte(passphrase)),
 		SavedAt:    now,
 		LastAccess: now,
 		TTL:        int64(time.Hour),
@@ -75,7 +75,7 @@ func TestMemoryKeyring_Set_EncryptsPlaintextPassphrase(t *testing.T) {
 		t.Fatalf("Unmarshal() error = %v", err)
 	}
 
-	if retrieved.Passphrase != "" {
+	if len(retrieved.Passphrase) > 0 {
 		t.Error("plaintext passphrase should be encrypted after Set")
 	}
 	if retrieved.EncryptedPassphrase == "" {
@@ -209,7 +209,7 @@ func TestMemoryKeyring_Get_UpdatesLastAccess(t *testing.T) {
 
 	now := time.Now().UTC()
 	sess := storedSession{
-		Passphrase: "secret",
+		Passphrase: passphraseBytes([]byte("secret")),
 		SavedAt:    now,
 		LastAccess: now,
 		TTL:        int64(time.Hour),
@@ -296,7 +296,7 @@ func TestMemoryKeyring_Set_ZeroesOldData(t *testing.T) {
 	mk.Set("openpass:"+vaultDir, wrapKeyAccount, wrapKey)
 
 	sess1 := storedSession{
-		Passphrase: "first-secret",
+		Passphrase: passphraseBytes([]byte("first-secret")),
 		SavedAt:    time.Now().UTC(),
 		LastAccess: time.Now().UTC(),
 		TTL:        int64(time.Hour),
@@ -305,7 +305,7 @@ func TestMemoryKeyring_Set_ZeroesOldData(t *testing.T) {
 	mk.Set("openpass:"+vaultDir, sessionAccount, string(payload1))
 
 	sess2 := storedSession{
-		Passphrase: "second-secret",
+		Passphrase: passphraseBytes([]byte("second-secret")),
 		SavedAt:    time.Now().UTC(),
 		LastAccess: time.Now().UTC(),
 		TTL:        int64(time.Hour),
@@ -321,7 +321,7 @@ func TestMemoryKeyring_Set_ZeroesOldData(t *testing.T) {
 	var retrieved storedSession
 	json.Unmarshal([]byte(got), &retrieved)
 	// After Set encrypts plaintext, the passphrase should be empty
-	if retrieved.Passphrase != "" {
+	if len(retrieved.Passphrase) > 0 {
 		t.Error("Passphrase should be encrypted/empty after Set")
 	}
 }

--- a/internal/session/memory_test.go
+++ b/internal/session/memory_test.go
@@ -70,7 +70,7 @@ func TestMemoryKeyring_EncryptsPlaintextPassphrase(t *testing.T) {
 	account := sessionAccount
 
 	sess := storedSession{
-		Passphrase: "plaintext-secret",
+		Passphrase: passphraseBytes([]byte("plaintext-secret")),
 		SavedAt:    time.Now().UTC(),
 		LastAccess: time.Now().UTC(),
 		TTL:        int64(time.Hour),
@@ -94,7 +94,7 @@ func TestMemoryKeyring_EncryptsPlaintextPassphrase(t *testing.T) {
 		t.Fatalf("json.Unmarshal() error = %v", err)
 	}
 
-	if gotSess.Passphrase != "" {
+	if len(gotSess.Passphrase) > 0 {
 		t.Error("Set() should encrypt plaintext passphrase")
 	}
 	if gotSess.EncryptedPassphrase == "" || gotSess.Nonce == "" {

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -59,7 +59,6 @@ import (
 	"fmt"
 	"io"
 	"time"
-	"unsafe"
 
 	"github.com/danieljustus/OpenPass/internal/crypto"
 	"github.com/danieljustus/OpenPass/internal/metrics"
@@ -103,13 +102,35 @@ func GetCacheStatus() CacheStatus {
 	return cacheStatusProvider()
 }
 
+// passphraseBytes is a byte slice that marshals to/from a plain JSON string
+// (not base64). This preserves backward compatibility with sessions stored
+// before the migration from string to []byte.
+type passphraseBytes []byte
+
+func (p passphraseBytes) MarshalJSON() ([]byte, error) {
+	return json.Marshal(string(p))
+}
+
+func (p *passphraseBytes) UnmarshalJSON(data []byte) error {
+	if string(data) == "null" {
+		*p = nil
+		return nil
+	}
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	*p = []byte(s)
+	return nil
+}
+
 type storedSession struct {
-	SavedAt             time.Time `json:"saved_at"`
-	LastAccess          time.Time `json:"last_access"`
-	Passphrase          string    `json:"passphrase,omitempty"`
-	EncryptedPassphrase string    `json:"encrypted_passphrase,omitempty"`
-	Nonce               string    `json:"nonce,omitempty"`
-	TTL                 int64     `json:"ttl_ns"`
+	SavedAt             time.Time       `json:"saved_at"`
+	LastAccess          time.Time       `json:"last_access"`
+	Passphrase          passphraseBytes `json:"passphrase,omitempty"`
+	EncryptedPassphrase string          `json:"encrypted_passphrase,omitempty"`
+	Nonce               string          `json:"nonce,omitempty"`
+	TTL                 int64           `json:"ttl_ns"`
 }
 
 type storedIdentity struct {
@@ -318,8 +339,11 @@ func resolvePassphrase(sess *storedSession, vaultDir string) ([]byte, error) {
 		return plain, nil
 	}
 
-	if sess.Passphrase != "" {
-		plain := []byte(sess.Passphrase)
+	if len(sess.Passphrase) > 0 {
+		// Copy before encrypting so the original backing array can be zeroed
+		// without affecting the returned plaintext.
+		plain := make([]byte, len(sess.Passphrase))
+		copy(plain, sess.Passphrase)
 		key, err := encryptionKey(vaultDir)
 		if err != nil {
 			return nil, err
@@ -328,13 +352,8 @@ func resolvePassphrase(sess *storedSession, vaultDir string) ([]byte, error) {
 		if encErr == nil {
 			sess.EncryptedPassphrase = enc
 			sess.Nonce = nonce
-			// Wipe the legacy plaintext from the struct string's backing memory
-			// before clearing the field, so the passphrase does not remain on
-			// the heap until the next GC cycle.
-			// #nosec G103 — intentional: unsafe.StringData aliases the backing
-			// array so Wipe can zero the only copy in memory.
-			crypto.Wipe(unsafe.Slice(unsafe.StringData(sess.Passphrase), len(sess.Passphrase)))
-			sess.Passphrase = ""
+			crypto.Wipe(sess.Passphrase)
+			sess.Passphrase = nil
 		}
 		return plain, nil
 	}

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -456,7 +456,7 @@ func TestMigration_OldFormatAutoMigratesToEncrypted(t *testing.T) {
 	if jsonErr := json.Unmarshal([]byte(raw), &sess); jsonErr != nil {
 		t.Fatalf("json.Unmarshal() error = %v", jsonErr)
 	}
-	if sess.Passphrase != "" {
+	if len(sess.Passphrase) > 0 {
 		t.Error("after migration, plaintext passphrase field should be empty")
 	}
 	if sess.EncryptedPassphrase == "" || sess.Nonce == "" {
@@ -494,7 +494,7 @@ func TestNewFormatStoredEncrypted(t *testing.T) {
 	if err := json.Unmarshal([]byte(raw), &sess); err != nil {
 		t.Fatalf("json.Unmarshal() error = %v", err)
 	}
-	if sess.Passphrase != "" {
+	if len(sess.Passphrase) > 0 {
 		t.Error("new format should not contain plaintext passphrase")
 	}
 	if sess.EncryptedPassphrase == "" {
@@ -821,7 +821,7 @@ func TestResolvePassphrase_BothEncryptedAndPlaintext(t *testing.T) {
 	sess := storedSession{
 		EncryptedPassphrase: enc,
 		Nonce:               nonce,
-		Passphrase:          "legacy-secret",
+		Passphrase:          passphraseBytes([]byte("legacy-secret")),
 		SavedAt:             time.Now().UTC(),
 		LastAccess:          time.Now().UTC(),
 		TTL:                 int64(time.Hour),
@@ -851,7 +851,7 @@ func TestResolvePassphrase_LegacyFormatMigrates(t *testing.T) {
 	setupTestWrapKey(t, fake, vaultDir)
 	passphrase := "legacy-value"
 	sess := storedSession{
-		Passphrase: passphrase,
+		Passphrase: passphraseBytes([]byte(passphrase)),
 		SavedAt:    time.Now().UTC(),
 		LastAccess: time.Now().UTC(),
 		TTL:        int64(time.Hour),
@@ -877,7 +877,7 @@ func TestResolvePassphrase_LegacyFormatMigrates(t *testing.T) {
 	if jsonErr := json.Unmarshal([]byte(raw), &updated); jsonErr != nil {
 		t.Fatalf("json.Unmarshal() error = %v", jsonErr)
 	}
-	if updated.Passphrase != "" {
+	if len(updated.Passphrase) > 0 {
 		t.Error("legacy plaintext should be cleared after migration")
 	}
 }
@@ -891,7 +891,7 @@ func TestResolvePassphrase_WipesPlaintextAfterMigration(t *testing.T) {
 	passphrase := "legacy-wipe-test-secret"
 
 	sess := &storedSession{
-		Passphrase: passphrase,
+		Passphrase: passphraseBytes([]byte(passphrase)),
 		SavedAt:    time.Now().UTC(),
 		LastAccess: time.Now().UTC(),
 		TTL:        int64(time.Hour),
@@ -913,13 +913,13 @@ func TestResolvePassphrase_WipesPlaintextAfterMigration(t *testing.T) {
 	if jsonErr := json.Unmarshal([]byte(raw), &loaded); jsonErr != nil {
 		t.Fatalf("json.Unmarshal() error = %v", jsonErr)
 	}
-	if loaded.Passphrase == "" {
+	if len(loaded.Passphrase) == 0 {
 		t.Fatal("expected legacy passphrase to be present before migration")
 	}
 
 	// Capture the backing data pointer before migration.
 	// #nosec G103 — intentional: confirming wipe side-effect in test.
-	origData := unsafe.StringData(loaded.Passphrase)
+	origData := unsafe.SliceData(loaded.Passphrase)
 	origLen := len(loaded.Passphrase)
 
 	got, err := resolvePassphrase(&loaded, vaultDir)
@@ -931,7 +931,7 @@ func TestResolvePassphrase_WipesPlaintextAfterMigration(t *testing.T) {
 	}
 
 	// After migration the original backing data should be zeroed
-	// (the string was explicitly wiped before being set to "").
+	// (the slice was explicitly wiped before being set to nil).
 	buf := unsafe.Slice(origData, origLen)
 	for i, b := range buf {
 		if b != 0 {
@@ -939,9 +939,9 @@ func TestResolvePassphrase_WipesPlaintextAfterMigration(t *testing.T) {
 		}
 	}
 
-	// The struct field must be empty string now
-	if loaded.Passphrase != "" {
-		t.Error("sess.Passphrase should be empty after migration")
+	// The struct field must be nil now
+	if len(loaded.Passphrase) > 0 {
+		t.Error("sess.Passphrase should be nil after migration")
 	}
 }
 
@@ -1056,7 +1056,7 @@ func TestResolvePassphrase_EncryptFailsDuringMigration(t *testing.T) {
 	plain := "legacy-passphrase"
 
 	sess := storedSession{
-		Passphrase: plain,
+		Passphrase: passphraseBytes([]byte(plain)),
 		SavedAt:    time.Now().UTC(),
 		LastAccess: time.Now().UTC(),
 		TTL:        int64(time.Hour),


### PR DESCRIPTION
- Change storedSession.Passphrase from string to passphraseBytes ([]byte with plain JSON string encoding) to eliminate the unsafe.StringData/unsafe.Slice pattern- Remove the  import from session.go entirely- In resolvePassphrase, copy the byte slice before encrypting so wiping the original does not affect the returned plaintext- Add passphraseBytes type with custom MarshalJSON/UnmarshalJSON for backward-compatible JSON serialization (plain string, not base64)- Fix resolvePassphrase: len(sess.Passphrase)>0 check, crypto.Wipe(sess.Passphrase) directly, set to nil- Update memory_keyring.go to use len() checks and nil assignment- Update all tests for the type change and remove unsafe.StringData from wipe verification test (use unsafe.SliceData instead)Closes #167
