### PR TITLE
chore(release): deprecate openpass Homebrew formula, simplify cosign args, add symvault to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ CLAUDE.md
 
 # Code review artifacts (local working files, not for release)
 .github/review/
+
+# New binary name (post-rename)
+symvault

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -182,6 +182,9 @@ brews:
     homepage: "https://github.com/danieljustus/symaira-vault"
     description: "Transitional package for Symaira Vault"
     license: "MIT"
+    custom_block: |
+      version_scheme 1
+      deprecate! date: "2026-05-28", because: "has been renamed to symvault", replacement_formula: "symvault"
     conflicts:
       - symvault
     install: |
@@ -248,7 +251,7 @@ sboms:
 signs:
   - cmd: cosign
     certificate: "${artifact}.pem"
-    args: ["sign-blob", "--yes", "--oidc-issuer=https://token.actions.githubusercontent.com", "--output-certificate=${certificate}", "--output-signature=${signature}", "${artifact}"]
+    args: ["sign-blob", "--yes", "--output-certificate=${certificate}", "--output-signature=${signature}", "${artifact}"]
     artifacts: all
 
 snapshot:

--- a/homebrew/Formula/openpass.rb
+++ b/homebrew/Formula/openpass.rb
@@ -14,6 +14,8 @@ class Openpass < Formula
   sha256 "{{ .Checksum }}"
 
   license "MIT"
+  version_scheme 1
+  deprecate! date: "2026-05-28", because: "has been renamed to symvault", replacement_formula: "symvault"
 
   depends_on "go" => :build
 


### PR DESCRIPTION
Mark the transitional openpass Homebrew formula as deprecated with symvault as replacement.

Changes:

- Add deprecation notice and version_scheme to .goreleaser.yml brew config

- Add deprecation notice and version_scheme to homebrew/Formula/openpass.rb

- Remove redundant --oidc-issuer from cosign sign-blob args (default is used)

- Add symvault binary to .gitignore (renamed from openpass)
