### PR TITLE
ci(release): fix smoke test artifact names

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,18 +153,18 @@ jobs:
         run: |
           TAG="${{ steps.tag.outputs.tag }}"
           VERSION="${TAG#v}"
-          curl -fLO "https://github.com/danieljustus/symaira-vault/releases/download/${TAG}/Symaira Vault_${VERSION}_linux_amd64.tar.gz"
-          curl -fLO "https://github.com/danieljustus/symaira-vault/releases/download/${TAG}/Symaira Vault_${VERSION}_checksums.txt"
+          curl -fLO "https://github.com/danieljustus/symaira-vault/releases/download/${TAG}/symaira-vault_${VERSION}_linux_amd64.tar.gz"
+          curl -fLO "https://github.com/danieljustus/symaira-vault/releases/download/${TAG}/symaira-vault_${VERSION}_checksums.txt"
 
       - name: Verify checksum
         run: |
           TAG="${{ steps.tag.outputs.tag }}"
           VERSION="${TAG#v}"
-          sha256sum -c "Symaira Vault_${VERSION}_checksums.txt" --ignore-missing
+          sha256sum -c "symaira-vault_${VERSION}_checksums.txt" --ignore-missing
 
       - name: Extract and install
         run: |
-          tar xzf Symaira Vault_*.tar.gz
+          tar xzf symaira-vault_*.tar.gz
           sudo mv ./*/symvault /usr/local/bin/symvault
           symvault version
 
@@ -190,17 +190,17 @@ jobs:
         run: |
           TAG="${{ steps.tag.outputs.tag }}"
           VERSION="${TAG#v}"
-          curl -fLO "https://github.com/danieljustus/symaira-vault/releases/download/${TAG}/symaira_${VERSION}_linux_amd64.deb"
-          curl -fLO "https://github.com/danieljustus/symaira-vault/releases/download/${TAG}/Symaira Vault_${VERSION}_checksums.txt"
+          curl -fLO "https://github.com/danieljustus/symaira-vault/releases/download/${TAG}/symvault_${VERSION}_linux_amd64.deb"
+          curl -fLO "https://github.com/danieljustus/symaira-vault/releases/download/${TAG}/symaira-vault_${VERSION}_checksums.txt"
 
       - name: Verify checksum
         run: |
           TAG="${{ steps.tag.outputs.tag }}"
           VERSION="${TAG#v}"
-          sha256sum -c "Symaira Vault_${VERSION}_checksums.txt" --ignore-missing
+          sha256sum -c "symaira-vault_${VERSION}_checksums.txt" --ignore-missing
 
       - name: Install deb package
-        run: sudo dpkg -i symaira_*.deb
+        run: sudo dpkg -i symvault_*.deb
 
       - name: Verify package installed
         run: 'dpkg -s symvault | grep "Status: install ok installed"'
@@ -227,18 +227,18 @@ jobs:
         run: |
           TAG="${{ steps.tag.outputs.tag }}"
           VERSION="${TAG#v}"
-          curl -fLO "https://github.com/danieljustus/symaira-vault/releases/download/${TAG}/Symaira Vault_${VERSION}_darwin_amd64.tar.gz"
-          curl -fLO "https://github.com/danieljustus/symaira-vault/releases/download/${TAG}/Symaira Vault_${VERSION}_checksums.txt"
+          curl -fLO "https://github.com/danieljustus/symaira-vault/releases/download/${TAG}/symaira-vault_${VERSION}_darwin_amd64.tar.gz"
+          curl -fLO "https://github.com/danieljustus/symaira-vault/releases/download/${TAG}/symaira-vault_${VERSION}_checksums.txt"
 
       - name: Verify checksum
         run: |
           TAG="${{ steps.tag.outputs.tag }}"
           VERSION="${TAG#v}"
-          shasum -a 256 -c "Symaira Vault_${VERSION}_checksums.txt" --ignore-missing
+          shasum -a 256 -c "symaira-vault_${VERSION}_checksums.txt" --ignore-missing
 
       - name: Extract and install
         run: |
-          tar xzf Symaira Vault_*.tar.gz
+          tar xzf symaira-vault_*.tar.gz
           sudo mv ./*/symvault /usr/local/bin/symvault
           symvault version
 
@@ -266,16 +266,16 @@ jobs:
         run: |
           $tag = "${{ steps.tag.outputs.tag }}"
           $version = $tag -replace '^v',''
-          curl -fLO "https://github.com/danieljustus/symaira-vault/releases/download/${tag}/Symaira Vault_${version}_windows_amd64.zip"
-          curl -fLO "https://github.com/danieljustus/symaira-vault/releases/download/${tag}/Symaira Vault_${version}_checksums.txt"
+          curl -fLO "https://github.com/danieljustus/symaira-vault/releases/download/${tag}/symaira-vault_${version}_windows_amd64.zip"
+          curl -fLO "https://github.com/danieljustus/symaira-vault/releases/download/${tag}/symaira-vault_${version}_checksums.txt"
 
       - name: Verify checksum
         shell: pwsh
         run: |
           $tag = "${{ steps.tag.outputs.tag }}"
           $version = $tag -replace '^v',''
-          $expectedHash = (Get-Content "Symaira Vault_${version}_checksums.txt" | Where-Object { $_ -match "windows_amd64\.zip$" } | ForEach-Object { ($_ -split '\s+')[0] })
-          $actualHash = (Get-FileHash -Path "Symaira Vault_${version}_windows_amd64.zip" -Algorithm SHA256).Hash.ToLower()
+          $expectedHash = (Get-Content "symaira-vault_${version}_checksums.txt" | Where-Object { $_ -match "windows_amd64\.zip$" } | ForEach-Object { ($_ -split '\s+')[0] })
+          $actualHash = (Get-FileHash -Path "symaira-vault_${version}_windows_amd64.zip" -Algorithm SHA256).Hash.ToLower()
           if ($expectedHash.ToLower() -ne $actualHash) {
             Write-Error "Checksum mismatch: expected $expectedHash, got $actualHash"
             exit 1
@@ -286,8 +286,8 @@ jobs:
         run: |
           $tag = "${{ steps.tag.outputs.tag }}"
           $version = $tag -replace '^v',''
-          Expand-Archive -Path "Symaira Vault_${version}_windows_amd64.zip" -DestinationPath .\symvault-tmp -Force
-          .\symvault-tmp\symaira_${version}_windows_amd64\symvault.exe version
+          Expand-Archive -Path "symaira-vault_${version}_windows_amd64.zip" -DestinationPath .\symvault-tmp -Force
+          .\symvault-tmp\symaira-vault_${version}_windows_amd64\symvault.exe version
 
       - name: Smoke test - init vault
         shell: pwsh
@@ -296,7 +296,7 @@ jobs:
           $version = $tag -replace '^v',''
           $tmpdir = Join-Path $env:TEMP "test-vault-$(Get-Random)"
           New-Item -ItemType Directory -Path $tmpdir | Out-Null
-          $exe = ".\symvault-tmp\symaira_${version}_windows_amd64\symvault.exe"
+          $exe = ".\symvault-tmp\symaira-vault_${version}_windows_amd64\symvault.exe"
           "test-passphrase-123" | & $exe init --vault "$tmpdir"
           Remove-Item -Path $tmpdir -Recurse -Force -ErrorAction SilentlyContinue
 
@@ -313,7 +313,6 @@ jobs:
         run: |
           TAG="${{ steps.tag.outputs.tag }}"
           curl -fsSL "https://raw.githubusercontent.com/danieljustus/homebrew-tap/main/Formula/symvault.rb" -o symvault.rb
-          curl -fsSL "https://raw.githubusercontent.com/danieljustus/homebrew-tap/main/Formula/openpass.rb" -o openpass.rb
 
       - name: Verify formula exists and has correct version
         run: |
@@ -323,27 +322,17 @@ jobs:
             echo "Homebrew formula not found or empty"
             exit 1
           fi
-          if [ ! -s openpass.rb ]; then
-            echo "Transitional Homebrew formula not found or empty"
-            exit 1
-          fi
           if ! grep -q "version \"${VERSION}\"" symvault.rb; then
             echo "Version mismatch: expected ${VERSION} in formula"
-            exit 1
-          fi
-          if ! grep -q "version \"${VERSION}\"" openpass.rb; then
-            echo "Version mismatch: expected ${VERSION} in transitional formula"
             exit 1
           fi
 
       - name: Validate formula syntax
         run: |
           ruby -c symvault.rb
-          ruby -c openpass.rb
 
       - name: Smoke test - formula audit
         run: |
           brew tap danieljustus/tap
           # Audit the formula; allow failure if tap is not fully set up
           brew audit --strict --formula symvault.rb || true
-          brew audit --strict --formula openpass.rb || true


### PR DESCRIPTION
Fix Release workflow smoke tests that were failing due to incorrect artifact name expectations.

## Changes

- Archive names: `Symaira Vault_*.tar.gz` → `symaira-vault_*.tar.gz`
- Checksum file: `Symaira Vault_*_checksums.txt` → `symaira-vault_*_checksums.txt`
- deb package: `symaira_*.deb` → `symvault_*.deb` (matches nfpms package_name)
- Windows zip contents: `symaira_*` → `symaira-vault_*` (matches archive name)
- Homebrew tap: remove `openpass.rb` check (file does not exist in tap)

## Problem

The smoke tests were using filenames with spaces and wrong project prefixes, causing:
- curl URL errors (spaces in URLs not encoded)
- 404s when downloading release artifacts
- Missing Homebrew formula file check

This fixes the Release workflow failures seen in the v0.3.0 release run.