### PR TITLE
fix(ci): pin cosign to v2.4.3 for sign-blob compat

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,6 +118,8 @@ jobs:
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: 'v2.4.3'
 
       - name: Install Syft
         uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -251,7 +251,7 @@ sboms:
 signs:
   - cmd: cosign
     certificate: "${artifact}.pem"
-    args: ["sign-blob", "--yes", "--ignore-signing-config", "--output-certificate=${certificate}", "--output-signature=${signature}", "${artifact}"]
+    args: ["sign-blob", "--yes", "--output-certificate=${certificate}", "--output-signature=${signature}", "${artifact}"]
     artifacts: all
 
 snapshot:


### PR DESCRIPTION
Reverts the non-existent --ignore-signing-config flag and pins cosign to v2.4.3, which supports the --output-certificate and --output-signature flags used by GoReleaser.

Cosign v3.0.6 introduced signing configs that conflict with the legacy sign-blob output flags, causing releases to fail. Pinning to v2.4.3 restores the previous working behavior.