### PR TITLE
Prepare v4.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,190 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v4.0.0] - 2026-05-21
+
+v4.0 reshapes OpenPass around AI-agent integration. The CLI becomes a
+first-class surface for agents (dual to MCP), agent profiles gain an explicit
+tier system, skill packages ship inside the binary, and the MCP server defaults
+to a lean 7-tool surface to reduce context-window pollution.
+
+See [docs/migration-v3-to-v4.md](docs/migration-v3-to-v4.md) for the upgrade
+guide and [docs/skills/openpass-agent/UPGRADE-TO-V4.md](docs/skills/openpass-agent/UPGRADE-TO-V4.md)
+for an AI-agent-ready upgrade prompt. Run `openpass migrate v4 --dry-run` to
+preview, then `openpass migrate v4` to apply.
+
+### Breaking changes
+
+- **CLI consolidation.** All AI-integration commands moved under
+  `openpass agent`. Replaced: `openpass mcp install`, `openpass mcp-config`,
+  `openpass mcp token …`, `openpass mcp-token-rotate`, `openpass agent setup`.
+  Deprecation stubs remain in v4.0 (print replacement, exit 2) and will be
+  removed in v4.1.
+- **MCP tool `openpass_delete` removed** (was an alias for `delete_entry` since
+  v2.x). Callers receive `ERR_TOOL_NOT_FOUND`. Use `delete_entry`.
+- **Default tier for `openpass agent install` is `safe`** (metadata-only).
+  Upgrade explicitly with `openpass agent upgrade <name> --tier standard`.
+- **Token `tools: ["*"]` now means "inherit from profile"** instead of "all
+  tools the server knows." Profile changes take effect on the next call.
+- **MCP `tools/list` lean mode by default** — returns 7 essential tools at
+  connect time. Pass `include_all_tools: true` in init or call `openpass_search`
+  for the full surface.
+
+### Added — agent integration
+
+- **`openpass agent install <name>`** — single command for agent setup:
+  generates scoped token + writes MCP config + drops embedded skill package +
+  runs smoke test. Flags: `--auto-detect`, `--tier`, `--http`, `--dry-run`,
+  `--skill-only`, `--config-only`, `--force`, `--output json|yaml|text`.
+- **`openpass agent upgrade <name> --tier <tier>`** — explicit, audited tier
+  change with interactive diff. Non-interactive `--yes --reason "…"` requires a
+  reason for the audit trail. Optional `--rotate-token`.
+- **`openpass agent uninstall <name>`** — removes profile, token, skill, and
+  MCP config entry; skill files without the OpenPass sentinel are preserved.
+- **`openpass agent doctor <name>` / `--all`** — end-to-end diagnostic for one
+  or all agent integrations; detects skill drift via hash comparison.
+- **`openpass agent list`** — installed agents with tier, token status, last-seen.
+- **`openpass agent token <name> new|list|revoke|rotate`** — token management
+  per agent.
+- **`openpass agent audit <name>` / `audit self`** — per-agent audit log with
+  `--since` and `--format table|json`.
+- **`openpass agent profile show|edit|export <name>`** — agent profile
+  inspection and editing in `$EDITOR` with schema validation + confirmation.
+- **`openpass agent skill export|refresh <agent>`** — pack skill for org
+  distribution or re-render in place.
+- **`openpass agent whoami --output json`** — CLI form of the `openpass_whoami`
+  MCP tool.
+- **`openpass agent prompt <path>.<field>`** — CLI form of `secure_input`.
+- **`openpass agent request <path>.<field> --reason "…"`** — CLI form of
+  `request_credential`.
+
+### Added — MCP tools
+
+- **`openpass_whoami`** — agent self-introspection: tier, allowed paths,
+  quotas, available tools, vault status, CLI-alternative hint. Available in
+  every tier; agents should call once per session.
+- **`openpass_audit_self`** — agents read their own recent audit events
+  (success, denied, redacted). Other agents' trails are not exposed.
+- **`openpass_search`** — discover and on-demand-load tools by intent string.
+  Returns matching tool spec inline plus `cli_alternative` for each match.
+- **Lean-mode `tools/list`** — 7-tool default surface (`openpass_whoami`,
+  `openpass_search`, `health`, `find_entries`, `get_entry_metadata`,
+  `request_credential`, `openpass_audit_self`); ~83% less initial context.
+- **Structured error responses** — every MCP error now returns
+  `{ code, message, hint, details, doc }` with codes from
+  `internal/mcp/errors/codes.go` (`ERR_PATH_FORBIDDEN`, `ERR_TOOL_NOT_ALLOWED`,
+  `ERR_APPROVAL_DENIED`, `ERR_QUOTA_EXCEEDED`, …).
+- **Tool descriptions for LLMs** — every tool documented in
+  `internal/mcp/tooldocs/<tool>.md` with `USE WHEN`, `DON'T USE WHEN`, `INPUT`,
+  `OUTPUT`, `COMBINES WELL WITH`, `EXAMPLE` sections.
+- **`find_entries` returns mini-metadata inline** — `path`, `name`, `updated`,
+  `version`, `score` per hit; saves repeat `get_entry_metadata` round-trips.
+
+### Added — tier system
+
+- **Three tier presets** in `internal/config/presets.go`: `safe` (alias for
+  `read-only`), `standard`, `admin`. Each is snapshot-tested to prevent silent
+  drift.
+- **`safe` (default)** — metadata-only tools, no writes, no clipboard/autotype,
+  no commands, deny-mode approvals, strict redaction.
+- **`standard`** — adds value-read, write, clipboard, autotype, prompts; uses
+  `prompt`-mode approvals for destructive ops.
+- **`admin`** — adds command execution, profile management, exposes
+  value-returning tools; prompts only on destructive ops.
+- **Audit events** for tier lifecycle: `AGENT_INSTALLED`, `AGENT_TIER_CHANGED`,
+  `AGENT_TIER_CHANGE_DENIED`, `AGENT_TOKEN_ROTATED`, `AGENT_UNINSTALLED`,
+  `AGENT_QUOTA_HIT`.
+
+### Added — skill packages
+
+- **Per-agent skills embedded in the binary** via `internal/agentskill/assets/`
+  with templates for `hermes`, `claude-code`, `codex`, `opencode`, `openclaw`,
+  plus a `common/` base.
+- **Sentinel-based lifecycle** — frontmatter `managed_by: openpass` +
+  SHA-256 hash. Install/refresh/uninstall only touch files with the sentinel;
+  user-edited skills are preserved unless `--force` is passed.
+- **Deterministic rendering** — golden-file tests in
+  `internal/agentskill/testdata/` enforce byte-identical re-renders.
+- **Per-agent paths** resolved automatically (`~/.claude/`, `~/.codex/`,
+  `~/.config/opencode/`, `~/.hermes/`, `~/.openclaw/`).
+
+### Added — CLI as agent surface
+
+- **`OPENPASS_AGENT=<name>` environment variable** applies the agent profile
+  (allowed paths, redaction, quotas, audit) to every CLI call. Same enforcement
+  logic as MCP.
+- **`internal/agentctx/`** — shared profile-context loader used by both CLI
+  and MCP dispatch paths; eliminates duplicate enforcement code.
+- **`internal/quotas/`** — file-lock-based shared quota counter between CLI
+  and MCP; both paths increment the same `~/.openpass/state/quotas/<agent>.json`.
+- **Standardized exit codes** on every command:
+  0/1/2/10/11/12/13/14/15.
+- **`--output text|json|yaml`** on every command; JSON output is the contract
+  for agent-driven CLI calls.
+
+### Added — migration
+
+- **`openpass migrate v4 [--dry-run] [--yes]`** — classifies existing v3
+  profiles into tiers, computes skill drift, backs up `config.yaml` to
+  `config.yaml.bak.v3-<timestamp>`, renders skill packages, re-validates token
+  registry, prints summary. Idempotent.
+- **Profile classification:** `canRunCommands=true → admin`; `canWrite=true`
+  and `canUseClipboard=true → standard`; metadata-only → `safe`; profiles
+  with redact-field overrides that don't match a preset → `custom`.
+- **`docs/migration-v3-to-v4.md`** — full user-facing upgrade guide.
+- **`docs/skills/openpass-agent/UPGRADE-TO-V4.md`** — AI-agent-ready prompt
+  to drive the upgrade end-to-end.
+
+### Security
+
+- Memory hygiene: TOTP secret, OPENPASS_PASSPHRASE, OPENPASS_MCP_TOKEN string
+  backing arrays wiped after read; passphrase wiping via `[]byte` instead of
+  `unsafe.StringData`; legacy passphrase wiped after migration (#154, #155,
+  #158, #159, #177).
+- Generated passwords protected with `SecureString` (mlock'd mmap) (#156).
+- `SafeMkdirAll` hardened against symlink-traversal attacks (#157).
+- `unsafe.StringData`/`unsafe.Slice` removed from TOTP input handling.
+- Prompt-injection hardening: 4 fixes + threat model + e2e tests; per-tool
+  `redactFields`, registry hash, tool-chain anomaly detection, import
+  quarantine (#91-95, #97).
+- API response sanitization for `execute_api_request` (#57, #62).
+- `generate_totp` hardened: default clipboard, return-value gated on approval
+  (#59).
+- 32 + 27 + 15 + 6 + 5 gosec/code-scanning alerts resolved across
+  the v3→v4 cycle (#121, #122, #123, #137 et al).
+
+### Fixed
+
+- `--dry-run` no longer creates real tokens in `mcp install` (#68).
+- Token registry reloads when the file changes on disk (#67).
+- Opencode install uses the correct root key and adds required fields (#66).
+- `openpass auth status --output json` uses `PrintResult` instead of the
+  deprecated `PrintJSON` (#180).
+- `migrateLegacyEntries` walks skip `IsNotExist` errors instead of bailing
+  out.
+- 2 `goconst` lint findings in `internal/config/config_load.go` and
+  `config_merge.go` resolved by reusing existing constants.
+
+### Performance
+
+- `EnforceRetention` uses `os.ReadDir` instead of `filepath.Glob`
+  (orders-of-magnitude faster on large vaults) (#161).
+
+### Refactored
+
+- `init()` functions replaced with explicit package-level initialization
+  (#162).
+- `copyAgentProfiles` replaced with JSON deep-copy (#178).
+- Session passphrase wiping uses `[]byte` instead of `unsafe.StringData`
+  (#177).
+
+### Documentation
+
+- Expanded error-wrapping conventions in `CONTRIBUTING.md` (#163).
+- Added CVE monitoring guidance for the deferred ProtonMail/go-crypto
+  transitive dependency (#179).
+- Added v4 release checklist (`docs/release-checklist-v4.md`).
+
 ## [v3.0.0] - 2026-05-15
 
 ### Added

--- a/cmd/mcp/agent_upgrade.go
+++ b/cmd/mcp/agent_upgrade.go
@@ -23,7 +23,8 @@ var (
 	agentUpgradeYes        bool
 	agentUpgradeReason     string
 	agentUpgradeRotate     bool
-	agentUpgradeValidTiers = map[string]bool{"read-only": true, "standard": true, "admin": true}
+	agentUpgradeValidTiers = map[string]bool{"safe": true, "read-only": true, "standard": true, "admin": true}
+	agentUpgradeTierAlias  = map[string]string{"safe": "read-only", "read-only": "read-only", "standard": "standard", "admin": "admin"}
 )
 
 type tierDiff struct {
@@ -170,9 +171,10 @@ var agentUpgradeCmd = &cobra.Command{
 	Short: "Upgrade an agent's security tier",
 	Long: `Show tier diff and upgrade an agent's security tier with interactive confirmation.
 
-The upgrade applies the named tier preset (read-only, standard, or admin) to the
-agent profile, updating all capability fields. Use --dry-run to preview changes
-without writing. Use --rotate-token to also rotate the agent's MCP token.
+The upgrade applies the named tier preset (safe, standard, or admin) to the
+agent profile, updating all capability fields. The legacy alias "read-only"
+is accepted as a synonym for "safe". Use --dry-run to preview changes without
+writing. Use --rotate-token to also rotate the agent's MCP token.
 
 The --reason flag is required when using --yes for non-interactive mode to ensure
 an audit trail.`,
@@ -192,15 +194,16 @@ an audit trail.`,
 		agentName := args[0]
 
 		if agentUpgradeTier == "" {
-			return fmt.Errorf("--tier is required (valid: read-only, standard, admin)")
+			return fmt.Errorf("--tier is required (valid: safe, standard, admin)")
 		}
 		if agentUpgradeYes && agentUpgradeReason == "" {
 			return fmt.Errorf("--reason is required when using --yes")
 		}
 
 		if !agentUpgradeValidTiers[agentUpgradeTier] {
-			return fmt.Errorf("invalid tier %q: valid values are read-only, standard, admin", agentUpgradeTier)
+			return fmt.Errorf("invalid tier %q: valid values are safe, standard, admin", agentUpgradeTier)
 		}
+		agentUpgradeTier = agentUpgradeTierAlias[agentUpgradeTier]
 
 		vaultDir := cli.GetVaultDir()
 		configPath := filepath.Join(vaultDir, "config.yaml")
@@ -310,7 +313,7 @@ an audit trail.`,
 }
 
 func init() {
-	agentUpgradeCmd.Flags().StringVar(&agentUpgradeTier, "tier", "", "Target security tier (read-only, standard, admin)")
+	agentUpgradeCmd.Flags().StringVar(&agentUpgradeTier, "tier", "", "Target security tier (safe, standard, admin; 'read-only' accepted as alias for 'safe')")
 	agentUpgradeCmd.Flags().BoolVar(&agentUpgradeDryRun, "dry-run", false, "Show diff without applying changes")
 	agentUpgradeCmd.Flags().BoolVar(&agentUpgradeYes, "yes", false, "Non-interactive mode (requires --reason)")
 	agentUpgradeCmd.Flags().StringVar(&agentUpgradeReason, "reason", "", "Audit reason for the upgrade (required with --yes)")

--- a/docs/adr/0004-cli-agent-optimization-v4.md
+++ b/docs/adr/0004-cli-agent-optimization-v4.md
@@ -1,7 +1,8 @@
 # OpenPass v4.0 — CLI & AI-Agent Optimization Design
 
-- **Status:** Draft
+- **Status:** Accepted
 - **Date:** 2026-05-17
+- **Accepted:** 2026-05-21
 - **Target release:** v4.0.0
 - **Author:** Daniel + Claude
 - **Scope:** CLI restructuring, MCP server runtime, agent skills, security defaults, dual-surface (CLI + MCP) integration

--- a/docs/migration-v3-to-v4.md
+++ b/docs/migration-v3-to-v4.md
@@ -47,8 +47,9 @@ Confirm your v3.x version:
 openpass version
 ```
 
-You need v3.9.0 or later to run the migration. If you are on an earlier v3
-version, upgrade first:
+v3.0.0 or later is supported as a migration source. If you are on an earlier
+v3 release, upgrade to the latest v3 first (or jump straight to v4 — the
+migration helper handles any v3.x profile):
 
 ```bash
 # macOS (Homebrew)
@@ -388,7 +389,7 @@ If you need to go back to v3.x:
 brew install openpass@3
 
 # Manual install from GitHub releases
-# Download v3.9.0 from https://github.com/danieljustus/OpenPass/releases
+# Download v3.0.0 from https://github.com/danieljustus/OpenPass/releases/tag/v3.0.0
 ```
 
 The v3.x binary reads the old config format. If you already ran the migration,

--- a/docs/release-checklist-v4.md
+++ b/docs/release-checklist-v4.md
@@ -1,0 +1,154 @@
+# Release Checklist — v4.0.0
+
+The release manager ticks every box below before running `git tag v4.0.0` and
+pushing the tag. The checklist is a hard gate: a missing tick blocks the
+release.
+
+The checklist matches ADR-0004 §7.12 plus the standard distribution gates we
+run on every minor.
+
+---
+
+## Pre-flight (run from a clean checkout of `main`)
+
+- [ ] `git status` is clean.
+- [ ] `git pull --ff-only origin main` succeeds (no divergence).
+- [ ] Working tree is on `main`, not a feature branch.
+- [ ] `make clean` removes all build artifacts (no `*.test`, `*.out`,
+      `openpass` binary, `coverage/` dir in repo root). The goreleaser
+      pre-hook would otherwise reject the build.
+- [ ] `go env GOWORK` is empty (or set via `env GOWORK=off`).
+
+## Build & static analysis
+
+- [ ] `make build` succeeds on the release machine.
+- [ ] `make vet` is clean (includes `passlint` analyzer).
+- [ ] `make lint` exits 0. `golangci-lint` findings, if any, are documented in
+      the PR that introduced them and explicitly approved.
+- [ ] `make fmt-check` is clean.
+
+## Tests
+
+- [ ] `make test-fast` is green on macOS.
+- [ ] `make test-fast` is green on Linux (or wait for CI to report green on
+      the merge commit).
+- [ ] CI matrix on the v4 commit is green for all OS targets (macOS, Linux,
+      Windows).
+- [ ] Security regression suite (`internal/mcp/server/security_*_test.go`,
+      `internal/mcp/server/tools_value_exposure_test.go`,
+      `cmd/passlint`) green.
+- [ ] Tier-preset snapshot tests (`internal/config/tier_presets_test.go`) green.
+- [ ] Skill golden-file tests (`internal/agentskill/skill_test.go`) green.
+
+## Documentation
+
+- [ ] `CHANGELOG.md` has a `## [v4.0.0]` entry with the correct date and the
+      breaking changes called out at the top.
+- [ ] `docs/migration-v3-to-v4.md` is up-to-date with the shipped CLI surface
+      and does not reference any non-existent intermediate version.
+- [ ] `docs/skills/openpass-agent/UPGRADE-TO-V4.md` is up-to-date.
+- [ ] `docs/adr/0004-cli-agent-optimization-v4.md` status is `Accepted` (not
+      `Draft`).
+- [ ] `README.md` v4 section (if any) reflects the new `openpass agent` CLI.
+- [ ] `docs/agent-integration.md` and `docs/mcp-api.md` reflect the v4 tool
+      surface (7-tool lean mode, `openpass_whoami`, `openpass_audit_self`,
+      `openpass_search`, structured errors).
+
+## Manual smoke (per platform)
+
+The release manager runs these by hand. Skip a row only with a written
+justification in the release PR.
+
+### macOS
+
+- [ ] `openpass agent install hermes --tier safe` succeeds end-to-end (config
+      written, token issued, skill dropped, smoke test passes).
+- [ ] `openpass agent upgrade hermes --tier standard` shows the spec'd diff
+      and the upgrade applies after confirmation.
+- [ ] Real Hermes session can call `mcp_openpass_openpass_whoami` and
+      `mcp_openpass_get_entry` against the upgraded profile.
+- [ ] `OPENPASS_AGENT=hermes openpass list --output json` respects the
+      profile's `allowedPaths`.
+- [ ] `openpass migrate v4` on a real v3 vault is lossless (round-trip:
+      restore backup, re-run, no diff).
+- [ ] LaunchAgent HTTP setup: `openpass serve --port 8765` reachable; GUI
+      approval prompt pops via `secureui`.
+- [ ] Skill drift detection: edit `~/.hermes/skills/openpass/SKILL.md`,
+      `openpass agent doctor hermes` reports drift.
+
+### Linux
+
+- [ ] `openpass agent install claude-code --tier safe` succeeds.
+- [ ] Basic vault ops (`openpass init` on a fresh dir, `openpass set`,
+      `openpass get`, `openpass list`) work.
+- [ ] systemd unit (if shipped) launches `openpass serve` cleanly.
+
+### Windows
+
+- [ ] `openpass agent install codex --tier safe` succeeds; path handling for
+      `~/.codex/config.toml` correct.
+- [ ] Basic vault ops work.
+
+## Distribution dry-run
+
+- [ ] `goreleaser release --snapshot --clean` produces all expected artifacts
+      under `dist/`.
+- [ ] `dist/openpass_*.tar.gz` and `dist/openpass_*_windows_*.zip` extract and
+      `./openpass version` prints the expected version string.
+- [ ] Checksums file is generated and includes every artifact.
+- [ ] SBOM (`*.sbom.json`) is generated.
+- [ ] Homebrew tap formula renders without unresolved templates.
+- [ ] Scoop manifest renders.
+- [ ] Nix flake builds: `nix build .#openpass` succeeds from a clean store.
+- [ ] macOS notarization gate (separate workflow) passes on a signed snapshot
+      build.
+
+## Security & supply-chain
+
+- [ ] `make vet` includes `passlint`; analyzer is loaded.
+- [ ] `govulncheck ./...` reports no actionable vulnerabilities (deferred
+      transitive CVEs documented in `docs/dependency-evaluations/`).
+- [ ] Code-scanning (gosec/CodeQL) on `main`: 0 open alerts.
+- [ ] Dependabot alerts on the repo: 0 open.
+- [ ] No secrets in the release tree: goreleaser pre-hook passes
+      (`identity.age`, `mcp-token`, `.env`, `coverage`, `*.test`).
+
+## Release artifact
+
+- [ ] Decide tag: `v4.0.0` (final) or `v4.0.0-rc.1` / `v4.0.0-beta.1`. Tag
+      message includes the breaking-changes summary.
+- [ ] Tag is signed (`git tag -s v4.0.0`) and `git verify-tag v4.0.0` checks
+      out.
+- [ ] Push tag: `git push origin v4.0.0`.
+- [ ] CI release workflow completes successfully; GitHub release is created
+      with the rendered changelog.
+- [ ] Release notes include a prominent link to
+      `docs/migration-v3-to-v4.md` and
+      `docs/skills/openpass-agent/UPGRADE-TO-V4.md`.
+- [ ] Homebrew tap PR auto-opens (or the bot updates the formula) and is
+      reviewable.
+
+## Post-release
+
+- [ ] Install the published binary on a fresh machine (or VM/container) via
+      the install script and confirm `openpass version` matches.
+- [ ] `brew install openpass && openpass version` works after the tap merges.
+- [ ] Update project page on <https://github.com/users/danieljustus/projects/1>
+      (issues/PRs moved to Done).
+- [ ] Announce in the README badge area and any external channels.
+- [ ] File any acceptance-criteria gaps from ADR-0004 §10 that landed as
+      follow-ups, so v4.1 planning has a clean starting list.
+
+---
+
+## Sign-off
+
+| Role | Name | Date |
+|---|---|---|
+| Release manager | | |
+| Security review | | |
+| Docs review | | |
+
+Once all boxes above are ticked and signed off, the release is GA. If any box
+remains unchecked, either complete it or open a release-blocking issue and
+stop.

--- a/docs/skills/openpass-agent/UPGRADE-TO-V4.md
+++ b/docs/skills/openpass-agent/UPGRADE-TO-V4.md
@@ -1,0 +1,292 @@
+---
+name: openpass-upgrade-to-v4
+description: AI-agent-ready prompt to upgrade an OpenPass installation from v3.x to v4.0 cleanly and safely.
+---
+
+# OpenPass v3 → v4 Upgrade Prompt (for AI agents)
+
+This file is a **self-contained prompt** an AI assistant can follow to upgrade
+a user's OpenPass installation from v3.x to v4.0 without losing data or
+introducing security regressions. It is also readable as a human checklist.
+
+If you are a user, you can copy the entire content of this file into your AI
+assistant and add: *"Run this upgrade on my machine."* The assistant will then
+execute the steps below in order, asking for confirmation at the destructive
+points.
+
+---
+
+## Mission
+
+Upgrade the user's OpenPass from v3.x to v4.0. Preserve the vault, all
+existing agent profiles, all scoped tokens, and the audit log. Introduce the
+new tier system, embedded skill packages, and lean MCP mode. Verify each
+installed agent still works after the upgrade.
+
+## Operating principles
+
+- **One step at a time.** Do not chain destructive commands.
+- **Show before write.** Use `--dry-run` first wherever it exists.
+- **Confirm before destructive ops.** Backup, profile rewrites, and tier
+  upgrades require user OK.
+- **Never echo secrets.** Do not print token values, passphrases, or vault
+  contents to chat. Use the structured `--output json` form for parsing
+  metadata, but redact secret-bearing fields before showing them back.
+- **Stop on the first hard error.** If a command exits non-zero with code
+  10/11/12/13/14/15, surface the structured error to the user and ask how to
+  proceed. Do not retry silently.
+
+---
+
+## Step 1 — Detect current state
+
+```bash
+openpass version --output json
+openpass auth status --output json
+openpass agent list --output json   # may not exist on pre-v4 binaries; tolerate failure
+```
+
+From the output, determine:
+- Installed version (semver). If `>= 4.0.0`, jump to Step 7 (post-migration
+  verification only).
+- Whether the vault is unlocked.
+- Which agents are configured.
+
+Also list any legacy config commands that the user's shell history references
+(`openpass mcp install`, `openpass mcp-config`, `openpass mcp token …`,
+`openpass mcp-token-rotate`, `openpass agent setup`). These will need to be
+replaced in user scripts after the upgrade.
+
+---
+
+## Step 2 — Back up vault and config
+
+Confirm with the user before running. This is the only step that cannot be
+re-done after the upgrade succeeds and the v3 backup is overwritten.
+
+```bash
+openpass backup ~/openpass-backup-pre-v4-$(date +%Y%m%d-%H%M%S).tar.gz
+```
+
+If `openpass backup` is unavailable, fall back to:
+
+```bash
+cp -a ~/.openpass ~/.openpass.backup.pre-v4.$(date +%Y%m%d-%H%M%S)
+```
+
+Verify the backup file exists and is non-empty before continuing.
+
+---
+
+## Step 3 — Install OpenPass v4
+
+Pick the method that matches the user's install path. Detect by checking what
+is on `PATH` and what package managers are present.
+
+| Install method | Command |
+|---|---|
+| Homebrew (macOS, Linux) | `brew upgrade openpass` |
+| Install script (macOS/Linux) | `curl -sSfL https://raw.githubusercontent.com/danieljustus/OpenPass/main/scripts/install.sh \| sh` |
+| Scoop (Windows) | `scoop update openpass` |
+| Nix | `nix profile upgrade openpass` (or rebuild the flake input) |
+| Binary download | Download v4.0.0 asset for the platform from <https://github.com/danieljustus/OpenPass/releases/tag/v4.0.0>, replace the binary, verify checksum |
+
+Verify the new version is in place:
+
+```bash
+openpass version --output json
+# expect: "version": "4.0.0..." or similar
+```
+
+Do **not** proceed if the version is still v3.x.
+
+---
+
+## Step 4 — Preview the migration
+
+```bash
+openpass migrate v4 --dry-run
+```
+
+Read the output carefully. It will show:
+- Per-agent inferred tier (`safe` / `standard` / `admin` / `custom`).
+- Per-agent skill drift (`create` / `refresh (drift)` / `manual install`).
+- The exact backup filename that will be written.
+
+Summarize the planned changes for the user in plain language. Ask if anything
+looks wrong before applying.
+
+If a profile is classified `custom`, point out which fields differ from any
+preset (commonly `redactFields` or non-standard `allowedExecutables`). The
+`custom` tier preserves the user's exact settings.
+
+---
+
+## Step 5 — Apply the migration
+
+```bash
+openpass migrate v4
+```
+
+The command is interactive by default. Confirm `y` when prompted. The tool
+will:
+
+1. Back up `~/.openpass/config.yaml` to `config.yaml.bak.v3-<timestamp>`.
+2. Add `tier`, `skill_path`, and `skill_version` fields to each agent profile.
+3. Re-render and install per-agent skill packages with the v4 sentinel header.
+4. Re-validate the token registry.
+5. Print a structured summary.
+
+For non-interactive contexts (CI, dotfile sync hooks), use `--yes`:
+
+```bash
+openpass migrate v4 --yes
+```
+
+If the command fails mid-flight: restore the backup
+(`cp ~/.openpass/config.yaml.bak.v3-<timestamp> ~/.openpass/config.yaml`) and
+ask the user to share the error. Do not retry blindly.
+
+---
+
+## Step 6 — Run doctor on each agent
+
+```bash
+openpass agent list --output json
+openpass agent doctor --all
+```
+
+For each agent that comes back with warnings or errors:
+
+- **Skill drift** — re-render in place:
+  `openpass agent install <name> --skill-only --force`
+- **Missing MCP config entry** — re-inject:
+  `openpass agent install <name> --config-only`
+- **Token invalid / expired** — rotate:
+  `openpass agent token <name> rotate`
+- **Profile classified `custom` but user wants a preset** — explicit upgrade:
+  `openpass agent upgrade <name> --tier <safe|standard|admin>` (interactive)
+
+Run `openpass agent whoami --output json` (or
+`OPENPASS_AGENT=<name> openpass agent whoami --output json`) to confirm the
+agent's effective permissions match what you expect.
+
+---
+
+## Step 7 — Update user scripts
+
+Search the user's shell history, dotfiles, and project scripts for legacy
+commands. Show the user any matches and propose replacements before editing.
+
+| Legacy (v3) | Replacement (v4) |
+|---|---|
+| `openpass agent setup <name>` | `openpass agent install <name>` |
+| `openpass mcp install <name>` | `openpass agent install <name>` |
+| `openpass mcp install --auto-detect` | `openpass agent install --auto-detect` |
+| `openpass mcp-config <agent>` | `openpass agent install <agent> --config-only` |
+| `openpass mcp token create …` | `openpass agent token <name> new …` |
+| `openpass mcp token list` | `openpass agent token list` |
+| `openpass mcp token revoke <id>` | `openpass agent token revoke <id>` |
+| `openpass mcp-token-rotate` | `openpass agent token <name> rotate` |
+
+For CI/automation scripts that upgrade tiers, add `--reason` (now required
+with `--yes`):
+
+```bash
+# Before
+openpass agent setup hermes --tier admin
+
+# After
+openpass agent upgrade hermes --tier admin --yes --reason "<ticket-or-context>"
+```
+
+---
+
+## Step 8 — Optional: enable CLI agent mode
+
+v4 lets agents drive the CLI with the same enforcement as MCP. For each
+configured agent, propose adding to the agent's launch script:
+
+```bash
+export OPENPASS_AGENT=<name>
+```
+
+Then the agent can call `openpass list --output json`,
+`openpass get path/to/entry --metadata-only --output json`, etc., and OpenPass
+applies the profile's allowed paths, redactions, quotas, and audit — the same
+way it would for an MCP call. This reduces context-window usage substantially
+for read-heavy work.
+
+Reserve MCP for operations that need OS mediation: `request_credential`,
+`secure_input`, `copy_to_clipboard`, `autotype`, write-with-approval,
+`run_command`.
+
+---
+
+## Step 9 — Verify and report
+
+End the upgrade by printing a short summary to the user:
+
+- New version installed
+- Number of agent profiles migrated, with tier breakdown
+- Skill files written or refreshed
+- Audit-log location: `~/.openpass/audit/`
+- Backup location (Step 2)
+- Any agents that still need attention (failed doctor checks)
+
+Recommend a follow-up after a few days:
+
+```bash
+openpass agent audit self --since 7d --output json
+```
+
+…to confirm the agents are behaving within expected tier/quota bounds.
+
+---
+
+## What you must not do
+
+- Do not delete `config.yaml.bak.v3-*` files. They are the rollback path.
+- Do not silently elevate any agent from `safe` to `standard`/`admin`. Tier
+  upgrades require explicit user consent (interactive) or a `--reason` (CI).
+- Do not write profile fields you do not understand. If `openpass migrate v4`
+  classified a profile as `custom`, leave it `custom` unless the user
+  explicitly requests a preset.
+- Do not echo, log, or attach any token values, passphrases, or vault
+  contents. Use redacted summaries.
+- Do not run `--force` on `agent install` unless the user explicitly accepted
+  that the conflicting file (skill or config) will be overwritten without a
+  sentinel check.
+
+---
+
+## Rollback
+
+If the user wants to undo the upgrade:
+
+1. Stop any running OpenPass processes: `pkill openpass` (best-effort).
+2. Reinstall v3.0.0 (or the version they were on):
+   ```bash
+   # macOS Homebrew: install legacy formula or download from releases
+   # Download from https://github.com/danieljustus/OpenPass/releases/tag/v3.0.0
+   ```
+3. Restore config:
+   ```bash
+   cp ~/.openpass/config.yaml.bak.v3-<timestamp> ~/.openpass/config.yaml
+   ```
+4. If skills were written to agent dirs and the user wants them gone, list
+   them with `find ~ -path '*/skills/openpass/SKILL.md'` and remove only the
+   ones with `managed_by: openpass` in their frontmatter.
+5. Tokens issued by v4 remain valid under v3 but v3 ignores the new metadata
+   fields. The user can rotate them with `openpass mcp-token-rotate` on v3.
+
+---
+
+## Reference
+
+- Migration guide (human-readable):
+  [`docs/migration-v3-to-v4.md`](../../migration-v3-to-v4.md)
+- Architecture decision: [`docs/adr/0004-cli-agent-optimization-v4.md`](../../adr/0004-cli-agent-optimization-v4.md)
+- Full v4 changelog: [`CHANGELOG.md`](../../../CHANGELOG.md)
+- Release notes:
+  <https://github.com/danieljustus/OpenPass/releases/tag/v4.0.0>

--- a/internal/config/config_load.go
+++ b/internal/config/config_load.go
@@ -111,7 +111,7 @@ func newDefaultAgentProfile(name string) AgentProfile {
 	canRunCommands := false
 	exposeValueTools := true
 	autoUnseal := true
-	deny := "deny"
+	deny := approvalModeDeny
 	return AgentProfile{
 		Name:             name,
 		AllowedPaths:     []string{},
@@ -130,7 +130,7 @@ func builtinAgentProfiles() map[string]AgentProfile {
 	canRunFalse := false
 	exposeTrue := true
 	autoUnsealTrue := true
-	deny := "deny"
+	deny := approvalModeDeny
 	return map[string]AgentProfile{
 		"default":     {Name: "default", AllowedPaths: []string{}, CanWrite: &canWriteFalse, CanRunCommands: &canRunFalse, ApprovalMode: &deny, ExposeValueTools: &exposeTrue, AutoUnseal: &autoUnsealTrue},
 		"claude-code": {Name: "claude-code", AllowedPaths: []string{}, CanWrite: &canWriteTrue, CanRunCommands: &canRunFalse, ApprovalMode: &deny, ExposeValueTools: &exposeTrue, AutoUnseal: &autoUnsealTrue, SkillPath: StrPtr("~/.claude/skills/openpass/SKILL.md")},

--- a/internal/config/config_merge.go
+++ b/internal/config/config_merge.go
@@ -161,10 +161,10 @@ func mergeAgentProfile(current AgentProfile, name string, yamlProfile AgentProfi
 		current.ApprovalMode = yamlProfile.ApprovalMode
 	} else if fields["requireApproval"] && yamlProfile.RequireApproval != nil {
 		if *yamlProfile.RequireApproval {
-			v := "prompt"
+			v := approvalModePrompt
 			current.ApprovalMode = &v
 		} else {
-			v := "none"
+			v := approvalModeNone
 			current.ApprovalMode = &v
 		}
 	}


### PR DESCRIPTION
## Summary

Closes the remaining release-prep gaps from the v4 readiness audit so we can tag `v4.0.0` from `main` after this merges.

- **CHANGELOG.md** — full `v4.0.0` block covering 59 commits since v3.0.0: CLI consolidation under `openpass agent`, three-tier system, embedded skill packages, lean-mode MCP (7-tool default), structured error codes, dual-surface CLI via `OPENPASS_AGENT`, shared CLI↔MCP audit log and quota counter, `openpass migrate v4`, plus the security/perf/refactor work.
- **docs/migration-v3-to-v4.md** — drops the bogus dependency on `v3.9.0` (never tagged) and points to `v3.0.0` as the supported migration source.
- **docs/skills/openpass-agent/UPGRADE-TO-V4.md** (new) — a self-contained prompt a user can paste into any AI assistant to drive the v3 → v4 upgrade safely. Covers backup, install, `migrate v4 --dry-run` → `migrate v4`, per-agent doctor, script rewrites, optional CLI agent mode, rollback, and explicit do-not-do rules (no silent tier elevation, no echoed secrets).
- **docs/release-checklist-v4.md** (new) — manual release gate per ADR-0004 §7.12: pre-flight cleanliness, build/lint/test, docs, per-platform smoke, distribution dry-run, security and supply-chain checks, sign-off.
- **ADR-0004 status** — `Draft` → `Accepted` (2026-05-21).
- **`openpass agent upgrade` accepts `safe`** as the canonical tier name (alias for the internal `read-only` preset), so the surface matches what `agent install` already exposes and what the ADR §5 spec calls out. Internal storage stays `read-only` for back-compat with existing v3 configs — no migration needed.
- **2 goconst lint findings fixed** in `internal/config/config_load.go` and `internal/config/config_merge.go` by reusing the existing `approvalMode{Deny,Prompt,None}` constants.

No code-path changes beyond the tier alias and the lint cleanups — this PR is overwhelmingly docs + release artifacts.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `make lint` returns 0 issues (was 2 goconst before)
- [x] `make test-fast` green across all packages, including agent upgrade tests
- [x] CI on this branch is green
- [ ] After merge: run `make clean` on release machine, then follow `docs/release-checklist-v4.md` before `git tag v4.0.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)