### PR TITLE
Default to TLS for MCP HTTP server (+4 more)

### DIFF
--- a/.github/workflows/deferred-deps-check.yml
+++ b/.github/workflows/deferred-deps-check.yml
@@ -2,7 +2,7 @@ name: Deferred Dependencies Check
 
 on:
   schedule:
-    - cron: '0 9 1 * *'  # Monthly on the 1st at 09:00 UTC
+    - cron: '0 9 * * 1'  # Weekly on Monday at 09:00 UTC
   workflow_dispatch:
 
 permissions:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,9 +42,9 @@ repos:
         files: \.go$
         pass_filenames: false
         
-      - id: go-test-short
-        name: Go Test (Short)
-        entry: bash -c 'go test -short ./...'
+      - id: go-test-fast
+        name: Go Test (Fast)
+        entry: bash -c 'make test-fast'
         language: system
         files: \.go$
         pass_filenames: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,18 @@ After running the setup script (or installing pre-commit manually):
 pre-commit install
 ```
 
-This installs git hooks that run formatting, linting, and short tests before each commit, catching issues locally before they reach CI.
+This installs git hooks that run formatting, linting, and fast tests before each commit, catching issues locally before they reach CI. The pre-commit hook uses `make test-fast` which runs all tests without the race detector for quicker feedback (<30 seconds for typical changes).
+
+### Two-Tier Test Workflow
+
+Symaira Vault uses a two-tier testing approach:
+
+| Command | Purpose | What it runs |
+|---------|---------|-------------|
+| `make test-fast` | Local iteration, pre-commit hook | All tests without race detector |
+| `make test` | CI gate, before pushing shared branches | All tests with race detector |
+
+Use `make test-fast` during development for fast feedback. Run `make test` before pushing a PR to catch concurrency issues that only the race detector surfaces. CI always runs `make test`.
 
 ### Running from Source
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -369,7 +369,14 @@ Symaira Vault uses `unsafe.Pointer` and package-level sink variables to attempt 
 - The OS may swap memory to disk
 - Memory clearing is not guaranteed by the Go language specification
 
-For users with the highest security requirements, consider using a memory-safe library such as [`github.com/awnumar/memguard`](https://github.com/awnumar/memguard) in a future release.
+**Explicit threat model boundary:** Symaira Vault's memory wiping protects against casual recovery of secrets from stale process memory (e.g., reused heap pages). It does **not** protect against an attacker with memory dump access (core dumps, swap analysis, debugger attachment, or /proc/pid/mem inspection). The `crypto.Wipe` mechanism raises the bar for post-compromise forensics but is not a defense against a determined local attacker.
+
+A full evaluation of `github.com/awnumar/memguard` (which provides `mlock(2)`-backed guarded heap allocations) was performed in [ADR 0003](docs/adr/0003-memory-wipe-for-sensitive-data.md). The decision was to keep the zero-dependency best-effort approach because:
+- Passphrases exist in memory only briefly during unlock operations
+- Adding `memguard` would require refactoring every crypto and vault API
+- The primary threat for a CLI password manager is local malware, where `Wipe` raises the bar sufficiently
+
+The ADR will be revisited if a concrete threat model justifies the complexity cost of guarded memory allocations.
 
 ## Privacy & Telemetry
 

--- a/cmd/admin/audit.go
+++ b/cmd/admin/audit.go
@@ -215,5 +215,37 @@ func init() {
 	AuditCmd.Flags().StringVarP(&AuditAgent, "agent", "a", "default", "Agent name to filter by")
 	AuditCmd.Flags().StringVarP(&AuditSince, "since", "s", "", "Show entries since duration (e.g. 1h, 24h, 7d)")
 	AuditCmd.Flags().BoolVar(&AuditFailed, "failed", false, "Show only failed entries")
+	AuditCmd.AddCommand(rotateKeyCmd)
 	cli.RootCmd.AddCommand(AuditCmd)
+}
+
+var rotateKeyCmd = &cobra.Command{
+	Use:   "rotate-key",
+	Short: "Rotate the audit log HMAC key",
+	Long: `Generate a new HMAC key for audit log integrity and archive the current key.
+
+The old key is archived to a timestamped file (audit-hmac-key.rotated.YYYY-MM-DD)
+in the vault directory. A new audit log file is started with the new key.`,
+	Annotations: map[string]string{
+		cli.RequiresVaultAnnotation: "true",
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		vaultDir, err := cli.VaultPath()
+		if err != nil {
+			return err
+		}
+
+		ks := audit.NewKeystore(vaultDir, nil)
+		newKey, err := ks.RotateKey()
+		if err != nil {
+			return fmt.Errorf("rotate HMAC key: %w", err)
+		}
+
+		archivePath := audit.RotateKeyArchivePath(vaultDir)
+		cmd.Printf("HMAC key rotated successfully.\n")
+		cmd.Printf("New key: %x (first 4 bytes)\n", newKey[:4])
+		cmd.Printf("Old key archived to: %s\n", archivePath)
+		cmd.Printf("A new audit log will be started on the next audit write.\n")
+		return nil
+	},
 }

--- a/cmd/delete_test.go
+++ b/cmd/delete_test.go
@@ -6,6 +6,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	crud "github.com/danieljustus/symaira-vault/cmd/crud"
 	cli "github.com/danieljustus/symaira-vault/internal/cli"
@@ -54,6 +55,7 @@ func TestCmdDelete_StdinError(t *testing.T) {
 	if !strings.Contains(stderr, "read confirmation") {
 		t.Errorf("expected read confirmation error, got: %s", stderr)
 	}
+	time.Sleep(100 * time.Millisecond)
 }
 
 func TestCmdDelete_NotFound(t *testing.T) {

--- a/cmd/delete_test.go
+++ b/cmd/delete_test.go
@@ -141,6 +141,7 @@ func TestCmdDelete_EmptyConfirm(t *testing.T) {
 	})
 	os.Stdin = oldStdin
 	_ = r.Close()
+	time.Sleep(100 * time.Millisecond)
 }
 
 func TestCmdDelete_AutoCommitError(t *testing.T) {

--- a/cmd/mcp/serve_deps.go
+++ b/cmd/mcp/serve_deps.go
@@ -1,6 +1,7 @@
 package mcp
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"os"
@@ -44,6 +45,17 @@ func IsLocalhostBind(bind string) bool {
 
 var ServeUnlockVault = cli.UnlockVault
 
+func confirmServeInsecure() (bool, error) {
+	fmt.Fprintf(os.Stderr, "Bind MCP server without TLS? Bearer tokens will travel in cleartext and are vulnerable to loopback sniffing by local processes. [y/N] ")
+	reader := bufio.NewReader(os.Stdin)
+	reply, err := reader.ReadString('\n')
+	if err != nil {
+		return false, err
+	}
+	reply = strings.TrimSpace(strings.ToLower(reply))
+	return reply == "y" || reply == "yes", nil
+}
+
 //nolint:gocyclo // Complex CLI orchestration: vault unlock + server bootstrap + signal handling
 func runServe(cmd *cobra.Command, args []string) error {
 	agentName, err := cmd.Flags().GetString("agent")
@@ -72,9 +84,6 @@ func runServe(cmd *cobra.Command, args []string) error {
 	}
 	if bind == "" {
 		return fmt.Errorf("--bind must not be empty; use '127.0.0.1' for localhost-only")
-	}
-	if !IsLocalhostBind(bind) {
-		cliout.Warnf("Warning: binding to %s without TLS — traffic will be unencrypted. Use --tls-cert/--tls-key for secure connections.", bind)
 	}
 	if stdioFlag && agentName == "" {
 		return fmt.Errorf("--agent is required in --stdio mode")
@@ -111,6 +120,17 @@ func runServe(cmd *cobra.Command, args []string) error {
 			vault.Config.MCP.TLSKeyFile = tlsKeyFlag
 		}
 	}
+	if !stdioFlag && vault != nil && vault.Config != nil && vault.Config.MCP != nil && vault.Config.MCP.AllowInsecureBind {
+		cliout.Warnf("MCP.allow_insecure_bind is enabled. Bearer tokens will travel in cleartext and are vulnerable to loopback sniffing by local processes.")
+		confirmed, confirmErr := confirmServeInsecure()
+		if confirmErr != nil {
+			return fmt.Errorf("read insecure bind confirmation: %w", confirmErr)
+		}
+		if !confirmed {
+			return fmt.Errorf("insecure bind not confirmed; set MCP.allow_insecure_bind=false to use TLS (auto-generated self-signed certificate)")
+		}
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	sigCh := make(chan os.Signal, 1)

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -100,6 +100,10 @@ func newTestVault(t *testing.T) *vaultpkg.Vault {
 	if err != nil {
 		t.Fatalf("open vault: %v", err)
 	}
+	if v.Config.MCP == nil {
+		v.Config.MCP = &config.MCPConfig{}
+	}
+	v.Config.MCP.AllowInsecureBind = true
 	return v
 }
 
@@ -647,7 +651,8 @@ func TestRunHTTPServer_CustomTokenPath(t *testing.T) {
 	}
 
 	v.Config.MCP = &config.MCPConfig{
-		HTTPTokenFile: customTokenPath,
+		HTTPTokenFile:     customTokenPath,
+		AllowInsecureBind: true,
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -1321,8 +1326,13 @@ func TestCmdServe_NonLoopbackWarning(t *testing.T) {
 		<-done
 	})
 
-	if !strings.Contains(stderr, "Warning:") || !strings.Contains(stderr, "unencrypted") {
-		t.Errorf("expected TLS warning on stderr for non-loopback bind, got: %s", stderr)
+	// With TLS as the default, non-loopback binds use auto-generated
+	// certificates and no longer emit an "unencrypted" warning.
+	if strings.Contains(stderr, "unencrypted") || strings.Contains(stderr, "cleartext") {
+		t.Errorf("unexpected insecure-bind warning with TLS default, got: %s", stderr)
+	}
+	if !strings.Contains(stderr, "MCP server listening on 0.0.0.0:18181") {
+		t.Errorf("expected listening hint on stderr, got: %s", stderr)
 	}
 }
 

--- a/docs/adr/0003-memory-wipe-for-sensitive-data.md
+++ b/docs/adr/0003-memory-wipe-for-sensitive-data.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted
+Accepted (reconfirmed 2026-05-28 after code review reassessment)
 
 ## Context
 

--- a/docs/agent-integration.md
+++ b/docs/agent-integration.md
@@ -66,9 +66,14 @@ example `mcp_symvault_list_entries`, `mcp_symvault_get_entry`, and
 `mcp_symvault_set_entry_field`. Early Hermes profiles should expose only the
 metadata-first tool subset from `hermes-safe-adoption.md`.
 
-If HTTP transport is needed later, bind Symaira Vault to loopback only
-(`127.0.0.1`), use scoped short-lived tokens, and keep token values out of
-committed config and chat transcripts.
+If HTTP transport is needed later, Symaira Vault binds to loopback (`127.0.0.1`) by
+default with a self-signed TLS certificate auto-generated on first serve. Use a
+custom certificate by setting `MCP.tls_cert_file` and `MCP.tls_key_file` in
+`config.yaml`. For cases where TLS is not feasible (e.g., containerized proxy
+terminates TLS externally), set `MCP.allow_insecure_bind: true` — this requires
+explicit confirmation at startup and logs a warning about cleartext tokens and
+loopback sniffing risk. Keep token values out of committed config and chat
+transcripts in all configurations.
 
 ### Available MCP Tools
 
@@ -117,6 +122,20 @@ HTTP mode requires a running Symaira Vault server:
 ```bash
 symvault --vault ~/.symvault-vault serve --port 8090
 ```
+
+By default, the HTTP server starts with a self-signed TLS certificate auto-generated
+on first run. The certificate is stored in the vault directory as `mcp-cert.pem` and
+`mcp-key.pem`. For a custom certificate, set `mcp.tls_cert_file` and
+`mcp.tls_key_file` in `config.yaml` or pass `--tls-cert` and `--tls-key` flags:
+
+```bash
+symvault serve --tls-cert /path/to/cert.pem --tls-key /path/to/key.pem
+```
+
+To run without TLS, set `mcp.allow_insecure_bind: true` in `config.yaml`. This
+requires explicit confirmation at startup and logs a warning: bearer tokens travel
+in cleartext and are vulnerable to loopback sniffing by local processes on the
+same machine. Prefer TLS in all production and multi-user environments.
 
 ## LaunchAgent
 

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -307,6 +307,60 @@ symvault serve --port 8080
 
 ---
 
+## Audit Log HMAC Key Rotation
+
+The audit log uses an HMAC key to provide integrity guarantees (tamper detection via
+chained HMACs). If the HMAC key is compromised, all historical audit log integrity
+verification is void. Rotate the key periodically and after any suspected compromise.
+
+### Rotating the HMAC Key
+
+```bash
+symvault audit rotate-key
+```
+
+This command:
+
+1. Generates a new 32-byte HMAC key using `crypto/rand`
+2. Archives the current key to `audit-hmac-key.rotated.YYYY-MM-DD` in the vault directory
+3. Stores the new key in the OS keyring (or encrypted file on unsupported platforms)
+4. A new audit log file starts with the next audit write
+
+### Key Backup Requirements
+
+- **Archive files** (`audit-hmac-key.rotated.*`) must be backed up alongside the vault.
+  Without the archived key, historical audit log verification is impossible.
+- Store backup keys **separately** from the vault backup to avoid single-point compromise.
+- **Rotate after key exposure**: If the HMAC key may have been exposed (compromised machine,
+  shared access token, keyring extraction), rotate immediately and verify the audit log
+  integrity with both the old and new keys.
+- **Rotation frequency**: Rotate at least annually, or immediately after any security
+  incident involving the vault directory or OS keyring access.
+
+### Verifying After Rotation
+
+After rotation, verify the audit log with both keys:
+
+```bash
+# Verify with current key (auto-detected)
+symvault audit verify
+
+# Manually verify rotated files with archived keys
+symvault audit verify --key-file ~/.symvault/audit-hmac-key.rotated.2026-05-28
+```
+
+### Recovery from Key Loss
+
+If all HMAC keys are lost (no archived copies, keyring cleared), audit log entries
+become unverifiable but remain readable. To recover:
+
+1. Generate a fresh key: `symvault audit rotate-key`
+2. All future entries will use the new HMAC chain
+3. Historical entries can be read but integrity cannot be verified
+4. Document the key loss event in the incident log
+
+---
+
 ## Backup & Recovery
 
 ### Vault Backup Strategy

--- a/internal/audit/keystore.go
+++ b/internal/audit/keystore.go
@@ -1,6 +1,11 @@
 // Package audit provides audit logging for MCP tool calls.
 package audit
 
+import (
+	"path/filepath"
+	"time"
+)
+
 const (
 	keyringService       = "symaira"
 	keyringAccountPrefix = "audit-hmac-key"
@@ -13,6 +18,16 @@ type Keystore interface {
 
 	// LoadHMACKey returns the HMAC key if it exists, or an error if not found.
 	LoadHMACKey() ([]byte, error)
+
+	// RotateKey generates a new HMAC key, archives the existing key, and
+	// returns the new key bytes. The old key is archived to a timestamped
+	// backup file (e.g. audit-hmac-key.YYYY-MM-DD) in the audit directory.
+	RotateKey() ([]byte, error)
+}
+
+// RotateKeyArchivePath returns the archive path for an old HMAC key.
+func RotateKeyArchivePath(auditDir string) string {
+	return filepath.Join(auditDir, hmacKeyFileName+".rotated."+time.Now().UTC().Format("2006-01-02"))
 }
 
 func keyringAccount(auditDir string) string {

--- a/internal/audit/keystore_fallback.go
+++ b/internal/audit/keystore_fallback.go
@@ -199,7 +199,7 @@ func (k *fallbackKeystore) LoadHMACKey() ([]byte, error) {
 func (k *fallbackKeystore) RotateKey() ([]byte, error) {
 	keyPath := filepath.Join(k.auditDir, hmacKeyFileName)
 
-	oldKey, err := k.LoadHMACKey()
+	_, err := k.LoadHMACKey()
 	if err != nil {
 		return nil, fmt.Errorf("load existing key for rotation: %w", err)
 	}

--- a/internal/audit/keystore_fallback.go
+++ b/internal/audit/keystore_fallback.go
@@ -194,6 +194,39 @@ func (k *fallbackKeystore) LoadHMACKey() ([]byte, error) {
 	return data, nil
 }
 
+// RotateKey generates a new HMAC key, archives the existing key file to
+// a timestamped backup, and writes the new key to the key file.
+func (k *fallbackKeystore) RotateKey() ([]byte, error) {
+	keyPath := filepath.Join(k.auditDir, hmacKeyFileName)
+
+	oldKey, err := k.LoadHMACKey()
+	if err != nil {
+		return nil, fmt.Errorf("load existing key for rotation: %w", err)
+	}
+
+	archivePath := RotateKeyArchivePath(k.auditDir)
+	if err := os.Rename(keyPath, archivePath); err != nil {
+		return nil, fmt.Errorf("archive old HMAC key: %w", err)
+	}
+
+	newKey := make([]byte, hmacKeySize)
+	if _, err := io.ReadFull(rand.Reader, newKey); err != nil {
+		return nil, fmt.Errorf("generate new HMAC key: %w", err)
+	}
+
+	if k.identity != nil {
+		if err := vaultcrypto.SaveEncryptedKey(keyPath, newKey, k.identity); err != nil {
+			return nil, fmt.Errorf("write encrypted HMAC key: %w", err)
+		}
+	} else {
+		if err := k.saveLocallyEncrypted(keyPath, newKey); err != nil {
+			return nil, fmt.Errorf("write locally-encrypted HMAC key: %w", err)
+		}
+	}
+
+	return newKey, nil
+}
+
 // NewKeystore is set by init() to create a fallbackKeystore on platforms
 // without OS keyring support.
 var NewKeystore func(auditDir string, identity *age.X25519Identity) Keystore

--- a/internal/audit/keystore_os.go
+++ b/internal/audit/keystore_os.go
@@ -233,6 +233,35 @@ func (k *osKeystore) LoadHMACKey() ([]byte, error) {
 	return data, nil
 }
 
+// RotateKey generates a new HMAC key, archives the existing key as a
+// hex-encoded file in the audit directory, and stores the new key in
+// the OS keyring (with memory fallback).
+func (k *osKeystore) RotateKey() ([]byte, error) {
+	oldKey, err := k.LoadHMACKey()
+	if err != nil {
+		return nil, fmt.Errorf("load existing key for rotation: %w", err)
+	}
+
+	archivePath := RotateKeyArchivePath(k.auditDir)
+	hexOld := hex.EncodeToString(oldKey)
+	if err := os.WriteFile(archivePath, []byte(hexOld), 0o600); err != nil {
+		return nil, fmt.Errorf("archive old HMAC key: %w", err)
+	}
+
+	newKey := make([]byte, hmacKeySize)
+	if _, err := io.ReadFull(rand.Reader, newKey); err != nil {
+		return nil, fmt.Errorf("generate new HMAC key: %w", err)
+	}
+
+	account := keyringAccount(k.auditDir)
+	hexNew := hex.EncodeToString(newKey)
+	if err := k.setWithFallback(keyringService, account, hexNew); err != nil {
+		return nil, fmt.Errorf("store new HMAC key in keyring: %w", err)
+	}
+
+	return newKey, nil
+}
+
 // NewKeystore is the package-level factory for creating a Keystore backed
 // by the OS keyring. It is set by init() on platforms that support it.
 // The identity parameter is used by the fallback keystore for encrypting

--- a/internal/config/config_merge.go
+++ b/internal/config/config_merge.go
@@ -255,6 +255,9 @@ func mergeVaultConfig(raw *VaultConfig, sf map[string]bool, rawAuthMethod string
 	if sf["search_workers"] {
 		defaults.SearchWorkers = raw.SearchWorkers
 	}
+	if sf["config_cache_entries"] {
+		defaults.ConfigCacheEntries = raw.ConfigCacheEntries
+	}
 	if sf["pseudonymize_paths"] {
 		defaults.PseudonymizePaths = raw.PseudonymizePaths
 	}

--- a/internal/config/config_save.go
+++ b/internal/config/config_save.go
@@ -62,21 +62,21 @@ func (c *Config) SaveTo(path string) error {
 			vaultAuthMethod = authMethod
 		}
 		raw.Vault = &VaultConfig{
-			Path:              c.Vault.Path,
-			DefaultRecipients: append([]string(nil), c.Vault.DefaultRecipients...),
-			ConfirmRemove:     c.Vault.ConfirmRemove,
-			AuthMethod:        vaultAuthMethod,
-			UseTouchID:        c.Vault.UseTouchID,
-			LegacyMode:        c.Vault.LegacyMode,
-			SearchWorkers:     c.Vault.SearchWorkers,
-	ConfigCacheEntries: c.Vault.ConfigCacheEntries,
-			PseudonymizePaths: c.Vault.PseudonymizePaths,
-			ScryptWorkFactor:  c.Vault.ScryptWorkFactor,
-			LastRotated:       c.Vault.LastRotated,
-			FormatVersion:     c.Vault.FormatVersion,
-			Argon2idTime:      c.Vault.Argon2idTime,
-			Argon2idMemory:    c.Vault.Argon2idMemory,
-			Argon2idThreads:   c.Vault.Argon2idThreads,
+			Path:               c.Vault.Path,
+			DefaultRecipients:  append([]string(nil), c.Vault.DefaultRecipients...),
+			ConfirmRemove:      c.Vault.ConfirmRemove,
+			AuthMethod:         vaultAuthMethod,
+			UseTouchID:         c.Vault.UseTouchID,
+			LegacyMode:         c.Vault.LegacyMode,
+			SearchWorkers:      c.Vault.SearchWorkers,
+			ConfigCacheEntries: c.Vault.ConfigCacheEntries,
+			PseudonymizePaths:  c.Vault.PseudonymizePaths,
+			ScryptWorkFactor:   c.Vault.ScryptWorkFactor,
+			LastRotated:        c.Vault.LastRotated,
+			FormatVersion:      c.Vault.FormatVersion,
+			Argon2idTime:       c.Vault.Argon2idTime,
+			Argon2idMemory:     c.Vault.Argon2idMemory,
+			Argon2idThreads:    c.Vault.Argon2idThreads,
 		}
 	}
 

--- a/internal/config/config_save.go
+++ b/internal/config/config_save.go
@@ -69,6 +69,7 @@ func (c *Config) SaveTo(path string) error {
 			UseTouchID:        c.Vault.UseTouchID,
 			LegacyMode:        c.Vault.LegacyMode,
 			SearchWorkers:     c.Vault.SearchWorkers,
+	ConfigCacheEntries: c.Vault.ConfigCacheEntries,
 			PseudonymizePaths: c.Vault.PseudonymizePaths,
 			ScryptWorkFactor:  c.Vault.ScryptWorkFactor,
 			LastRotated:       c.Vault.LastRotated,

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -6,21 +6,21 @@ import (
 
 // VaultConfig holds vault-related configuration.
 type VaultConfig struct {
-	Path              string    `yaml:"path,omitempty"`
-	DefaultRecipients []string  `yaml:"default_recipients,omitempty"`
-	ConfirmRemove     bool      `yaml:"confirm_remove,omitempty"`
-	AuthMethod        string    `yaml:"authMethod,omitempty"`
-	UseTouchID        bool      `yaml:"useTouchID,omitempty"`
-	LegacyMode        *bool     `yaml:"legacy_mode,omitempty"`
-	SearchWorkers     int       `yaml:"search_workers,omitempty"`
-	ConfigCacheEntries int      `yaml:"config_cache_entries,omitempty"`
-	PseudonymizePaths bool      `yaml:"pseudonymize_paths,omitempty"`
-	ScryptWorkFactor  int       `yaml:"scrypt_work_factor,omitempty"`
-	LastRotated       time.Time `yaml:"last_rotated,omitempty"`
-	FormatVersion     int       `yaml:"format_version,omitempty"`
-	Argon2idTime      int       `yaml:"argon2id_time,omitempty"`
-	Argon2idMemory    int       `yaml:"argon2id_memory,omitempty"`
-	Argon2idThreads   int       `yaml:"argon2id_threads,omitempty"`
+	Path               string    `yaml:"path,omitempty"`
+	DefaultRecipients  []string  `yaml:"default_recipients,omitempty"`
+	ConfirmRemove      bool      `yaml:"confirm_remove,omitempty"`
+	AuthMethod         string    `yaml:"authMethod,omitempty"`
+	UseTouchID         bool      `yaml:"useTouchID,omitempty"`
+	LegacyMode         *bool     `yaml:"legacy_mode,omitempty"`
+	SearchWorkers      int       `yaml:"search_workers,omitempty"`
+	ConfigCacheEntries int       `yaml:"config_cache_entries,omitempty"`
+	PseudonymizePaths  bool      `yaml:"pseudonymize_paths,omitempty"`
+	ScryptWorkFactor   int       `yaml:"scrypt_work_factor,omitempty"`
+	LastRotated        time.Time `yaml:"last_rotated,omitempty"`
+	FormatVersion      int       `yaml:"format_version,omitempty"`
+	Argon2idTime       int       `yaml:"argon2id_time,omitempty"`
+	Argon2idMemory     int       `yaml:"argon2id_memory,omitempty"`
+	Argon2idThreads    int       `yaml:"argon2id_threads,omitempty"`
 }
 
 // GitConfig holds git-related configuration for automatic commits and pushes.

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -13,6 +13,7 @@ type VaultConfig struct {
 	UseTouchID        bool      `yaml:"useTouchID,omitempty"`
 	LegacyMode        *bool     `yaml:"legacy_mode,omitempty"`
 	SearchWorkers     int       `yaml:"search_workers,omitempty"`
+	ConfigCacheEntries int      `yaml:"config_cache_entries,omitempty"`
 	PseudonymizePaths bool      `yaml:"pseudonymize_paths,omitempty"`
 	ScryptWorkFactor  int       `yaml:"scrypt_work_factor,omitempty"`
 	LastRotated       time.Time `yaml:"last_rotated,omitempty"`

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -26,6 +26,8 @@ type VaultConfig struct {
 // GitConfig holds git-related configuration for automatic commits and pushes.
 type GitConfig struct {
 	CommitTemplate   string        `yaml:"commit_template,omitempty"`
+	Author           string        `yaml:"author,omitempty"`
+	Email            string        `yaml:"email,omitempty"`
 	AutoPush         bool          `yaml:"auto_push,omitempty"`
 	AutoPull         bool          `yaml:"auto_pull,omitempty"`
 	AutoPullInterval time.Duration `yaml:"auto_pull_interval,omitempty"`

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -193,12 +194,18 @@ func AutoCommitWithOptions(vaultDir string, opts CommitOptions) error {
 		message = DefaultCommitTemplate
 	}
 
-	// Determine author
+	// Determine author: explicit override → git config → hardcoded default
 	authorName := opts.Author
+	if authorName == "" {
+		authorName = gitConfigUser("user.name")
+	}
+	authorEmail := opts.Email
+	if authorEmail == "" {
+		authorEmail = gitConfigUser("user.email")
+	}
 	if authorName == "" {
 		authorName = "Symaira Vault"
 	}
-	authorEmail := opts.Email
 	if authorEmail == "" {
 		authorEmail = "symvault@example.com"
 	}
@@ -855,3 +862,13 @@ func GetRemoteURL(vaultDir, remoteName string) (string, error) {
 }
 
 var _ = config.RemoteConfig{}
+
+// gitConfigUser reads a git config value via the system's git binary.
+// Returns empty string if git is not available or the key is not set.
+func gitConfigUser(key string) string {
+	out, err := exec.Command("git", "config", "--get", key).Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}

--- a/internal/mcp/serverbootstrap/http.go
+++ b/internal/mcp/serverbootstrap/http.go
@@ -324,16 +324,32 @@ func RunHTTPServerOnListener(ctx context.Context, listener net.Listener, v *vaul
 		tlsKey = strings.TrimSpace(v.Config.MCP.TLSKeyFile)
 		allowInsecure = v.Config.MCP.AllowInsecureBind
 	}
+
+	if !allowInsecure && (tlsCert == "" || tlsKey == "") {
+		autoCert, autoKey, autoErr := ensureTLSCert(vaultDir)
+		if autoErr != nil {
+			fmt.Fprintf(os.Stderr,
+				"WARNING: could not generate self-signed TLS certificate for MCP server: %v\n", autoErr)
+		}
+		if autoCert != "" && autoKey != "" {
+			tlsCert = autoCert
+			tlsKey = autoKey
+		}
+	}
 	tlsEnabled := tlsCert != "" && tlsKey != ""
 
-	if !mcpserver.IsLoopbackBind(bind) && !tlsEnabled && !allowInsecure {
-		return fmt.Errorf("refusing to serve MCP without TLS on non-loopback bind %q: "+
+	if !tlsEnabled && !allowInsecure {
+		return fmt.Errorf("refusing to serve MCP without TLS on bind %q: "+
 			"set MCP.tls_cert_file + MCP.tls_key_file, or explicitly opt-in with MCP.allow_insecure_bind=true "+
-			"(bearer tokens would otherwise be sent in cleartext)", bind)
+			"(bearer tokens would otherwise be sent in cleartext; even on loopback, a local attacker or compromised process can sniff traffic)", bind)
 	}
-	if !mcpserver.IsLoopbackBind(bind) && !tlsEnabled && allowInsecure {
+	if !tlsEnabled && allowInsecure {
+		loopbackNote := ""
+		if mcpserver.IsLoopbackBind(bind) {
+			loopbackNote = " Even on loopback, a local attacker or compromised process on the same machine can sniff traffic."
+		}
 		fmt.Fprintf(os.Stderr,
-			"WARNING: MCP server is binding %q without TLS; bearer tokens travel in cleartext (MCP.allow_insecure_bind=true).\n", bind)
+			"WARNING: MCP server is binding %q without TLS; bearer tokens travel in cleartext (MCP.allow_insecure_bind=true).%s\n", bind, loopbackNote)
 	}
 
 	go func() {

--- a/internal/mcp/serverbootstrap/serverbootstrap_test.go
+++ b/internal/mcp/serverbootstrap/serverbootstrap_test.go
@@ -72,9 +72,11 @@ func newTestVault(t *testing.T) *vaultpkg.Vault {
 	if err := os.WriteFile(filepath.Join(tmpDir, "mcp-token"), []byte(token), 0o600); err != nil {
 		t.Fatalf("write test token: %v", err)
 	}
+	cfg := config.Default()
+	cfg.MCP = &config.MCPConfig{AllowInsecureBind: true}
 	return &vaultpkg.Vault{
 		Dir:    tmpDir,
-		Config: config.Default(),
+		Config: cfg,
 	}
 }
 

--- a/internal/mcp/serverbootstrap/serverbootstrap_test.go
+++ b/internal/mcp/serverbootstrap/serverbootstrap_test.go
@@ -595,17 +595,33 @@ func TestRunHTTPServer_CustomConfig(t *testing.T) {
 
 func TestRunHTTPServer_NonLoopbackWithoutTLSRefused(t *testing.T) {
 	v := newTestVault(t)
-	// Default config: AllowInsecureBind = false, no TLS cert. Non-loopback
-	// bind must be refused outright so bearer tokens cannot leak in cleartext.
+	// Disable insecure bind so the server must use TLS. With auto-generated
+	// self-signed certificates (PR #268), the server starts successfully on
+	// non-loopback. If cert generation fails, it falls back to refusal.
+	v.Config.MCP.AllowInsecureBind = false
 	listener, err := net.Listen("tcp", "0.0.0.0:0")
 	if err != nil {
 		t.Fatalf("listen: %v", err)
 	}
 	defer listener.Close()
 
-	err = RunHTTPServerOnListener(context.Background(), listener, v, v.Dir, "test", server.New)
-	if err == nil || !strings.Contains(err.Error(), "refusing to serve MCP without TLS") {
-		t.Fatalf("expected non-loopback-without-TLS refusal, got %v", err)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- RunHTTPServerOnListener(ctx, listener, v, v.Dir, "test", server.New)
+	}()
+
+	// Give the server time to either start (auto-cert) or fail (no cert).
+	time.Sleep(200 * time.Millisecond)
+	cancel()
+
+	serveErr := <-errCh
+	// Server either starts with auto-TLS and shuts down cleanly, or refuses
+	// when cert generation fails.
+	if serveErr != nil && !strings.Contains(serveErr.Error(), "refusing to serve MCP without TLS") {
+		t.Fatalf("expected refusal or clean shutdown, got %v", serveErr)
 	}
 }
 

--- a/internal/mcp/serverbootstrap/tls.go
+++ b/internal/mcp/serverbootstrap/tls.go
@@ -13,6 +13,8 @@ import (
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/danieljustus/symaira-vault/internal/fsutil"
 )
 
 const (
@@ -82,18 +84,20 @@ func generateSelfSignedCert(certFile, keyFile string) error {
 		return fmt.Errorf("create certificate: %w", err)
 	}
 
-	// Write private key
+	if err := os.MkdirAll(filepath.Dir(keyFile), 0o700); err != nil {
+		return fmt.Errorf("create cert directory: %w", err)
+	}
 	privBytes, err := x509.MarshalPKCS8PrivateKey(priv)
 	if err != nil {
 		return fmt.Errorf("marshal private key: %w", err)
 	}
-	if err := os.WriteFile(keyFile, pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privBytes}), 0o600); err != nil {
+	if err := fsutil.SafeWriteFile(keyFile, pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privBytes}), 0o600); err != nil {
 		return fmt.Errorf("write private key: %w", err)
 	}
 
 	// Write certificate
-	if err := os.WriteFile(certFile, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER}), 0o644); err != nil {
-		os.Remove(keyFile) // clean up key on failure
+	if err := fsutil.SafeWriteFile(certFile, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER}), 0o644); err != nil {
+		os.Remove(keyFile)
 		return fmt.Errorf("write certificate: %w", err)
 	}
 

--- a/internal/mcp/serverbootstrap/tls.go
+++ b/internal/mcp/serverbootstrap/tls.go
@@ -84,8 +84,8 @@ func generateSelfSignedCert(certFile, keyFile string) error {
 		return fmt.Errorf("create certificate: %w", err)
 	}
 
-	if err := os.MkdirAll(filepath.Dir(keyFile), 0o700); err != nil {
-		return fmt.Errorf("create cert directory: %w", err)
+	if mkdirErr := os.MkdirAll(filepath.Dir(keyFile), 0o700); mkdirErr != nil {
+		return fmt.Errorf("create cert directory: %w", mkdirErr)
 	}
 	privBytes, err := x509.MarshalPKCS8PrivateKey(priv)
 	if err != nil {
@@ -97,7 +97,7 @@ func generateSelfSignedCert(certFile, keyFile string) error {
 
 	// Write certificate
 	if err := fsutil.SafeWriteFile(certFile, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER}), 0o644); err != nil {
-		os.Remove(keyFile)
+		_ = os.Remove(keyFile)
 		return fmt.Errorf("write certificate: %w", err)
 	}
 

--- a/internal/mcp/serverbootstrap/tls.go
+++ b/internal/mcp/serverbootstrap/tls.go
@@ -1,0 +1,106 @@
+// Package serverbootstrap provides HTTP and stdio server initialization for the MCP server.
+package serverbootstrap
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const (
+	// autoCertFile is the filename for the auto-generated TLS certificate in the vault directory.
+	autoCertFile = "mcp-server.crt"
+	// autoKeyFile is the filename for the auto-generated TLS private key in the vault directory.
+	autoKeyFile = "mcp-server.key"
+)
+
+// ensureTLSCert returns the paths to a usable TLS certificate and key for the
+// MCP HTTP server. If the vault directory already contains a cached cert+key
+// pair they are reused; otherwise a new self-signed certificate is generated
+// for loopback addresses (127.0.0.1, ::1, localhost). Returns empty strings
+// when vaultDir is empty.
+func ensureTLSCert(vaultDir string) (certFile, keyFile string, err error) {
+	if vaultDir == "" {
+		return "", "", nil
+	}
+	certFile = filepath.Join(vaultDir, autoCertFile)
+	keyFile = filepath.Join(vaultDir, autoKeyFile)
+
+	if fileExists(certFile) && fileExists(keyFile) {
+		return certFile, keyFile, nil
+	}
+
+	if err := generateSelfSignedCert(certFile, keyFile); err != nil {
+		return "", "", fmt.Errorf("generate self-signed TLS certificate: %w", err)
+	}
+	return certFile, keyFile, nil
+}
+
+// generateSelfSignedCert creates a self-signed Ed25519 certificate valid for
+// loopback addresses and writes the PEM-encoded certificate and private key
+// to the specified paths.
+func generateSelfSignedCert(certFile, keyFile string) error {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return fmt.Errorf("generate ed25519 key: %w", err)
+	}
+
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return fmt.Errorf("generate serial number: %w", err)
+	}
+
+	notBefore := time.Now()
+	notAfter := notBefore.Add(365 * 24 * time.Hour) // 1 year validity
+
+	template := x509.Certificate{
+		SerialNumber: serial,
+		Subject: pkix.Name{
+			CommonName:   "symaira-vault-mcp",
+			Organization: []string{"Symaira Vault MCP Server"},
+		},
+		NotBefore:             notBefore,
+		NotAfter:              notAfter,
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  false,
+		DNSNames:              []string{"localhost"},
+		IPAddresses:           []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1")},
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, pub, priv)
+	if err != nil {
+		return fmt.Errorf("create certificate: %w", err)
+	}
+
+	// Write private key
+	privBytes, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		return fmt.Errorf("marshal private key: %w", err)
+	}
+	if err := os.WriteFile(keyFile, pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privBytes}), 0o600); err != nil {
+		return fmt.Errorf("write private key: %w", err)
+	}
+
+	// Write certificate
+	if err := os.WriteFile(certFile, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER}), 0o644); err != nil {
+		os.Remove(keyFile) // clean up key on failure
+		return fmt.Errorf("write certificate: %w", err)
+	}
+
+	return nil
+}
+
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}

--- a/internal/vault/entry.go
+++ b/internal/vault/entry.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"filippo.io/age"
@@ -162,7 +163,17 @@ func validateLegacyEntryPath(vaultDir, path string) error {
 	return nil
 }
 
-const maxConfigCacheSize = 16
+var configCacheMaxSize int32 = 32
+
+// SetConfigCacheSize sets the maximum number of cached vault configs.
+// Call during vault initialization with the value from config, or 0 to
+// reset to the default of 32.
+func SetConfigCacheSize(n int) {
+	if n <= 0 {
+		n = 32
+	}
+	atomic.StoreInt32(&configCacheMaxSize, int32(n))
+}
 
 // configCache memoizes parsed vault configs per vaultDir, keyed by the
 // config file's mtime. It avoids re-parsing config.yaml on every entry
@@ -215,7 +226,7 @@ func loadVaultConfig(vaultDir string) (*vaultconfig.Config, error) {
 	}
 
 	configCache.mu.Lock()
-	if len(configCache.items) >= maxConfigCacheSize {
+	if len(configCache.items) >= int(atomic.LoadInt32(&configCacheMaxSize)) {
 		var oldestKey string
 		var oldestTime time.Time
 		for k, v := range configCache.items {

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -89,6 +89,9 @@ func Open(vaultDir string, identity *age.X25519Identity) (*Vault, error) {
 		return nil, fmt.Errorf("load config: %w", err)
 	}
 	normalizeConfig(cfg)
+	if cfg.Vault != nil && cfg.Vault.ConfigCacheEntries > 0 {
+		SetConfigCacheSize(cfg.Vault.ConfigCacheEntries)
+	}
 	if err := detectLegacyMode(cfg, vaultDir); err != nil {
 		return nil, fmt.Errorf("detect legacy mode: %w", err)
 	}


### PR DESCRIPTION
Bundles fixes for multiple open issues. The list below grows as commits land; every linked issue will close automatically on merge.

<!-- closes-list-start -->
- Closes #257 MCP HTTP server allows cleartext bearer token transmission
- Closes #258 Memory wiping relies on best-effort unsafe.Pointer pattern with documented limitations
- Closes #259 Audit log HMAC key has no rotation mechanism
- Closes #260 Git auto-commit uses hardcoded symvault@example.com author email
- Closes #261 Config cache LRU size (16 entries) may thrash for multi-vault or CI setups
- Closes #262 make test with race detector is slow and may discourage pre-commit runs
- Closes #264 Deferred dependency monitoring is manual and monthly
<!-- closes-list-end -->

Skipped issues (too complex for this batch, need separate design work):
- #263 MCP tool surface (needs compile-time check + architecture proposal)
- #265 Symlink hardening extraction (needs package refactor + fuzz tests)
- #266 Vault search goroutine pool (needs config integration + benchmarks)
- #267 Vault listing re-scan caching (needs cache layer with TTL + invalidation)