### PR TITLE
fix(mcp): replace Ed25519 with ECDSA P-256 for self-signed TLS certificates (#293)

### DIFF
--- a/internal/mcp/serverbootstrap/serverbootstrap_test.go
+++ b/internal/mcp/serverbootstrap/serverbootstrap_test.go
@@ -3,7 +3,11 @@ package serverbootstrap
 import (
 	"bytes"
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/x509"
 	"encoding/json"
+	"encoding/pem"
 	"errors"
 	"fmt"
 	"net"
@@ -1119,5 +1123,65 @@ func TestRunHTTPServer_OAuthClientPersistenceAcrossRestart(t *testing.T) {
 		if errBody["error"] == "invalid_client" {
 			t.Fatalf("client was not persisted across restart: %v", errBody)
 		}
+	}
+}
+
+func TestGenerateSelfSignedCert_ECDSA_P256(t *testing.T) {
+	tmpDir := t.TempDir()
+	certFile := filepath.Join(tmpDir, "test.crt")
+	keyFile := filepath.Join(tmpDir, "test.key")
+
+	if err := generateSelfSignedCert(certFile, keyFile); err != nil {
+		t.Fatalf("generateSelfSignedCert failed: %v", err)
+	}
+
+	certPEM, err := os.ReadFile(certFile)
+	if err != nil {
+		t.Fatalf("read cert file: %v", err)
+	}
+
+	block, _ := pem.Decode(certPEM)
+	if block == nil {
+		t.Fatal("failed to decode certificate PEM")
+	}
+
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatalf("parse certificate: %v", err)
+	}
+
+	if cert.PublicKeyAlgorithm != x509.ECDSA {
+		t.Errorf("expected public key algorithm ECDSA, got %v", cert.PublicKeyAlgorithm)
+	}
+
+	ecdsaPub, ok := cert.PublicKey.(*ecdsa.PublicKey)
+	if !ok {
+		t.Fatalf("expected *ecdsa.PublicKey, got %T", cert.PublicKey)
+	}
+
+	if ecdsaPub.Curve != elliptic.P256() {
+		t.Errorf("expected P-256 curve, got %v", ecdsaPub.Curve.Params().Name)
+	}
+
+	foundLocalhost := false
+	for _, dns := range cert.DNSNames {
+		if dns == "localhost" {
+			foundLocalhost = true
+			break
+		}
+	}
+	if !foundLocalhost {
+		t.Error("expected DNSNames to contain 'localhost'")
+	}
+
+	foundLoopback := false
+	for _, ip := range cert.IPAddresses {
+		if ip.Equal(net.ParseIP("127.0.0.1")) || ip.Equal(net.ParseIP("::1")) {
+			foundLoopback = true
+			break
+		}
+	}
+	if !foundLoopback {
+		t.Error("expected IPAddresses to contain loopback address")
 	}
 }

--- a/internal/mcp/serverbootstrap/tls.go
+++ b/internal/mcp/serverbootstrap/tls.go
@@ -2,7 +2,8 @@
 package serverbootstrap
 
 import (
-	"crypto/ed25519"
+	"crypto/ecdsa"
+	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/x509"
 	"crypto/x509/pkix"
@@ -46,14 +47,15 @@ func ensureTLSCert(vaultDir string) (certFile, keyFile string, err error) {
 	return certFile, keyFile, nil
 }
 
-// generateSelfSignedCert creates a self-signed Ed25519 certificate valid for
+// generateSelfSignedCert creates a self-signed ECDSA P-256 certificate valid for
 // loopback addresses and writes the PEM-encoded certificate and private key
 // to the specified paths.
 func generateSelfSignedCert(certFile, keyFile string) error {
-	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
-		return fmt.Errorf("generate ed25519 key: %w", err)
+		return fmt.Errorf("generate ecdsa key: %w", err)
 	}
+	pub := &priv.PublicKey
 
 	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
 	if err != nil {


### PR DESCRIPTION
Bundles fixes for multiple open issues. The list below grows as commits land; every linked issue will close automatically on merge.

<!-- closes-list-start -->
- Closes #293 MCP HTTP server fails on macOS due to Ed25519 self-signed TLS certificates
<!-- closes-list-end -->
