### PR TITLE
fix(ci): add --ignore-signing-config to cosign args for v3 compat

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -251,7 +251,7 @@ sboms:
 signs:
   - cmd: cosign
     certificate: "${artifact}.pem"
-    args: ["sign-blob", "--yes", "--output-certificate=${certificate}", "--output-signature=${signature}", "${artifact}"]
+    args: ["sign-blob", "--yes", "--ignore-signing-config", "--output-certificate=${certificate}", "--output-signature=${signature}", "${artifact}"]
     artifacts: all
 
 snapshot:


### PR DESCRIPTION
Fixes cosign v3 signing failure that caused v0.2.0 release to fail.

Error: cannot specify service URLs and use signing config

The --ignore-signing-config flag tells cosign to ignore any default signing config and use command-line flags only.