### PR TITLE
fix(security): G304 in internal/vault/search_index.go

### DIFF
--- a/internal/vault/search_index.go
+++ b/internal/vault/search_index.go
@@ -331,7 +331,7 @@ func (idx *EncryptedIndex) saveToDisk(vaultDir string) error {
 
 func (idx *EncryptedIndex) loadFromDisk(vaultDir string, identity *age.X25519Identity) error {
 	indexPath := indexFilePath(vaultDir)
-	ct, err := os.ReadFile(indexPath) // #nosec G304 — indexPath is filepath.Join(vaultDir, ".search-index"); vaultDir is validated by validateVaultDir() and the filename is hardcoded.
+	ct, err := os.ReadFile(indexPath) // #nosec G304 — indexPath is filepath.Join(vaultDir, ".search-index"). Callers pass Vault.Dir from Open, which validates the directory via validateVaultDir(), and the filename is hardcoded.
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return nil

--- a/internal/vault/search_index.go
+++ b/internal/vault/search_index.go
@@ -331,7 +331,7 @@ func (idx *EncryptedIndex) saveToDisk(vaultDir string) error {
 
 func (idx *EncryptedIndex) loadFromDisk(vaultDir string, identity *age.X25519Identity) error {
 	indexPath := indexFilePath(vaultDir)
-	ct, err := os.ReadFile(indexPath)
+	ct, err := os.ReadFile(indexPath) // #nosec G304 — indexPath is filepath.Join(vaultDir, ".search-index"); vaultDir is validated by validateVaultDir() and the filename is hardcoded.
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return nil


### PR DESCRIPTION
Add #nosec G304 annotation for os.ReadFile call in loadFromDisk.

The indexPath is constructed via indexFilePath(vaultDir) which returns
filepath.Join(vaultDir, ".search-index"). The vaultDir parameter is
validated by validateVaultDir() (checks for path traversal sequences)
before use, and the filename is hardcoded — not user-controlled input.

Closes alert #177
Rule: G304 (Potential file inclusion via variable)
