### PR TITLE
feat(migration): add legacy Touch ID keychain and passphrase env fallback

### DIFF
--- a/cmd/auth/auth.go
+++ b/cmd/auth/auth.go
@@ -4,7 +4,6 @@ package auth
 import (
 	"context"
 	"fmt"
-	"os"
 	"path/filepath"
 
 	cli "github.com/danieljustus/symaira-vault/internal/cli"
@@ -13,6 +12,7 @@ import (
 
 	configpkg "github.com/danieljustus/symaira-vault/internal/config"
 	cryptopkg "github.com/danieljustus/symaira-vault/internal/crypto"
+	"github.com/danieljustus/symaira-vault/internal/envutil"
 	"github.com/danieljustus/symaira-vault/internal/session"
 	"github.com/danieljustus/symaira-vault/internal/ui/cliout"
 	vaultpkg "github.com/danieljustus/symaira-vault/internal/vault"
@@ -158,9 +158,9 @@ func passphraseForBiometricSetup(vaultDir string) ([]byte, error) {
 		return passphrase, nil
 	}
 
-	if envPass := os.Getenv("OPENPASS_PASSPHRASE"); envPass != "" {
+	if envPass := envutil.Getenv("SYMVAULT_PASSPHRASE", "OPENPASS_PASSPHRASE"); envPass != "" {
 		passphrase := []byte(envPass)
-		_ = os.Unsetenv("OPENPASS_PASSPHRASE")
+		envutil.Unsetenv("SYMVAULT_PASSPHRASE", "OPENPASS_PASSPHRASE")
 		if _, err := vaultpkg.OpenWithPassphrase(vaultDir, passphrase); err != nil {
 			return nil, fmt.Errorf("open vault: %w", err)
 		}

--- a/cmd/auth_test.go
+++ b/cmd/auth_test.go
@@ -26,6 +26,21 @@ func (c cmdMockBiometricStore) Load(context.Context, string) ([]byte, error) {
 }
 func (c cmdMockBiometricStore) Delete(string) error { return nil }
 
+type cmdRecordingBiometricStore struct {
+	available bool
+	saved     []byte
+}
+
+func (c *cmdRecordingBiometricStore) IsAvailable() bool { return c.available }
+func (c *cmdRecordingBiometricStore) Save(_ context.Context, _ string, passphrase []byte) error {
+	c.saved = append([]byte(nil), passphrase...)
+	return nil
+}
+func (c *cmdRecordingBiometricStore) Load(context.Context, string) ([]byte, error) {
+	return nil, session.ErrBiometricNotConfigured
+}
+func (c *cmdRecordingBiometricStore) Delete(string) error { return nil }
+
 func TestAuthSetPassphraseUpdatesConfig(t *testing.T) {
 	vaultDir, _ := initVault(t)
 	defer setupVaultFlag(t, vaultDir)()
@@ -60,6 +75,32 @@ func TestAuthSetPassphraseUpdatesConfig(t *testing.T) {
 	}
 	if got := loaded.EffectiveAuthMethod(); got != configpkg.AuthMethodPassphrase {
 		t.Fatalf("auth method = %q, want passphrase", got)
+	}
+}
+
+func TestAuthSetTouchIDUsesSymvaultPassphraseEnv(t *testing.T) {
+	vaultDir, passphrase := initVault(t)
+	defer setupVaultFlag(t, vaultDir)()
+
+	store := &cmdRecordingBiometricStore{available: true}
+	oldStore := session.DefaultBiometricPassphraseStore()
+	session.SetBiometricPassphraseStore(store)
+	t.Cleanup(func() { session.SetBiometricPassphraseStore(oldStore) })
+	t.Setenv("SYMVAULT_PASSPHRASE", string(passphrase))
+
+	if err := auth.AuthSetCmd.RunE(auth.AuthSetCmd, []string{"touchid"}); err != nil {
+		t.Fatalf("auth set touchid error = %v", err)
+	}
+	if string(store.saved) != string(passphrase) {
+		t.Fatalf("saved passphrase = %q, want %q", store.saved, passphrase)
+	}
+
+	loaded, err := configpkg.Load(filepath.Join(vaultDir, "config.yaml"))
+	if err != nil {
+		t.Fatalf("Load() after auth set error = %v", err)
+	}
+	if got := loaded.EffectiveAuthMethod(); got != configpkg.AuthMethodTouchID {
+		t.Fatalf("auth method = %q, want touchid", got)
 	}
 }
 

--- a/docs/MIGRATION-RENAME.md
+++ b/docs/MIGRATION-RENAME.md
@@ -17,8 +17,9 @@ project and CLI binary names change.
 | **Homebrew formula** | `openpass` | `symvault` |
 | **Scoop package** | `openpass` | `symvault` |
 
-**Your vault data stays the same.** The rename is cosmetic; no vault migration is
-required.
+**Your vault data stays the same.** The encrypted vault format is unchanged.
+Local integrations such as shell commands, service files, environment variables,
+and macOS Touch ID Keychain entries may still need rename-aware handling.
 
 ---
 
@@ -204,6 +205,7 @@ The following environment variables have been renamed:
 | `OPENPASS_VAULT` | `SYMVAULT_VAULT` |
 | `OPENPASS_CONFIG` | `SYMVAULT_CONFIG` |
 | `OPENPASS_AGENT` | `SYMVAULT_AGENT` |
+| `OPENPASS_PASSPHRASE` | `SYMVAULT_PASSPHRASE` |
 
 **Backward compatibility:** If `SYMVAULT_VAULT` is not set, Symaira Vault still
 falls back to `OPENPASS_VAULT`. Deprecated `OPENPASS_*` variables emit a warning
@@ -236,6 +238,40 @@ export SYMVAULT_VAULT="$HOME/.symvault"
 # 4. Add to your shell profile
 echo 'export SYMVAULT_VAULT="$HOME/.symvault"' >> ~/.zshrc
 ```
+
+## Touch ID / macOS Keychain
+
+OpenPass stored Touch ID unlock passphrases in macOS Keychain under service
+names derived from the old binary name and vault path:
+
+| Case | Keychain service |
+|---|---|
+| Old OpenPass | `openpass-biometric:<vault-path>` |
+| New Symaira Vault | `symvault-biometric:<vault-path>` |
+
+This matters if the vault was moved or copied from `~/.openpass` to
+`~/.symvault`: the encrypted vault files may be identical, but the Keychain item
+can still point at `openpass-biometric:$HOME/.openpass`.
+
+Current Symaira Vault builds handle this automatically on macOS:
+
+- `symvault unlock` first tries the current `symvault-biometric:<vault-path>`
+  item.
+- If that is missing, it tries legacy `openpass-biometric:<vault-path>` items.
+- For the default directory rename, it also checks both service names for
+  `$HOME/.openpass` when the active vault is `$HOME/.symvault`.
+- After the passphrase successfully opens the active vault, Symaira Vault writes
+  the canonical `symvault-biometric:<active-vault>` item so future unlocks no
+  longer depend on the legacy entry.
+- `symvault auth set passphrase` removes biometric entries for the active vault
+  path under both the current and legacy service names. It does not remove
+  Keychain items for a different vault path.
+
+If both `~/.openpass` and `~/.symvault` exist but contain different vaults,
+`~/.symvault` is selected by default. A legacy Touch ID passphrase from
+`~/.openpass` will only be kept if it actually decrypts the selected vault.
+Otherwise unlock fails safely and you must choose the right vault with `--vault`
+or `SYMVAULT_VAULT`.
 
 ---
 

--- a/internal/cli/unlock.go
+++ b/internal/cli/unlock.go
@@ -40,7 +40,7 @@ func UnlockVaultWithTTL(vaultDir string, interactive bool, ttlOverride time.Dura
 
 	cfg := loadVaultConfigForUnlock(vaultDir)
 
-	passphrase, passphraseFromEnv, passphraseFromBiometric, err := resolveUnlockPassphrase(vaultDir, interactive, cfg)
+	passphrase, passphraseFromEnv, _, err := resolveUnlockPassphrase(vaultDir, interactive, cfg)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -63,7 +63,7 @@ func UnlockVaultWithTTL(vaultDir string, interactive bool, ttlOverride time.Dura
 			_ = SessionSaveIdentity(vaultDir, v.Identity.String(), ttl)
 		}
 	}
-	if cfg.EffectiveAuthMethod() == configpkg.AuthMethodTouchID && !passphraseFromBiometric && (!passphraseFromEnv || cacheEnvPassphrase) {
+	if cfg.EffectiveAuthMethod() == configpkg.AuthMethodTouchID && (!passphraseFromEnv || cacheEnvPassphrase) {
 		if err := SessionSaveBiometric(context.Background(), vaultDir, passphrase); err != nil && interactive {
 			cliout.Warnf("Warning: could not update Touch ID unlock: %v", err)
 		}

--- a/internal/cli/unlock_test.go
+++ b/internal/cli/unlock_test.go
@@ -1,0 +1,123 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	configpkg "github.com/danieljustus/symaira-vault/internal/config"
+	"github.com/danieljustus/symaira-vault/internal/session"
+	vaultpkg "github.com/danieljustus/symaira-vault/internal/vault"
+)
+
+func TestUnlockVaultWithTTLRefreshesTouchIDItemAfterBiometricUnlock(t *testing.T) {
+	vaultDir := t.TempDir()
+	passphrase := []byte("test-passphrase")
+	cfg := configpkg.Default()
+	if err := cfg.SetAuthMethod(configpkg.AuthMethodTouchID); err != nil {
+		t.Fatalf("SetAuthMethod() error = %v", err)
+	}
+	if _, err := vaultpkg.InitWithPassphrase(vaultDir, passphrase, cfg); err != nil {
+		t.Fatalf("InitWithPassphrase() error = %v", err)
+	}
+	if err := cfg.SaveTo(filepath.Join(vaultDir, "config.yaml")); err != nil {
+		t.Fatalf("SaveTo() error = %v", err)
+	}
+
+	oldLoadPassphrase := SessionLoadPassphrase
+	oldSavePassphrase := SessionSavePassphrase
+	oldLoadBiometric := SessionLoadBiometric
+	oldSaveBiometric := SessionSaveBiometric
+	oldLoadIdentity := SessionLoadIdentity
+	oldSaveIdentity := SessionSaveIdentity
+	t.Cleanup(func() {
+		SessionLoadPassphrase = oldLoadPassphrase
+		SessionSavePassphrase = oldSavePassphrase
+		SessionLoadBiometric = oldLoadBiometric
+		SessionSaveBiometric = oldSaveBiometric
+		SessionLoadIdentity = oldLoadIdentity
+		SessionSaveIdentity = oldSaveIdentity
+	})
+
+	SessionLoadIdentity = func(string) (string, error) { return "", errors.New("miss") }
+	SessionLoadPassphrase = func(string) ([]byte, error) { return nil, errors.New("miss") }
+	SessionSavePassphrase = func(string, []byte, time.Duration) error { return nil }
+	SessionSaveIdentity = func(string, string, time.Duration) error { return nil }
+	SessionLoadBiometric = func(context.Context, string) ([]byte, error) {
+		return append([]byte(nil), passphrase...), nil
+	}
+	var savedVaultDir string
+	var savedPassphrase []byte
+	SessionSaveBiometric = func(_ context.Context, dir string, p []byte) error {
+		savedVaultDir = dir
+		savedPassphrase = append([]byte(nil), p...)
+		return nil
+	}
+
+	v, _, err := UnlockVaultWithTTL(vaultDir, false, 0, false)
+	if err != nil {
+		t.Fatalf("UnlockVaultWithTTL() error = %v", err)
+	}
+	if v == nil {
+		t.Fatal("UnlockVaultWithTTL() returned nil vault")
+	}
+	if savedVaultDir != vaultDir {
+		t.Fatalf("biometric vault dir = %q, want %q", savedVaultDir, vaultDir)
+	}
+	if string(savedPassphrase) != string(passphrase) {
+		t.Fatalf("biometric passphrase = %q, want %q", savedPassphrase, passphrase)
+	}
+}
+
+func TestUnlockVaultWithTTLDoesNotSaveTouchIDItemForUncachedEnvPassphrase(t *testing.T) {
+	vaultDir := t.TempDir()
+	passphrase := []byte("test-passphrase")
+	cfg := configpkg.Default()
+	if err := cfg.SetAuthMethod(configpkg.AuthMethodTouchID); err != nil {
+		t.Fatalf("SetAuthMethod() error = %v", err)
+	}
+	if _, err := vaultpkg.InitWithPassphrase(vaultDir, passphrase, cfg); err != nil {
+		t.Fatalf("InitWithPassphrase() error = %v", err)
+	}
+	if err := cfg.SaveTo(filepath.Join(vaultDir, "config.yaml")); err != nil {
+		t.Fatalf("SaveTo() error = %v", err)
+	}
+
+	oldLoadPassphrase := SessionLoadPassphrase
+	oldSavePassphrase := SessionSavePassphrase
+	oldLoadBiometric := SessionLoadBiometric
+	oldSaveBiometric := SessionSaveBiometric
+	oldLoadIdentity := SessionLoadIdentity
+	oldSaveIdentity := SessionSaveIdentity
+	t.Cleanup(func() {
+		SessionLoadPassphrase = oldLoadPassphrase
+		SessionSavePassphrase = oldSavePassphrase
+		SessionLoadBiometric = oldLoadBiometric
+		SessionSaveBiometric = oldSaveBiometric
+		SessionLoadIdentity = oldLoadIdentity
+		SessionSaveIdentity = oldSaveIdentity
+	})
+
+	SessionLoadIdentity = func(string) (string, error) { return "", errors.New("miss") }
+	SessionLoadPassphrase = func(string) ([]byte, error) { return nil, errors.New("miss") }
+	SessionLoadBiometric = func(context.Context, string) ([]byte, error) {
+		return nil, session.ErrBiometricNotConfigured
+	}
+	SessionSavePassphrase = func(string, []byte, time.Duration) error { return nil }
+	SessionSaveIdentity = func(string, string, time.Duration) error { return nil }
+	SessionSaveBiometric = func(context.Context, string, []byte) error {
+		t.Fatal("SessionSaveBiometric should not be called for uncached env passphrase")
+		return nil
+	}
+	t.Setenv("SYMVAULT_PASSPHRASE", string(passphrase))
+
+	v, _, err := UnlockVaultWithTTL(vaultDir, false, 0, false)
+	if err != nil {
+		t.Fatalf("UnlockVaultWithTTL() error = %v", err)
+	}
+	if v == nil {
+		t.Fatal("UnlockVaultWithTTL() returned nil vault")
+	}
+}

--- a/internal/session/touchid_darwin.go
+++ b/internal/session/touchid_darwin.go
@@ -209,7 +209,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path/filepath"
 	"unsafe"
+
+	configpkg "github.com/danieljustus/symaira-vault/internal/config"
 )
 
 var errTouchIDNotAvailable = errors.New("touch id not available")
@@ -256,8 +259,64 @@ func newTouchIDAuthenticator() BiometricAuthenticator {
 
 const biometricAccount = "passphrase"
 
+const (
+	currentBiometricServicePrefix = "symvault-biometric:"
+	legacyBiometricServicePrefix  = "openpass-biometric:"
+)
+
 func biometricServiceName(vaultDir string) string {
-	return "symvault-biometric:" + vaultDir
+	return currentBiometricServicePrefix + vaultDir
+}
+
+func biometricServiceNames(vaultDir string) []string {
+	candidates := []string{
+		currentBiometricServicePrefix + vaultDir,
+		legacyBiometricServicePrefix + vaultDir,
+	}
+
+	if legacyDir := legacyDefaultVaultDir(vaultDir); legacyDir != "" && legacyDir != vaultDir {
+		candidates = append(candidates,
+			currentBiometricServicePrefix+legacyDir,
+			legacyBiometricServicePrefix+legacyDir,
+		)
+	}
+
+	return uniqueServices(candidates...)
+}
+
+func biometricDeleteServiceNames(vaultDir string) []string {
+	return uniqueServices(
+		currentBiometricServicePrefix+vaultDir,
+		legacyBiometricServicePrefix+vaultDir,
+	)
+}
+
+func uniqueServices(candidates ...string) []string {
+	var services []string
+	for _, service := range candidates {
+		if service == "" {
+			continue
+		}
+		exists := false
+		for _, existing := range services {
+			if existing == service {
+				exists = true
+				break
+			}
+		}
+		if !exists {
+			services = append(services, service)
+		}
+	}
+	return services
+}
+
+func legacyDefaultVaultDir(vaultDir string) string {
+	clean := filepath.Clean(vaultDir)
+	if filepath.Base(clean) != configpkg.DefaultVaultSubdir {
+		return ""
+	}
+	return filepath.Join(filepath.Dir(clean), configpkg.LegacyDefaultVaultSubdir)
 }
 
 type touchIDPassphraseStore struct{}
@@ -295,7 +354,26 @@ func (t *touchIDPassphraseStore) Load(ctx context.Context, vaultDir string) ([]b
 		return nil, ErrBiometricNotAvailable
 	}
 
-	service := C.CString(biometricServiceName(vaultDir))
+	var lastNotConfigured error
+	for _, serviceName := range biometricServiceNames(vaultDir) {
+		passphrase, err := t.loadFromService(serviceName)
+		if err == nil {
+			return passphrase, nil
+		}
+		if errors.Is(err, ErrBiometricNotConfigured) {
+			lastNotConfigured = err
+			continue
+		}
+		return nil, err
+	}
+	if lastNotConfigured != nil {
+		return nil, lastNotConfigured
+	}
+	return nil, ErrBiometricNotConfigured
+}
+
+func (t *touchIDPassphraseStore) loadFromService(serviceName string) ([]byte, error) {
+	service := C.CString(serviceName)
 	account := C.CString(biometricAccount)
 	reason := C.CString("Unlock Symaira Vault vault")
 	defer C.free(unsafe.Pointer(service))
@@ -319,7 +397,17 @@ func (t *touchIDPassphraseStore) Load(ctx context.Context, vaultDir string) ([]b
 }
 
 func (t *touchIDPassphraseStore) Delete(vaultDir string) error {
-	service := C.CString(biometricServiceName(vaultDir))
+	var firstErr error
+	for _, serviceName := range biometricDeleteServiceNames(vaultDir) {
+		if err := t.deleteFromService(serviceName); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+func (t *touchIDPassphraseStore) deleteFromService(serviceName string) error {
+	service := C.CString(serviceName)
 	account := C.CString(biometricAccount)
 	defer C.free(unsafe.Pointer(service))
 	defer C.free(unsafe.Pointer(account))

--- a/internal/session/touchid_test.go
+++ b/internal/session/touchid_test.go
@@ -4,6 +4,7 @@ package session
 
 import (
 	"context"
+	"reflect"
 	"testing"
 	"time"
 )
@@ -14,6 +15,44 @@ func TestBiometricServiceName(t *testing.T) {
 	want := "symvault-biometric:/home/user/.symvault"
 	if got != want {
 		t.Errorf("biometricServiceName(%q) = %q, want %q", vaultDir, got, want)
+	}
+}
+
+func TestBiometricServiceNamesIncludeOpenPassFallbacks(t *testing.T) {
+	vaultDir := "/Users/alice/.symvault"
+	got := biometricServiceNames(vaultDir)
+	want := []string{
+		"symvault-biometric:/Users/alice/.symvault",
+		"openpass-biometric:/Users/alice/.symvault",
+		"symvault-biometric:/Users/alice/.openpass",
+		"openpass-biometric:/Users/alice/.openpass",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("biometricServiceNames(%q) = %#v, want %#v", vaultDir, got, want)
+	}
+}
+
+func TestBiometricServiceNamesKeepsCustomPathScoped(t *testing.T) {
+	vaultDir := "/Volumes/Safe/vault"
+	got := biometricServiceNames(vaultDir)
+	want := []string{
+		"symvault-biometric:/Volumes/Safe/vault",
+		"openpass-biometric:/Volumes/Safe/vault",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("biometricServiceNames(%q) = %#v, want %#v", vaultDir, got, want)
+	}
+}
+
+func TestBiometricDeleteServiceNamesDoNotCrossVaultPaths(t *testing.T) {
+	vaultDir := "/Users/alice/.symvault"
+	got := biometricDeleteServiceNames(vaultDir)
+	want := []string{
+		"symvault-biometric:/Users/alice/.symvault",
+		"openpass-biometric:/Users/alice/.symvault",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("biometricDeleteServiceNames(%q) = %#v, want %#v", vaultDir, got, want)
 	}
 }
 


### PR DESCRIPTION
Add backward-compatible handling for OpenPass → Symaira Vault rename:

- Try SYMVAULT_PASSPHRASE first, fall back to OPENPASS_PASSPHRASE
- Touch ID unlock tries legacy openpass-biometric:* keychain items
- After successful unlock, re-save under canonical symvault-biometric:*
- Delete both legacy and current service names when removing biometric
- Document Touch ID migration in MIGRATION-RENAME.md

This ensures users who set up Touch ID under OpenPass can still unlock
after renaming to Symaira Vault, without manual keychain migration.
