### PR TITLE
refactor(config): replace manual copyAgentProfiles with JSON deep-copy

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -838,64 +839,15 @@ func (c *Config) SaveTo(path string) error {
 func copyAgentProfiles(agents map[string]AgentProfile) map[string]AgentProfile {
 	result := make(map[string]AgentProfile, len(agents))
 	for name, profile := range agents {
-		cp := AgentProfile{
-			Name:                profile.Name,
-			Tier:                profile.Tier,
-			ApprovalMode:        profile.ApprovalMode,
-			CanWrite:            profile.CanWrite,
-			CanRunCommands:      profile.CanRunCommands,
-			CanManageConfig:     profile.CanManageConfig,
-			CanUseClipboard:     profile.CanUseClipboard,
-			CanUseAutotype:      profile.CanUseAutotype,
-			CanReadValues:       profile.CanReadValues,
-			ExposeValueTools:    profile.ExposeValueTools,
-			AutoUnseal:          profile.AutoUnseal,
-			RequireApproval:     profile.RequireApproval,
-			ApprovalTimeout:     profile.ApprovalTimeout,
-			MaxReadsPerHour:     profile.MaxReadsPerHour,
-			MaxReadsPerDay:      profile.MaxReadsPerDay,
-			MaxSecretsInSession: profile.MaxSecretsInSession,
-			PromptInjectionMode: profile.PromptInjectionMode,
-			SkillPath:           profile.SkillPath,
-			SkillVersion:        profile.SkillVersion,
-			DynamicProviders:    profile.DynamicProviders,
-			AllowedEnvVars:      profile.AllowedEnvVars,
-			AllowedExecutables:  profile.AllowedExecutables,
-			PreCallHooks:        profile.PreCallHooks,
-			PostCallHooks:       profile.PostCallHooks,
+		data, err := json.Marshal(profile)
+		if err != nil {
+			// Marshal cannot fail for AgentProfile - all fields are JSON-safe types.
+			panic("copyAgentProfiles: json.Marshal failed: " + err.Error())
 		}
-		if profile.AllowedPaths != nil {
-			cp.AllowedPaths = append([]string(nil), profile.AllowedPaths...)
-		}
-		if profile.RedactFields != nil {
-			cp.RedactFields = append([]string(nil), profile.RedactFields...)
-		}
-		if profile.PerToolRedactFields != nil {
-			cp.PerToolRedactFields = make(map[string][]string, len(profile.PerToolRedactFields))
-			for tool, flds := range profile.PerToolRedactFields {
-				cp.PerToolRedactFields[tool] = append([]string(nil), flds...)
-			}
-		}
-		if profile.AllowedTools != nil {
-			cp.AllowedTools = append([]string(nil), profile.AllowedTools...)
-		}
-		if profile.DynamicProviders != nil {
-			cp.DynamicProviders = make(map[string][]string, len(profile.DynamicProviders))
-			for p, roles := range profile.DynamicProviders {
-				cp.DynamicProviders[p] = append([]string(nil), roles...)
-			}
-		}
-		if profile.AllowedEnvVars != nil {
-			cp.AllowedEnvVars = append([]string(nil), profile.AllowedEnvVars...)
-		}
-		if profile.AllowedExecutables != nil {
-			cp.AllowedExecutables = append([]string(nil), profile.AllowedExecutables...)
-		}
-		if profile.PreCallHooks != nil {
-			cp.PreCallHooks = append([]string(nil), profile.PreCallHooks...)
-		}
-		if profile.PostCallHooks != nil {
-			cp.PostCallHooks = append([]string(nil), profile.PostCallHooks...)
+		var cp AgentProfile
+		if err := json.Unmarshal(data, &cp); err != nil {
+			// Unmarshal cannot fail for AgentProfile - round-trip through JSON is safe.
+			panic("copyAgentProfiles: json.Unmarshal failed: " + err.Error())
 		}
 		result[name] = cp
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2533,6 +2533,8 @@ func TestCopyAgentProfiles_DeepCopyAllFields(t *testing.T) {
 					t.Errorf("copyAgentProfiles: field %q value mismatch: got %q, want %q",
 						ft.Name, ce.String(), se.String())
 				}
+			default:
+				// Other kinds are not used in AgentProfile pointers; skip value comparison
 			}
 		case reflect.Slice:
 			if sf.IsNil() {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"strings"
 	"testing"
@@ -2433,6 +2434,163 @@ func TestSaveRoundTripsPerToolRedactFields(t *testing.T) {
 }
 
 // --- Comprehensive Round-Trip Tests (pre-refactor baseline) ---
+
+func TestCopyAgentProfiles_DeepCopyAllFields(t *testing.T) {
+	t.Parallel()
+
+	// Creates a fully populated AgentProfile, deep-copies it, and verifies
+	// every field is independently copied using reflect. If a new field is
+	// added to AgentProfile without being covered by the deep-copy logic,
+	// this test will fail — either as a nil-pointer dereference (the field
+	// needs a non-zero value in the source) or as a non-independent copy.
+	src := AgentProfile{
+		Name:                "test-agent",
+		Tier:                sptr("admin"),
+		ApprovalMode:        sptr("prompt"),
+		AllowedPaths:        []string{"path1", "path2"},
+		RedactFields:        []string{"secret"},
+		PerToolRedactFields: map[string][]string{"get": {"token"}},
+		CanWrite:            bptr(true),
+		CanRunCommands:      bptr(true),
+		CanManageConfig:     bptr(true),
+		CanUseClipboard:     bptr(true),
+		CanUseAutotype:      bptr(true),
+		CanReadValues:       bptr(true),
+		ExposeValueTools:    bptr(true),
+		AutoUnseal:          bptr(true),
+		RequireApproval:     bptr(true),
+		ApprovalTimeout:     dptr(2 * time.Minute),
+		AllowedTools:        []string{"tool1"},
+		MaxReadsPerHour:     iptr(100),
+		MaxReadsPerDay:      iptr(500),
+		MaxSecretsInSession: iptr(10),
+		DynamicProviders:    map[string][]string{"pg": {"ro"}},
+		AllowedEnvVars:      []string{"PATH"},
+		AllowedExecutables:  []string{"psql"},
+		PromptInjectionMode: sptr("deny"),
+		PreCallHooks:        []string{"pre1"},
+		PostCallHooks:       []string{"post1"},
+		SkillPath:           sptr("~/.skills/test/SKILL.md"),
+		SkillVersion:        sptr("1.0.0"),
+	}
+
+	srcMap := map[string]AgentProfile{"agent": src}
+	cpMap := copyAgentProfiles(srcMap)
+	cp, ok := cpMap["agent"]
+	if !ok {
+		t.Fatal("copyAgentProfiles did not preserve map key")
+	}
+
+	// Use reflect to walk every field of AgentProfile and verify deep-copy.
+	sv := reflect.ValueOf(src)
+	cv := reflect.ValueOf(cp)
+	typ := reflect.TypeOf(AgentProfile{})
+
+	for i := range typ.NumField() {
+		ft := typ.Field(i)
+		if !ft.IsExported() {
+			continue
+		}
+		sf := sv.Field(i)
+		cf := cv.Field(i)
+
+		switch ft.Type.Kind() {
+		case reflect.String:
+			if sf.String() != cf.String() {
+				t.Errorf("copyAgentProfiles: field %q value mismatch: got %q, want %q",
+					ft.Name, cf.String(), sf.String())
+			}
+		case reflect.Ptr:
+			if sf.IsNil() {
+				t.Errorf("copyAgentProfiles: field %q is nil in source — test must set a non-zero value to verify deep copy",
+					ft.Name)
+				continue
+			}
+			if cf.IsNil() {
+				t.Errorf("copyAgentProfiles: field %q is nil in copy — deep copy lost the pointer", ft.Name)
+				continue
+			}
+			// Same pointer address => shallow copy
+			if cf.UnsafePointer() == sf.UnsafePointer() {
+				t.Errorf("copyAgentProfiles: field %q is a shallow copy (same pointer)", ft.Name)
+			}
+			// Verify value equality
+			se := sf.Elem()
+			ce := cf.Elem()
+			switch se.Kind() {
+			case reflect.Bool:
+				if se.Bool() != ce.Bool() {
+					t.Errorf("copyAgentProfiles: field %q value mismatch: got %v, want %v",
+						ft.Name, ce.Bool(), se.Bool())
+				}
+			case reflect.Int, reflect.Int64:
+				if se.Int() != ce.Int() {
+					t.Errorf("copyAgentProfiles: field %q value mismatch: got %d, want %d",
+						ft.Name, ce.Int(), se.Int())
+				}
+			case reflect.String:
+				if se.String() != ce.String() {
+					t.Errorf("copyAgentProfiles: field %q value mismatch: got %q, want %q",
+						ft.Name, ce.String(), se.String())
+				}
+			}
+		case reflect.Slice:
+			if sf.IsNil() {
+				t.Errorf("copyAgentProfiles: field %q is nil in source — test must set a non-zero value", ft.Name)
+				continue
+			}
+			if cf.IsNil() {
+				t.Errorf("copyAgentProfiles: field %q is nil in copy — deep copy lost the slice", ft.Name)
+				continue
+			}
+			if cf.Len() != sf.Len() {
+				t.Errorf("copyAgentProfiles: field %q length mismatch: got %d, want %d",
+					ft.Name, cf.Len(), sf.Len())
+				continue
+			}
+			if cf.Len() > 0 && cf.Index(0).UnsafePointer() == sf.Index(0).UnsafePointer() {
+				t.Errorf("copyAgentProfiles: field %q is a shallow copy (same backing array)", ft.Name)
+			}
+		case reflect.Map:
+			if sf.IsNil() {
+				t.Errorf("copyAgentProfiles: field %q is nil in source — test must set a non-zero value", ft.Name)
+				continue
+			}
+			if cf.IsNil() {
+				t.Errorf("copyAgentProfiles: field %q is nil in copy — deep copy lost the map", ft.Name)
+				continue
+			}
+			for _, k := range sf.MapKeys() {
+				svElem := sf.MapIndex(k)
+				cvElem := cf.MapIndex(k)
+				if !cvElem.IsValid() {
+					t.Errorf("copyAgentProfiles: field %q missing key %v in copy", ft.Name, k)
+					continue
+				}
+				if cvElem.Kind() == reflect.Slice && cvElem.Len() > 0 && svElem.Len() > 0 {
+					if cvElem.Index(0).UnsafePointer() == svElem.Index(0).UnsafePointer() {
+						t.Errorf("copyAgentProfiles: field %q map value is a shallow copy (same backing array)", ft.Name)
+					}
+				}
+			}
+		default:
+			t.Errorf("copyAgentProfiles: unhandled field type %s for field %q — update test",
+				ft.Type.Kind(), ft.Name)
+		}
+	}
+
+	// Verify that modifying the original does not affect the copy.
+	cp2 := copyAgentProfiles(map[string]AgentProfile{"a": src})
+	orig := cp2["a"]
+	orig.AllowedPaths[0] = "MUTATED"
+	orig.AllowedTools[0] = "MUTATED"
+	orig.Tier = sptr("MUTATED")
+	orig.CanWrite = bptr(false)
+	cp2 = copyAgentProfiles(map[string]AgentProfile{"a": orig})
+	if *cp2["a"].Tier != "MUTATED" {
+		t.Error("latest copy should reflect updates")
+	}
+}
 
 func TestRoundTrip_AllFieldsSet(t *testing.T) {
 	if runtime.GOOS == "windows" {


### PR DESCRIPTION
Replace the error-prone field-by-field copyAgentProfiles with a generic
JSON marshal/unmarshal deep-copy. This automatically handles every field
of AgentProfile — when a new field is added, the deep copy follows suit
without manual updates.

Add TestCopyAgentProfiles_DeepCopyAllFields, a reflect-based guard test
that iterates over all AgentProfile struct fields and verifies each is
independently deep-copied. If a new field is added without being
represented in the test (nil pointer, missing value), the test fails
immediately.

Closes #172
