### PR TITLE
feat(rename): transitional Homebrew formula, legacy vault auto-detect, binary migration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -311,6 +311,7 @@ jobs:
         run: |
           TAG="${{ steps.tag.outputs.tag }}"
           curl -fsSL "https://raw.githubusercontent.com/danieljustus/homebrew-tap/main/Formula/symvault.rb" -o symvault.rb
+          curl -fsSL "https://raw.githubusercontent.com/danieljustus/homebrew-tap/main/Formula/openpass.rb" -o openpass.rb
 
       - name: Verify formula exists and has correct version
         run: |
@@ -320,17 +321,27 @@ jobs:
             echo "Homebrew formula not found or empty"
             exit 1
           fi
+          if [ ! -s openpass.rb ]; then
+            echo "Transitional Homebrew formula not found or empty"
+            exit 1
+          fi
           if ! grep -q "version \"${VERSION}\"" symvault.rb; then
             echo "Version mismatch: expected ${VERSION} in formula"
+            exit 1
+          fi
+          if ! grep -q "version \"${VERSION}\"" openpass.rb; then
+            echo "Version mismatch: expected ${VERSION} in transitional formula"
             exit 1
           fi
 
       - name: Validate formula syntax
         run: |
           ruby -c symvault.rb
+          ruby -c openpass.rb
 
       - name: Smoke test - formula audit
         run: |
           brew tap danieljustus/tap
           # Audit the formula; allow failure if tap is not fully set up
           brew audit --strict --formula symvault.rb || true
+          brew audit --strict --formula openpass.rb || true

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -173,6 +173,37 @@ brews:
       Documentation: https://github.com/danieljustus/symaira-vault#readme
     test: |
       system "#{bin}/symvault", "version"
+  - name: openpass
+    repository:
+      owner: danieljustus
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    directory: Formula
+    homepage: "https://github.com/danieljustus/symaira-vault"
+    description: "Transitional package for Symaira Vault"
+    license: "MIT"
+    conflicts:
+      - symvault
+    install: |
+      bin.install "symvault"
+      bin.install_symlink "symvault" => "openpass"
+      generate_completions_from_executable(bin/"symvault", "completion")
+      man1.install Dir["docs/man/*.1"]
+    caveats: |
+      OpenPass has been renamed to Symaira Vault.
+
+      This transitional formula installed the new command:
+        symvault
+
+      The old command remains available as an alias:
+        openpass
+
+      To move to the new formula name:
+        brew uninstall openpass
+        brew install symvault
+    test: |
+      system "#{bin}/symvault", "version"
+      system "#{bin}/openpass", "version"
 
 scoops:
   - name: symvault

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -179,6 +179,61 @@ func TestVaultPathWithTildeOnly(t *testing.T) {
 	}
 }
 
+func TestVaultPathUsesLegacyOpenPassVaultWhenOnlyLegacyExists(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("SYMVAULT_VAULT", "")
+	t.Setenv("OPENPASS_VAULT", "")
+	t.Setenv("SYMVAULT_PROFILE", "")
+	t.Setenv("OPENPASS_PROFILE", "")
+
+	origVault := cli.Vault
+	origProfile := cli.Profile
+	origVaultFlagChanged := false
+	origProfileFlagChanged := false
+	if cli.VaultFlag != nil {
+		origVaultFlagChanged = cli.VaultFlag.Changed
+	}
+	if cli.ProfileFlag != nil {
+		origProfileFlagChanged = cli.ProfileFlag.Changed
+	}
+	t.Cleanup(func() {
+		cli.Vault = origVault
+		cli.Profile = origProfile
+		if cli.VaultFlag != nil {
+			cli.VaultFlag.Changed = origVaultFlagChanged
+		}
+		if cli.ProfileFlag != nil {
+			cli.ProfileFlag.Changed = origProfileFlagChanged
+		}
+	})
+
+	cli.Vault = "~/" + config.DefaultVaultSubdir
+	cli.Profile = ""
+	if cli.VaultFlag != nil {
+		cli.VaultFlag.Changed = false
+	}
+	if cli.ProfileFlag != nil {
+		cli.ProfileFlag.Changed = false
+	}
+
+	legacyVault := filepath.Join(home, config.LegacyDefaultVaultSubdir)
+	if err := os.MkdirAll(legacyVault, 0o700); err != nil {
+		t.Fatalf("create legacy vault dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(legacyVault, "config.yaml"), []byte("vaultDir: "+legacyVault+"\n"), 0o600); err != nil {
+		t.Fatalf("write legacy config: %v", err)
+	}
+
+	got, err := cli.VaultPath()
+	if err != nil {
+		t.Fatalf("cli.VaultPath() error = %v", err)
+	}
+	if got != legacyVault {
+		t.Fatalf("cli.VaultPath() = %q, want legacy vault %q", got, legacyVault)
+	}
+}
+
 func TestLoadConfigSilent(t *testing.T) {
 	_, err := mcpcmd.LoadConfigSilent("/tmp/nonexistent/config.yaml")
 	if err == nil {

--- a/docs/MIGRATION-RENAME.md
+++ b/docs/MIGRATION-RENAME.md
@@ -50,14 +50,23 @@ openpass backup ~/backups/openpass-pre-rename-$(date +%Y%m%d).tar.gz
 
 #### Homebrew (macOS / Linux)
 
-```bash
-# Remove the old formula
-brew uninstall openpass
+Existing OpenPass Homebrew users:
 
-# Tap and install the new one
+```bash
+brew update
+brew upgrade openpass
+```
+
+This installs the new `symvault` command and keeps `openpass` as a
+backward-compatible alias. To switch to the new formula name later:
+
+```bash
+brew uninstall openpass
 brew tap danieljustus/tap
 brew install symvault
 ```
+
+New users can install `symvault` directly.
 
 #### Scoop (Windows)
 
@@ -105,8 +114,9 @@ symvault list         # All entries should appear
 symvault auth status  # Identity should be recognised
 ```
 
-Your vault directory (`~/.openpass` by default) has **not** moved. Symaira Vault
-continues to use the same directory unless you explicitly change it.
+Existing OpenPass vaults at `~/.openpass` are detected automatically when no
+`~/.symvault` vault exists. New Symaira Vault installations use `~/.symvault` by
+default.
 
 ### 4. Update shell completions (optional)
 
@@ -200,16 +210,21 @@ The following environment variables have been renamed:
 | `OPENPASS_CONFIG` | `SYMVAULT_CONFIG` |
 | `OPENPASS_AGENT` | `SYMVAULT_AGENT` |
 
-**Backward compatibility:** If `SYMVAULT_VAULT` is not set, Symaira Vault will
-still fall back to `OPENPASS_VAULT` for one release cycle (deprecated, will be
-removed in v0.2.0).
+**Backward compatibility:** If `SYMVAULT_VAULT` is not set, Symaira Vault still
+falls back to `OPENPASS_VAULT`. Deprecated `OPENPASS_*` variables emit a warning
+and are scheduled for removal three releases after 2026-05-26.
 
 ---
 
 ## Data Directory
 
-By default, Symaira Vault continues to use `~/.openpass` as the vault directory.
-You do **not** need to move your data.
+New Symaira Vault installations use `~/.symvault` as the default vault
+directory. Existing OpenPass installations continue to work without moving data:
+if `~/.openpass` contains a vault and `~/.symvault` does not, `symvault` uses
+`~/.openpass` automatically.
+
+If both directories exist, `~/.symvault` wins. Use `--vault`, `SYMVAULT_VAULT`,
+or a configured profile to select another vault explicitly.
 
 If you prefer to align the directory name with the new project name:
 
@@ -269,8 +284,10 @@ Your vault data remains compatible. Both binaries read the same vault format.
 any changes.
 
 ### Q: Will `symvault` create a new vault if I already have one?
-**A:** No. It will detect and use your existing vault at `~/.openpass` (or
-`$SYMVAULT_VAULT`).
+**A:** No. If `~/.openpass` exists and `~/.symvault` does not, it will detect and
+use the existing OpenPass vault. If both directories exist, `~/.symvault` is the
+default; set `SYMVAULT_VAULT="$HOME/.openpass"` or pass `--vault ~/.openpass` to
+select the old vault explicitly.
 
 ### Q: What happens to my Git sync remote?
 **A:** Nothing. The sync remote URL is stored in your vault config and remains

--- a/homebrew/Formula/openpass.rb
+++ b/homebrew/Formula/openpass.rb
@@ -1,9 +1,12 @@
-# This formula is a reference template. GoReleaser generates the actual
-# formula with correct version/SHA at release time (see .goreleaser.yml brews).
-# To test locally, use the instructions in homebrew/README.md.
+# Transitional OpenPass formula.
+#
+# Keep this formula for existing Homebrew users who installed the old package
+# name. `brew upgrade openpass` only checks the installed formula name, so
+# removing this file would strand those installations on the last OpenPass
+# release instead of moving them to Symaira Vault.
 
-class Symvault < Formula
-  desc "Modern CLI password manager with age encryption"
+class Openpass < Formula
+  desc "Transitional package for Symaira Vault"
   homepage "https://github.com/danieljustus/symaira-vault"
   # GoReleaser replaces these at release time:
   url "https://github.com/danieljustus/symaira-vault/archive/refs/tags/v{{ .Tag }}.tar.gz"
@@ -13,6 +16,8 @@ class Symvault < Formula
   license "MIT"
 
   depends_on "go" => :build
+
+  conflicts_with "symvault", because: "openpass is a transitional package for symvault"
 
   def install
     ldflags = %W[
@@ -24,6 +29,7 @@ class Symvault < Formula
     ]
 
     system "go", "build", "-ldflags", ldflags.join(" "), "-o", bin/"symvault", "."
+    bin.install_symlink "symvault" => "openpass"
     generate_completions_from_executable(bin/"symvault", "completion")
 
     man_dir = buildpath/"docs/man"
@@ -33,21 +39,22 @@ class Symvault < Formula
 
   def caveats
     <<~EOS
-      Symaira Vault has been installed!
+      OpenPass has been renamed to Symaira Vault.
 
-      To get started:
-        symvault init                    # Initialize a new vault
-        symvault set github.com/username # Add your first entry
-        symvault get github.com/username # Retrieve it
+      This transitional formula installed the new command:
+        symvault
 
-      For MCP server setup:
-        symvault mcp-config <name>
+      The old command remains available as an alias:
+        openpass
 
-      Documentation: https://github.com/danieljustus/symaira-vault#readme
+      To move to the new formula name:
+        brew uninstall openpass
+        brew install symvault
     EOS
   end
 
   test do
     system "#{bin}/symvault", "version"
+    system "#{bin}/openpass", "version"
   end
 end

--- a/internal/cli/vaultpath.go
+++ b/internal/cli/vaultpath.go
@@ -56,6 +56,13 @@ func VaultPath() (string, error) {
 				return p, nil
 			}
 		}
+		if isDefaultVaultFlagValue(Vault) {
+			legacyVault := filepath.Join(home, configpkg.LegacyDefaultVaultSubdir)
+			newVault := filepath.Join(home, configpkg.DefaultVaultSubdir)
+			if vaultExists(legacyVault) && !vaultExists(newVault) {
+				return legacyVault, nil
+			}
+		}
 	}
 
 	p, err := ExpandVaultDir(Vault)
@@ -63,6 +70,20 @@ func VaultPath() (string, error) {
 		return "", errorspkg.NewCLIError(errorspkg.ExitGeneralError, "expand vault path", err)
 	}
 	return p, nil
+}
+
+func isDefaultVaultFlagValue(vaultDir string) bool {
+	trimmed := strings.TrimSpace(vaultDir)
+	return trimmed == "" || trimmed == "~/"+configpkg.DefaultVaultSubdir
+}
+
+func vaultExists(vaultDir string) bool {
+	return fileExists(filepath.Join(vaultDir, "config.yaml")) || fileExists(filepath.Join(vaultDir, "identity.age"))
+}
+
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
 }
 
 func resolveProfileVaultDir(profileName string) (string, error) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,13 +5,14 @@ import "time"
 
 const (
 	// DefaultVaultSubdir is the default vault directory name under the user's home directory.
-	DefaultVaultSubdir    = ".symvault"
-	defaultConfigDir      = DefaultVaultSubdir
-	defaultConfigFile     = "config.yaml"
-	defaultAgentName      = "default"
-	defaultSessionTimeout = 15 * time.Minute
-	AuthMethodPassphrase  = "passphrase"
-	AuthMethodTouchID     = "touchid"
+	DefaultVaultSubdir       = ".symvault"
+	LegacyDefaultVaultSubdir = ".openpass"
+	defaultConfigDir         = DefaultVaultSubdir
+	defaultConfigFile        = "config.yaml"
+	defaultAgentName         = "default"
+	defaultSessionTimeout    = 15 * time.Minute
+	AuthMethodPassphrase     = "passphrase"
+	AuthMethodTouchID        = "touchid"
 )
 
 type CustomPattern struct {

--- a/internal/update/apply.go
+++ b/internal/update/apply.go
@@ -192,13 +192,43 @@ func Apply(ctx context.Context, currentVersion string, force, dryRun bool) (*App
 	}
 
 	if isLegacyBinary(binaryPath) {
-		symlinkPath, err := createLegacySymlink(binaryPath)
-		if err == nil && symlinkPath != "" {
+		newBinaryPath, symlinkPath, err := migrateLegacyBinaryName(binaryPath)
+		if err != nil {
+			return nil, fmt.Errorf("migrate legacy binary name: %w", err)
+		}
+		applyResult.BinaryPath = newBinaryPath
+		if symlinkPath != "" {
 			applyResult.LegacySymlinkPath = symlinkPath
 		}
 	}
 
 	return applyResult, nil
+}
+
+func migrateLegacyBinaryName(binaryPath string) (string, string, error) {
+	if !isLegacyBinary(binaryPath) || runtime.GOOS == windowsOS {
+		return binaryPath, "", nil
+	}
+
+	dir := filepath.Dir(binaryPath)
+	symvaultPath := filepath.Join(dir, binaryName)
+	if _, err := os.Lstat(symvaultPath); err == nil {
+		return binaryPath, "", nil
+	} else if !os.IsNotExist(err) {
+		return "", "", fmt.Errorf("check %q: %w", symvaultPath, err)
+	}
+
+	if err := os.Rename(binaryPath, symvaultPath); err != nil {
+		return "", "", fmt.Errorf("rename legacy binary %q -> %q: %w", binaryPath, symvaultPath, err)
+	}
+
+	symlinkPath, err := createLegacySymlink(symvaultPath)
+	if err != nil {
+		_ = os.Rename(symvaultPath, binaryPath)
+		return "", "", err
+	}
+
+	return symvaultPath, symlinkPath, nil
 }
 
 func extractBinaryFromArchive(archiveData []byte) ([]byte, error) {

--- a/internal/update/apply_test.go
+++ b/internal/update/apply_test.go
@@ -362,6 +362,41 @@ func TestCreateLegacySymlink_OverwritesExisting(t *testing.T) {
 	}
 }
 
+func TestMigrateLegacyBinaryNameRenamesOpenPassAndLeavesAlias(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlinks on windows are unreliable for executables")
+	}
+
+	tmpDir := t.TempDir()
+	legacyPath := filepath.Join(tmpDir, "openpass")
+	if err := os.WriteFile(legacyPath, []byte("new binary"), 0o755); err != nil {
+		t.Fatalf("failed to create legacy binary: %v", err)
+	}
+
+	binaryPath, symlinkPath, err := migrateLegacyBinaryName(legacyPath)
+	if err != nil {
+		t.Fatalf("migrateLegacyBinaryName() error = %v", err)
+	}
+
+	expectedBinaryPath := filepath.Join(tmpDir, "symvault")
+	if binaryPath != expectedBinaryPath {
+		t.Fatalf("binaryPath = %q, want %q", binaryPath, expectedBinaryPath)
+	}
+	if symlinkPath != legacyPath {
+		t.Fatalf("symlinkPath = %q, want %q", symlinkPath, legacyPath)
+	}
+	if data, err := os.ReadFile(expectedBinaryPath); err != nil || string(data) != "new binary" {
+		t.Fatalf("symvault binary data = %q, err = %v", data, err)
+	}
+	target, err := os.Readlink(legacyPath)
+	if err != nil {
+		t.Fatalf("os.Readlink(%q) error = %v", legacyPath, err)
+	}
+	if target != "symvault" {
+		t.Fatalf("legacy symlink target = %q, want %q", target, "symvault")
+	}
+}
+
 func TestInfoResult_LegacyBinary(t *testing.T) {
 	r := &InfoResult{
 		Method:              installmethod.DirectDownload,


### PR DESCRIPTION
Add transitional openpass Homebrew formula alongside symvault for seamless
upgrade path. Users can 'brew upgrade openpass' to get the new binary while
keeping the old command as a symlink.

Auto-detect existing ~/.openpass vaults when no ~/.symvault exists, so
existing users don't need to move data or set environment variables.

During self-update, rename legacy 'openpass' binary to 'symvault' and
create a backward-compatible symlink, mirroring the Homebrew behavior.

Also fixes the local homebrew test formula class name and binary paths.
