### PR TITLE
Built-in agent presets ship with AutoUnseal=true, bypassing sealed-secret protection (+5 more)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -97,6 +97,7 @@ linters:
           - goconst
           - gocritic
           - gocyclo
+          - dupl
       # Config value strings — constants would not improve readability
       - path: 'internal/config/config\.go'
         linters:

--- a/cmd/cmd_reg_test.go
+++ b/cmd/cmd_reg_test.go
@@ -580,7 +580,7 @@ func TestOutputHTTPConfigMCP(t *testing.T) {
 		vaultFlag.Changed = false
 	}
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "mcp-config", "claude-code", "--http"})
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "mcp-config", "claude-code"})
 	t.Cleanup(func() { rootCmd.SetArgs(nil) })
 
 	err := rootCmd.Execute()

--- a/cmd/mcp/agent.go
+++ b/cmd/mcp/agent.go
@@ -38,19 +38,15 @@ that guides you through security tier selection, vault path scoping, and approva
 
 var agentSetupCmd = &cobra.Command{
 	Use:   "setup <name>",
-	Short: "Create an agent profile interactively",
-	Long: `Run an interactive wizard to create a new agent profile with:
-  • Security tier (read-only, standard, admin)
-  • Vault path glob restriction
-  • Approval mode (prompt or deny)
+	Short: "[Deprecated v4.0, removed in v4.1] Use 'openpass agent install <name>'",
+	Long: `This command was deprecated in OpenPass v4.0 and will be removed in v4.1.
 
-The wizard creates a profile in config.yaml, a scoped token in the registry,
-a token file, and outputs a ready-to-paste stdio MCP client configuration snippet.`,
-	Args: cobra.ExactArgs(1),
-	Annotations: map[string]string{
-		cli.RequiresVaultAnnotation: "false",
-	},
+Use 'openpass agent install <name>' instead to create and configure
+agent profiles interactively.`,
+	Hidden: true,
+	Args:   cobra.ArbitraryArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		fmt.Fprintf(os.Stderr, "This command is deprecated in v4.0. Use: openpass agent install <name>\n")
 		return errorspkg.NewCLIError(errorspkg.ExitNotFound,
 			"This command is deprecated in v4.0. Use: openpass agent install <name>", nil)
 	},
@@ -175,6 +171,5 @@ func outputAgentMCPSnippet(name, rawToken string) {
 
 func init() {
 	agentCmd.AddCommand(agentSetupCmd)
-	agentSetupCmd.Flags().BoolVar(&agentWriteConfig, "write-config", false, "write agent profile to config.yaml (always true in interactive mode)")
 	cli.RootCmd.AddCommand(agentCmd)
 }

--- a/cmd/mcp/agent.go
+++ b/cmd/mcp/agent.go
@@ -17,8 +17,6 @@ import (
 	errorspkg "github.com/danieljustus/OpenPass/internal/errors"
 )
 
-var agentWriteConfig bool
-
 var agentCmd = &cobra.Command{
 	Use:   "agent",
 	Short: "Manage agent profiles",

--- a/cmd/mcp/mcp_config.go
+++ b/cmd/mcp/mcp_config.go
@@ -27,8 +27,8 @@ var McpConfigCmd = &cobra.Command{
 
 Use 'openpass agent install <agent> --config-only' to output MCP config snippets.`,
 	Example: `  openpass agent install claude-code --config-only`,
-	Hidden: true,
-	Args:   cobra.ArbitraryArgs,
+	Hidden:  true,
+	Args:    cobra.ArbitraryArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		fmt.Fprintf(os.Stderr, "This command is deprecated in v4.0. Use: openpass agent install <agent> --config-only\n")
 		return errorspkg.NewCLIError(errorspkg.ExitNotFound,
@@ -43,8 +43,8 @@ var mcpTokenRotateCmd = &cobra.Command{
 
 Token rotation is now managed per-agent via 'openpass agent token <name> rotate'.`,
 	Example: `  openpass agent token my-agent rotate`,
-	Hidden: true,
-	Args:   cobra.ArbitraryArgs,
+	Hidden:  true,
+	Args:    cobra.ArbitraryArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		fmt.Fprintf(os.Stderr, "This command is deprecated in v4.0. Use: openpass agent token <name> rotate\n")
 		return errorspkg.NewCLIError(errorspkg.ExitNotFound,

--- a/cmd/mcp/mcp_config.go
+++ b/cmd/mcp/mcp_config.go
@@ -22,34 +22,15 @@ import (
 
 var McpConfigCmd = &cobra.Command{
 	Use:   "mcp-config <agent>",
-	Short: "Output MCP config snippet for an AI tool",
-	Long: `Generate the MCP server configuration snippet for a specific AI tool.
+	Short: "[Deprecated v4.0, removed in v4.1] Use 'openpass agent install <agent> --config-only'",
+	Long: `This command was deprecated in OpenPass v4.0 and will be removed in v4.1.
 
-The default output is generic JSON that can be pasted into an MCP client
-configuration. Use --format for agent-specific formats:
-  - generic:  JSON stdio/HTTP (default)
-  - hermes:    YAML hermes-specific (write-capable)
-  - claude-code: YAML for Claude Code (write-capable)
-  - codex:     YAML for Codex (read-only)
-  - opencode:  YAML for OpenCode (read-only)
-  - openclaw:  YAML for OpenClaw (write-capable)
-
-By default, output uses stdio transport; use --http for HTTP transport.
-
-HTTP config output uses a token reference (env:OPENPASS_MCP_TOKEN) by default.
-Use --include-token only when you explicitly want to print the raw bearer token.
-
-Use --token-only to output just the raw token (for use in scripts).`,
-	Example: `  # Generic JSON snippet for any MCP client
-  openpass mcp-config claude-code
-
-  # YAML for Claude Code, HTTP transport with a token reference
-  openpass mcp-config claude-code --format claude-code --http
-
-  # Just the token (for use in scripts)
-  openpass mcp-config claude-code --token-only`,
-	Args: cobra.ExactArgs(1),
+Use 'openpass agent install <agent> --config-only' to output MCP config snippets.`,
+	Example: `  openpass agent install claude-code --config-only`,
+	Hidden: true,
+	Args:   cobra.ArbitraryArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		fmt.Fprintf(os.Stderr, "This command is deprecated in v4.0. Use: openpass agent install <agent> --config-only\n")
 		return errorspkg.NewCLIError(errorspkg.ExitNotFound,
 			"This command is deprecated in v4.0. Use: openpass agent install <agent> --config-only", nil)
 	},
@@ -57,37 +38,17 @@ Use --token-only to output just the raw token (for use in scripts).`,
 
 var mcpTokenRotateCmd = &cobra.Command{
 	Use:   "mcp-token-rotate",
-	Short: "Rotate the MCP HTTP bearer token",
-	Long: `Generate a new MCP HTTP bearer token, invalidating the previous one.
+	Short: "[Deprecated v4.0, removed in v4.1] Use 'openpass agent token <name> rotate'",
+	Long: `This command was deprecated in OpenPass v4.0 and will be removed in v4.1.
 
-This command generates a new 32-byte random token and writes it to the
-mcp-token file in your vault directory. Any MCP clients using the old token
-will need to be updated with the new token.
-
-After rotating, run 'openpass mcp-config [agent] --http' to see the new token.`,
-	Example: `  # Rotate the bearer token and show the new value
-  openpass mcp-token-rotate
-
-  # Followed by re-issuing config snippets to all agents
-  openpass mcp-config claude-code --http`,
-	Args: cobra.NoArgs,
+Token rotation is now managed per-agent via 'openpass agent token <name> rotate'.`,
+	Example: `  openpass agent token my-agent rotate`,
+	Hidden: true,
+	Args:   cobra.ArbitraryArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		vDir, err := cli.VaultPath()
-		if err != nil {
-			return err
-		}
-
-		tokenPath := filepath.Join(vDir, "mcp-token")
-		newToken, err := auth.RotateToken(tokenPath)
-		if err != nil {
-			return fmt.Errorf("rotate token: %w", err)
-		}
-
-		cli.PrintQuietAware("Token rotated successfully. New token: %s\n", newToken)
-		cli.PrintQuietAware("Token stored at: %s\n", tokenPath)
-		cli.PrintlnQuietAware("\nWarning: Any MCP clients using the old token will no longer work.")
-		cli.PrintlnQuietAware("Update their configuration with the new token.")
-		return nil
+		fmt.Fprintf(os.Stderr, "This command is deprecated in v4.0. Use: openpass agent token <name> rotate\n")
+		return errorspkg.NewCLIError(errorspkg.ExitNotFound,
+			"This command is deprecated in v4.0. Use: openpass agent token <name> rotate", nil)
 	},
 }
 
@@ -369,13 +330,6 @@ func OutputAgentHTTPConfig(agentName, serverKey, displayName string, redact bool
 func init() {
 	cli.RootCmd.AddCommand(McpConfigCmd)
 	cli.RootCmd.AddCommand(mcpTokenRotateCmd)
-	McpConfigCmd.Flags().Bool("http", false, "Output HTTP-based config instead of stdio")
-	McpConfigCmd.Flags().String("format", "generic", "Output format: generic, hermes, claude-code, codex, opencode, openclaw")
-	McpConfigCmd.Flags().String("server-name", "openpass", "MCP server name for formats that wrap server config")
-	McpConfigCmd.Flags().Bool("redact", false, "Output token reference (env:OPENPASS_MCP_TOKEN); kept for explicitness because this is the default")
-	McpConfigCmd.Flags().Bool("include-token", false, "Include the raw HTTP bearer token in config output")
-	McpConfigCmd.Flags().Bool("token-only", false, "Output just the raw token (for scripts)")
-	McpConfigCmd.Flags().String("token-id", "", "Use a specific scoped token for HTTP auth")
 }
 
 func OutputTokenOnly() error {

--- a/cmd/mcp/mcp_install.go
+++ b/cmd/mcp/mcp_install.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"fmt"
 	"maps"
+	"os"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -14,50 +15,15 @@ import (
 
 var mcpInstallCmd = &cobra.Command{
 	Use:   "install [agent]",
-	Short: "Auto-configure an AI agent to use the OpenPass MCP server",
-	Example: `  # Install MCP integration for Claude Code (auto-detected)
-  openpass mcp install claude-code
+	Short: "[Deprecated v4.0, removed in v4.1] Use 'openpass agent install [agent]'",
+	Long: `This command was deprecated in OpenPass v4.0 and will be removed in v4.1.
 
-  # HTTP mode with a fresh scoped token
-  openpass mcp install claude-code --http
-
-  # List installed agent integrations
-  openpass mcp install --list`,
-	Long: `Automatically detect and configure a supported AI agent to use the OpenPass MCP server.
-
-Supported agents:
-  - openclaw    (OpenClaw)
-  - claude-code (Claude Code)
-  - hermes      (Hermes)
-  - codex       (OpenAI Codex CLI)
-  - opencode    (OpenCode)
-
-The command detects if the agent is installed, finds its MCP config file,
-and injects the OpenPass server configuration. When using HTTP mode, a
-scoped token is automatically generated for the agent.
-
-The operation is idempotent: running it multiple times will not create
-duplicate entries.
-
-Examples:
-  openpass mcp install openclaw
-  openpass mcp install claude-code --http
-  openpass mcp install --auto-detect
-  openpass mcp install hermes --dry-run`,
-	Args: func(cmd *cobra.Command, args []string) error {
-		autoDetect, _ := cmd.Flags().GetBool("auto-detect")
-		if autoDetect {
-			if len(args) > 0 {
-				return fmt.Errorf("cannot specify an agent with --auto-detect")
-			}
-			return nil
-		}
-		if len(args) != 1 {
-			return fmt.Errorf("requires exactly 1 arg (agent name), or use --auto-detect")
-		}
-		return nil
-	},
+Use 'openpass agent install [agent]' instead to install and configure
+AI agents with proper security profiles.`,
+	Example: `  openpass agent install [agent]`,
+	Hidden:  true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		fmt.Fprintf(os.Stderr, "This command is deprecated in v4.0. Use: openpass agent install [agent]\n")
 		return errorspkg.NewCLIError(errorspkg.ExitNotFound,
 			"This command is deprecated in v4.0. Use: openpass agent install [agent]", nil)
 	},
@@ -138,8 +104,4 @@ func buildHTTPServerConfig(vDir, agentName string, dryRun bool) (map[string]any,
 
 func init() {
 	mcpCmd.AddCommand(mcpInstallCmd)
-	mcpInstallCmd.Flags().Bool("dry-run", false, "Preview changes without applying them")
-	mcpInstallCmd.Flags().Bool("auto-detect", false, "Detect all installed agents and configure them")
-	mcpInstallCmd.Flags().Bool("http", false, "Use HTTP transport with auto-generated bearer token")
-	mcpInstallCmd.Flags().Bool("stdio", true, "Use stdio transport (default)")
 }

--- a/cmd/mcp/mcp_token.go
+++ b/cmd/mcp/mcp_token.go
@@ -20,7 +20,8 @@ var mcpCmd = &cobra.Command{
 
 All MCP server functionality (install, configure, token management) is
 now available via the 'openpass agent' command family.`,
-	Hidden: true,
+	Example: `  openpass agent install claude-code`,
+	Hidden:  true,
 }
 
 var McpTokenCmd = &cobra.Command{
@@ -31,7 +32,7 @@ var McpTokenCmd = &cobra.Command{
 Scoped token management is now available via 'openpass agent token <name>'
 with subcommands new, list, revoke, and rotate.`,
 	Example: `  openpass agent token my-agent new`,
-	Hidden: true,
+	Hidden:  true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		fmt.Fprintf(os.Stderr, "This command is deprecated in v4.0. Use: openpass agent token <name> new/list/revoke\n")
 		return errorspkg.NewCLIError(errorspkg.ExitNotFound,

--- a/cmd/mcp/mcp_token.go
+++ b/cmd/mcp/mcp_token.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -14,31 +15,25 @@ import (
 
 var mcpCmd = &cobra.Command{
 	Use:   "mcp",
-	Short: "MCP server commands",
-	Long:  `Commands for managing the Model Context Protocol (MCP) server integration.`,
-	Example: `  # Generate a per-tool token
-  openpass mcp token create --name "ide-tools" --tools list,get
+	Short: "[Deprecated v4.0] MCP server commands — use 'openpass agent' instead",
+	Long: `MCP management commands have been replaced by the agent command group.
 
-  # List configured tokens
-  openpass mcp token list`,
+All MCP server functionality (install, configure, token management) is
+now available via the 'openpass agent' command family.`,
+	Hidden: true,
 }
 
 var McpTokenCmd = &cobra.Command{
 	Use:   "token",
-	Short: "Manage MCP scoped tokens",
-	Long: `Create, list, and revoke per-tool scoped tokens for MCP HTTP authentication.
+	Short: "[Deprecated v4.0, removed in v4.1] Use 'openpass agent token <name>'",
+	Long: `This command was deprecated in OpenPass v4.0 and will be removed in v4.1.
 
-Scoped tokens allow fine-grained access control for MCP clients. Each token can
-be restricted to specific tools and has an optional expiration time.`,
-	Example: `  # Create a read-only token expiring in 24h
-   openpass mcp token create --name "ci-readonly" --tools list,get --ttl 24h
-
-   # List all tokens
-   openpass mcp token list
-
-   # Revoke by ID
-   openpass mcp token revoke <token-id>`,
+Scoped token management is now available via 'openpass agent token <name>'
+with subcommands new, list, revoke, and rotate.`,
+	Example: `  openpass agent token my-agent new`,
+	Hidden: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		fmt.Fprintf(os.Stderr, "This command is deprecated in v4.0. Use: openpass agent token <name> new/list/revoke\n")
 		return errorspkg.NewCLIError(errorspkg.ExitNotFound,
 			"This command is deprecated in v4.0. Use: openpass agent token <name> new/list/revoke", nil)
 	},
@@ -46,12 +41,13 @@ be restricted to specific tools and has an optional expiration time.`,
 
 var TokenCreateCmd = &cobra.Command{
 	Use:   "create",
-	Short: "Create a new scoped token",
-	Long: `Create a new scoped MCP token with restricted tool access.
+	Short: "[Deprecated v4.0, removed in v4.1] Use 'openpass agent token <name> new'",
+	Long: `This command was deprecated in OpenPass v4.0 and will be removed in v4.1.
 
-The raw token is printed exactly once — copy it immediately. It cannot be
-retrieved later.`,
+Create scoped tokens via 'openpass agent token <name> new'.`,
+	Hidden: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		fmt.Fprintf(os.Stderr, "This command is deprecated in v4.0. Use: openpass agent token <name> new\n")
 		return errorspkg.NewCLIError(errorspkg.ExitNotFound,
 			"This command is deprecated in v4.0. Use: openpass agent token <name> new", nil)
 	},
@@ -59,9 +55,13 @@ retrieved later.`,
 
 var tokenListCmd = &cobra.Command{
 	Use:   "list",
-	Short: "List all scoped tokens",
-	Long:  `List all scoped tokens in the registry, including their status and expiration.`,
+	Short: "[Deprecated v4.0, removed in v4.1] Use 'openpass agent token <name> list'",
+	Long: `This command was deprecated in OpenPass v4.0 and will be removed in v4.1.
+
+List tokens via 'openpass agent token <name> list'.`,
+	Hidden: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		fmt.Fprintf(os.Stderr, "This command is deprecated in v4.0. Use: openpass agent token <name> list\n")
 		return errorspkg.NewCLIError(errorspkg.ExitNotFound,
 			"This command is deprecated in v4.0. Use: openpass agent token <name> list", nil)
 	},
@@ -69,10 +69,14 @@ var tokenListCmd = &cobra.Command{
 
 var tokenRevokeCmd = &cobra.Command{
 	Use:   "revoke <token-id>",
-	Short: "Revoke a scoped token",
-	Long:  `Revoke a scoped token by its ID. Revoked tokens are immediately invalidated.`,
-	Args:  cobra.ExactArgs(1),
+	Short: "[Deprecated v4.0, removed in v4.1] Use 'openpass agent token <name> revoke'",
+	Long: `This command was deprecated in OpenPass v4.0 and will be removed in v4.1.
+
+Revoke tokens via 'openpass agent token <name> revoke'.`,
+	Hidden: true,
+	Args:   cobra.ArbitraryArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		fmt.Fprintf(os.Stderr, "This command is deprecated in v4.0. Use: openpass agent token <name> revoke\n")
 		return errorspkg.NewCLIError(errorspkg.ExitNotFound,
 			"This command is deprecated in v4.0. Use: openpass agent token <name> revoke", nil)
 	},
@@ -135,9 +139,4 @@ func init() {
 	McpTokenCmd.AddCommand(TokenCreateCmd)
 	McpTokenCmd.AddCommand(tokenListCmd)
 	McpTokenCmd.AddCommand(tokenRevokeCmd)
-
-	TokenCreateCmd.Flags().StringSlice("tools", []string{"*"}, "Comma-separated allowed tools, or '*' for all")
-	TokenCreateCmd.Flags().String("ttl", "", "Token TTL (e.g. 24h, 7d); defaults to mcp.scoped_token_ttl from config")
-	TokenCreateCmd.Flags().String("agent", "", "Agent profile to associate")
-	TokenCreateCmd.Flags().String("label", "", "Human-readable label")
 }

--- a/cmd/mcp_config_test.go
+++ b/cmd/mcp_config_test.go
@@ -240,13 +240,11 @@ func TestCmdMCPConfig_HTTPMode(t *testing.T) {
 	cfgPath := filepath.Join(vaultDir, "config.yaml")
 	cfg := "mcp:\n  bind: 127.0.0.1\n  port: 9999\n  http_token_file: \"\"\n"
 	_ = os.WriteFile(cfgPath, []byte(cfg), 0o600)
-	_ = execWithStdout("--vault", vaultDir, "mcp-config", "default", "--http")
+	_ = execWithStdout("--vault", vaultDir, "mcp-config", "default")
 }
 
 func TestCmdMCPConfig_Stdio(t *testing.T) {
 	vaultFlagReset(t)
-	_ = mcpcmd.McpConfigCmd.Flags().Set("http", "false")
-	t.Cleanup(func() { _ = mcpcmd.McpConfigCmd.Flags().Set("http", "false") })
 
 	cli.RootCmd.SetArgs([]string{"mcp-config", "myagent"})
 	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
@@ -292,7 +290,7 @@ func TestCmdMCPConfig_HTTP(t *testing.T) {
 		t.Fatalf("init vault: %v", err)
 	}
 
-	cli.RootCmd.SetArgs([]string{"--vault", vaultDir, "mcp-config", "myagent", "--http"})
+	cli.RootCmd.SetArgs([]string{"--vault", vaultDir, "mcp-config", "myagent"})
 	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
 
 	err := cli.RootCmd.Execute()
@@ -308,11 +306,7 @@ func TestCmdMCPConfig_HTTP(t *testing.T) {
 func TestCmdMCPConfig_HermesHTTP(t *testing.T) {
 	vaultDir, _ := initVault(t)
 	vaultFlagReset(t)
-	_ = mcpcmd.McpConfigCmd.Flags().Set("format", "generic")
-	_ = mcpcmd.McpConfigCmd.Flags().Set("server-name", "openpass")
 	t.Cleanup(func() {
-		_ = mcpcmd.McpConfigCmd.Flags().Set("format", "generic")
-		_ = mcpcmd.McpConfigCmd.Flags().Set("server-name", "openpass")
 	})
 
 	cfgContent := "mcp:\n  bind: 127.0.0.1\n  port: 8090\n"
@@ -320,7 +314,7 @@ func TestCmdMCPConfig_HermesHTTP(t *testing.T) {
 		t.Fatalf("write config: %v", err)
 	}
 
-	cli.RootCmd.SetArgs([]string{"--vault", vaultDir, "mcp-config", "hermes", "--http", "--format", "hermes"})
+	cli.RootCmd.SetArgs([]string{"--vault", vaultDir, "mcp-config", "hermes"})
 	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
 
 	err := cli.RootCmd.Execute()
@@ -364,7 +358,6 @@ func TestOutputHTTPConfig_VaultPathError(t *testing.T) {
 func TestOutputHTTPConfig_CustomTokenFile(t *testing.T) {
 	vaultDir, _ := initVault(t)
 	vaultFlagReset(t)
-	t.Cleanup(func() { _ = mcpcmd.McpConfigCmd.Flags().Set("include-token", "false") })
 
 	customTokenPath := filepath.Join(t.TempDir(), "custom-token")
 	customTokenValue := "my-custom-token-value-12345"
@@ -377,7 +370,7 @@ func TestOutputHTTPConfig_CustomTokenFile(t *testing.T) {
 		t.Fatalf("write config: %v", err)
 	}
 
-	cli.RootCmd.SetArgs([]string{"--vault", vaultDir, "mcp-config", "myagent", "--http"})
+	cli.RootCmd.SetArgs([]string{"--vault", vaultDir, "mcp-config", "myagent"})
 	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
 
 	err := cli.RootCmd.Execute()
@@ -389,7 +382,7 @@ func TestOutputHTTPConfig_CustomTokenFile(t *testing.T) {
 		t.Errorf("expected deprecation message, got: %v", err)
 	}
 
-	cli.RootCmd.SetArgs([]string{"--vault", vaultDir, "mcp-config", "myagent", "--http", "--include-token"})
+	cli.RootCmd.SetArgs([]string{"--vault", vaultDir, "mcp-config", "myagent"})
 	err = cli.RootCmd.Execute()
 
 	if err == nil {
@@ -409,7 +402,7 @@ func TestOutputHTTPConfig_TokenLoadError(t *testing.T) {
 		t.Fatalf("write config: %v", err)
 	}
 
-	cli.RootCmd.SetArgs([]string{"--vault", vaultDir, "mcp-config", "myagent", "--http"})
+	cli.RootCmd.SetArgs([]string{"--vault", vaultDir, "mcp-config", "myagent"})
 	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
 
 	err := cli.RootCmd.Execute()
@@ -430,7 +423,7 @@ func TestOutputHTTPConfig_StaleRuntimePort(t *testing.T) {
 		t.Fatalf("save runtime port: %v", err)
 	}
 
-	cli.RootCmd.SetArgs([]string{"--vault", vaultDir, "mcp-config", "myagent", "--http"})
+	cli.RootCmd.SetArgs([]string{"--vault", vaultDir, "mcp-config", "myagent"})
 	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
 
 	err := cli.RootCmd.Execute()

--- a/cmd/mcp_token_test.go
+++ b/cmd/mcp_token_test.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
 	"runtime"
 	"strings"
@@ -50,9 +49,8 @@ func TestMCPTokenCreate_Defaults(t *testing.T) {
 	vaultFlagReset(t)
 	t.Cleanup(func() { resetCobraCommand(cli.RootCmd) })
 
-	cli.RootCmd.SetArgs([]string{"--vault", vaultDir, "mcp", "token", "create", "--label", "test-default"})
+	cli.RootCmd.SetArgs([]string{"--vault", vaultDir, "mcp", "token", "create"})
 	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
-	t.Cleanup(func() { _ = mcpcmd.TokenCreateCmd.Flags().Set("ttl", "") })
 
 	err := cli.RootCmd.Execute()
 
@@ -83,12 +81,8 @@ func TestMCPTokenCreate_WithToolsAndAgent(t *testing.T) {
 	cli.RootCmd.SetArgs([]string{
 		"--vault", vaultDir,
 		"mcp", "token", "create",
-		"--tools", "list_entries,get_entry",
-		"--agent", "claude-code",
-		"--label", "scoped-test",
 	})
 	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
-	t.Cleanup(func() { _ = mcpcmd.TokenCreateCmd.Flags().Set("ttl", "") })
 
 	err := cli.RootCmd.Execute()
 
@@ -119,12 +113,8 @@ func TestMCPTokenCreate_MultipleToolFlags(t *testing.T) {
 	cli.RootCmd.SetArgs([]string{
 		"--vault", vaultDir,
 		"mcp", "token", "create",
-		"--tools", "list_entries",
-		"--tools", "get_entry",
-		"--label", "multi-flag",
 	})
 	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
-	t.Cleanup(func() { _ = mcpcmd.TokenCreateCmd.Flags().Set("ttl", "") })
 
 	err := cli.RootCmd.Execute()
 
@@ -155,11 +145,8 @@ func TestMCPTokenCreate_WithTTL(t *testing.T) {
 	cli.RootCmd.SetArgs([]string{
 		"--vault", vaultDir,
 		"mcp", "token", "create",
-		"--ttl", "7d",
-		"--label", "ttl-test",
 	})
 	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
-	t.Cleanup(func() { _ = mcpcmd.TokenCreateCmd.Flags().Set("ttl", "") })
 
 	err := cli.RootCmd.Execute()
 
@@ -193,10 +180,8 @@ func TestMCPTokenCreate_DefaultTTLFromConfig(t *testing.T) {
 	cli.RootCmd.SetArgs([]string{
 		"--vault", vaultDir,
 		"mcp", "token", "create",
-		"--label", "config-ttl",
 	})
 	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
-	t.Cleanup(func() { _ = mcpcmd.TokenCreateCmd.Flags().Set("ttl", "") })
 
 	err := cli.RootCmd.Execute()
 
@@ -227,11 +212,8 @@ func TestMCPTokenCreate_InvalidTTL(t *testing.T) {
 	cli.RootCmd.SetArgs([]string{
 		"--vault", vaultDir,
 		"mcp", "token", "create",
-		"--ttl", "not-a-duration",
-		"--label", "invalid",
 	})
 	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
-	t.Cleanup(func() { _ = mcpcmd.TokenCreateCmd.Flags().Set("ttl", "") })
 
 	err := cli.RootCmd.Execute()
 
@@ -259,9 +241,8 @@ func TestMCPTokenCreate_VaultPathError(t *testing.T) {
 	vaultFlagReset(t)
 	t.Cleanup(func() { resetCobraCommand(cli.RootCmd) })
 
-	cli.RootCmd.SetArgs([]string{"mcp", "token", "create", "--label", "fail"})
+	cli.RootCmd.SetArgs([]string{"mcp", "token", "create"})
 	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
-	t.Cleanup(func() { _ = mcpcmd.TokenCreateCmd.Flags().Set("ttl", "") })
 
 	var execErr error
 	captureStderr(func() {
@@ -291,7 +272,6 @@ func TestMCPTokenList_Empty(t *testing.T) {
 
 	cli.RootCmd.SetArgs([]string{"--vault", vaultDir, "mcp", "token", "list"})
 	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
-	t.Cleanup(func() { _ = mcpcmd.TokenCreateCmd.Flags().Set("ttl", "") })
 
 	err := cli.RootCmd.Execute()
 
@@ -333,7 +313,6 @@ func TestMCPTokenList_WithTokens(t *testing.T) {
 
 	cli.RootCmd.SetArgs([]string{"--vault", vaultDir, "mcp", "token", "list"})
 	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
-	t.Cleanup(func() { _ = mcpcmd.TokenCreateCmd.Flags().Set("ttl", "") })
 
 	err = cli.RootCmd.Execute()
 
@@ -375,7 +354,6 @@ func TestMCPTokenRevoke_Success(t *testing.T) {
 
 	cli.RootCmd.SetArgs([]string{"--vault", vaultDir, "mcp", "token", "revoke", token.ID})
 	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
-	t.Cleanup(func() { _ = mcpcmd.TokenCreateCmd.Flags().Set("ttl", "") })
 
 	err = cli.RootCmd.Execute()
 
@@ -404,7 +382,6 @@ func TestMCPTokenRevoke_NotFound(t *testing.T) {
 
 	cli.RootCmd.SetArgs([]string{"--vault", vaultDir, "mcp", "token", "revoke", "nonexistent-id"})
 	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
-	t.Cleanup(func() { _ = mcpcmd.TokenCreateCmd.Flags().Set("ttl", "") })
 
 	err := cli.RootCmd.Execute()
 
@@ -496,7 +473,6 @@ func TestMCPTokenList_RevokedToken(t *testing.T) {
 
 	cli.RootCmd.SetArgs([]string{"--vault", vaultDir, "mcp", "token", "list"})
 	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
-	t.Cleanup(func() { _ = mcpcmd.TokenCreateCmd.Flags().Set("ttl", "") })
 
 	err = cli.RootCmd.Execute()
 
@@ -589,11 +565,8 @@ func TestMCPTokenCreate_ZeroTTL(t *testing.T) {
 	cli.RootCmd.SetArgs([]string{
 		"--vault", vaultDir,
 		"mcp", "token", "create",
-		"--ttl", "0h",
-		"--label", "zero-ttl",
 	})
 	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
-	t.Cleanup(func() { _ = mcpcmd.TokenCreateCmd.Flags().Set("ttl", "") })
 
 	err := cli.RootCmd.Execute()
 
@@ -641,7 +614,6 @@ func TestMCPTokenList_ExpiredTokenExcluded(t *testing.T) {
 
 	cli.RootCmd.SetArgs([]string{"--vault", vaultDir, "mcp", "token", "list"})
 	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
-	t.Cleanup(func() { _ = mcpcmd.TokenCreateCmd.Flags().Set("ttl", "") })
 
 	err = cli.RootCmd.Execute()
 
@@ -672,11 +644,8 @@ func TestMCPTokenCreate_PreservesInRegistry(t *testing.T) {
 	cli.RootCmd.SetArgs([]string{
 		"--vault", vaultDir,
 		"mcp", "token", "create",
-		"--tools", "list_entries",
-		"--label", "persist-test",
 	})
 	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
-	t.Cleanup(func() { _ = mcpcmd.TokenCreateCmd.Flags().Set("ttl", "") })
 
 	err := cli.RootCmd.Execute()
 
@@ -705,7 +674,6 @@ func TestMCPTokenRevoke_MissingArg(t *testing.T) {
 
 	cli.RootCmd.SetArgs([]string{"--vault", vaultDir, "mcp", "token", "revoke"})
 	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
-	t.Cleanup(func() { _ = mcpcmd.TokenCreateCmd.Flags().Set("ttl", "") })
 
 	var execErr error
 	captureStderr(func() {
@@ -752,7 +720,6 @@ func TestMCPTokenCreate_ToolsLongOutput(t *testing.T) {
 
 	cli.RootCmd.SetArgs([]string{"--vault", vaultDir, "mcp", "token", "list"})
 	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
-	t.Cleanup(func() { _ = mcpcmd.TokenCreateCmd.Flags().Set("ttl", "") })
 
 	err = cli.RootCmd.Execute()
 
@@ -795,7 +762,6 @@ func TestMCPTokenList_HeaderFormat(t *testing.T) {
 
 	cli.RootCmd.SetArgs([]string{"--vault", vaultDir, "mcp", "token", "list"})
 	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
-	t.Cleanup(func() { _ = mcpcmd.TokenCreateCmd.Flags().Set("ttl", "") })
 
 	err = cli.RootCmd.Execute()
 
@@ -840,11 +806,8 @@ func TestMCPTokenCreate_NegativeDayTTL(t *testing.T) {
 	cli.RootCmd.SetArgs([]string{
 		"--vault", vaultDir,
 		"mcp", "token", "create",
-		"--ttl", "-1d",
-		"--label", "negative",
 	})
 	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
-	t.Cleanup(func() { _ = mcpcmd.TokenCreateCmd.Flags().Set("ttl", "") })
 
 	err := cli.RootCmd.Execute()
 
@@ -877,10 +840,8 @@ func TestMCPTokenCreate_RegistryFilePermissions(t *testing.T) {
 	cli.RootCmd.SetArgs([]string{
 		"--vault", vaultDir,
 		"mcp", "token", "create",
-		"--label", "perms-test",
 	})
 	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
-	t.Cleanup(func() { _ = mcpcmd.TokenCreateCmd.Flags().Set("ttl", "") })
 
 	err := cli.RootCmd.Execute()
 
@@ -913,7 +874,6 @@ func TestMCPTokenCreate_EmptyLabelOK(t *testing.T) {
 		"mcp", "token", "create",
 	})
 	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
-	t.Cleanup(func() { _ = mcpcmd.TokenCreateCmd.Flags().Set("ttl", "") })
 
 	err := cli.RootCmd.Execute()
 
@@ -943,7 +903,6 @@ func TestMCPTokenRevoke_VaultPathError(t *testing.T) {
 
 	cli.RootCmd.SetArgs([]string{"mcp", "token", "revoke", "some-id"})
 	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
-	t.Cleanup(func() { _ = mcpcmd.TokenCreateCmd.Flags().Set("ttl", "") })
 
 	var execErr error
 	captureStderr(func() {
@@ -973,7 +932,6 @@ func TestMCPTokenList_VaultPathError(t *testing.T) {
 
 	cli.RootCmd.SetArgs([]string{"mcp", "token", "list"})
 	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
-	t.Cleanup(func() { _ = mcpcmd.TokenCreateCmd.Flags().Set("ttl", "") })
 
 	var execErr error
 	captureStderr(func() {
@@ -1004,11 +962,8 @@ func TestMCPTokenCreate_WithDaySuffixTTL(t *testing.T) {
 	cli.RootCmd.SetArgs([]string{
 		"--vault", vaultDir,
 		"mcp", "token", "create",
-		"--ttl", "7d",
-		"--label", "week-token",
 	})
 	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
-	t.Cleanup(func() { _ = mcpcmd.TokenCreateCmd.Flags().Set("ttl", "") })
 
 	err := cli.RootCmd.Execute()
 
@@ -1051,7 +1006,6 @@ func TestMCPTokenList_EmptyAgentAndLabel(t *testing.T) {
 
 	cli.RootCmd.SetArgs([]string{"--vault", vaultDir, "mcp", "token", "list"})
 	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
-	t.Cleanup(func() { _ = mcpcmd.TokenCreateCmd.Flags().Set("ttl", "") })
 
 	err = cli.RootCmd.Execute()
 
@@ -1082,10 +1036,8 @@ func TestMCPTokenCreate_RawTokenUnique(t *testing.T) {
 		cli.RootCmd.SetArgs([]string{
 			"--vault", vaultDir,
 			"mcp", "token", "create",
-			"--label", fmt.Sprintf("token-%d", i),
 		})
 		t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
-		t.Cleanup(func() { _ = mcpcmd.TokenCreateCmd.Flags().Set("ttl", "") })
 
 		err := cli.RootCmd.Execute()
 		if err == nil {

--- a/docs/skills/openpass-agent/SKILL.md
+++ b/docs/skills/openpass-agent/SKILL.md
@@ -22,10 +22,37 @@ Canonical OpenPass MCP tool names:
 - `generate_totp`
 - `delete_entry`
 - `openpass_delete` (deprecated alias for `delete_entry`)
+- `execute_with_secret` — Run a shell command with a vault secret injected as an
+  environment variable. The secret value never appears in the command string,
+  argv, or chat transcript.
+- `execute_api_request` — Make an authenticated HTTP request using a stored
+  secret (API key, PAT, bearer token). The secret is attached by the server and
+  never revealed to the agent.
 
 Some MCP clients prepend a namespace (for example `mcp_openpass_list_entries`).
 If canonical names are unavailable, inspect the client's MCP tool list and map
 to these equivalents.
+
+### Safe API Request Example
+
+To call the GitHub API with a stored PAT, use `execute_api_request`:
+
+```json
+{
+  "template": "github",
+  "endpoint": "/repos/owner/repo/issues",
+  "method": "GET"
+}
+```
+
+Do NOT call `get_entry_value` followed by curl — this exposes the token
+in the chat transcript.
+
+### Anti-pattern: Manual secret exposure
+
+Never pass a secret as an argv argument or echo it in a shell command.
+Use the secret-injecting tools so the value lives only in env vars of
+the spawned subprocess.
 
 ## Cache Validation for Credential Sync
 

--- a/go.mod
+++ b/go.mod
@@ -137,7 +137,7 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	go.yaml.in/yaml/v4 v4.0.0-rc.2 // indirect
 	golang.org/x/mod v0.36.0 // indirect
-	golang.org/x/net v0.54.0 // indirect
+	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260401024825-9d38bb4040a9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -258,8 +258,8 @@ golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f/go.mod h1:J1xhfL/vlindoeF/aI
 golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
 golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/net v0.54.0 h1:2zJIZAxAHV/OHCDTCOHAYehQzLfSXuf/5SoL/Dv6w/w=
-golang.org/x/net v0.54.0/go.mod h1:Sj4oj8jK6XmHpBZU/zWHw3BV3abl4Kvi+Ut7cQcY+cQ=
+golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
+golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
 golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
 golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/internal/config/config_load.go
+++ b/internal/config/config_load.go
@@ -129,15 +129,15 @@ func builtinAgentProfiles() map[string]AgentProfile {
 	canWriteFalse := false
 	canRunFalse := false
 	exposeTrue := true
-	autoUnsealTrue := true
+	autoUnsealFalse := false
 	deny := approvalModeDeny
 	return map[string]AgentProfile{
-		"default":     {Name: "default", AllowedPaths: []string{}, CanWrite: &canWriteFalse, CanRunCommands: &canRunFalse, ApprovalMode: &deny, ExposeValueTools: &exposeTrue, AutoUnseal: &autoUnsealTrue},
-		"claude-code": {Name: "claude-code", AllowedPaths: []string{}, CanWrite: &canWriteTrue, CanRunCommands: &canRunFalse, ApprovalMode: &deny, ExposeValueTools: &exposeTrue, AutoUnseal: &autoUnsealTrue, SkillPath: StrPtr("~/.claude/skills/openpass/SKILL.md")},
-		"codex":       {Name: "codex", AllowedPaths: []string{}, CanWrite: &canWriteFalse, CanRunCommands: &canRunFalse, ApprovalMode: &deny, ExposeValueTools: &exposeTrue, AutoUnseal: &autoUnsealTrue, SkillPath: StrPtr("~/.codex/skills/openpass/AGENTS.md")},
-		"hermes":      {Name: "hermes", AllowedPaths: []string{}, CanWrite: &canWriteTrue, CanRunCommands: &canRunFalse, ApprovalMode: &deny, ExposeValueTools: &exposeTrue, AutoUnseal: &autoUnsealTrue, SkillPath: StrPtr("~/.hermes/skills/openpass/SKILL.md")},
-		"openclaw":    {Name: "openclaw", AllowedPaths: []string{}, CanWrite: &canWriteTrue, CanRunCommands: &canRunFalse, ApprovalMode: &deny, ExposeValueTools: &exposeTrue, AutoUnseal: &autoUnsealTrue, SkillPath: StrPtr("~/.openclaw/skills/openpass/SKILL.md")},
-		"opencode":    {Name: "opencode", AllowedPaths: []string{}, CanWrite: &canWriteFalse, CanRunCommands: &canRunFalse, ApprovalMode: &deny, ExposeValueTools: &exposeTrue, AutoUnseal: &autoUnsealTrue, SkillPath: StrPtr("~/.opencode/skills/openpass/SKILL.md")},
+		"default":     {Name: "default", AllowedPaths: []string{}, CanWrite: &canWriteFalse, CanRunCommands: &canRunFalse, ApprovalMode: &deny, ExposeValueTools: &exposeTrue, AutoUnseal: &autoUnsealFalse},
+		"claude-code": {Name: "claude-code", AllowedPaths: []string{}, CanWrite: &canWriteTrue, CanRunCommands: &canRunFalse, ApprovalMode: &deny, ExposeValueTools: &exposeTrue, AutoUnseal: &autoUnsealFalse, SkillPath: StrPtr("~/.claude/skills/openpass/SKILL.md")},
+		"codex":       {Name: "codex", AllowedPaths: []string{}, CanWrite: &canWriteFalse, CanRunCommands: &canRunFalse, ApprovalMode: &deny, ExposeValueTools: &exposeTrue, AutoUnseal: &autoUnsealFalse, SkillPath: StrPtr("~/.codex/skills/openpass/AGENTS.md")},
+		"hermes":      {Name: "hermes", AllowedPaths: []string{}, CanWrite: &canWriteTrue, CanRunCommands: &canRunFalse, ApprovalMode: &deny, ExposeValueTools: &exposeTrue, AutoUnseal: &autoUnsealFalse, SkillPath: StrPtr("~/.hermes/skills/openpass/SKILL.md")},
+		"openclaw":    {Name: "openclaw", AllowedPaths: []string{}, CanWrite: &canWriteTrue, CanRunCommands: &canRunFalse, ApprovalMode: &deny, ExposeValueTools: &exposeTrue, AutoUnseal: &autoUnsealFalse, SkillPath: StrPtr("~/.openclaw/skills/openpass/SKILL.md")},
+		"opencode":    {Name: "opencode", AllowedPaths: []string{}, CanWrite: &canWriteFalse, CanRunCommands: &canRunFalse, ApprovalMode: &deny, ExposeValueTools: &exposeTrue, AutoUnseal: &autoUnsealFalse, SkillPath: StrPtr("~/.opencode/skills/openpass/SKILL.md")},
 	}
 }
 

--- a/internal/config/config_load.go
+++ b/internal/config/config_load.go
@@ -127,17 +127,18 @@ func newDefaultAgentProfile(name string) AgentProfile {
 func builtinAgentProfiles() map[string]AgentProfile {
 	canWriteTrue := true
 	canWriteFalse := false
+	canRunTrue := true
 	canRunFalse := false
 	exposeTrue := true
 	autoUnsealFalse := false
 	deny := approvalModeDeny
 	return map[string]AgentProfile{
 		"default":     {Name: "default", AllowedPaths: []string{}, CanWrite: &canWriteFalse, CanRunCommands: &canRunFalse, ApprovalMode: &deny, ExposeValueTools: &exposeTrue, AutoUnseal: &autoUnsealFalse},
-		"claude-code": {Name: "claude-code", AllowedPaths: []string{}, CanWrite: &canWriteTrue, CanRunCommands: &canRunFalse, ApprovalMode: &deny, ExposeValueTools: &exposeTrue, AutoUnseal: &autoUnsealFalse, SkillPath: StrPtr("~/.claude/skills/openpass/SKILL.md")},
-		"codex":       {Name: "codex", AllowedPaths: []string{}, CanWrite: &canWriteFalse, CanRunCommands: &canRunFalse, ApprovalMode: &deny, ExposeValueTools: &exposeTrue, AutoUnseal: &autoUnsealFalse, SkillPath: StrPtr("~/.codex/skills/openpass/AGENTS.md")},
-		"hermes":      {Name: "hermes", AllowedPaths: []string{}, CanWrite: &canWriteTrue, CanRunCommands: &canRunFalse, ApprovalMode: &deny, ExposeValueTools: &exposeTrue, AutoUnseal: &autoUnsealFalse, SkillPath: StrPtr("~/.hermes/skills/openpass/SKILL.md")},
-		"openclaw":    {Name: "openclaw", AllowedPaths: []string{}, CanWrite: &canWriteTrue, CanRunCommands: &canRunFalse, ApprovalMode: &deny, ExposeValueTools: &exposeTrue, AutoUnseal: &autoUnsealFalse, SkillPath: StrPtr("~/.openclaw/skills/openpass/SKILL.md")},
-		"opencode":    {Name: "opencode", AllowedPaths: []string{}, CanWrite: &canWriteFalse, CanRunCommands: &canRunFalse, ApprovalMode: &deny, ExposeValueTools: &exposeTrue, AutoUnseal: &autoUnsealFalse, SkillPath: StrPtr("~/.opencode/skills/openpass/SKILL.md")},
+		"claude-code": {Name: "claude-code", AllowedPaths: []string{}, CanWrite: &canWriteTrue, CanRunCommands: &canRunTrue, ApprovalMode: &deny, ExposeValueTools: &exposeTrue, AutoUnseal: &autoUnsealFalse, SkillPath: StrPtr("~/.claude/skills/openpass/SKILL.md")},
+		"codex":       {Name: "codex", AllowedPaths: []string{}, CanWrite: &canWriteFalse, CanRunCommands: &canRunTrue, ApprovalMode: &deny, ExposeValueTools: &exposeTrue, AutoUnseal: &autoUnsealFalse, SkillPath: StrPtr("~/.codex/skills/openpass/AGENTS.md")},
+		"hermes":      {Name: "hermes", AllowedPaths: []string{}, CanWrite: &canWriteTrue, CanRunCommands: &canRunTrue, ApprovalMode: &deny, ExposeValueTools: &exposeTrue, AutoUnseal: &autoUnsealFalse, SkillPath: StrPtr("~/.hermes/skills/openpass/SKILL.md")},
+		"openclaw":    {Name: "openclaw", AllowedPaths: []string{}, CanWrite: &canWriteTrue, CanRunCommands: &canRunTrue, ApprovalMode: &deny, ExposeValueTools: &exposeTrue, AutoUnseal: &autoUnsealFalse, SkillPath: StrPtr("~/.openclaw/skills/openpass/SKILL.md")},
+		"opencode":    {Name: "opencode", AllowedPaths: []string{}, CanWrite: &canWriteFalse, CanRunCommands: &canRunTrue, ApprovalMode: &deny, ExposeValueTools: &exposeTrue, AutoUnseal: &autoUnsealFalse, SkillPath: StrPtr("~/.opencode/skills/openpass/SKILL.md")},
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -34,16 +34,17 @@ func TestDefaultReturnsSensibleConfig(t *testing.T) {
 
 	// Built-in profile assertions
 	type wantProfile struct {
-		approvalMode string
-		canWrite     bool
+		approvalMode   string
+		canWrite       bool
+		canRunCommands bool
 	}
 	wantProfiles := map[string]wantProfile{
-		"default":     {canWrite: false, approvalMode: "deny"},
-		"claude-code": {canWrite: true, approvalMode: "deny"},
-		"codex":       {canWrite: false, approvalMode: "deny"},
-		"hermes":      {canWrite: true, approvalMode: "deny"},
-		"openclaw":    {canWrite: true, approvalMode: "deny"},
-		"opencode":    {canWrite: false, approvalMode: "deny"},
+		"default":     {canWrite: false, canRunCommands: false, approvalMode: "deny"},
+		"claude-code": {canWrite: true, canRunCommands: true, approvalMode: "deny"},
+		"codex":       {canWrite: false, canRunCommands: true, approvalMode: "deny"},
+		"hermes":      {canWrite: true, canRunCommands: true, approvalMode: "deny"},
+		"openclaw":    {canWrite: true, canRunCommands: true, approvalMode: "deny"},
+		"opencode":    {canWrite: false, canRunCommands: true, approvalMode: "deny"},
 	}
 	for name, want := range wantProfiles {
 		got, ok := cfg.Agents[name]
@@ -52,6 +53,9 @@ func TestDefaultReturnsSensibleConfig(t *testing.T) {
 		}
 		if *got.CanWrite != want.canWrite {
 			t.Fatalf("profile %q CanWrite = %v, want %v", name, got.CanWrite, want.canWrite)
+		}
+		if *got.CanRunCommands != want.canRunCommands {
+			t.Fatalf("profile %q CanRunCommands = %v, want %v", name, *got.CanRunCommands, want.canRunCommands)
 		}
 		if *got.ApprovalMode != want.approvalMode {
 			t.Fatalf("profile %q ApprovalMode = %q, want %q", name, *got.ApprovalMode, want.approvalMode)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -945,6 +945,26 @@ func TestDefault_ReturnsBuiltInAgentProfiles(t *testing.T) {
 	}
 }
 
+func TestBuiltinAgentProfilesAutoUnsealIsFalse(t *testing.T) {
+	t.Parallel()
+
+	profiles := builtinAgentProfiles()
+	for _, name := range []string{"default", "claude-code", "codex", "hermes", "openclaw", "opencode"} {
+		t.Run(name, func(t *testing.T) {
+			profile, ok := profiles[name]
+			if !ok {
+				t.Fatalf("missing built-in profile: %s", name)
+			}
+			if profile.AutoUnseal == nil {
+				t.Fatal("AutoUnseal should not be nil")
+			}
+			if *profile.AutoUnseal {
+				t.Fatalf("AutoUnseal = true for profile %q, want false (secrets should be sealed by default)", name)
+			}
+		})
+	}
+}
+
 func TestDefault_SessionTimeoutHasDefault(t *testing.T) {
 	t.Parallel()
 

--- a/internal/envfilter/filter.go
+++ b/internal/envfilter/filter.go
@@ -7,6 +7,7 @@ package envfilter
 import (
 	"os"
 	"os/exec"
+	"sort"
 	"strings"
 )
 
@@ -102,4 +103,32 @@ func PrepareCmd(cmd *exec.Cmd, additional ...string) {
 		whitelist = MergeWhitelist(DefaultWhitelist(), additional)
 	}
 	cmd.Env = FilterEnv(whitelist)
+}
+
+// DeniedEnvVars returns the list of environment variable names that are
+// denied from agent-supplied env_vars to prevent interpreter/loader injection.
+func DeniedEnvVars() []string {
+	return []string{
+		"LD_PRELOAD", "LD_LIBRARY_PATH", "LD_AUDIT",
+		"DYLD_INSERT_LIBRARIES", "DYLD_LIBRARY_PATH", "DYLD_FALLBACK_LIBRARY_PATH",
+		"NODE_OPTIONS", "PYTHONSTARTUP", "PYTHONPATH",
+		"BASH_ENV", "ENV", "RUBYOPT", "PERL5OPT", "PERL5LIB",
+	}
+}
+
+// RejectDenied returns a sorted slice of denied env var keys found in the input map.
+func RejectDenied(env map[string]string) []string {
+	denied := DeniedEnvVars()
+	deniedSet := make(map[string]bool, len(denied))
+	for _, v := range denied {
+		deniedSet[v] = true
+	}
+	var rejected []string
+	for k := range env {
+		if deniedSet[k] {
+			rejected = append(rejected, k)
+		}
+	}
+	sort.Strings(rejected)
+	return rejected
 }

--- a/internal/envfilter/filter_test.go
+++ b/internal/envfilter/filter_test.go
@@ -263,6 +263,59 @@ func TestFilterEnv_SubstringKeyMatch(t *testing.T) {
 	}
 }
 
+func TestRejectDenied_LDPreload(t *testing.T) {
+	result := RejectDenied(map[string]string{"LD_PRELOAD": "/tmp/evil.so"})
+	if len(result) != 1 || result[0] != "LD_PRELOAD" {
+		t.Errorf("RejectDenied(LD_PRELOAD) = %v, want [LD_PRELOAD]", result)
+	}
+}
+
+func TestRejectDenied_NodeOptions(t *testing.T) {
+	result := RejectDenied(map[string]string{"NODE_OPTIONS": "--inspect"})
+	if len(result) != 1 || result[0] != "NODE_OPTIONS" {
+		t.Errorf("RejectDenied(NODE_OPTIONS) = %v, want [NODE_OPTIONS]", result)
+	}
+}
+
+func TestRejectDenied_BashEnv(t *testing.T) {
+	result := RejectDenied(map[string]string{"BASH_ENV": "/tmp/malicious.sh"})
+	if len(result) != 1 || result[0] != "BASH_ENV" {
+		t.Errorf("RejectDenied(BASH_ENV) = %v, want [BASH_ENV]", result)
+	}
+}
+
+func TestRejectDenied_BenignVar(t *testing.T) {
+	result := RejectDenied(map[string]string{"MY_API_BASE": "https://api.example.com"})
+	if len(result) != 0 {
+		t.Errorf("RejectDenied(MY_API_BASE) = %v, want []", result)
+	}
+}
+
+func TestRejectDenied_MixedDeniedAndBenign(t *testing.T) {
+	result := RejectDenied(map[string]string{
+		"LD_PRELOAD":   "/tmp/evil.so",
+		"MY_API_BASE":  "https://api.example.com",
+		"BASH_ENV":     "/tmp/malicious.sh",
+		"NODE_OPTIONS": "--inspect",
+	})
+	expected := []string{"BASH_ENV", "LD_PRELOAD", "NODE_OPTIONS"}
+	if len(result) != len(expected) {
+		t.Fatalf("RejectDenied(mixed) length = %d, want %d", len(result), len(expected))
+	}
+	for i, v := range expected {
+		if result[i] != v {
+			t.Errorf("RejectDenied(mixed)[%d] = %s, want %s", i, result[i], v)
+		}
+	}
+}
+
+func TestRejectDenied_EmptyMap(t *testing.T) {
+	result := RejectDenied(map[string]string{})
+	if len(result) != 0 {
+		t.Errorf("RejectDenied({}) = %v, want []", result)
+	}
+}
+
 // Test helpers
 
 func contains(slice []string, item string) bool {

--- a/internal/mcp/server/tools_execute_with_secret.go
+++ b/internal/mcp/server/tools_execute_with_secret.go
@@ -255,7 +255,7 @@ func sanitizeEnvVarName(name string) string {
 // checkExecuteWithSecretApproval checks the agent's approval mode for secret-injected execution.
 func (s *Server) checkExecuteWithSecretApproval(ctx context.Context, command []string, resolvedEnv map[string]string) error {
 	return s.requireApproval(ctx, Intent{
-		Action:  "execute_with_secret",
+		Action: "execute_with_secret",
 		Summary: fmt.Sprintf("agent %q requests to execute command [%s] with secret injection (env vars: %v)",
 			s.agent.Name, strings.Join(command, " "), mapKeys(resolvedEnv)),
 	})

--- a/internal/mcp/server/tools_execute_with_secret.go
+++ b/internal/mcp/server/tools_execute_with_secret.go
@@ -10,6 +10,7 @@ import (
 	"time"
 	"unicode"
 
+	"github.com/danieljustus/OpenPass/internal/envfilter"
 	mcp "github.com/danieljustus/OpenPass/internal/mcp"
 	"github.com/danieljustus/OpenPass/internal/metrics"
 	"github.com/danieljustus/OpenPass/internal/secrets"
@@ -131,7 +132,16 @@ func (s *Server) handleExecuteWithSecret(ctx context.Context, req mcp.CallToolRe
 		}
 	}
 
-	approvalErr := s.checkExecuteWithSecretApproval(ctx)
+	// Check for denied env vars
+	if len(resolvedEnv) > 0 {
+		denied := envfilter.RejectDenied(resolvedEnv)
+		if len(denied) > 0 {
+			s.logAudit(ctx, "execute_with_secret", "<validation-denied-env>", false)
+			return mcp.NewToolResultError(fmt.Sprintf("env_vars contains denied keys: %s", strings.Join(denied, ", "))), nil
+		}
+	}
+
+	approvalErr := s.checkExecuteWithSecretApproval(ctx, command, resolvedEnv)
 	if approvalErr != nil {
 		s.logAudit(ctx, "execute_with_secret", "<approval-denied>", false)
 		metrics.RecordApproval(s.agent.Name, "denied")
@@ -243,9 +253,20 @@ func sanitizeEnvVarName(name string) string {
 }
 
 // checkExecuteWithSecretApproval checks the agent's approval mode for secret-injected execution.
-func (s *Server) checkExecuteWithSecretApproval(ctx context.Context) error {
+func (s *Server) checkExecuteWithSecretApproval(ctx context.Context, command []string, resolvedEnv map[string]string) error {
 	return s.requireApproval(ctx, Intent{
 		Action:  "execute_with_secret",
-		Summary: fmt.Sprintf("agent %q requests to execute a command with secret injection", s.agent.Name),
+		Summary: fmt.Sprintf("agent %q requests to execute command [%s] with secret injection (env vars: %v)",
+			s.agent.Name, strings.Join(command, " "), mapKeys(resolvedEnv)),
 	})
+}
+
+// mapKeys returns a sorted slice of keys from the given map.
+func mapKeys(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
 }

--- a/internal/mcp/server/tools_execute_with_secret_test.go
+++ b/internal/mcp/server/tools_execute_with_secret_test.go
@@ -1022,6 +1022,42 @@ func TestHandleExecuteWithSecret_ApprovalPromptNoTTY(t *testing.T) {
 	}
 }
 
+func TestHandleExecuteWithSecret_DeniedEnvVarLDPreload(t *testing.T) {
+	srv := newTestServer(t, config.AgentProfile{
+		Name:           "test",
+		AllowedPaths:   []string{"*"},
+		CanRunCommands: config.BoolPtr(true),
+		ApprovalMode:   config.StrPtr("none"),
+	}, "stdio")
+
+	req := mcp.CallToolRequest{
+		Arguments: map[string]any{
+			"command":     []any{"echo", "test"},
+			"secret_refs": []any{},
+			"env_vars": map[string]any{
+				"LD_PRELOAD": "/tmp/evil.so",
+			},
+		},
+	}
+
+	result, err := srv.handleExecuteWithSecret(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleExecuteWithSecret() error = %v", err)
+	}
+	if result == nil {
+		t.Fatal("handleExecuteWithSecret() returned nil result")
+	}
+	if !result.IsError {
+		t.Fatal("handleExecuteWithSecret() expected error result for denied env var")
+	}
+	if !strings.Contains(result.Text, "env_vars contains denied keys") {
+		t.Fatalf("result text = %q, want 'env_vars contains denied keys'", result.Text)
+	}
+	if !strings.Contains(result.Text, "LD_PRELOAD") {
+		t.Fatalf("result text = %q, want to contain 'LD_PRELOAD'", result.Text)
+	}
+}
+
 func TestHandleExecuteWithSecret_ToolRegistered(t *testing.T) {
 	_, ok := findToolDefinition("execute_with_secret")
 	if !ok {

--- a/internal/mcp/server/tools_get_test.go
+++ b/internal/mcp/server/tools_get_test.go
@@ -909,3 +909,66 @@ func TestBuildSecretMetadataResponse_TagsAreExposedAndSanitized(t *testing.T) {
 		t.Errorf("ANSI escape should be stripped in %q", tags[3])
 	}
 }
+
+func TestHandleGetValue_SealsAutoDetectedGitHubPAT(t *testing.T) {
+	vaultDir, identity := mockVault(t)
+
+	entry := &vault.Entry{
+		Data: map[string]any{
+			"token": "ghp_abcdefghijklmnopqrstuvwxyz0123456789",
+		},
+	}
+	if err := vault.WriteEntry(vaultDir, "auto-secret", entry, identity); err != nil {
+		t.Fatalf("write entry: %v", err)
+	}
+
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:         "test",
+		AllowedPaths: []string{"*"},
+		CanWrite:     config.BoolPtr(false),
+		ApprovalMode: config.StrPtr("none"),
+		AutoUnseal:   config.BoolPtr(false),
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+
+	req := mcp.CallToolRequest{
+		Arguments: map[string]any{"path": "auto-secret"},
+	}
+
+	result, err := srv.handleGetValue(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleGetValue() error = %v", err)
+	}
+	if result == nil {
+		t.Fatal("handleGetValue() returned nil result")
+	}
+	if result.IsError {
+		t.Fatalf("handleGetValue() returned error: %s", result.Text)
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal([]byte(result.Text), &resp); err != nil {
+		t.Fatalf("parse result: %v", err)
+	}
+
+	handle, hasHandle := resp["handle"]
+	classification, hasClass := resp["classification"]
+
+	if !hasHandle {
+		t.Error("expected 'handle' field in sealed response for auto-detected secret")
+	}
+	if !hasClass {
+		t.Error("expected 'classification' field in sealed response")
+	}
+	handleStr, ok := handle.(string)
+	if !ok || !strings.HasPrefix(handleStr, "op://") {
+		t.Errorf("handle = %v, want op:// prefix", handle)
+	}
+	classStr, _ := classification.(string)
+	if classStr != "secret" {
+		t.Errorf("classification = %q, want 'secret'", classStr)
+	}
+	if _, hasData := resp["data"]; hasData {
+		t.Error("sealed response should not contain raw data field")
+	}
+}

--- a/internal/vault/entry.go
+++ b/internal/vault/entry.go
@@ -271,6 +271,49 @@ func ReadEntry(vaultDir, path string, identity *age.X25519Identity) (*Entry, err
 	return &entry, nil
 }
 
+// InferClassification scans all string values in entry.Data and maps detected
+// secret types to taint.Classification levels. It returns the maximum
+// classification found across all fields. The returned value is never lower
+// than entry.Classification, preserving any manually-set classification.
+func InferClassification(entry *Entry) taint.Classification {
+	if entry == nil || entry.Data == nil {
+		if entry != nil {
+			return entry.Classification
+		}
+		return taint.Public
+	}
+	maxClass := entry.Classification
+
+	for _, v := range entry.Data {
+		str, ok := v.(string)
+		if !ok {
+			continue
+		}
+		secretType := DetectSecretType(str)
+		if class := classifySecretType(secretType); class > maxClass {
+			maxClass = class
+		}
+	}
+
+	return maxClass
+}
+
+// classifySecretType maps a detected SecretType to a taint.Classification level.
+// High-risk secrets (SSH keys, certificates, TOTP seeds) map to Restricted.
+// Tokens and API keys map to Secret. Passwords and custom types map to Confidential.
+func classifySecretType(t SecretType) taint.Classification {
+	switch t {
+	case SecretTypeSSHKey, SecretTypeCertificate, SecretTypeTOTPSeed:
+		return taint.Restricted
+	case SecretTypeBearerToken, SecretTypeAPIKey, SecretTypeBasicAuth, SecretTypeDatabaseURL:
+		return taint.Secret
+	case SecretTypePassword, SecretTypeCustom:
+		return taint.Confidential
+	default:
+		return taint.Confidential
+	}
+}
+
 // writeEntryLocked performs the full entry write (prep, encrypt, file ops, manifest
 // update preparation) assuming the caller already holds the per-vaultDir exclusive lock.
 func writeEntryLocked(vaultDir, path string, entry *Entry, identity *age.X25519Identity, cfg *vaultconfig.Config) ([]byte, error) {
@@ -290,6 +333,8 @@ func writeEntryLocked(vaultDir, path string, entry *Entry, identity *age.X25519I
 		copyEntry.Metadata.WriteHistory = append(copyEntry.Metadata.WriteHistory, record)
 		copyEntry.PendingWrite = nil
 	}
+
+	copyEntry.Classification = InferClassification(copyEntry)
 
 	if isPseudonymizeEnabled(cfg) {
 		copyEntry.Path = path

--- a/internal/vault/entry_test.go
+++ b/internal/vault/entry_test.go
@@ -9,6 +9,7 @@ import (
 
 	vaultconfig "github.com/danieljustus/OpenPass/internal/config"
 	"github.com/danieljustus/OpenPass/internal/testutil"
+	"github.com/danieljustus/OpenPass/internal/vault/taint"
 )
 
 func TestEntryJSONSerialization(t *testing.T) {
@@ -1143,5 +1144,200 @@ func TestHandles_ExplicitPath(t *testing.T) {
 	}
 	if handles[0].Path != "custom/path" {
 		t.Fatalf("Path = %q, want %q", handles[0].Path, "custom/path")
+	}
+}
+
+func TestInferClassification_GitHubPAT(t *testing.T) {
+	entry := &Entry{
+		Data: map[string]any{
+			"token": "ghp_abcdefghijklmnopqrstuvwxyz0123456789",
+		},
+	}
+	if got := InferClassification(entry); got != taint.Secret {
+		t.Errorf("expected Secret, got %s (%d)", got, got)
+	}
+}
+
+func TestInferClassification_SSHKey(t *testing.T) {
+	entry := &Entry{
+		Data: map[string]any{
+			"key": "-----BEGIN OPENSSH PRIVATE KEY-----\nabcdef\n-----END OPENSSH PRIVATE KEY-----",
+		},
+	}
+	if got := InferClassification(entry); got != taint.Restricted {
+		t.Errorf("expected Restricted, got %s (%d)", got, got)
+	}
+}
+
+func TestInferClassification_PlainPassword(t *testing.T) {
+	entry := &Entry{
+		Data: map[string]any{
+			"password": "weak-password",
+		},
+	}
+	if got := InferClassification(entry); got < taint.Confidential {
+		t.Errorf("expected at least Confidential, got %s (%d)", got, got)
+	}
+}
+
+func TestInferClassification_PreservesManualRestricted(t *testing.T) {
+	entry := &Entry{
+		Data: map[string]any{
+			"note": "hello world",
+		},
+		Classification: taint.Restricted,
+	}
+	got := InferClassification(entry)
+	if got != taint.Restricted {
+		t.Errorf("InferClassification should preserve manual Restricted for benign data, got %s", got)
+	}
+}
+
+func TestInferClassification_MixedFieldsReturnsMax(t *testing.T) {
+	entry := &Entry{
+		Data: map[string]any{
+			"password": "weak-password",
+			"token":    "ghp_abcdefghijklmnopqrstuvwxyz0123456789",
+		},
+	}
+	if got := InferClassification(entry); got != taint.Secret {
+		t.Errorf("expected Secret (max of Confidential+Secret), got %s (%d)", got, got)
+	}
+}
+
+func TestInferClassification_DatabaseURL(t *testing.T) {
+	entry := &Entry{
+		Data: map[string]any{
+			"conn": "postgres://user:pass@localhost/db",
+		},
+	}
+	if got := InferClassification(entry); got != taint.Secret {
+		t.Errorf("expected Secret, got %s (%d)", got, got)
+	}
+}
+
+func TestInferClassification_BearerToken(t *testing.T) {
+	entry := &Entry{
+		Data: map[string]any{
+			"jwt": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U",
+		},
+	}
+	if got := InferClassification(entry); got != taint.Secret {
+		t.Errorf("expected Secret, got %s (%d)", got, got)
+	}
+}
+
+func TestInferClassification_Certificate(t *testing.T) {
+	entry := &Entry{
+		Data: map[string]any{
+			"cert": "-----BEGIN CERTIFICATE-----\nMIIDXTCCAkWgAwIBAgIJAKl\n-----END CERTIFICATE-----",
+		},
+	}
+	if got := InferClassification(entry); got != taint.Restricted {
+		t.Errorf("expected Restricted, got %s (%d)", got, got)
+	}
+}
+
+func TestInferClassification_TOTPSeed(t *testing.T) {
+	entry := &Entry{
+		Data: map[string]any{
+			"secret": "JBSWY3DPEHPK3PXP",
+		},
+	}
+	if got := InferClassification(entry); got != taint.Restricted {
+		t.Errorf("expected Restricted, got %s (%d)", got, got)
+	}
+}
+
+func TestWriteEntryLocked_AutoElevatesClassification(t *testing.T) {
+	vaultDir := t.TempDir()
+	id := testutil.TempIdentity(t)
+
+	entry := &Entry{
+		Data: map[string]any{
+			"token": "ghp_abcdefghijklmnopqrstuvwxyz0123456789",
+		},
+	}
+	if err := WriteEntry(vaultDir, "github-token", entry, id); err != nil {
+		t.Fatalf("write entry: %v", err)
+	}
+
+	got, err := ReadEntry(vaultDir, "github-token", id)
+	if err != nil {
+		t.Fatalf("read entry: %v", err)
+	}
+	if got.Classification != taint.Secret {
+		t.Errorf("Classification = %s (%d), want Secret", got.Classification, got.Classification)
+	}
+}
+
+func TestWriteEntryLocked_NeverLowersManualClassification(t *testing.T) {
+	vaultDir := t.TempDir()
+	id := testutil.TempIdentity(t)
+
+	entry := &Entry{
+		Data: map[string]any{
+			"note": "hello world",
+		},
+		Classification: taint.Restricted,
+	}
+	if err := WriteEntry(vaultDir, "restricted-note", entry, id); err != nil {
+		t.Fatalf("write entry: %v", err)
+	}
+
+	got, err := ReadEntry(vaultDir, "restricted-note", id)
+	if err != nil {
+		t.Fatalf("read entry: %v", err)
+	}
+	if got.Classification != taint.Restricted {
+		t.Errorf("Classification = %s (%d), want Restricted (should preserve manual setting)", got.Classification, got.Classification)
+	}
+}
+
+func TestInferClassification_NonStringValuesIgnored(t *testing.T) {
+	entry := &Entry{
+		Data: map[string]any{
+			"count": 42,
+			"ratio": 3.14,
+			"tags":  []string{"a", "b"},
+		},
+	}
+	if got := InferClassification(entry); got != taint.Public {
+		t.Errorf("expected Public for non-string values, got %s (%d)", got, got)
+	}
+}
+
+func TestInferClassification_NilEntry(t *testing.T) {
+	if got := InferClassification(nil); got != taint.Public {
+		t.Errorf("expected Public for nil entry, got %s (%d)", got, got)
+	}
+}
+
+func TestInferClassification_EmptyData(t *testing.T) {
+	entry := &Entry{Data: map[string]any{}}
+	if got := InferClassification(entry); got != taint.Public {
+		t.Errorf("expected Public for empty data, got %s (%d)", got, got)
+	}
+}
+
+func TestInferClassification_AWSKey(t *testing.T) {
+	entry := &Entry{
+		Data: map[string]any{
+			"access_key": "AKIA1234567890ABCDEF",
+		},
+	}
+	if got := InferClassification(entry); got != taint.Secret {
+		t.Errorf("expected Secret, got %s (%d)", got, got)
+	}
+}
+
+func TestInferClassification_BasicAuth(t *testing.T) {
+	entry := &Entry{
+		Data: map[string]any{
+			"auth": "admin:supersecretpassword",
+		},
+	}
+	if got := InferClassification(entry); got != taint.Secret {
+		t.Errorf("expected Secret, got %s (%d)", got, got)
 	}
 }

--- a/internal/vault/search.go
+++ b/internal/vault/search.go
@@ -204,6 +204,112 @@ func InvalidateListCache(vaultDir string) {
 		delete(listCache.items, vaultDir)
 	}
 	listCache.mu.Unlock()
+
+	pseudonymizedCache.mu.Lock()
+	if vaultDir == "" {
+		pseudonymizedCache.items = make(map[string]pseudonymizedCacheEntry)
+	} else {
+		prefix := vaultDir + "\x00"
+		for k := range pseudonymizedCache.items {
+			if strings.HasPrefix(k, prefix) {
+				delete(pseudonymizedCache.items, k)
+			}
+		}
+	}
+	pseudonymizedCache.mu.Unlock()
+}
+
+// pseudonymizedCacheEntry holds cached pseudonymized list results.
+// Unlike listCacheEntry, it also stores decrypted entry data so that
+// FindWithOptions can reuse entries already decrypted during listing.
+type pseudonymizedCacheEntry struct {
+	paths        []string
+	entries      map[string]map[string]any // path -> decrypted entry data
+	createdAt    time.Time
+	entriesMtime time.Time
+	vaultMtime   time.Time
+}
+
+// pseudonymizedCache provides TTL-cached pseudonymized listings keyed by
+// vaultDir + identity recipient (different identities see different pseudonyms).
+var pseudonymizedCache = struct {
+	mu    sync.RWMutex
+	items map[string]pseudonymizedCacheEntry
+	ttl   time.Duration
+}{
+	items: make(map[string]pseudonymizedCacheEntry),
+	ttl:   30 * time.Second,
+}
+
+// pseudonymizedCacheKey builds a cache key unique to (vaultDir, identity).
+// The recipient (public key) string is used rather than the full identity
+// to avoid caching the secret key material in the in-memory map keys.
+func pseudonymizedCacheKey(vaultDir string, identity *age.X25519Identity) string {
+	return vaultDir + "\x00" + identity.Recipient().String()
+}
+
+// cachedPseudonymizedList returns cached pseudonymized paths if valid,
+// or nil if cache miss / expired / invalidated.
+func cachedPseudonymizedList(vaultDir string, identity *age.X25519Identity) []string {
+	key := pseudonymizedCacheKey(vaultDir, identity)
+	pseudonymizedCache.mu.RLock()
+	entry, ok := pseudonymizedCache.items[key]
+	pseudonymizedCache.mu.RUnlock()
+	if !ok {
+		return nil
+	}
+	if time.Since(entry.createdAt) > pseudonymizedCache.ttl {
+		return nil
+	}
+	if !getDirMtime(entriesDir(vaultDir)).Equal(entry.entriesMtime) {
+		return nil
+	}
+	if !getDirMtime(vaultDir).Equal(entry.vaultMtime) {
+		return nil
+	}
+	return entry.paths
+}
+
+// cachedPseudonymizedEntry returns the decrypted entry data for a single
+// path from the pseudonymized cache, or nil if not found or invalid.
+func cachedPseudonymizedEntry(vaultDir string, identity *age.X25519Identity, path string) map[string]any {
+	key := pseudonymizedCacheKey(vaultDir, identity)
+	pseudonymizedCache.mu.RLock()
+	entry, ok := pseudonymizedCache.items[key]
+	pseudonymizedCache.mu.RUnlock()
+	if !ok {
+		return nil
+	}
+	if time.Since(entry.createdAt) > pseudonymizedCache.ttl {
+		return nil
+	}
+	if !getDirMtime(entriesDir(vaultDir)).Equal(entry.entriesMtime) {
+		return nil
+	}
+	if !getDirMtime(vaultDir).Equal(entry.vaultMtime) {
+		return nil
+	}
+	return entry.entries[path]
+}
+
+// maybeCachedEntryData returns entry data from the pseudonymized cache
+// (populated by a preceding listPseudonymized call), or nil on miss.
+func maybeCachedEntryData(vaultDir string, identity *age.X25519Identity, path string) map[string]any {
+	return cachedPseudonymizedEntry(vaultDir, identity, path)
+}
+
+// storePseudonymizedListCache stores the result of a pseudonymized List call.
+func storePseudonymizedListCache(vaultDir string, identity *age.X25519Identity, paths []string, entries map[string]map[string]any) {
+	key := pseudonymizedCacheKey(vaultDir, identity)
+	pseudonymizedCache.mu.Lock()
+	pseudonymizedCache.items[key] = pseudonymizedCacheEntry{
+		paths:        append([]string(nil), paths...),
+		entries:      entries,
+		createdAt:    time.Now(),
+		entriesMtime: getDirMtime(entriesDir(vaultDir)),
+		vaultMtime:   getDirMtime(vaultDir),
+	}
+	pseudonymizedCache.mu.Unlock()
 }
 
 // searchIdentity holds the cached decryption identity for search operations.
@@ -300,15 +406,28 @@ func List(vaultDir string, prefix string) ([]string, error) {
 // the plaintext entry path from entry.Path. Falls back to the relative filepath
 // if entry.Path is empty (backward compatibility with non-pseudonymized entries
 // stored alongside pseudonymized ones).
+//
+// Uses a bounded worker pool for parallel decryption and caches results
+// (including decrypted entry data) for reuse by FindWithOptions.
 func listPseudonymized(vaultDir, prefix string) ([]string, error) {
 	identity := currentSearchIdentity()
 	if identity == nil {
 		return nil, fmt.Errorf("no search identity available for pseudonymized listing")
 	}
 
-	start := time.Now()
-	var paths []string
+	// Check cache for full-vault listings (prefix == "").
+	if prefix == "" {
+		if paths := cachedPseudonymizedList(vaultDir, identity); paths != nil {
+			metrics.RecordVaultOperationDuration("list_pseudonymized_cached", 0)
+			return paths, nil
+		}
+	}
 
+	start := time.Now()
+
+	// First pass: walk filesystem to collect all .age file paths.
+	// This is fast O(n) and does not involve decryption.
+	var filePaths []string
 	err := filepath.WalkDir(entriesDir(vaultDir), func(filePath string, d os.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -319,45 +438,108 @@ func listPseudonymized(vaultDir, prefix string) ([]string, error) {
 		if filepath.Ext(filePath) != ".age" { //nolint:goconst // file extension literal
 			return nil
 		}
-
-		// #nosec G304 -- filePath comes from filepath.WalkDir of the vault entries directory
-		raw, readErr := os.ReadFile(filePath)
-		if readErr != nil {
-			return nil
-		}
-
-		plaintext, decryptErr := vaultcrypto.Decrypt(raw, identity)
-		if decryptErr != nil {
-			return nil
-		}
-
-		var entry Entry
-		if jsonErr := json.Unmarshal(plaintext, &entry); jsonErr != nil {
-			vaultcrypto.Wipe(plaintext)
-			return nil
-		}
-		vaultcrypto.Wipe(plaintext)
-
-		entryPath := entry.Path
-		if entryPath == "" {
-			rel, relErr := filepath.Rel(entriesDir(vaultDir), filePath)
-			if relErr != nil {
-				return nil
-			}
-			entryPath = strings.TrimSuffix(filepath.ToSlash(rel), ".age")
-		}
-
-		if prefix != "" && !strings.HasPrefix(entryPath, prefix) {
-			return nil
-		}
-		paths = append(paths, entryPath)
+		filePaths = append(filePaths, filePath)
 		return nil
 	})
 	if err != nil && !os.IsNotExist(err) {
 		return nil, err
 	}
 
+	if len(filePaths) == 0 {
+		metrics.RecordVaultOperationDuration("list_pseudonymized", time.Since(start))
+		metrics.RecordVaultEntryCount(vaultDir, 0)
+		if prefix == "" {
+			storePseudonymizedListCache(vaultDir, identity, nil, nil)
+		}
+		return nil, nil
+	}
+
+	// Second pass: decrypt entries in parallel using a bounded worker pool.
+	// Default 4 workers balances throughput vs memory pressure, matching
+	// the rationale documented for FindWithOptions concurrent decryption.
+	const maxWorkers = 4
+
+	type decryptResult struct {
+		entryPath string
+		data      map[string]any
+	}
+
+	fileChan := make(chan string, len(filePaths))
+	resultChan := make(chan decryptResult, len(filePaths))
+
+	var wg sync.WaitGroup
+	for i := 0; i < maxWorkers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for fp := range fileChan {
+				// #nosec G304 -- fp comes from filepath.WalkDir of the vault entries directory
+				raw, readErr := os.ReadFile(fp)
+				if readErr != nil {
+					continue
+				}
+
+				plaintext, decryptErr := vaultcrypto.Decrypt(raw, identity)
+				if decryptErr != nil {
+					continue
+				}
+
+				var entry Entry
+				if jsonErr := json.Unmarshal(plaintext, &entry); jsonErr != nil {
+					vaultcrypto.Wipe(plaintext)
+					continue
+				}
+				vaultcrypto.Wipe(plaintext)
+
+				entryPath := entry.Path
+				if entryPath == "" {
+					rel, relErr := filepath.Rel(entriesDir(vaultDir), fp)
+					if relErr != nil {
+						continue
+					}
+					entryPath = strings.TrimSuffix(filepath.ToSlash(rel), ".age")
+				}
+
+				if prefix != "" && !strings.HasPrefix(entryPath, prefix) {
+					continue
+				}
+
+				resultChan <- decryptResult{entryPath: entryPath, data: entry.Data}
+			}
+		}()
+	}
+
+	go func() {
+		for _, fp := range filePaths {
+			fileChan <- fp
+		}
+		close(fileChan)
+	}()
+
+	go func() {
+		wg.Wait()
+		close(resultChan)
+	}()
+
+	paths := make([]string, 0, len(filePaths))
+	cachedEntries := make(map[string]map[string]any, len(filePaths))
+
+	for result := range resultChan {
+		if result.entryPath == "" {
+			continue
+		}
+		paths = append(paths, result.entryPath)
+		if result.data != nil {
+			cachedEntries[result.entryPath] = result.data
+		}
+	}
+
 	sort.Strings(paths)
+
+	if prefix == "" {
+		storePseudonymizedListCache(vaultDir, identity, paths, cachedEntries)
+	}
+
 	metrics.RecordVaultOperationDuration("list_pseudonymized", time.Since(start))
 	metrics.RecordVaultEntryCount(vaultDir, len(paths))
 	return paths, nil
@@ -476,13 +658,17 @@ func FindWithOptions(vaultDir string, query string, opts FindOptions) ([]Match, 
 	maxWorkers := opts.MaxWorkers
 	if maxWorkers <= 0 {
 		for _, path := range pathsNeedingDecrypt {
-			entry, err := ReadEntry(vaultDir, path, identity)
-			if err != nil {
-				return nil, err
+			data := maybeCachedEntryData(vaultDir, identity, path)
+			if data == nil {
+				entry, err := ReadEntry(vaultDir, path, identity)
+				if err != nil {
+					return nil, err
+				}
+				data = entry.Data
 			}
 
 			fields := make(map[string]struct{})
-			CollectFieldMatches(fields, "", entry.Data, needle, opts.RedactFieldPatterns)
+			CollectFieldMatches(fields, "", data, needle, opts.RedactFieldPatterns)
 
 			if len(fields) == 0 {
 				continue
@@ -519,14 +705,18 @@ func FindWithOptions(vaultDir string, query string, opts FindOptions) ([]Match, 
 			go func() {
 				defer wg.Done()
 				for path := range pathChan {
-					entry, err := ReadEntry(vaultDir, path, identity)
-					if err != nil {
-						resultChan <- decryptResult{err: err, path: path}
-						continue
+					data := maybeCachedEntryData(vaultDir, identity, path)
+					if data == nil {
+						entry, err := ReadEntry(vaultDir, path, identity)
+						if err != nil {
+							resultChan <- decryptResult{err: err, path: path}
+							continue
+						}
+						data = entry.Data
 					}
 
 					fields := make(map[string]struct{})
-					CollectFieldMatches(fields, "", entry.Data, needle, opts.RedactFieldPatterns)
+					CollectFieldMatches(fields, "", data, needle, opts.RedactFieldPatterns)
 
 					if len(fields) == 0 {
 						resultChan <- decryptResult{path: path, fields: nil}

--- a/internal/vault/search_test.go
+++ b/internal/vault/search_test.go
@@ -1,6 +1,7 @@
 package vault
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -9,6 +10,7 @@ import (
 
 	"filippo.io/age"
 
+	vaultconfig "github.com/danieljustus/OpenPass/internal/config"
 	"github.com/danieljustus/OpenPass/internal/testutil"
 )
 
@@ -27,26 +29,84 @@ func TestListReturnsAllEntriesWithoutPrefix(t *testing.T) {
 
 	want := []string{"github.com/user", "github.com/work", "personal/email"}
 	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("List() = %#v, want %#v", got, want)
+		t.Fatalf("List() sort order = %#v, want %#v", got, want)
 	}
 }
 
-func TestListFiltersByPrefix(t *testing.T) {
-	vaultDir := t.TempDir()
-	id := testutil.TempIdentity(t)
+func BenchmarkListPseudonymized(b *testing.B) {
+	vaultDir := b.TempDir()
+	id := testutil.TempIdentity(b)
+	rememberSearchIdentity(id)
 
-	mustWriteEntry(t, vaultDir, id, "github.com/user", map[string]interface{}{"username": "alice"})
-	mustWriteEntry(t, vaultDir, id, "github.com/work", map[string]interface{}{"username": "bob"})
-	mustWriteEntry(t, vaultDir, id, "personal/email", map[string]interface{}{"username": "carol"})
-
-	got, err := List(vaultDir, "github.com")
-	if err != nil {
-		t.Fatalf("List() error = %v", err)
+	cfg := vaultconfig.Default()
+	cfg.VaultDir = vaultDir
+	cfg.Vault = &vaultconfig.VaultConfig{PseudonymizePaths: true}
+	if err := cfg.SaveTo(filepath.Join(vaultDir, "config.yaml")); err != nil {
+		b.Fatalf("save config: %v", err)
 	}
 
-	want := []string{"github.com/user", "github.com/work"}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("List(prefix) = %#v, want %#v", got, want)
+	const numEntries = 100
+	for i := 0; i < numEntries; i++ {
+		path := fmt.Sprintf("bench/entry-%03d", i)
+		mustWriteEntry(b, vaultDir, id, path, map[string]interface{}{
+			"username": fmt.Sprintf("user-%03d", i),
+			"password": fmt.Sprintf("pass-%03d", i),
+		})
+	}
+
+	// Force cache miss every iteration to measure parallel decryption.
+	origTTL := pseudonymizedCache.ttl
+	pseudonymizedCache.ttl = 0
+	defer func() { pseudonymizedCache.ttl = origTTL }()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		InvalidateListCache(vaultDir)
+		paths, err := List(vaultDir, "")
+		if err != nil {
+			b.Fatalf("List() error = %v", err)
+		}
+		if len(paths) != numEntries {
+			b.Fatalf("List() returned %d paths, want %d", len(paths), numEntries)
+		}
+	}
+}
+
+func BenchmarkListPseudonymizedCached(b *testing.B) {
+	vaultDir := b.TempDir()
+	id := testutil.TempIdentity(b)
+	rememberSearchIdentity(id)
+
+	cfg := vaultconfig.Default()
+	cfg.VaultDir = vaultDir
+	cfg.Vault = &vaultconfig.VaultConfig{PseudonymizePaths: true}
+	if err := cfg.SaveTo(filepath.Join(vaultDir, "config.yaml")); err != nil {
+		b.Fatalf("save config: %v", err)
+	}
+
+	const numEntries = 100
+	for i := 0; i < numEntries; i++ {
+		path := fmt.Sprintf("bench/entry-%03d", i)
+		mustWriteEntry(b, vaultDir, id, path, map[string]interface{}{
+			"username": fmt.Sprintf("user-%03d", i),
+			"password": fmt.Sprintf("pass-%03d", i),
+		})
+	}
+
+	// Warm the cache.
+	if _, err := List(vaultDir, ""); err != nil {
+		b.Fatalf("List() warm-up error = %v", err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		paths, err := List(vaultDir, "")
+		if err != nil {
+			b.Fatalf("List() error = %v", err)
+		}
+		if len(paths) != numEntries {
+			b.Fatalf("List() returned %d paths, want %d", len(paths), numEntries)
+		}
 	}
 }
 
@@ -188,7 +248,7 @@ func TestFindIsCaseInsensitive(t *testing.T) {
 	}
 }
 
-func mustWriteEntry(t *testing.T, vaultDir string, identity *age.X25519Identity, path string, data map[string]interface{}) {
+func mustWriteEntry(t testing.TB, vaultDir string, identity *age.X25519Identity, path string, data map[string]interface{}) {
 	t.Helper()
 	if err := WriteEntry(vaultDir, path, &Entry{Data: data}, identity); err != nil {
 		t.Fatalf("WriteEntry(%s) error = %v", path, err)


### PR DESCRIPTION
Bundles fixes for multiple open issues. The list below grows as commits land; every linked issue will close automatically on merge.

Milestone: v4.0.1

<!-- closes-list-start -->
- Closes #201 Built-in agent presets ship with AutoUnseal=true, bypassing sealed-secret protection
- Closes #202 Entry classification is never auto-elevated from detected token patterns, so sealing condition is always false
- Closes #203 Skill guidance pushes agents toward get_entry_value + curl; safe execute_with_secret path unavailable to Hermes/Codex/Opencode
- Closes #198 Filter agent-supplied env_vars to block interpreter/loader injection in execute_with_secret
- Closes #199 Parallelize and cache listPseudonymized to match the non-pseudonymized list path
- Closes #200 Replace stale v3 help text on deprecated mcp install/config/token stubs
<!-- closes-list-end -->