### PR TITLE
fix(ci): reload token registry after atomic replacement

### DIFF
--- a/internal/mcp/auth/token.go
+++ b/internal/mcp/auth/token.go
@@ -541,10 +541,10 @@ func (r *TokenRegistry) cleanupOnce() {
 func (r *TokenRegistry) StartFileWatcher(ctx context.Context, interval time.Duration) func() {
 	stopCh := make(chan struct{})
 
-	var lastModTime time.Time
+	var lastInfo os.FileInfo
 	fi, err := os.Stat(r.path)
 	if err == nil {
-		lastModTime = fi.ModTime()
+		lastInfo = fi
 	}
 
 	go func() {
@@ -557,9 +557,8 @@ func (r *TokenRegistry) StartFileWatcher(ctx context.Context, interval time.Dura
 				if err != nil {
 					continue
 				}
-				mt := fi.ModTime()
-				if mt.After(lastModTime) {
-					lastModTime = mt
+				if lastInfo == nil || !os.SameFile(fi, lastInfo) || !fi.ModTime().Equal(lastInfo.ModTime()) || fi.Size() != lastInfo.Size() {
+					lastInfo = fi
 					if err := r.Load(); err != nil {
 						fmt.Fprintf(os.Stderr, "error reloading token registry from %s: %v\n", r.path, err)
 					}

--- a/internal/mcp/auth/token_test.go
+++ b/internal/mcp/auth/token_test.go
@@ -1215,6 +1215,54 @@ func TestTokenRegistry_FileWatcherReloadsOnChange(t *testing.T) {
 	}
 }
 
+func TestTokenRegistry_FileWatcherReloadsAtomicReplacementWithSameModTime(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mcp-tokens.json")
+
+	reg := NewTokenRegistry(path)
+	if _, _, err := reg.Create("initial", []string{"*"}, "", 1*time.Hour); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	initialInfo, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat initial registry: %v", err)
+	}
+	initialModTime := initialInfo.ModTime()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	stop := reg.StartFileWatcher(ctx, 50*time.Millisecond)
+	defer stop()
+
+	reg2 := NewTokenRegistry(path)
+	if err := reg2.Load(); err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	_, raw2, err := reg2.Create("cli-created", []string{"get_entry"}, "cli", 0)
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	hash2 := sha256Hex(raw2)
+
+	if err := os.Chtimes(path, initialModTime, initialModTime); err != nil {
+		t.Fatalf("preserve registry modtime: %v", err)
+	}
+
+	deadline := time.After(500 * time.Millisecond)
+	ticker := time.NewTicker(25 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-deadline:
+			t.Fatal("file watcher should reload after atomic replacement even when modtime is unchanged")
+		case <-ticker.C:
+			if _, found := reg.Get(hash2); found {
+				return
+			}
+		}
+	}
+}
+
 func TestTokenRegistry_FileWatcherStopsOnContextCancel(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "mcp-tokens.json")


### PR DESCRIPTION
Fixes the Linux CI failure in TestTokenRegistry_FileWatcherReloadsOnChange by making the token registry watcher detect atomic file replacement even when the replacement keeps the same modification time. Adds a regression test for unchanged modtime replacements.