### PR TITLE
fix(auth status): use PrintResult instead of deprecated PrintJSON for --output json

### DIFF
--- a/cmd/auth/auth.go
+++ b/cmd/auth/auth.go
@@ -50,8 +50,11 @@ var AuthStatusCmd = &cobra.Command{
 			"cache":            cache,
 		}
 		if cli.WantJSONOutput(AuthStatusJSON) {
-			cli.PrintJSON(payload)
-			return nil
+			printer, err := cli.NewPrinter("json")
+			if err != nil {
+				return err
+			}
+			return printer.Print(payload)
 		}
 		cli.PrintlnQuietAware("Vault: " + vaultDir)
 		cli.PrintlnQuietAware("Auth method: " + method)

--- a/cmd/auth_test.go
+++ b/cmd/auth_test.go
@@ -2,11 +2,13 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	auth "github.com/danieljustus/OpenPass/cmd/auth"
+	cli "github.com/danieljustus/OpenPass/internal/cli"
 	configpkg "github.com/danieljustus/OpenPass/internal/config"
 	"github.com/danieljustus/OpenPass/internal/session"
 )
@@ -65,16 +67,49 @@ func TestAuthStatusJSON(t *testing.T) {
 	vaultDir, _ := initVault(t)
 	defer setupVaultFlag(t, vaultDir)()
 
-	oldJSON := auth.AuthStatusJSON
-	auth.AuthStatusJSON = true
-	t.Cleanup(func() { auth.AuthStatusJSON = oldJSON })
+	t.Run("deprecated --json flag", func(t *testing.T) {
+		oldJSON := auth.AuthStatusJSON
+		auth.AuthStatusJSON = true
+		t.Cleanup(func() { auth.AuthStatusJSON = oldJSON })
 
-	output := captureStdout(func() {
-		if err := auth.AuthStatusCmd.RunE(auth.AuthStatusCmd, nil); err != nil {
-			t.Fatalf("auth status error = %v", err)
+		output := captureStdout(func() {
+			if err := auth.AuthStatusCmd.RunE(auth.AuthStatusCmd, nil); err != nil {
+				t.Fatalf("auth status error = %v", err)
+			}
+		})
+		if !strings.Contains(output, `"method"`) {
+			t.Fatalf("output = %q, want JSON status", output)
 		}
 	})
-	if !strings.Contains(output, `"method"`) {
-		t.Fatalf("output = %q, want JSON status", output)
-	}
+
+	t.Run("--output json (global flag)", func(t *testing.T) {
+		oldFmt := cli.OutputFormat
+		cli.OutputFormat = "json"
+		t.Cleanup(func() { cli.OutputFormat = oldFmt })
+
+		// Ensure the deprecated --json flag is off so only --output json drives it
+		oldJSON := auth.AuthStatusJSON
+		auth.AuthStatusJSON = false
+		t.Cleanup(func() { auth.AuthStatusJSON = oldJSON })
+
+		output := captureStdout(func() {
+			if err := auth.AuthStatusCmd.RunE(auth.AuthStatusCmd, nil); err != nil {
+				t.Fatalf("auth status error = %v", err)
+			}
+		})
+		if !strings.Contains(output, `"method"`) {
+			t.Fatalf("output = %q, want JSON status", output)
+		}
+		// Verify it's valid JSON
+		var parsed map[string]interface{}
+		if err := json.Unmarshal([]byte(strings.TrimSpace(output)), &parsed); err != nil {
+			t.Fatalf("invalid JSON output: %v\noutput: %s", err, output)
+		}
+		if _, ok := parsed["method"]; !ok {
+			t.Fatalf("JSON missing 'method' key: %v", parsed)
+		}
+		if _, ok := parsed["vault"]; !ok {
+			t.Fatalf("JSON missing 'vault' key: %v", parsed)
+		}
+	})
 }


### PR DESCRIPTION
The auth status command now uses cli.NewPrinter("json") when JSON
output is requested (via either --output json or the deprecated --json
flag), making it consistent with list, find, and get commands.

Previously it used cli.PrintJSON (deprecated) which bypassed the
format selection logic and was inconsistent with other commands.

Extended auth status test to validate JSON output via --output json
(the preferred approach) and verify the output is valid JSON.

Closes #169
