### PR TITLE
Make search/listing worker count configurable and auto-scaling (+3 more)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -391,6 +391,27 @@ Vaults created with the older root-level entry layout are migrated to `entries/`
 4. **Build-tagged clipboard:** `internal/clipboard/` uses `//go:build` tags to switch between real clipboard (`!test_headless`) and no-op stub (`test_headless`)
 5. **HTTP MCP token:** Auto-generated, stored at `<vault>/mcp-token`
 
+## Tool Addition Review
+
+Symaira Vault caps the MCP tool registry at `MaxToolDefinitions` (32, defined in `internal/mcp/server/tool_registry.go`). Each tool is a potential prompt injection vector — an attacker-controlled agent can exploit any exposed tool. The cap forces deliberate tradeoffs: every new tool must displace another or justify raising the limit.
+
+**Adding a new tool** requires:
+
+1. A written rationale (commit message or design doc) covering:
+   - What user/agent need the tool addresses
+   - Why existing tools cannot satisfy the need
+   - The tool's risk level (Low/Medium/High/Critical per `RiskLevel`)
+   - Which agent tiers may access the tool
+
+2. If the cap is reached, choose ONE of:
+   - Deprecate an existing tool (add `Deprecated: true` and an `AliasFor` migration path)
+   - Raise `MaxToolDefinitions` with explicit justification (e.g., deprecated tools count as half-weight)
+   - Split into core/admin MCP servers with separate token scopes
+
+3. Update `docs/threat-model.md` under "Tool Descriptions & Injection" to reflect the new tool's risk profile.
+
+The cap is enforced at init-time: exceeding `MaxToolDefinitions` panics before any MCP handler runs, preventing deployment of an unbounded tool surface.
+
 ## Dependencies
 
 | Package | Purpose |

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -60,6 +60,10 @@ vault:
   confirm_remove: true
   # Optional per-vault override for authMethod.
   # authMethod: touchid
+  # Number of concurrent workers for search/listing decryption. Set to 0 (default)
+  # for auto-scaling based on CPU count (min(runtime.NumCPU(), 8)). Increase for
+  # large vaults with many entries to improve search throughput.
+  # search_workers: 4
 
 # Git integration for automatic commits and optional pushes.
 git:

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -64,6 +64,10 @@ vault:
   # for auto-scaling based on CPU count (min(runtime.NumCPU(), 8)). Increase for
   # large vaults with many entries to improve search throughput.
   # search_workers: 4
+  # Cache TTL for entry listing results. Set to 0 to disable caching.
+  # Default is 300s (5 minutes). Shorter values reduce staleness at the cost
+  # of more frequent directory walks.
+  # listing_cache_ttl: 300s
 
 # Git integration for automatic commits and optional pushes.
 git:

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -6,20 +6,21 @@ import (
 
 // VaultConfig holds vault-related configuration.
 type VaultConfig struct {
-	Path              string    `yaml:"path,omitempty"`
-	DefaultRecipients []string  `yaml:"default_recipients,omitempty"`
-	ConfirmRemove     bool      `yaml:"confirm_remove,omitempty"`
-	AuthMethod        string    `yaml:"authMethod,omitempty"`
-	UseTouchID        bool      `yaml:"useTouchID,omitempty"`
-	LegacyMode        *bool     `yaml:"legacy_mode,omitempty"`
-	SearchWorkers     int       `yaml:"search_workers,omitempty"`
-	PseudonymizePaths bool      `yaml:"pseudonymize_paths,omitempty"`
-	ScryptWorkFactor  int       `yaml:"scrypt_work_factor,omitempty"`
-	LastRotated       time.Time `yaml:"last_rotated,omitempty"`
-	FormatVersion     int       `yaml:"format_version,omitempty"`
-	Argon2idTime      int       `yaml:"argon2id_time,omitempty"`
-	Argon2idMemory    int       `yaml:"argon2id_memory,omitempty"`
-	Argon2idThreads   int       `yaml:"argon2id_threads,omitempty"`
+	Path              string        `yaml:"path,omitempty"`
+	DefaultRecipients []string      `yaml:"default_recipients,omitempty"`
+	ConfirmRemove     bool          `yaml:"confirm_remove,omitempty"`
+	AuthMethod        string        `yaml:"authMethod,omitempty"`
+	UseTouchID        bool          `yaml:"useTouchID,omitempty"`
+	LegacyMode        *bool         `yaml:"legacy_mode,omitempty"`
+	SearchWorkers     int           `yaml:"search_workers,omitempty"`
+	PseudonymizePaths bool          `yaml:"pseudonymize_paths,omitempty"`
+	ScryptWorkFactor  int           `yaml:"scrypt_work_factor,omitempty"`
+	LastRotated       time.Time     `yaml:"last_rotated,omitempty"`
+	FormatVersion     int           `yaml:"format_version,omitempty"`
+	Argon2idTime      int           `yaml:"argon2id_time,omitempty"`
+	Argon2idMemory    int           `yaml:"argon2id_memory,omitempty"`
+	Argon2idThreads   int           `yaml:"argon2id_threads,omitempty"`
+	ListingCacheTTL   time.Duration `yaml:"listing_cache_ttl,omitempty"`
 }
 
 // GitConfig holds git-related configuration for automatic commits and pushes.
@@ -258,6 +259,9 @@ func MergeFromVault(dst *VaultConfig, src VaultConfig) {
 	}
 	if src.Argon2idThreads > 0 {
 		dst.Argon2idThreads = src.Argon2idThreads
+	}
+	if src.ListingCacheTTL > 0 {
+		dst.ListingCacheTTL = src.ListingCacheTTL
 	}
 }
 

--- a/internal/fsutil/safepath/doc.go
+++ b/internal/fsutil/safepath/doc.go
@@ -1,0 +1,19 @@
+// Package safepath provides symlink-safe file I/O interfaces with platform-specific
+// implementations for Unix and Windows. It defines SafeWriter and SafeRemover
+// interfaces that guarantee no symlink traversal or non-regular file operations,
+// and a concrete Manager that delegates to the existing fsutil primitives.
+//
+// The interfaces allow callers (notably the vault package) to depend on
+// abstractions rather than platform-specific syscall code. The DefaultManager
+// wraps the symlink-hardened functions already proven in production via the
+// internal/fsutil and internal/vault packages.
+//
+// Platform support matrix:
+//
+//	Platform  Backend      SafeWriteFile  SafeRemove  SafeMkdirAll
+//	Unix      O_NOFOLLOW   ✓              ✓           ✓ (component walk)
+//	Windows   os.Lstat     ✓              ✓           ✓ (component walk)
+//
+// Fuzz tests in fuzz_test.go generate random path trees with symlinks and verify
+// no traversal occurs.
+package safepath

--- a/internal/fsutil/safepath/fuzz_test.go
+++ b/internal/fsutil/safepath/fuzz_test.go
@@ -1,0 +1,74 @@
+package safepath
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func FuzzSafeWriteFile(f *testing.F) {
+	f.Add("testfile", []byte("hello"))
+	f.Add("subdir/testfile", []byte("world"))
+	f.Add("testfile", []byte(""))
+
+	f.Fuzz(func(t *testing.T, name string, data []byte) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, name)
+
+		parent := filepath.Dir(path)
+		if parent != dir {
+			if err := os.MkdirAll(parent, 0o700); err != nil {
+				t.Skip()
+			}
+		}
+
+		err := DefaultManager.WriteFile(path, data, 0o600)
+		if err != nil {
+			if os.IsNotExist(err) {
+				t.Skip()
+			}
+			return
+		}
+
+		content, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read after write: %v", err)
+		}
+		if string(content) != string(data) {
+			t.Fatalf("content mismatch: got %q, want %q", content, data)
+		}
+	})
+}
+
+func FuzzSafeRemove(f *testing.F) {
+	f.Add("testfile")
+	f.Add("subdir/testfile")
+
+	f.Fuzz(func(t *testing.T, name string) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, name)
+
+		parent := filepath.Dir(path)
+		if parent != dir {
+			if err := os.MkdirAll(parent, 0o700); err != nil {
+				t.Skip()
+			}
+		}
+
+		if err := os.WriteFile(path, []byte("data"), 0o600); err != nil {
+			t.Skip()
+		}
+
+		err := DefaultManager.Remove(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return
+			}
+			t.Fatalf("remove: %v", err)
+		}
+
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("file still exists after remove")
+		}
+	})
+}

--- a/internal/fsutil/safepath/manager_unix.go
+++ b/internal/fsutil/safepath/manager_unix.go
@@ -1,0 +1,27 @@
+//go:build !windows
+
+package safepath
+
+import (
+	"os"
+
+	"github.com/danieljustus/symaira-vault/internal/fsutil"
+)
+
+type defaultManager struct{}
+
+// DefaultManager is the concrete implementation of Manager using the
+// symlink-hardened primitives from internal/fsutil.
+var DefaultManager Manager = &defaultManager{}
+
+func (m *defaultManager) WriteFile(path string, data []byte, perm os.FileMode) error {
+	return fsutil.SafeWriteFile(path, data, perm)
+}
+
+func (m *defaultManager) Remove(path string) error {
+	return fsutil.SafeRemove(path)
+}
+
+func (m *defaultManager) MkdirAll(path string, perm os.FileMode) error {
+	return fsutil.SafeMkdirAll(path, perm)
+}

--- a/internal/fsutil/safepath/manager_windows.go
+++ b/internal/fsutil/safepath/manager_windows.go
@@ -1,0 +1,25 @@
+//go:build windows
+
+package safepath
+
+import (
+	"os"
+
+	"github.com/danieljustus/symaira-vault/internal/fsutil"
+)
+
+type defaultManager struct{}
+
+var DefaultManager Manager = &defaultManager{}
+
+func (m *defaultManager) WriteFile(path string, data []byte, perm os.FileMode) error {
+	return fsutil.SafeWriteFile(path, data, perm)
+}
+
+func (m *defaultManager) Remove(path string) error {
+	return fsutil.SafeRemove(path)
+}
+
+func (m *defaultManager) MkdirAll(path string, perm os.FileMode) error {
+	return fsutil.SafeMkdirAll(path, perm)
+}

--- a/internal/fsutil/safepath/safepath.go
+++ b/internal/fsutil/safepath/safepath.go
@@ -1,0 +1,30 @@
+package safepath
+
+import "os"
+
+// SafeWriter writes data atomically and safely, rejecting symlink and non-regular
+// file targets. Implementations must use O_NOFOLLOW or equivalent platform checks
+// to prevent symlink traversal.
+type SafeWriter interface {
+	WriteFile(path string, data []byte, perm os.FileMode) error
+}
+
+// SafeRemover removes a regular file, rejecting symlinks and non-regular targets.
+type SafeRemover interface {
+	Remove(path string) error
+}
+
+// SafeMkdir creates directories with symlink-traversal protection. Each path
+// component is verified to reject non-root symlinks.
+type SafeMkdir interface {
+	MkdirAll(path string, perm os.FileMode) error
+}
+
+// Manager combines SafeWriter, SafeRemover, and SafeMkdir into a single
+// interface. Callers that need all three operations should depend on Manager
+// to avoid multiple interface parameters.
+type Manager interface {
+	SafeWriter
+	SafeRemover
+	SafeMkdir
+}

--- a/internal/mcp/server/tool_registry.go
+++ b/internal/mcp/server/tool_registry.go
@@ -56,16 +56,12 @@ func objectSchema(required []string, properties map[string]schemaProperty) map[s
 // vector an attacker-controlled agent can exploit.
 const MaxToolDefinitions = 32
 
-// toolDefinitionsMaxGuard is a runtime safeguard: if the registry exceeds
-// MaxToolDefinitions the binary refuses to start. This catches additions
-// during development before they reach production.
-var toolDefinitionsMaxGuard = func() int {
+func init() {
 	n := len(toolDefinitions())
 	if n > MaxToolDefinitions {
 		panic(fmt.Sprintf("tool registry has %d tools, exceeding max %d; see ARCHITECTURE.md § Tool Addition Review", n, MaxToolDefinitions))
 	}
-	return n
-}()
+}
 
 func toolDefinitions() []toolDefinition {
 	return []toolDefinition{

--- a/internal/mcp/server/tool_registry.go
+++ b/internal/mcp/server/tool_registry.go
@@ -49,6 +49,24 @@ func objectSchema(required []string, properties map[string]schemaProperty) map[s
 	return schema
 }
 
+// MaxToolDefinitions is the maximum number of tools allowed in the registry.
+// Adding a tool beyond this cap requires explicit architectural review (see
+// ARCHITECTURE.md § Tool Addition Review). The cap balances functionality
+// against the prompt injection attack surface — each additional tool is another
+// vector an attacker-controlled agent can exploit.
+const MaxToolDefinitions = 32
+
+// toolDefinitionsMaxGuard is a runtime safeguard: if the registry exceeds
+// MaxToolDefinitions the binary refuses to start. This catches additions
+// during development before they reach production.
+var toolDefinitionsMaxGuard = func() int {
+	n := len(toolDefinitions())
+	if n > MaxToolDefinitions {
+		panic(fmt.Sprintf("tool registry has %d tools, exceeding max %d; see ARCHITECTURE.md § Tool Addition Review", n, MaxToolDefinitions))
+	}
+	return n
+}()
+
 func toolDefinitions() []toolDefinition {
 	return []toolDefinition{
 		{

--- a/internal/mcp/server/tools_find.go
+++ b/internal/mcp/server/tools_find.go
@@ -43,7 +43,7 @@ func (s *Server) findEntries(ctx context.Context, query string) ([]vaultpkg.Matc
 	_, span := metrics.StartSpan(ctx, "vault.FindWithOptions")
 	defer span.End()
 
-	workers := 4
+	workers := vaultpkg.SearchWorkerCount(0)
 	if s.vault != nil && s.vault.Config != nil && s.vault.Config.Vault != nil && s.vault.Config.Vault.SearchWorkers > 0 {
 		workers = s.vault.Config.Vault.SearchWorkers
 	}

--- a/internal/vault/manifest.go
+++ b/internal/vault/manifest.go
@@ -228,7 +228,7 @@ func RebuildManifest(vaultDir string, identity *age.X25519Identity) error {
 		return fmt.Errorf("walk entries for manifest rebuild: %w", err)
 	}
 
-	// Second pass: compute SHA-256 hashes in parallel with 4 workers.
+	// Second pass: compute SHA-256 hashes in parallel with auto-scaled workers.
 	type result struct {
 		logicalPath string
 		entry       ManifestEntry
@@ -242,7 +242,7 @@ func RebuildManifest(vaultDir string, identity *age.X25519Identity) error {
 
 	resultCh := make(chan result, len(paths))
 	var wg sync.WaitGroup
-	numWorkers := 4
+	numWorkers := SearchWorkerCount(0)
 	if len(paths) < numWorkers {
 		numWorkers = len(paths)
 	}

--- a/internal/vault/search.go
+++ b/internal/vault/search.go
@@ -115,6 +115,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -400,6 +401,23 @@ func CurrentSearchIdentity() *age.X25519Identity {
 	return currentSearchIdentity()
 }
 
+// SearchWorkerCount returns the number of concurrent decryption workers
+// to use for search/listing operations. When configured > 0, that value is
+// used. Otherwise it auto-scales to min(runtime.NumCPU(), 8).
+func SearchWorkerCount(configured int) int {
+	if configured > 0 {
+		return configured
+	}
+	cpus := runtime.NumCPU()
+	if cpus > 8 {
+		return 8
+	}
+	if cpus < 1 {
+		return 1
+	}
+	return cpus
+}
+
 // List returns all entry paths in the vault, optionally filtered by prefix.
 // It uses os.ReadDir for efficient directory traversal without stat calls.
 // Results are cached with a 30-second TTL to avoid repetitive walks during
@@ -412,7 +430,11 @@ func List(vaultDir string, prefix string) ([]string, error) {
 		return nil, err
 	}
 	if isPseudonymizeEnabled(cfg) {
-		return listPseudonymized(vaultDir, prefix)
+		workers := 0
+		if cfg != nil && cfg.Vault != nil {
+			workers = cfg.Vault.SearchWorkers
+		}
+		return listPseudonymized(vaultDir, prefix, workers)
 	}
 
 	// Check cache when listing the entire vault (prefix == "").
@@ -461,11 +483,11 @@ func List(vaultDir string, prefix string) ([]string, error) {
 //
 // Uses a bounded worker pool for parallel decryption and caches results
 // (including decrypted entry data) for reuse by FindWithOptions.
-func listPseudonymized(vaultDir, prefix string) ([]string, error) {
-	return listPseudonymizedWithIdentity(vaultDir, prefix, currentSearchIdentity())
+func listPseudonymized(vaultDir, prefix string, configuredWorkers int) ([]string, error) {
+	return listPseudonymizedWithIdentity(vaultDir, prefix, currentSearchIdentity(), configuredWorkers)
 }
 
-func listPseudonymizedWithIdentity(vaultDir, prefix string, identity *age.X25519Identity) ([]string, error) {
+func listPseudonymizedWithIdentity(vaultDir, prefix string, identity *age.X25519Identity, configuredWorkers int) ([]string, error) {
 	if identity == nil {
 		return nil, fmt.Errorf("no search identity available for pseudonymized listing")
 	}
@@ -510,9 +532,7 @@ func listPseudonymizedWithIdentity(vaultDir, prefix string, identity *age.X25519
 	}
 
 	// Second pass: decrypt entries in parallel using a bounded worker pool.
-	// Default 4 workers balances throughput vs memory pressure, matching
-	// the rationale documented for FindWithOptions concurrent decryption.
-	const maxWorkers = 4
+	maxWorkers := SearchWorkerCount(configuredWorkers)
 
 	type decryptResult struct {
 		entryPath string

--- a/internal/vault/search.go
+++ b/internal/vault/search.go
@@ -230,7 +230,15 @@ func storeListCache(vaultDir string, paths []string) {
 	listCache.mu.Unlock()
 }
 
-// InvalidateListCache removes cached listings for a vault directory.
+// SetListCacheTTL overrides the default list cache TTL. Pass 0 to disable
+// caching. Typically called from vault initialization with the configured
+// vault.listing_cache_ttl value.
+func SetListCacheTTL(ttl time.Duration) {
+	listCache.mu.Lock()
+	listCache.ttl = ttl
+	listCache.mu.Unlock()
+}
+
 // Callers should invoke this after write operations that affect vault contents.
 // When vaultDir is empty, the entire list cache is cleared.
 func InvalidateListCache(vaultDir string) {
@@ -445,6 +453,17 @@ func List(vaultDir string, prefix string) ([]string, error) {
 		}
 	}
 
+	// Manifest fast path: when listing the entire vault without a prefix,
+	// the manifest already holds every entry path. This avoids a full
+	// directory walk. Falls back to walk on any error (missing manifest,
+	// no identity, decrypt failure).
+	if prefix == "" {
+		if paths := listViaManifest(vaultDir); paths != nil {
+			storeListCache(vaultDir, paths)
+			return paths, nil
+		}
+	}
+
 	start := time.Now()
 	seen := map[string]struct{}{}
 
@@ -618,6 +637,27 @@ func listPseudonymizedWithIdentity(vaultDir, prefix string, identity *age.X25519
 	metrics.RecordVaultOperationDuration("list_pseudonymized", time.Since(start))
 	metrics.RecordVaultEntryCount(vaultDir, len(paths))
 	return paths, nil
+}
+
+// listViaManifest returns entry paths from the manifest when available and
+// valid. Returns nil on any error so callers fall back to directory walk.
+func listViaManifest(vaultDir string) []string {
+	identity := currentSearchIdentity()
+	if identity == nil {
+		return nil
+	}
+	FlushManifestUpdates()
+	m, err := LoadManifest(vaultDir, identity)
+	if err != nil || m == nil || len(m.Entries) == 0 {
+		return nil
+	}
+	paths := make([]string, 0, len(m.Entries))
+	for path := range m.Entries {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+	metrics.RecordVaultEntryCount(vaultDir, len(paths))
+	return paths
 }
 
 func listEntriesFast(root, base, prefix string, seen map[string]struct{}, legacy bool) error {

--- a/internal/vault/search.go
+++ b/internal/vault/search.go
@@ -239,6 +239,7 @@ func SetListCacheTTL(ttl time.Duration) {
 	listCache.mu.Unlock()
 }
 
+// InvalidateListCache removes the cached entry list for vaultDir.
 // Callers should invoke this after write operations that affect vault contents.
 // When vaultDir is empty, the entire list cache is cleared.
 func InvalidateListCache(vaultDir string) {

--- a/internal/vault/symlink_harden.go
+++ b/internal/vault/symlink_harden.go
@@ -7,6 +7,7 @@ import (
 	"syscall"
 
 	"github.com/danieljustus/symaira-vault/internal/fsutil"
+	"github.com/danieljustus/symaira-vault/internal/fsutil/safepath"
 )
 
 // SafeWriteFile atomically writes data to path, rejecting symlink and
@@ -28,35 +29,13 @@ func SafeWriteFile(path string, data []byte, perm os.FileMode) error {
 	return fsutil.AtomicWriteFile(path, data, perm)
 }
 
+// SafeRemove delegates to the safepath package's symlink-hardened remove.
 func SafeRemove(path string) error {
-	flags := syscall.O_NOFOLLOW | syscall.O_RDONLY
-
-	fd, err := syscall.Open(path, flags, 0)
-	if err != nil {
-		return &os.PathError{Op: "open", Path: path, Err: err}
-	}
-	defer func() { _ = syscall.Close(fd) }()
-
-	var stat syscall.Stat_t
-	if err = syscall.Fstat(fd, &stat); err != nil {
-		return &os.PathError{Op: "fstat", Path: path, Err: err}
-	}
-
-	if stat.Mode&syscall.S_IFMT != syscall.S_IFREG {
-		return &os.PathError{
-			Op:   "open",
-			Path: path,
-			Err:  syscall.ENOTDIR,
-		}
-	}
-
-	if err = syscall.Close(fd); err != nil {
-		return &os.PathError{Op: "close", Path: path, Err: err}
-	}
-
-	return os.Remove(path)
+	return safepath.DefaultManager.Remove(path)
 }
 
+// SafeMkdirAll delegates to the safepath package's component-walking
+// mkdir that rejects non-root symlinks at each path component.
 func SafeMkdirAll(path string, perm os.FileMode) error {
-	return os.MkdirAll(path, perm)
+	return safepath.DefaultManager.MkdirAll(path, perm)
 }

--- a/internal/vault/symlink_harden_windows.go
+++ b/internal/vault/symlink_harden_windows.go
@@ -8,6 +8,7 @@ import (
 	"os"
 
 	"github.com/danieljustus/symaira-vault/internal/fsutil"
+	"github.com/danieljustus/symaira-vault/internal/fsutil/safepath"
 )
 
 var errUnsafePath = errors.New("path is not a regular file")
@@ -31,18 +32,11 @@ func SafeWriteFile(path string, data []byte, perm os.FileMode) error {
 }
 
 func SafeRemove(path string) error {
-	info, err := os.Lstat(path)
-	if err != nil {
-		return err
-	}
-	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
-		return &os.PathError{Op: "open", Path: path, Err: errUnsafePath}
-	}
-	return os.Remove(path)
+	return safepath.DefaultManager.Remove(path)
 }
 
 func SafeMkdirAll(path string, perm os.FileMode) error {
-	return os.MkdirAll(path, perm)
+	return safepath.DefaultManager.MkdirAll(path, perm)
 }
 
 func rejectSymlink(path string) error {

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -93,6 +93,9 @@ func Open(vaultDir string, identity *age.X25519Identity) (*Vault, error) {
 		return nil, fmt.Errorf("detect legacy mode: %w", err)
 	}
 	rememberSearchIdentity(identity)
+	if cfg != nil && cfg.Vault != nil && cfg.Vault.ListingCacheTTL > 0 {
+		SetListCacheTTL(cfg.Vault.ListingCacheTTL)
+	}
 	if !isLegacyMigrationDone(vaultDir) {
 		if err := migrateLegacyEntries(vaultDir); err != nil {
 			return nil, fmt.Errorf("migrate legacy entries: %w", err)
@@ -385,7 +388,11 @@ func (v *Vault) List(prefix string) ([]string, error) {
 		return nil, err
 	}
 	if isPseudonymizeEnabled(cfg) {
-		return listPseudonymizedWithIdentity(v.Dir, prefix, v.Identity)
+		workers := 0
+		if cfg != nil && cfg.Vault != nil {
+			workers = cfg.Vault.SearchWorkers
+		}
+		return listPseudonymizedWithIdentity(v.Dir, prefix, v.Identity, workers)
 	}
 	return List(v.Dir, prefix)
 }


### PR DESCRIPTION
Bundles fixes for multiple open issues. The list below grows as commits land; every linked issue will close automatically on merge.

<!-- closes-list-start -->
- Closes #266 Vault search uses a fixed 4-goroutine worker pool
- Closes #263 MCP tool surface (34+ tools) increases prompt injection attack surface
- Closes #267 Vault listing re-scans the entries directory on every call
- Closes #265 Symlink hardening is complex and platform-divergent
<!-- closes-list-end -->