### PR TITLE
Audit log HMAC key stored on disk instead of OS keyring (+5 more)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -378,6 +378,54 @@ A full evaluation of `github.com/awnumar/memguard` (which provides `mlock(2)`-ba
 
 The ADR will be revisited if a concrete threat model justifies the complexity cost of guarded memory allocations.
 
+### OS Keyring Buffer Retention
+
+Symaira Vault uses [`zalando/go-keyring`](https://github.com/zalando/go-keyring) to
+cache session passphrases in the OS keyring. The library interface uses Go `string`
+values (`keyring.Set(service, user, password string)`), which introduces additional
+memory copies beyond Symaira Vault's own `crypto.Wipe` scope:
+
+- **macOS**: Passphrases are piped via `stdin` to `/usr/bin/security`. The kernel
+  manages the stdin buffer, and the command-line tool may retain the value in its
+  own memory space until the process exits.
+- **Linux / D-Bus**: Passphrases are serialized into D-Bus message buffers (Secret
+  Service API). D-Bus is a local IPC bus; message buffers are managed by the
+  D-Bus daemon and may persist in the daemon's memory beyond the library call.
+- **Windows**: Passphrases pass through the Credential Manager API, which may
+  retain data in internal buffers managed by the operating system.
+
+These intermediate copies are created by the OS keyring transport layer and are
+outside Go's control — they cannot be reached by `crypto.Wipe()`. An attacker with
+kernel-level memory access, swap analysis, or D-Bus message interception capability
+may recover passphrase fragments from these buffers.
+
+**Evaluation of go-keyring wipe hooks** (May 2026): The `go-keyring` v0.2.8
+library exposes no zeroing or wipe API. Its `Keyring` interface defines only
+`Set`, `Get`, `Delete`, and `DeleteAll`. The library communicates with OS-native
+tools (`security`, D-Bus, Credential Manager) that manage their own buffers
+independently. No amount of Go-level memory zeroing can reach these
+OS-managed buffers.
+
+**Deployment advisory for high-security environments:**
+
+- **Enable mlock where supported**: On Linux, use `setrlimit(RLIMIT_MEMLOCK)` to
+  prevent the process heap from being swapped to disk. This reduces the risk of
+  passphrase data appearing in swap files. The `symvault` binary does not call
+  `mlock` by default; site operators must configure this via systemd or PAM.
+  ```ini
+  # systemd service unit
+  [Service]
+  LimitMEMLOCK=infinity
+  MemoryDenyWriteExecute=yes
+  ```
+- **Minimize session TTL**: Set `sessionTimeout: 0` in `config.yaml` to disable
+  session caching entirely. This forces passphrase entry on every operation,
+  eliminating the keyring as a persistence vector.
+- **Use stdio MCP mode**: The `symvault serve --stdio` mode avoids D-Bus entirely
+  for MCP transport, reducing the keyring's attack surface to the unlock path.
+- **Prefer passphrase-only unlock**: Set `authMethod: passphrase` to avoid
+  biometric keychain items that may have different access control properties.
+
 ## Privacy & Telemetry
 
 Symaira Vault does **NOT** collect any product analytics, error reports, or usage telemetry.

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -34,6 +34,8 @@ const (
 	hmacKeyFileName        = "audit-hmac-key"
 	hmacKeySize            = 32
 	hexHMACSize            = sha256.Size * 2 // 64 hex chars
+	defaultBufferSize      = 256             // max buffered entries before blocking
+	defaultFlushInterval   = 100             // milliseconds between flushes
 )
 
 // Environment variable names for audit configuration
@@ -46,11 +48,13 @@ const (
 	envMaxAgeDaysLegacy = "OPENPASS_AUDIT_MAX_AGE_DAYS"
 )
 
-// Config holds the configuration for audit log rotation.
+// Config holds the configuration for audit log rotation and buffering.
 type Config struct {
-	MaxFileSize int64
-	MaxBackups  int
-	MaxAgeDays  int
+	MaxFileSize   int64
+	MaxBackups    int
+	MaxAgeDays    int
+	BufferSize    int
+	FlushInterval time.Duration
 }
 
 // config holds the parsed audit configuration.
@@ -58,6 +62,7 @@ var config = parseAuditConfig(nil)
 
 // SetConfig overrides the global audit configuration with values from config.yaml.
 // Environment variables still take precedence over config file values.
+// When BufferSize > 0, async buffered writing is enabled.
 func SetConfig(cfg *Config) {
 	config = parseAuditConfig(cfg)
 }
@@ -168,6 +173,13 @@ type Logger struct {
 	mu        sync.Mutex
 	hmacKey   []byte
 	prevHMAC  []byte
+
+	entryCh    chan *LogEntry
+	flushReq   chan chan struct{}
+	flushDone  chan struct{}
+	bufferSize int
+	closed     bool
+	syncMode   bool
 }
 
 func New(agentName string, vaultDir string) (*Logger, error) {
@@ -223,10 +235,15 @@ func New(agentName string, vaultDir string) (*Logger, error) {
 	}
 
 	l := &Logger{
-		file:      file,
-		agentName: agentName,
-		path:      cleanPath,
-		hmacKey:   hmacKey,
+		file:       file,
+		agentName:  agentName,
+		path:       cleanPath,
+		hmacKey:    hmacKey,
+		bufferSize: defaultBufferSize,
+		entryCh:    make(chan *LogEntry, defaultBufferSize),
+		flushReq:   make(chan chan struct{}, 1),
+		flushDone:  make(chan struct{}),
+		syncMode:   true,
 	}
 
 	if rotErr := l.rotateIfNeeded(); rotErr != nil {
@@ -241,6 +258,8 @@ func New(agentName string, vaultDir string) (*Logger, error) {
 	}
 	l.prevHMAC = prevHMAC
 
+	go l.flushLoop()
+
 	return l, nil
 }
 
@@ -249,37 +268,36 @@ func (l *Logger) LogEntry(entry LogEntry) error {
 		return nil
 	}
 
+	l.mu.Lock()
+	closed := l.closed
+	l.mu.Unlock()
+	if closed {
+		return fmt.Errorf("audit logger is closed")
+	}
+
 	if entry.Timestamp == "" {
 		entry.Timestamp = time.Now().UTC().Format(time.RFC3339)
 	}
 
+	if l.syncMode {
+		l.writeEntry(&entry)
+		return nil
+	}
+
+	select {
+	case l.entryCh <- &entry:
+		return nil
+	default:
+		return fmt.Errorf("audit buffer full (%d entries), dropping log entry", l.bufferSize)
+	}
+}
+
+// SetSyncMode enables or disables synchronous writes. When sync mode is
+// enabled, LogEntry writes directly to disk without buffering.
+func (l *Logger) SetSyncMode(sync bool) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
-
-	if len(l.hmacKey) > 0 {
-		entry.HMAC = computeHMAC(l.hmacKey, l.prevHMAC, entry)
-	}
-
-	data, err := json.Marshal(entry)
-	if err != nil {
-		return err
-	}
-	data = append(data, '\n')
-	if _, err := l.file.Write(data); err != nil {
-		return err
-	}
-
-	if entry.HMAC != "" {
-		if prevBytes, derr := hex.DecodeString(entry.HMAC); derr == nil {
-			l.prevHMAC = prevBytes
-		}
-	}
-
-	if err := l.file.Sync(); err != nil {
-		return err
-	}
-
-	return nil
+	l.syncMode = sync
 }
 
 func (l *Logger) rotateIfNeeded() error {
@@ -578,6 +596,18 @@ func (l *Logger) Close() error {
 	if l == nil || l.file == nil {
 		return nil
 	}
+
+	l.mu.Lock()
+	if l.closed {
+		l.mu.Unlock()
+		return nil
+	}
+	l.closed = true
+	l.mu.Unlock()
+
+	close(l.entryCh)
+	<-l.flushDone
+
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	err := l.file.Close()
@@ -586,6 +616,91 @@ func (l *Logger) Close() error {
 	l.hmacKey = nil
 	l.prevHMAC = nil
 	return err
+}
+
+// Flush forces all buffered entries to be written to disk immediately.
+// It blocks until the flush is complete.
+func (l *Logger) Flush() {
+	if l == nil {
+		return
+	}
+	done := make(chan struct{})
+	select {
+	case l.flushReq <- done:
+		<-done
+	default:
+	}
+}
+
+func (l *Logger) flushLoop() {
+	ticker := time.NewTicker(time.Duration(defaultFlushInterval) * time.Millisecond)
+	defer ticker.Stop()
+
+	var batch []*LogEntry
+
+	flush := func() {
+		if len(batch) > 0 {
+			l.flushBatch(batch)
+			batch = batch[:0]
+		}
+	}
+
+	for {
+		select {
+		case entry, ok := <-l.entryCh:
+			if !ok {
+				flush()
+				close(l.flushDone)
+				return
+			}
+			batch = append(batch, entry)
+			if len(batch) >= l.bufferSize/2 {
+				flush()
+			}
+		case done := <-l.flushReq:
+			flush()
+			close(done)
+		case <-ticker.C:
+			flush()
+		}
+	}
+}
+
+func (l *Logger) flushBatch(entries []*LogEntry) {
+	for _, entry := range entries {
+		l.writeEntry(entry)
+	}
+	if l.file != nil {
+		_ = l.file.Sync()
+	}
+}
+
+func (l *Logger) writeEntry(entry *LogEntry) {
+	if entry == nil {
+		return
+	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if len(l.hmacKey) > 0 {
+		entry.HMAC = computeHMAC(l.hmacKey, l.prevHMAC, *entry)
+	}
+
+	data, err := json.Marshal(entry)
+	if err != nil {
+		return
+	}
+	data = append(data, '\n')
+	if _, err := l.file.Write(data); err != nil {
+		return
+	}
+
+	if entry.HMAC != "" {
+		if prevBytes, derr := hex.DecodeString(entry.HMAC); derr == nil {
+			l.prevHMAC = prevBytes
+		}
+	}
 }
 
 func (l *Logger) readLastHMAC() ([]byte, error) {

--- a/internal/audit/audit_test.go
+++ b/internal/audit/audit_test.go
@@ -1720,6 +1720,7 @@ func TestMaxLogSizeTrigger(t *testing.T) {
 		t.Fatalf("New() error = %v", err)
 	}
 	defer func() { _ = logger.Close() }()
+	logger.SetSyncMode(true)
 
 	// Write exactly 1MB - should NOT trigger rotation yet
 	data := strings.Repeat("x", 1024*1024)
@@ -2280,6 +2281,7 @@ func TestRotateIfNeededSizeLimit_Symvault(t *testing.T) {
 		t.Fatalf("New() error = %v", err)
 	}
 	defer func() { _ = logger.Close() }()
+	logger.SetSyncMode(true)
 
 	// Write until we exceed 1MB
 	data := strings.Repeat("x", 1024*1024) // 1MB of data

--- a/internal/audit/keystore_test.go
+++ b/internal/audit/keystore_test.go
@@ -132,6 +132,7 @@ func TestKeystoreHMACVerificationAfterKeystoreUse(t *testing.T) {
 		t.Fatalf("New() error = %v", err)
 	}
 	defer func() { _ = logger.Close() }()
+	logger.SetSyncMode(true)
 
 	_ = logger.LogEntry(LogEntry{
 		Agent:  "test-agent",

--- a/internal/audit/keystore_test.go
+++ b/internal/audit/keystore_test.go
@@ -1,0 +1,153 @@
+package audit
+
+import (
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestKeystoreLoadOrCreateAndLoadBack(t *testing.T) {
+	dir := t.TempDir()
+
+	ks := NewKeystore(dir, nil)
+	key, err := ks.LoadOrCreateHMACKey()
+	if err != nil {
+		t.Fatalf("LoadOrCreateHMACKey() error = %v", err)
+	}
+	if len(key) != hmacKeySize {
+		t.Fatalf("got key length %d, want %d", len(key), hmacKeySize)
+	}
+
+	loaded, err := ks.LoadHMACKey()
+	if err != nil {
+		t.Fatalf("LoadHMACKey() error = %v", err)
+	}
+	if len(loaded) != hmacKeySize {
+		t.Fatalf("loaded key length %d, want %d", len(loaded), hmacKeySize)
+	}
+
+	if hex.EncodeToString(key) != hex.EncodeToString(loaded) {
+		t.Fatal("loaded key does not match created key")
+	}
+}
+
+func TestKeystoreLoadHMACKeyNotFound(t *testing.T) {
+	dir := t.TempDir()
+
+	ks := NewKeystore(dir, nil)
+	_, err := ks.LoadHMACKey()
+	if err == nil {
+		t.Fatal("expected error for non-existent key, got nil")
+	}
+}
+
+func TestKeystoreRotateKey(t *testing.T) {
+	dir := t.TempDir()
+
+	ks := NewKeystore(dir, nil)
+	key, err := ks.LoadOrCreateHMACKey()
+	if err != nil {
+		t.Fatalf("LoadOrCreateHMACKey() error = %v", err)
+	}
+
+	newKey, err := ks.RotateKey()
+	if err != nil {
+		t.Fatalf("RotateKey() error = %v", err)
+	}
+	if len(newKey) != hmacKeySize {
+		t.Fatalf("new key length %d, want %d", len(newKey), hmacKeySize)
+	}
+
+	if hex.EncodeToString(key) == hex.EncodeToString(newKey) {
+		t.Fatal("rotated key should differ from original")
+	}
+
+	loaded, err := ks.LoadHMACKey()
+	if err != nil {
+		t.Fatalf("LoadHMACKey() after rotation error = %v", err)
+	}
+	if hex.EncodeToString(newKey) != hex.EncodeToString(loaded) {
+		t.Fatal("loaded key does not match rotated key")
+	}
+
+	archivePath := RotateKeyArchivePath(dir)
+	if _, err := os.Stat(archivePath); os.IsNotExist(err) {
+		t.Skipf("archive file not created at %s (expected on file-based keystore)", archivePath)
+	}
+}
+
+func TestKeystoreIdempotentLoadOrCreate(t *testing.T) {
+	dir := t.TempDir()
+
+	ks := NewKeystore(dir, nil)
+	key1, err := ks.LoadOrCreateHMACKey()
+	if err != nil {
+		t.Fatalf("first LoadOrCreateHMACKey() error = %v", err)
+	}
+
+	key2, err := ks.LoadOrCreateHMACKey()
+	if err != nil {
+		t.Fatalf("second LoadOrCreateHMACKey() error = %v", err)
+	}
+
+	if hex.EncodeToString(key1) != hex.EncodeToString(key2) {
+		t.Fatal("LoadOrCreateHMACKey() produced different keys on subsequent calls")
+	}
+}
+
+func TestKeystoreWithAuditLogIntegration(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	logger, err := New("keystore-integ-test", "")
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	defer func() { _ = logger.Close() }()
+
+	if len(logger.hmacKey) != hmacKeySize {
+		t.Fatalf("logger HMAC key length %d, want %d", len(logger.hmacKey), hmacKeySize)
+	}
+
+	auditDir := filepath.Join(home, ".symvault")
+
+	ks := NewKeystore(auditDir, nil)
+	loaded, err := ks.LoadHMACKey()
+	if err != nil {
+		t.Fatalf("LoadHMACKey() error = %v", err)
+	}
+
+	if hex.EncodeToString(logger.hmacKey) != hex.EncodeToString(loaded) {
+		t.Fatal("keystore key does not match logger's HMAC key")
+	}
+}
+
+func TestKeystoreHMACVerificationAfterKeystoreUse(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	logger, err := New("verify-keystore-test", "")
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	defer func() { _ = logger.Close() }()
+
+	_ = logger.LogEntry(LogEntry{
+		Agent:  "test-agent",
+		Action: "get",
+		Path:   "test/path",
+		OK:     true,
+	})
+
+	result, err := logger.Verify()
+	if err != nil {
+		t.Fatalf("Verify() error = %v", err)
+	}
+	if !result.Valid {
+		t.Fatal("expected valid chain after keystore-backed key usage")
+	}
+	if result.Verified != 1 {
+		t.Fatalf("Verified = %d, want 1", result.Verified)
+	}
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -103,14 +103,20 @@ func Execute() {
 	if err := RootCmd.Execute(); err != nil {
 		cliout.Errorf("Error: %v", err)
 		exitCode := errorspkg.ExitCodeFromError(err)
-		switch exitCode {
-		case errorspkg.ExitNotFound:
-			cliout.Hintf("Try: symvault find <search-term>")
-		case errorspkg.ExitNotInitialized:
-			cliout.Hintf("Run 'symvault init' for a quick start, or 'symvault setup' for the guided wizard.")
-		case errorspkg.ExitLocked:
-			cliout.Hintf("Unlock with 'symvault unlock', or set SYMVAULT_PASSPHRASE (or OPENPASS_PASSPHRASE) for non-interactive use.")
-		case errorspkg.ExitSuccess, errorspkg.ExitGeneralError, errorspkg.ExitPermissionDenied, errorspkg.ExitDoctorWarn, errorspkg.ExitDoctorFail, errorspkg.ExitConfigError, errorspkg.ExitUpdateAvailable:
+		if hint := errorspkg.HintForError(err); hint != "" {
+			cliout.Hintf("%s", hint)
+		} else {
+			switch exitCode {
+			case errorspkg.ExitNotFound:
+				cliout.Hintf("Try: symvault find <search-term>")
+			case errorspkg.ExitNotInitialized:
+				cliout.Hintf("Run 'symvault init' for a quick start, or 'symvault setup' for the guided wizard.")
+			case errorspkg.ExitLocked:
+				cliout.Hintf("Unlock with 'symvault unlock', or set SYMVAULT_PASSPHRASE (or OPENPASS_PASSPHRASE) for non-interactive use.")
+			case errorspkg.ExitConfigError:
+				cliout.Hintf("Run 'symvault doctor' to diagnose and fix configuration issues.")
+			case errorspkg.ExitSuccess, errorspkg.ExitGeneralError, errorspkg.ExitPermissionDenied, errorspkg.ExitDoctorWarn, errorspkg.ExitDoctorFail, errorspkg.ExitUpdateAvailable:
+			}
 		}
 		OsExit(int(exitCode))
 	}

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -73,12 +73,14 @@ func IsWriteError(err error) bool {
 	return false
 }
 
-// CLIError is a structured error with an exit code and user-friendly message.
+// CLIError is a structured error with an exit code, user-friendly message,
+// and optional remediation hint displayed to the user after the error.
 type CLIError struct {
 	Code    ExitCode
 	Kind    ErrorKind
 	Message string
 	Cause   error
+	Hint    string
 }
 
 // Error implements the error interface.
@@ -101,6 +103,21 @@ func NewCLIError(code ExitCode, msg string, cause error) *CLIError {
 		Message: msg,
 		Cause:   cause,
 	}
+}
+
+// WithHint returns a new CLIError with the hint set.
+func (e *CLIError) WithHint(hint string) *CLIError {
+	e.Hint = hint
+	return e
+}
+
+// HintForError returns a remediation hint for a known error type.
+func HintForError(err error) string {
+	var cliErr *CLIError
+	if errors.As(err, &cliErr) && cliErr.Hint != "" {
+		return cliErr.Hint
+	}
+	return ""
 }
 
 // ExitCodeFromError extracts the exit code from an error.
@@ -146,6 +163,7 @@ func NotFound(format string, args ...any) *CLIError {
 		Kind:    ErrNotFound,
 		Message: fmt.Sprintf(format, args...),
 		Cause:   ErrEntryNotFound,
+		Hint:    "Try: symvault list to browse entries, or symvault find <term> to search by keyword.",
 	}
 }
 

--- a/internal/errors/errors_test.go
+++ b/internal/errors/errors_test.go
@@ -3,6 +3,7 @@ package errors
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 )
 
@@ -187,5 +188,58 @@ func TestIsWriteError_NotFoundError(t *testing.T) {
 	err := NotFound("entry %q not found", "github")
 	if IsWriteError(err) {
 		t.Error("expected IsWriteError=false for NotFound error")
+	}
+}
+
+func TestNotFoundHasHint(t *testing.T) {
+	err := NotFound("entry not found: foo")
+	if err.Hint == "" {
+		t.Error("expected NotFound error to have a hint")
+	}
+	if !strings.Contains(err.Hint, "symvault list") && !strings.Contains(err.Hint, "symvault find") {
+		t.Errorf("expected hint to mention symvault list or symvault find, got: %s", err.Hint)
+	}
+}
+
+func TestWithHint(t *testing.T) {
+	err := NewCLIError(ExitGeneralError, "something went wrong", nil)
+	err.WithHint("Run symvault doctor to check your configuration.")
+
+	if err.Hint != "Run symvault doctor to check your configuration." {
+		t.Errorf("hint = %q, want specific hint", err.Hint)
+	}
+}
+
+func TestHintForError(t *testing.T) {
+	err := NotFound("entry not found: foo")
+	hint := HintForError(err)
+	if hint == "" {
+		t.Error("expected HintForError to return a hint for NotFound")
+	}
+}
+
+func TestHintForError_NoHint(t *testing.T) {
+	err := fmt.Errorf("plain error")
+	hint := HintForError(err)
+	if hint != "" {
+		t.Errorf("expected empty hint for plain error, got: %s", hint)
+	}
+}
+
+func TestCLIErrorWithoutHint(t *testing.T) {
+	err := NewCLIError(ExitLocked, "vault is locked", nil)
+	hint := HintForError(err)
+	if hint != "" {
+		t.Errorf("expected empty hint for CLIError without hint, got: %s", hint)
+	}
+}
+
+func TestCLIErrorWithHintTakesPrecedence(t *testing.T) {
+	err := NewCLIError(ExitPermissionDenied, "access denied", nil)
+	err.WithHint("Check your agent's token scope: symvault mcp token list")
+
+	hint := HintForError(err)
+	if hint != "Check your agent's token scope: symvault mcp token list" {
+		t.Errorf("hint = %q, want token scope hint", hint)
 	}
 }

--- a/internal/mcp/auth/token.go
+++ b/internal/mcp/auth/token.go
@@ -191,15 +191,30 @@ type TokenRegistry struct {
 	entries     map[string]*ScopedToken // keyed by token hash
 	stopFn      func()                  // stops the background cleanup goroutine
 	watchStopFn func()                  // stops the file watcher goroutine
+
+	revokedRetention time.Duration // how long to keep revoked tokens before removal
 }
+
+// DefaultRevokedTokenRetention is the default retention period for revoked
+// tokens before they are purged from the registry.
+const DefaultRevokedTokenRetention = 30 * 24 * time.Hour
 
 // NewTokenRegistry creates a TokenRegistry that loads/saves from the given
 // file path. The caller must call Load() to populate the registry from disk.
 func NewTokenRegistry(path string) *TokenRegistry {
 	return &TokenRegistry{
-		path:    path,
-		entries: make(map[string]*ScopedToken),
+		path:             path,
+		entries:          make(map[string]*ScopedToken),
+		revokedRetention: DefaultRevokedTokenRetention,
 	}
+}
+
+// SetRevokedRetention overrides the retention period for revoked tokens.
+// A zero or negative duration disables automatic cleanup of revoked tokens.
+func (r *TokenRegistry) SetRevokedRetention(d time.Duration) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.revokedRetention = d
 }
 
 // Load reads the JSON registry file from disk and populates the in-memory
@@ -522,16 +537,47 @@ func (r *TokenRegistry) StartCleanup(ctx context.Context, interval time.Duration
 	return r.stopFn
 }
 
-// cleanupOnce performs a single sweep that removes expired tokens.
-func (r *TokenRegistry) cleanupOnce() {
+// CleanupResult reports the outcome of a token registry cleanup pass.
+type CleanupResult struct {
+	ExpiredRemoved    int
+	RevokedRemoved    int
+	RemovedIDs        []string
+}
+
+// Cleanup performs a single sweep that removes expired tokens and revoked
+// tokens past their retention period. It returns counts and IDs of removed
+// tokens for audit logging by the caller.
+func (r *TokenRegistry) Cleanup() CleanupResult {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
+	var result CleanupResult
+	retention := r.revokedRetention
+	now := time.Now()
+
 	for hash, t := range r.entries {
 		if t.IsExpired() {
+			result.ExpiredRemoved++
+			result.RemovedIDs = append(result.RemovedIDs, t.ID)
 			delete(r.entries, hash)
+			continue
+		}
+		if t.Revoked && retention > 0 && t.RevokedAt != nil {
+			if now.Sub(*t.RevokedAt) >= retention {
+				result.RevokedRemoved++
+				result.RemovedIDs = append(result.RemovedIDs, t.ID)
+				delete(r.entries, hash)
+			}
 		}
 	}
+
+	return result
+}
+
+// cleanupOnce performs a single sweep that removes expired and long-revoked
+// tokens. It is called by the background cleanup goroutine.
+func (r *TokenRegistry) cleanupOnce() {
+	r.Cleanup()
 }
 
 // StartFileWatcher begins polling the registry file's modification time at the

--- a/internal/mcp/auth/token.go
+++ b/internal/mcp/auth/token.go
@@ -539,9 +539,9 @@ func (r *TokenRegistry) StartCleanup(ctx context.Context, interval time.Duration
 
 // CleanupResult reports the outcome of a token registry cleanup pass.
 type CleanupResult struct {
-	ExpiredRemoved    int
-	RevokedRemoved    int
-	RemovedIDs        []string
+	ExpiredRemoved int
+	RevokedRemoved int
+	RemovedIDs     []string
 }
 
 // Cleanup performs a single sweep that removes expired tokens and revoked

--- a/internal/mcp/auth/token_test.go
+++ b/internal/mcp/auth/token_test.go
@@ -1454,3 +1454,167 @@ func TestLoadOrCreateToken_FileTokenIgnoresEnv_Symvault(t *testing.T) {
 		t.Fatalf("expected stderr warning, got %q", buf.String())
 	}
 }
+
+func TestTokenRegistry_RevokedTokenCleanupAfterRetention(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mcp-tokens.json")
+
+	reg := NewTokenRegistry(path)
+	reg.SetRevokedRetention(50 * time.Millisecond)
+
+	st, _, err := reg.Create("test-token", []string{"*"}, "", 1*time.Hour)
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	if !reg.Revoke(st.ID) {
+		t.Fatal("Revoke() failed")
+	}
+
+	result := reg.Cleanup()
+	if result.RevokedRemoved != 0 {
+		t.Fatalf("RevokedRemoved = %d, want 0 (retention not yet elapsed)", result.RevokedRemoved)
+	}
+
+	time.Sleep(150 * time.Millisecond)
+
+	result = reg.Cleanup()
+	if result.RevokedRemoved != 1 {
+		t.Fatalf("RevokedRemoved = %d, want 1", result.RevokedRemoved)
+	}
+	if len(result.RemovedIDs) != 1 || result.RemovedIDs[0] != st.ID {
+		t.Fatalf("RemovedIDs = %v, want [%s]", result.RemovedIDs, st.ID)
+	}
+}
+
+func TestTokenRegistry_ExpiredTokensCleanedUp(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mcp-tokens.json")
+
+	reg := NewTokenRegistry(path)
+
+	_, _, err := reg.Create("short-lived", []string{"*"}, "", 50*time.Millisecond)
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	_, _, err = reg.Create("persistent", []string{"*"}, "", 1*time.Hour)
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	time.Sleep(150 * time.Millisecond)
+
+	result := reg.Cleanup()
+	if result.ExpiredRemoved != 1 {
+		t.Fatalf("ExpiredRemoved = %d, want 1", result.ExpiredRemoved)
+	}
+	if len(result.RemovedIDs) != 1 {
+		t.Fatalf("len(RemovedIDs) = %d, want 1", len(result.RemovedIDs))
+	}
+}
+
+func TestTokenRegistry_ZeroRetentionDisablesRevokedCleanup(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mcp-tokens.json")
+
+	reg := NewTokenRegistry(path)
+	reg.SetRevokedRetention(0)
+
+	st, _, err := reg.Create("test-token", []string{"*"}, "", 1*time.Hour)
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	if !reg.Revoke(st.ID) {
+		t.Fatal("Revoke() failed")
+	}
+
+	result := reg.Cleanup()
+	if result.RevokedRemoved != 0 {
+		t.Fatalf("RevokedRemoved = %d, want 0 (retention disabled)", result.RevokedRemoved)
+	}
+}
+
+func TestTokenRegistry_DefaultRevokedRetention(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mcp-tokens.json")
+
+	reg := NewTokenRegistry(path)
+
+	reg.mu.RLock()
+	retention := reg.revokedRetention
+	reg.mu.RUnlock()
+
+	if retention != DefaultRevokedTokenRetention {
+		t.Fatalf("default retention = %v, want %v", retention, DefaultRevokedTokenRetention)
+	}
+}
+
+func TestTokenRegistry_BackgroundCleanupRemovesRevoked(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mcp-tokens.json")
+
+	reg := NewTokenRegistry(path)
+	reg.SetRevokedRetention(50 * time.Millisecond)
+
+	_, _, err := reg.Create("short-lived", []string{"*"}, "", 100*time.Millisecond)
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	st, _, err := reg.Create("revoked-then-cleaned", []string{"*"}, "", 1*time.Hour)
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	if !reg.Revoke(st.ID) {
+		t.Fatal("Revoke() failed")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	stop := reg.StartCleanup(ctx, 50*time.Millisecond)
+	defer stop()
+
+	time.Sleep(300 * time.Millisecond)
+
+	reg.mu.RLock()
+	count := len(reg.entries)
+	reg.mu.RUnlock()
+
+	if count != 0 {
+		t.Errorf("entries after cleanup = %d, want 0 (both expired and revoked removed)", count)
+	}
+}
+
+func TestTokenRegistry_CleanupReportsBothTypes(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mcp-tokens.json")
+
+	reg := NewTokenRegistry(path)
+	reg.SetRevokedRetention(50 * time.Millisecond)
+
+	_, _, err := reg.Create("expired", []string{"*"}, "", 50*time.Millisecond)
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	st, _, err := reg.Create("revoked", []string{"*"}, "", 1*time.Hour)
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	if !reg.Revoke(st.ID) {
+		t.Fatal("Revoke() failed")
+	}
+
+	time.Sleep(150 * time.Millisecond)
+
+	result := reg.Cleanup()
+	if result.ExpiredRemoved != 1 {
+		t.Fatalf("ExpiredRemoved = %d, want 1", result.ExpiredRemoved)
+	}
+	if result.RevokedRemoved != 1 {
+		t.Fatalf("RevokedRemoved = %d, want 1", result.RevokedRemoved)
+	}
+	if len(result.RemovedIDs) != 2 {
+		t.Fatalf("len(RemovedIDs) = %d, want 2", len(result.RemovedIDs))
+	}
+}

--- a/internal/mcp/server/protocol_test.go
+++ b/internal/mcp/server/protocol_test.go
@@ -368,7 +368,7 @@ func TestProtocolHandler_Close_NilTools(t *testing.T) {
 	}
 }
 
-func TestProtocolHandler_Close_Error(t *testing.T) {
+func TestProtocolHandler_Close_Idempotent(t *testing.T) {
 	srv := newTestServer(t, config.AgentProfile{
 		Name:         "test",
 		AllowedPaths: []string{"*"},
@@ -379,9 +379,10 @@ func TestProtocolHandler_Close_Error(t *testing.T) {
 
 	_ = srv.auditLog.Close()
 
+	// Logger.Close is idempotent — a second close must not error.
 	err := handler.Close()
-	if err == nil {
-		t.Fatal("Close() expected error, got nil")
+	if err != nil {
+		t.Fatalf("Close() after audit log closed returned error: %v", err)
 	}
 }
 

--- a/internal/mcp/serverbootstrap/http.go
+++ b/internal/mcp/serverbootstrap/http.go
@@ -89,6 +89,19 @@ func RunHTTPServerOnListener(ctx context.Context, listener net.Listener, v *vaul
 	}
 	defer func() { _ = authAuditLog.Close() }()
 
+	if registry != nil {
+		result := registry.Cleanup()
+		totalRemoved := result.ExpiredRemoved + result.RevokedRemoved
+		if totalRemoved > 0 {
+			_ = authAuditLog.LogEntry(audit.LogEntry{
+				Agent:  "system",
+				Action: "token_cleanup",
+				Reason: fmt.Sprintf("removed %d expired, %d revoked (%d total)", result.ExpiredRemoved, result.RevokedRemoved, totalRemoved),
+				OK:     true,
+			})
+		}
+	}
+
 	rateLimit := 60
 	var trustedProxyIPs []string
 	if v != nil && v.Config != nil && v.Config.MCP != nil {

--- a/internal/vault/search.go
+++ b/internal/vault/search.go
@@ -412,9 +412,13 @@ func CurrentSearchIdentity() *age.X25519Identity {
 
 // SearchWorkerCount returns the number of concurrent decryption workers
 // to use for search/listing operations. When configured > 0, that value is
-// used. Otherwise it auto-scales to min(runtime.NumCPU(), 8).
+// used (capped at 64 to prevent resource exhaustion). Otherwise it
+// auto-scales to min(runtime.NumCPU(), 8).
 func SearchWorkerCount(configured int) int {
 	if configured > 0 {
+		if configured > 64 {
+			return 64
+		}
 		return configured
 	}
 	cpus := runtime.NumCPU()

--- a/internal/vault/search_test.go
+++ b/internal/vault/search_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"testing"
 	"time"
 
@@ -705,5 +706,52 @@ func TestIsRedactedField(t *testing.T) {
 				t.Errorf("isRedactedField(%q, %v) = %v, want %v", tt.field, tt.patterns, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestSearchWorkerCount_AutoScale(t *testing.T) {
+	workers := SearchWorkerCount(0)
+	cpus := runtime.NumCPU()
+	if cpus > 8 {
+		if workers != 8 {
+			t.Errorf("SearchWorkerCount(0) = %d, want 8 (capped at 8 with %d CPUs)", workers, cpus)
+		}
+	} else {
+		if workers < 1 || workers > 8 {
+			t.Errorf("SearchWorkerCount(0) = %d, want between 1 and 8", workers)
+		}
+	}
+}
+
+func TestSearchWorkerCount_ConfiguredValue(t *testing.T) {
+	workers := SearchWorkerCount(12)
+	if workers != 12 {
+		t.Errorf("SearchWorkerCount(12) = %d, want 12", workers)
+	}
+}
+
+func TestSearchWorkerCount_CappedAtMaximum(t *testing.T) {
+	workers := SearchWorkerCount(99999)
+	if workers != 64 {
+		t.Errorf("SearchWorkerCount(99999) = %d, want 64 (capped)", workers)
+	}
+}
+
+func TestSearchWorkerCount_BoundaryValues(t *testing.T) {
+	if w := SearchWorkerCount(1); w != 1 {
+		t.Errorf("SearchWorkerCount(1) = %d, want 1", w)
+	}
+	if w := SearchWorkerCount(64); w != 64 {
+		t.Errorf("SearchWorkerCount(64) = %d, want 64", w)
+	}
+	if w := SearchWorkerCount(65); w != 64 {
+		t.Errorf("SearchWorkerCount(65) = %d, want 64 (capped)", w)
+	}
+}
+
+func TestSearchWorkerCount_NegativeDefault(t *testing.T) {
+	workers := SearchWorkerCount(-1)
+	if workers < 1 {
+		t.Errorf("SearchWorkerCount(-1) = %d, want >= 1", workers)
 	}
 }


### PR DESCRIPTION
Bundles fixes for multiple open issues. The list below grows as commits land; every linked issue will close automatically on merge.

Milestone: v4.0.1

<!-- closes-list-start -->
- Closes #280 Audit log HMAC key stored on disk instead of OS keyring
- Closes #281 MCP token registry lacks automatic cleanup of expired tokens
- Closes #282 Session passphrase intermediate copies may persist in go-keyring buffers
- Closes #283 CLI error messages lack actionable remediation hints for common failures
- Closes #287 Search worker count is hardcoded to 4 with no tuning option
- Closes #288 Audit log writes are synchronous and unbuffered
<!-- closes-list-end -->