### PR TITLE
feat: add MCP tool security annotations (readOnlyHint, destructiveHint)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,6 +100,62 @@ jobs:
           go-version-input: '1.26.3'
           go-package: ./...
 
+  docker:
+    name: Docker
+    runs-on: ubuntu-latest
+    needs: [test, govulncheck, lint]
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/danieljustus/symvault
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
+        with:
+          subject-name: ghcr.io/danieljustus/symvault
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
+
   release:
     name: Release
     runs-on: macos-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -196,6 +196,55 @@ jobs:
         with:
           subject-path: 'dist/**'
 
+      - name: Upload MCPB bundles to release
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          gh release upload "$TAG" dist/*.mcpb --clobber
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  smoke-test-mcpb:
+    name: Smoke Test (MCPB Bundle)
+    runs-on: ubuntu-latest
+    needs: [release]
+    steps:
+      - name: Get release tag
+        id: tag
+        run: echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+
+      - name: Download MCPB bundle
+        run: |
+          TAG="${{ steps.tag.outputs.tag }}"
+          VERSION="${TAG#v}"
+          curl -fLO "https://github.com/danieljustus/symaira-vault/releases/download/${TAG}/symvault_${VERSION}_linux_amd64.mcpb"
+
+      - name: Verify MCPB structure
+        run: |
+          unzip -q symvault_*.mcpb -d mcpb-test
+          test -f mcpb-test/manifest.json
+          test -f mcpb-test/server/symvault
+          test -x mcpb-test/server/symvault
+
+      - name: Verify manifest.json
+        run: |
+          python3 -c "
+import json
+with open('mcpb-test/manifest.json') as f:
+    m = json.load(f)
+assert m['manifest_version'] == '0.3'
+assert m['name'] == 'symvault'
+assert m['server']['type'] == 'binary'
+assert m['server']['entry_point'] == 'server/symvault'
+assert m['server']['mcp_config']['args'] == ['serve', '--stdio']
+print('manifest.json validated')
+"
+
+      - name: Verify binary works
+        run: |
+          TAG="${{ steps.tag.outputs.tag }}"
+          VERSION="${TAG#v}"
+          ./mcpb-test/server/symvault version | grep -q "$VERSION"
+
   smoke-test-linux:
     name: Smoke Test (Linux amd64)
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,8 @@ CLAUDE.md
 
 # New binary name (post-rename)
 symvault
+
+# Docker runtime data (environment-specific)
+docker/certs/
+docker/caddy/data/
+docker/caddy/config/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,6 +27,9 @@ builds:
   - id: symvault-static
     main: .
     binary: symvault
+    hooks:
+      post:
+        - 'scripts/build-mcpb.sh --version "{{ .Version }}" --os "{{ .Os }}" --arch "{{ .Arch }}"'
     env:
       - CGO_ENABLED=0
       - GOWORK=off
@@ -51,6 +54,9 @@ builds:
   - id: symvault-darwin
     main: .
     binary: symvault
+    hooks:
+      post:
+        - 'scripts/build-mcpb.sh --version "{{ .Version }}" --os "{{ .Os }}" --arch "{{ .Arch }}"'
     env:
       - CGO_ENABLED=1
       - GOWORK=off

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,39 @@
-# Minimal Dockerfile for Symaira Vault
-# Uses scratch base for smallest possible image
-# Build context: repository root with goreleaser-built binary
+# Multi-stage build for Symvault Vault
+# Build stage
+FROM golang:1.26-alpine AS build
 
-FROM scratch
+RUN apk add --no-cache gcc musl-dev
 
-# Copy CA certificates for HTTPS operations (git push/pull)
-COPY --from=alpine:latest /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
 
-# Copy the binary built by GoReleaser
-COPY symaira /usr/bin/symaira
+COPY . .
+RUN CGO_ENABLED=0 go build -ldflags="-s -w" -o /usr/bin/symvault .
 
-# Symaira Vault stores vault data in ~/.symaira by default
-# In container context, users should mount a volume:
-#   docker run -v ~/.symaira:/root/.symaira ghcr.io/danieljustus/symaira:latest
-VOLUME ["/root/.symaira"]
+# Final stage
+FROM alpine:3.21
 
-ENTRYPOINT ["/usr/bin/symaira"]
+RUN apk add --no-cache ca-certificates tzdata
+
+RUN addgroup -S symvault && adduser -S symvault -G symvault -h /home/symvault
+
+COPY --from=build /usr/bin/symvault /usr/bin/symvault
+
+RUN mkdir -p /home/symvault/.symvault && chown -R symvault:symvault /home/symvault/.symvault
+
+USER symvault
+
+VOLUME ["/home/symvault/.symvault"]
+
+LABEL org.opencontainers.image.title="Symvault Vault"
+LABEL org.opencontainers.image.description="Modern CLI password manager with age encryption"
+LABEL org.opencontainers.image.url="https://github.com/danieljustus/symaira-vault"
+LABEL org.opencontainers.image.source="https://github.com/danieljustus/symaira-vault"
+LABEL org.opencontainers.image.licenses="MIT"
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+  CMD ["symvault", "version"]
+
+ENTRYPOINT ["symvault"]
 CMD ["--help"]

--- a/cmd/mcp/serve.go
+++ b/cmd/mcp/serve.go
@@ -39,4 +39,5 @@ func init() {
 	ServeCmd.Flags().String("bind", "127.0.0.1", "Bind address for HTTP server")
 	ServeCmd.Flags().String("tls-cert", "", "TLS certificate file path (overrides config)")
 	ServeCmd.Flags().String("tls-key", "", "TLS key file path (overrides config)")
+	ServeCmd.Flags().String("tls-ca", "", "CA certificate file path for mTLS client verification (enables mTLS)")
 }

--- a/cmd/mcp/serve_deps.go
+++ b/cmd/mcp/serve_deps.go
@@ -82,6 +82,10 @@ func runServe(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("read tls-key flag: %w", err)
 	}
+	tlsCAFlag, err := cmd.Flags().GetString("tls-ca")
+	if err != nil {
+		return fmt.Errorf("read tls-ca flag: %w", err)
+	}
 	if bind == "" {
 		return fmt.Errorf("--bind must not be empty; use '127.0.0.1' for localhost-only")
 	}
@@ -118,6 +122,10 @@ func runServe(cmd *cobra.Command, args []string) error {
 		}
 		if tlsKeyFlag != "" {
 			vault.Config.MCP.TLSKeyFile = tlsKeyFlag
+		}
+		if tlsCAFlag != "" {
+			vault.Config.MCP.TLSClientCAFile = tlsCAFlag
+			vault.Config.MCP.MTLSEnabled = true
 		}
 	}
 	if !stdioFlag && vault != nil && vault.Config != nil && vault.Config.MCP != nil && vault.Config.MCP.AllowInsecureBind {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,40 @@
+services:
+  caddy:
+    image: caddy:2-alpine
+    container_name: symvault-proxy
+    restart: unless-stopped
+    ports:
+      - "443:443"
+      - "80:80"
+    volumes:
+      - ./docker/caddy/Caddyfile:/etc/caddy/Caddyfile:ro
+      - ./docker/caddy/data:/data
+      - ./docker/caddy/config:/config
+      - ./docker/certs:/certs:ro
+    networks:
+      - symvault
+    depends_on:
+      - symvault
+
+  symvault:
+    image: ghcr.io/danieljustus/symvault:latest
+    container_name: symvault
+    restart: unless-stopped
+    expose:
+      - "8080"
+    volumes:
+      - vault_data:/home/symvault/.symvault
+      - ./docker/certs:/certs:ro
+    environment:
+      - SYMVAULT_VAULT=/home/symvault/.symvault
+      - SYMVAULT_SERVE_TLS_CERT=/certs/server.crt
+      - SYMVAULT_SERVE_TLS_KEY=/certs/server.key
+    networks:
+      - symvault
+
+volumes:
+  vault_data:
+
+networks:
+  symvault:
+    driver: bridge

--- a/docker/caddy/Caddyfile
+++ b/docker/caddy/Caddyfile
@@ -1,0 +1,17 @@
+# Symvault Vault HTTPS proxy
+# Update the domain below for production use
+symvault.example.com {
+    tls /certs/server.crt /certs/server.key
+
+    reverse_proxy symvault:8080 {
+        header_up Host {host}
+        header_up X-Real-IP {remote_host}
+        header_up X-Forwarded-For {remote_host}
+        header_up X-Forwarded-Proto {scheme}
+    }
+
+    log {
+        output file /data/access.log
+        format json
+    }
+}

--- a/docs/agent-integration.md
+++ b/docs/agent-integration.md
@@ -446,6 +446,69 @@ Use a two-phase migration:
 Avoid putting tokens, passphrases, and passwords in prompts. If that happens,
 consider them exposed and rotate them.
 
+## Perplexity AI Integration
+
+Symaira Vault provides two MCP tools for using Perplexity AI's search and question-answering
+capabilities directly from AI agents, without requiring an MCP server from Perplexity.
+
+### Tools
+
+- **`perplexity_search`**: Accepts a natural language query and returns synthesized search
+  results with citations from the web.
+- **`perplexity_ask`**: Accepts a question with optional vault entry context and returns an
+  AI-generated answer with citations.
+
+### Setup
+
+1. **Create a Perplexity API key** at [perplexity.ai/settings/api](https://www.perplexity.ai/settings/api).
+
+2. **Store the API key** using one of two methods:
+
+   **Option A: Vault entry (recommended)**:
+   ```bash
+   symvault set perplexity.credential --value "pplx-..."
+   symvault add perplexity --fields credential
+   ```
+
+   **Option B: Config file** (`~/.symvault/config.yaml`):
+   ```yaml
+   mcp:
+     perplexity:
+       api_key: "pplx-..."
+       base_url: "https://api.perplexity.ai"  # optional, default
+       rate_limit_per_min: 10                  # optional, default
+   ```
+
+3. **Verify the integration**:
+   ```bash
+   symvault mcp test perplexity_search --args '{"query": "latest AI developments"}'
+   ```
+
+### API Template
+
+Perplexity is also available as an `execute_api_request` template using the vault entry
+`perplexity`:
+
+```yaml
+template: perplexity
+endpoint: /chat/completions
+method: POST
+body: '{"model":"sonar-pro","messages":[{"role":"user","content":"your query"}]}'
+```
+
+### Configuration Reference
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `mcp.perplexity.api_key` | string | — | Perplexity API key (prefer vault entry) |
+| `mcp.perplexity.base_url` | string | `https://api.perplexity.ai` | Custom API endpoint |
+| `mcp.perplexity.rate_limit_per_min` | int | `10` | Max API requests per minute |
+
+### Audit Logging
+
+All Perplexity API calls are logged to the audit log with the action, query/question
+summary, model used, citation count, and success status.
+
 ## Metrics and Observability
 
 Symaira Vault exposes Prometheus metrics for monitoring MCP server health, request

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -228,3 +228,73 @@ rpm -q symvault
 # Alpine
 apk info symvault
 ```
+
+## Docker
+
+Symvault Vault is available as a Docker image on GitHub Container Registry:
+
+**Image:** `ghcr.io/danieljustus/symvault`
+
+### Quick Start
+
+```bash
+# Pull the image
+docker pull ghcr.io/danieljustus/symvault:latest
+
+# Run a one-off command
+docker run --rm -v "$HOME/.symvault:/home/symvault/.symvault" \
+  ghcr.io/danieljustus/symvault version
+
+# Initialize a new vault
+docker run --rm -it -v "$HOME/.symvault:/home/symvault/.symvault" \
+  ghcr.io/danieljustus/symvault init
+```
+
+### MCP HTTP Server with Docker
+
+Run the MCP HTTP server behind a TLS proxy:
+
+```bash
+# Start the MCP server
+docker run -d --name symvault \
+  -v "$HOME/.symvault:/home/symvault/.symvault" \
+  -p 8080:8080 \
+  ghcr.io/danieljustus/symvault serve --port 8080
+```
+
+### Remote Gateway Deployment
+
+For production deployments with HTTPS, use the provided `docker-compose.yml`:
+
+1. Clone the repository:
+   ```bash
+   git clone https://github.com/danieljustus/symaira-vault
+   cd symaira-vault
+   ```
+
+2. Place your TLS certificates in `docker/certs/`:
+   ```bash
+   cp /path/to/server.crt docker/certs/
+   cp /path/to/server.key docker/certs/
+   ```
+
+3. Update `docker/caddy/Caddyfile` with your domain.
+
+4. Start the services:
+   ```bash
+   docker compose up -d
+   ```
+
+The compose setup provisions:
+- **Caddy** — TLS termination and reverse proxy
+- **Symvault** — MCP server behind the proxy
+- **vault_data** — Persistent volume for vault data
+
+### Multi-Architecture
+
+The Docker image supports both `linux/amd64` and `linux/arm64`:
+
+```bash
+# Inspect the image for supported architectures
+docker manifest inspect ghcr.io/danieljustus/symvault:latest
+```

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -6,9 +6,9 @@ Symaira Vault is distributed through multiple channels to support different plat
 
 | OS | Arch | Formats |
 |----|------|---------|
-| Linux | amd64, arm64 | tar.gz, deb, rpm, apk |
-| macOS | amd64, arm64 | tar.gz, Homebrew |
-| Windows | amd64, arm64 | zip |
+| Linux | amd64, arm64 | tar.gz, deb, rpm, apk, mcpb |
+| macOS | amd64, arm64 | tar.gz, Homebrew, mcpb |
+| Windows | amd64 | zip |
 | FreeBSD | amd64, arm64 | tar.gz |
 | NixOS / Nix | amd64, arm64 | Nix flake |
 
@@ -29,6 +29,7 @@ Each release includes:
 - `symvault_<version>_<os>_<arch>.deb` (Debian/Ubuntu)
 - `symvault_<version>_<os>_<arch>.rpm` (Fedora/RHEL)
 - `symvault_<version>_<os>_<arch>.apk` (Alpine)
+- `symvault_<version>_<os>_<arch>.mcpb` (MCP Bundle for Claude Desktop)
 - `symaira-vault_<version>_checksums.txt` (SHA-256 checksums)
 
 ### Homebrew (macOS/Linux)
@@ -107,6 +108,23 @@ nix run github:danieljustus/symaira-vault
 ```
 
 > **Note:** Go module dependencies are pinned via `vendorHash` in `flake.nix`. If updating dependencies, run `go mod vendor && nix hash path --sri vendor/` and update the hash.
+
+### MCP Bundle (.mcpb)
+
+Symaira Vault can be installed as an MCP Bundle for Claude Desktop and other MCP clients that support the `.mcpb` format.
+
+```bash
+# Download the MCP bundle for your platform
+curl -fLO https://github.com/danieljustus/symaira-vault/releases/latest/download/symvault_<version>_<os>_<arch>.mcpb
+
+# Install (copy to Claude Desktop config directory)
+mkdir -p ~/Library/Application\ Support/Claude/mcp-bundles
+cp symvault_*.mcpb ~/Library/Application\ Support/Claude/mcp-bundles/
+```
+
+Available MCPB platforms: `darwin-amd64`, `darwin-arm64`, `linux-amd64`, `linux-arm64`.
+
+For detailed installation instructions, see [docs/mcpb-install.md](mcpb-install.md).
 
 ### Go Install
 

--- a/docs/mcp-api.md
+++ b/docs/mcp-api.md
@@ -39,6 +39,8 @@ Symaira Vault exposes a Model Context Protocol (MCP) server that allows AI agent
 | `get_entry` | Retrieve entry contents | No |
 | `get_entry_metadata` | Get entry metadata without sensitive data | No |
 | `find_entries` | Search entries by path | No |
+| `search` | Search vault entries by query (OpenAI Company Knowledge format) | No |
+| `fetch` | Fetch vault entry by path/id (OpenAI Company Knowledge format) | No |
 | `generate_password` | Generate secure passwords | No |
 | `generate_totp` | Generate TOTP codes | No |
 | `copy_to_clipboard` | Copy entry password to system clipboard (auto-clears) | No |
@@ -581,6 +583,127 @@ Search for entries by path substring.
   ]
 }
 ```
+
+---
+
+### search
+
+Search vault entries by query. Returns results in OpenAI Company Knowledge compatible format with both structured and text content.
+
+**Request**:
+
+```json
+{
+  "tool": "search",
+  "arguments": {
+    "query": "aws"
+  }
+}
+```
+
+**Parameters**:
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `query` | string | Yes | Search query to match against entry paths and field values |
+
+**Response**:
+
+The response includes both `structuredContent` and `content` fields simultaneously:
+
+```json
+{
+  "structuredContent": {
+    "results": [
+      {
+        "id": "work/aws",
+        "title": "aws",
+        "url": "symvault://entry/work/aws"
+      },
+      {
+        "id": "work/aws-staging",
+        "title": "aws-staging",
+        "url": "symvault://entry/work/aws-staging"
+      }
+    ]
+  },
+  "content": [
+    {
+      "type": "text",
+      "text": "[{\"id\":\"work/aws\",\"title\":\"aws\",\"url\":\"symvault://entry/work/aws\"},{\"id\":\"work/aws-staging\",\"title\":\"aws-staging\",\"url\":\"symvault://entry/work/aws-staging\"}]"
+    }
+  ]
+}
+```
+
+**Notes**:
+- Uses the same search engine as `find_entries`
+- Each result includes `id` (entry path), `title` (entry name), and `url` (vault URL)
+- Scope filtering respects the agent's `allowedPaths` configuration
+- Read-only operation (no write permissions required)
+
+---
+
+### fetch
+
+Fetch a vault entry by path/id. Returns full entry content with metadata and values in OpenAI Company Knowledge compatible format.
+
+**Request**:
+
+```json
+{
+  "tool": "fetch",
+  "arguments": {
+    "id": "work/aws"
+  }
+}
+```
+
+**Parameters**:
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `id` | string | Yes | Entry path or id to fetch (e.g., "github" or "work/aws") |
+
+**Response**:
+
+The response includes both `structuredContent` and `content` fields simultaneously:
+
+```json
+{
+  "structuredContent": {
+    "id": "work/aws",
+    "title": "aws",
+    "url": "symvault://entry/work/aws",
+    "metadata": {
+      "created": "2026-01-15T14:32:00Z",
+      "updated": "2026-04-21T09:45:00Z",
+      "version": 5,
+      "type": "password"
+    },
+    "values": {
+      "password": "...",
+      "username": "admin"
+    }
+  },
+  "content": [
+    {
+      "type": "text",
+      "text": "{\"id\":\"work/aws\",\"title\":\"aws\",\"url\":\"symvault://entry/work/aws\",\"metadata\":{\"created\":\"2026-01-15T14:32:00Z\",\"updated\":\"2026-04-21T09:45:00Z\",\"version\":5,\"type\":\"password\"},\"values\":{\"password\":\"...\",\"username\":\"admin\"}}"
+    }
+  ]
+}
+```
+
+**Notes**:
+- The `metadata` field always contains `created`, `updated`, `version`, and `type`
+- The `values` field is only included when the agent's profile has value access (standard/admin tier or `canReadValues: true`)
+- Scope filtering respects the agent's `allowedPaths` configuration
+- Read-only operation (no write permissions required)
+
+**Errors**:
+- `access_denied`: Entry path is outside the agent's allowed scope
+- `not_found`: Entry does not exist
 
 ---
 
@@ -1528,6 +1651,7 @@ async function getCredential(path) {
 
 | Version | Changes |
 |---------|---------|
+| 2.5.0 | Added `search` and `fetch` tools for OpenAI Company Knowledge compatibility; added `structuredContent` field support in tool responses |
 | 2.2.0 | Added `copy_to_clipboard`, `autotype`, and `run_command` tools; added `canUseClipboard` and `canUseAutotype` agent permissions; added scoped token management |
 | 2.0.0 | Added `run_command` tool, `canRunCommands` permission, and HTTP MCP authentication |
 | 1.0.0 | Initial MCP API documentation |

--- a/docs/mcpb-install.md
+++ b/docs/mcpb-install.md
@@ -1,0 +1,148 @@
+# MCP Bundle (.mcpb) Installation
+
+The MCP Bundle format (`.mcpb`) packages the Symaira Vault MCP server as a single distributable file for easy installation in Claude Desktop and other MCP clients.
+
+## What is a .mcpb Bundle?
+
+A `.mcpb` file is a ZIP archive containing:
+
+```
+bundle.mcpb
+├── manifest.json       # MCP Bundle manifest (v0.3)
+└── server/
+    └── symvault        # Symaira Vault binary
+```
+
+The `manifest.json` declares the server metadata and how to launch it:
+
+```json
+{
+  "manifest_version": "0.3",
+  "name": "symvault",
+  "version": "<version>",
+  "description": "Secure password manager MCP server",
+  "author": {"name": "danieljustus"},
+  "server": {
+    "type": "binary",
+    "entry_point": "server/symvault",
+    "mcp_config": {
+      "command": "${__dirname}/server/symvault",
+      "args": ["serve", "--stdio"]
+    }
+  }
+}
+```
+
+## Downloading
+
+Download the `.mcpb` file for your platform from the [latest release](https://github.com/danieljustus/symaira-vault/releases/latest):
+
+```bash
+# macOS arm64 (Apple Silicon) - recommended for M1/M2/M3 Macs
+curl -fLO https://github.com/danieljustus/symaira-vault/releases/latest/download/symvault_<version>_darwin_arm64.mcpb
+
+# macOS amd64 (Intel)
+curl -fLO https://github.com/danieljustus/symaira-vault/releases/latest/download/symvault_<version>_darwin_amd64.mcpb
+
+# Linux amd64
+curl -fLO https://github.com/danieljustus/symaira-vault/releases/latest/download/symvault_<version>_linux_amd64.mcpb
+
+# Linux arm64
+curl -fLO https://github.com/danieljustus/symaira-vault/releases/latest/download/symvault_<version>_linux_arm64.mcpb
+```
+
+## Installing in Claude Desktop
+
+### macOS
+
+1. Create the MCP bundles directory if it doesn't exist:
+   ```bash
+   mkdir -p ~/Library/Application\ Support/Claude/mcp-bundles
+   ```
+
+2. Copy the `.mcpb` file:
+   ```bash
+   cp symvault_*.mcpb ~/Library/Application\ Support/Claude/mcp-bundles/
+   ```
+
+3. Restart Claude Desktop. The symvault MCP server will be available automatically.
+
+### Linux
+
+1. Create the MCP bundles directory:
+   ```bash
+   mkdir -p ~/.config/Claude/mcp-bundles
+   ```
+
+2. Copy the `.mcpb` file:
+   ```bash
+   cp symvault_*.mcpb ~/.config/Claude/mcp-bundles/
+   ```
+
+3. Restart Claude Desktop.
+
+### Windows
+
+1. Create the MCP bundles directory:
+   ```powershell
+   New-Item -ItemType Directory -Force -Path "$env:APPDATA\Claude\mcp-bundles"
+   ```
+
+2. Copy the `.mcpb` file:
+   ```powershell
+   Copy-Item symvault_*.mcpb "$env:APPDATA\Claude\mcp-bundles\"
+   ```
+
+3. Restart Claude Desktop.
+
+## Verification
+
+After installing, verify the bundle is correctly set up:
+
+```bash
+# Extract and inspect the bundle
+unzip -q symvault_*.mcpb -d /tmp/mcpb-verify
+cat /tmp/mcpb-verify/manifest.json
+/tmp/mcpb-verify/server/symvault version
+rm -rf /tmp/mcpb-verify
+```
+
+Check that `manifest.json` contains:
+- `"manifest_version": "0.3"`
+- `"server": {"type": "binary", ...}`
+- `"args": ["serve", "--stdio"]`
+
+## Using in Claude Code
+
+Claude Code does not use the `.mcpb` bundle format directly. Instead, configure the MCP server in your `.claude.json`:
+
+```json
+{
+  "mcpServers": {
+    "symvault": {
+      "command": "symvault",
+      "args": ["serve", "--stdio"]
+    }
+  }
+}
+```
+
+Or use the automatic config generator:
+
+```bash
+symvault mcp-config claude-code
+```
+
+## Building from Source
+
+To build a `.mcpb` bundle from a local build:
+
+```bash
+# Build the binary
+make build
+
+# Create the .mcpb bundle
+scripts/build-mcpb.sh --version "$(git describe --tags --always)" --os "$(go env GOOS)" --arch "$(go env GOARCH)" --binary ./symvault
+```
+
+The output file `dist/symvault_<version>_<os>_<arch>.mcpb` can be installed as described above.

--- a/internal/config/config_load.go
+++ b/internal/config/config_load.go
@@ -252,7 +252,8 @@ func loadSectionFields(doc *yaml.Node) map[string]map[string]bool {
 					for j := 0; j < len(secNode.Content)-1; j += 2 {
 						fieldKey := secNode.Content[j].Value
 						fields[fieldKey] = true
-						if fieldKey == "oauth" && sec == "mcp" {
+						switch {
+						case fieldKey == "oauth" && sec == "mcp":
 							oAuthNode := secNode.Content[j+1]
 							if oAuthNode.Kind == yaml.MappingNode {
 								oAuthFields := make(map[string]bool)
@@ -260,6 +261,15 @@ func loadSectionFields(doc *yaml.Node) map[string]map[string]bool {
 									oAuthFields[oAuthNode.Content[k].Value] = true
 								}
 								result["mcp_oauth"] = oAuthFields
+							}
+						case fieldKey == "perplexity" && sec == "mcp":
+							perpNode := secNode.Content[j+1]
+							if perpNode.Kind == yaml.MappingNode {
+								perpFields := make(map[string]bool)
+								for k := 0; k < len(perpNode.Content)-1; k += 2 {
+									perpFields[perpNode.Content[k].Value] = true
+								}
+								result["mcp_perplexity"] = perpFields
 							}
 						}
 					}

--- a/internal/config/config_merge.go
+++ b/internal/config/config_merge.go
@@ -314,6 +314,7 @@ func mergeGitConfig(raw *GitConfig, sf map[string]bool) *GitConfig {
 	return &defaults
 }
 
+//nolint:gocyclo // merging many config fields is inherently sequential
 func mergeMCPConfig(raw *MCPConfig, sf, oaf, ppf map[string]bool) *MCPConfig {
 	defaults := defaultMCPConfig()
 	if raw.ApprovalRequired {

--- a/internal/config/config_merge.go
+++ b/internal/config/config_merge.go
@@ -364,6 +364,12 @@ func mergeMCPConfig(raw *MCPConfig, sf, oaf map[string]bool) *MCPConfig {
 	if sf["tls_key_file"] {
 		defaults.TLSKeyFile = raw.TLSKeyFile
 	}
+	if sf["tls_client_ca_file"] {
+		defaults.TLSClientCAFile = raw.TLSClientCAFile
+	}
+	if sf["mtls_enabled"] {
+		defaults.MTLSEnabled = raw.MTLSEnabled
+	}
 	if sf["allow_insecure_bind"] {
 		defaults.AllowInsecureBind = raw.AllowInsecureBind
 	}

--- a/internal/config/config_merge.go
+++ b/internal/config/config_merge.go
@@ -112,7 +112,7 @@ func mergeSections(cfg *Config, raw Config, sectionFields map[string]map[string]
 		cfg.Git = mergeGitConfig(raw.Git, sectionFields["git"])
 	}
 	if raw.MCP != nil {
-		cfg.MCP = mergeMCPConfig(raw.MCP, sectionFields["mcp"], sectionFields["mcp_oauth"])
+		cfg.MCP = mergeMCPConfig(raw.MCP, sectionFields["mcp"], sectionFields["mcp_oauth"], sectionFields["mcp_perplexity"])
 	}
 	if raw.Update != nil {
 		cfg.Update = mergeUpdateConfig(raw.Update, sectionFields["update"])
@@ -314,7 +314,7 @@ func mergeGitConfig(raw *GitConfig, sf map[string]bool) *GitConfig {
 	return &defaults
 }
 
-func mergeMCPConfig(raw *MCPConfig, sf, oaf map[string]bool) *MCPConfig {
+func mergeMCPConfig(raw *MCPConfig, sf, oaf, ppf map[string]bool) *MCPConfig {
 	defaults := defaultMCPConfig()
 	if raw.ApprovalRequired {
 		fmt.Fprintln(os.Stderr, "Warning: approval_required is deprecated and will be removed in a future version")
@@ -382,6 +382,20 @@ func mergeMCPConfig(raw *MCPConfig, sf, oaf map[string]bool) *MCPConfig {
 		}
 		if oaf["refresh_token_ttl"] && raw.OAuth.RefreshTokenTTL > 0 {
 			defaults.OAuth.RefreshTokenTTL = raw.OAuth.RefreshTokenTTL
+		}
+	}
+	if sf["perplexity"] && raw.Perplexity != nil {
+		if defaults.Perplexity == nil {
+			defaults.Perplexity = &PerplexityConfig{}
+		}
+		if ppf["api_key"] && raw.Perplexity.APIKey != "" {
+			defaults.Perplexity.APIKey = raw.Perplexity.APIKey
+		}
+		if ppf["base_url"] && raw.Perplexity.BaseURL != "" {
+			defaults.Perplexity.BaseURL = raw.Perplexity.BaseURL
+		}
+		if ppf["rate_limit_per_min"] && raw.Perplexity.RateLimitPerMin > 0 {
+			defaults.Perplexity.RateLimitPerMin = raw.Perplexity.RateLimitPerMin
 		}
 	}
 	return &defaults

--- a/internal/config/config_save.go
+++ b/internal/config/config_save.go
@@ -117,6 +117,12 @@ func (c *Config) SaveTo(path string) error {
 		if c.MCP.TLSKeyFile != "" {
 			raw.MCP.TLSKeyFile = c.MCP.TLSKeyFile
 		}
+		if c.MCP.TLSClientCAFile != "" {
+			raw.MCP.TLSClientCAFile = c.MCP.TLSClientCAFile
+		}
+		if c.MCP.MTLSEnabled {
+			raw.MCP.MTLSEnabled = true
+		}
 	}
 
 	if c.Update != nil {

--- a/internal/config/dottedpath.go
+++ b/internal/config/dottedpath.go
@@ -98,6 +98,8 @@ func KnownConfigKeys() []string {
 		"mcp.metrics_auth_required",
 		"mcp.tls_cert_file",
 		"mcp.tls_key_file",
+		"mcp.tls_client_ca_file",
+		"mcp.mtls_enabled",
 		"mcp.allow_insecure_bind",
 
 		// Update

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -41,28 +41,36 @@ type OAuthConfig struct {
 	RefreshTokenTTL time.Duration `yaml:"refresh_token_ttl,omitempty"`
 }
 
+// PerplexityConfig holds Perplexity API client configuration.
+type PerplexityConfig struct {
+	APIKey          string `yaml:"api_key,omitempty"`
+	BaseURL         string `yaml:"base_url,omitempty"`
+	RateLimitPerMin int    `yaml:"rate_limit_per_min,omitempty"`
+}
+
 // MCPConfig holds MCP server-related configuration for AI agent integration.
 type MCPConfig struct {
-	Port                int           `yaml:"port,omitempty"`
-	Bind                string        `yaml:"bind,omitempty"`
-	HTTPTokenFile       string        `yaml:"httpTokenFile,omitempty"`
-	OTLPEndpoint        string        `yaml:"otlp_endpoint,omitempty"`
-	Stdio               bool          `yaml:"stdio,omitempty"`
-	ApprovalRequired    bool          `yaml:"approval_required,omitempty"`
-	ReadHeaderTimeout   time.Duration `yaml:"read_header_timeout,omitempty"`
-	ReadTimeout         time.Duration `yaml:"read_timeout,omitempty"`
-	WriteTimeout        time.Duration `yaml:"write_timeout,omitempty"`
-	ShutdownTimeout     time.Duration `yaml:"shutdown_timeout,omitempty"`
-	ApprovalTimeout     time.Duration `yaml:"approval_timeout,omitempty"`
-	RateLimit           int           `yaml:"rate_limit,omitempty"`
-	TrustedProxyIPs     []string      `yaml:"trusted_proxy_ips,omitempty"`
-	MetricsAuthRequired bool          `yaml:"metrics_auth_required,omitempty"`
-	TLSCertFile         string        `yaml:"tls_cert_file,omitempty"`
-	TLSKeyFile          string        `yaml:"tls_key_file,omitempty"`
-	TLSClientCAFile     string        `yaml:"tls_client_ca_file,omitempty"`
-	MTLSEnabled         bool          `yaml:"mtls_enabled,omitempty"`
-	AllowInsecureBind   bool          `yaml:"allow_insecure_bind,omitempty"`
-	OAuth               *OAuthConfig  `yaml:"oauth,omitempty"`
+	Port                int               `yaml:"port,omitempty"`
+	Bind                string            `yaml:"bind,omitempty"`
+	HTTPTokenFile       string            `yaml:"httpTokenFile,omitempty"`
+	OTLPEndpoint        string            `yaml:"otlp_endpoint,omitempty"`
+	Stdio               bool              `yaml:"stdio,omitempty"`
+	ApprovalRequired    bool              `yaml:"approval_required,omitempty"`
+	ReadHeaderTimeout   time.Duration     `yaml:"read_header_timeout,omitempty"`
+	ReadTimeout         time.Duration     `yaml:"read_timeout,omitempty"`
+	WriteTimeout        time.Duration     `yaml:"write_timeout,omitempty"`
+	ShutdownTimeout     time.Duration     `yaml:"shutdown_timeout,omitempty"`
+	ApprovalTimeout     time.Duration     `yaml:"approval_timeout,omitempty"`
+	RateLimit           int               `yaml:"rate_limit,omitempty"`
+	TrustedProxyIPs     []string          `yaml:"trusted_proxy_ips,omitempty"`
+	MetricsAuthRequired bool              `yaml:"metrics_auth_required,omitempty"`
+	TLSCertFile         string            `yaml:"tls_cert_file,omitempty"`
+	TLSKeyFile          string            `yaml:"tls_key_file,omitempty"`
+	TLSClientCAFile     string            `yaml:"tls_client_ca_file,omitempty"`
+	MTLSEnabled         bool              `yaml:"mtls_enabled,omitempty"`
+	AllowInsecureBind   bool              `yaml:"allow_insecure_bind,omitempty"`
+	OAuth               *OAuthConfig      `yaml:"oauth,omitempty"`
+	Perplexity          *PerplexityConfig `yaml:"perplexity,omitempty"`
 }
 
 // UpdateConfig holds update check-related configuration.
@@ -125,6 +133,14 @@ func defaultGitConfig() GitConfig {
 		AutoPull:         true,
 		AutoPullInterval: 10 * time.Second,
 		CommitTemplate:   "Update from Symaira Vault",
+	}
+}
+
+// defaultPerplexityConfig returns the default Perplexity API configuration.
+func defaultPerplexityConfig() PerplexityConfig {
+	return PerplexityConfig{
+		BaseURL:         "https://api.perplexity.ai",
+		RateLimitPerMin: 10,
 	}
 }
 
@@ -353,6 +369,20 @@ func MergeFromMCP(dst *MCPConfig, src MCPConfig) {
 		}
 		if src.OAuth.RefreshTokenTTL > 0 {
 			dst.OAuth.RefreshTokenTTL = src.OAuth.RefreshTokenTTL
+		}
+	}
+	if src.Perplexity != nil {
+		if dst.Perplexity == nil {
+			dst.Perplexity = &PerplexityConfig{}
+		}
+		if src.Perplexity.APIKey != "" {
+			dst.Perplexity.APIKey = src.Perplexity.APIKey
+		}
+		if src.Perplexity.BaseURL != "" {
+			dst.Perplexity.BaseURL = src.Perplexity.BaseURL
+		}
+		if src.Perplexity.RateLimitPerMin > 0 {
+			dst.Perplexity.RateLimitPerMin = src.Perplexity.RateLimitPerMin
 		}
 	}
 }

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -59,6 +59,8 @@ type MCPConfig struct {
 	MetricsAuthRequired bool          `yaml:"metrics_auth_required,omitempty"`
 	TLSCertFile         string        `yaml:"tls_cert_file,omitempty"`
 	TLSKeyFile          string        `yaml:"tls_key_file,omitempty"`
+	TLSClientCAFile     string        `yaml:"tls_client_ca_file,omitempty"`
+	MTLSEnabled         bool          `yaml:"mtls_enabled,omitempty"`
 	AllowInsecureBind   bool          `yaml:"allow_insecure_bind,omitempty"`
 	OAuth               *OAuthConfig  `yaml:"oauth,omitempty"`
 }
@@ -332,6 +334,12 @@ func MergeFromMCP(dst *MCPConfig, src MCPConfig) {
 	}
 	if src.TLSKeyFile != "" {
 		dst.TLSKeyFile = src.TLSKeyFile
+	}
+	if src.TLSClientCAFile != "" {
+		dst.TLSClientCAFile = src.TLSClientCAFile
+	}
+	if src.MTLSEnabled {
+		dst.MTLSEnabled = true
 	}
 	if src.AllowInsecureBind {
 		dst.AllowInsecureBind = true

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -136,14 +136,6 @@ func defaultGitConfig() GitConfig {
 	}
 }
 
-// defaultPerplexityConfig returns the default Perplexity API configuration.
-func defaultPerplexityConfig() PerplexityConfig {
-	return PerplexityConfig{
-		BaseURL:         "https://api.perplexity.ai",
-		RateLimitPerMin: 10,
-	}
-}
-
 // defaultMCPConfig returns the default MCP server configuration.
 func defaultMCPConfig() MCPConfig {
 	return MCPConfig{

--- a/internal/mcp/apitemplates/builtin/perplexity.yaml
+++ b/internal/mcp/apitemplates/builtin/perplexity.yaml
@@ -1,0 +1,9 @@
+base_url: https://api.perplexity.ai
+auth_type: bearer
+entry_ref: op:///perplexity
+allowed_endpoints:
+  - /chat/completions
+allowed_methods:
+  - POST
+default_headers:
+  Content-Type: application/json

--- a/internal/mcp/mcptypes.go
+++ b/internal/mcp/mcptypes.go
@@ -110,8 +110,9 @@ func (r CallToolRequest) GetBool(key string, def bool) bool {
 
 // CallToolResult represents the result of calling an MCP tool
 type CallToolResult struct {
-	Text    string
-	IsError bool
+	Text              string
+	IsError           bool
+	StructuredContent any
 }
 
 // NewToolResultError creates a new tool result representing an error
@@ -122,6 +123,14 @@ func NewToolResultError(msg string) *CallToolResult {
 // NewToolResultText creates a new tool result containing text
 func NewToolResultText(text string) *CallToolResult {
 	return &CallToolResult{Text: text}
+}
+
+// NewToolResultStructured creates a new tool result containing both structured
+// content and a serialized text representation. StructuredContent is surfaced
+// as the "structuredContent" field in the response alongside the standard
+// "content" array.
+func NewToolResultStructured(text string, structured any) *CallToolResult {
+	return &CallToolResult{Text: text, StructuredContent: structured}
 }
 
 // Tool represents an MCP tool definition

--- a/internal/mcp/server/tool_registry.go
+++ b/internal/mcp/server/tool_registry.go
@@ -262,7 +262,7 @@ func callToolResultPayload(result *mcp.CallToolResult) map[string]any {
 		result = mcp.NewToolResultText("")
 	}
 	sanitized := globalChokepoint.SanitizeForMCP(result.Text)
-	return map[string]any{
+	payload := map[string]any{
 		"content": []map[string]any{
 			{
 				"type": "text",
@@ -271,6 +271,10 @@ func callToolResultPayload(result *mcp.CallToolResult) map[string]any {
 		},
 		"isError": result.IsError,
 	}
+	if result.StructuredContent != nil {
+		payload["structuredContent"] = result.StructuredContent
+	}
+	return payload
 }
 
 func decodeToolRequest(args json.RawMessage) (mcp.CallToolRequest, error) {

--- a/internal/mcp/server/tool_registry.go
+++ b/internal/mcp/server/tool_registry.go
@@ -16,14 +16,16 @@ type toolHandler func(*Server, context.Context, mcp.CallToolRequest) (*mcp.CallT
 type toolAvailable func(*Server) bool
 
 type toolDefinition struct {
-	Name        string
-	Description string
-	InputSchema map[string]any
-	Handler     toolHandler
-	Available   toolAvailable
-	Deprecated  bool
-	AliasFor    string
-	RiskLevel   RiskLevel
+	Name            string
+	Description     string
+	InputSchema     map[string]any
+	Handler         toolHandler
+	Available       toolAvailable
+	Deprecated      bool
+	AliasFor        string
+	RiskLevel       RiskLevel
+	ReadOnlyHint    bool
+	DestructiveHint bool
 }
 
 type schemaProperty struct {
@@ -217,6 +219,12 @@ func toolsListPayload(s *Server) []map[string]any {
 		if def.AliasFor != "" {
 			payload["aliasFor"] = def.AliasFor
 		}
+		if def.ReadOnlyHint {
+			payload["readOnlyHint"] = true
+		}
+		if def.DestructiveHint {
+			payload["destructiveHint"] = true
+		}
 		tools = append(tools, payload)
 	}
 	return tools
@@ -283,9 +291,11 @@ func computeToolRegistryHashDefs(defs []toolDefinition) string {
 	hashDefs := make([]mcp.ToolHashDef, len(defs))
 	for i, d := range defs {
 		hashDefs[i] = mcp.ToolHashDef{
-			Name:        d.Name,
-			Description: d.Description,
-			InputSchema: d.InputSchema,
+			Name:            d.Name,
+			Description:     d.Description,
+			InputSchema:     d.InputSchema,
+			ReadOnlyHint:    d.ReadOnlyHint,
+			DestructiveHint: d.DestructiveHint,
 		}
 	}
 	return mcp.ComputeToolRegistryHash(hashDefs)

--- a/internal/mcp/server/tool_registry.go
+++ b/internal/mcp/server/tool_registry.go
@@ -57,7 +57,7 @@ func objectSchema(required []string, properties map[string]schemaProperty) map[s
 // ARCHITECTURE.md § Tool Addition Review). The cap balances functionality
 // against the prompt injection attack surface — each additional tool is another
 // vector an attacker-controlled agent can exploit.
-const MaxToolDefinitions = 32
+const MaxToolDefinitions = 34
 
 var (
 	toolRegistry   []toolDefinition

--- a/internal/mcp/server/tools_audit_self.go
+++ b/internal/mcp/server/tools_audit_self.go
@@ -100,5 +100,6 @@ func init() {
 		}),
 		Handler:   (*Server).handleAuditSelf,
 		RiskLevel: RiskLevelLow,
+		ReadOnlyHint: true,
 	})
 }

--- a/internal/mcp/server/tools_audit_self.go
+++ b/internal/mcp/server/tools_audit_self.go
@@ -98,8 +98,8 @@ func init() {
 		InputSchema: objectSchema(nil, map[string]schemaProperty{
 			"limit": {Type: "number", Description: "Maximum number of events to return (default 50, max 100)"},
 		}),
-		Handler:   (*Server).handleAuditSelf,
-		RiskLevel: RiskLevelLow,
+		Handler:      (*Server).handleAuditSelf,
+		RiskLevel:    RiskLevelLow,
 		ReadOnlyHint: true,
 	})
 }

--- a/internal/mcp/server/tools_auth.go
+++ b/internal/mcp/server/tools_auth.go
@@ -97,6 +97,7 @@ func init() {
 		InputSchema: objectSchema(nil, map[string]schemaProperty{}),
 		Handler:     (*Server).handleGetAuthStatus,
 		RiskLevel:   RiskLevelLow,
+		ReadOnlyHint: true,
 	})
 	RegisterTool(toolDefinition{
 		Name:        "set_auth_method",
@@ -106,5 +107,6 @@ func init() {
 		}),
 		Handler:   (*Server).handleSetAuthMethod,
 		RiskLevel: RiskLevelHigh,
+		DestructiveHint: true,
 	})
 }

--- a/internal/mcp/server/tools_auth.go
+++ b/internal/mcp/server/tools_auth.go
@@ -92,11 +92,11 @@ func (s *Server) handleSetAuthMethod(ctx context.Context, req mcp.CallToolReques
 
 func init() {
 	RegisterTool(toolDefinition{
-		Name:        "get_auth_status",
-		Description: "Return Symaira Vault unlock authentication status",
-		InputSchema: objectSchema(nil, map[string]schemaProperty{}),
-		Handler:     (*Server).handleGetAuthStatus,
-		RiskLevel:   RiskLevelLow,
+		Name:         "get_auth_status",
+		Description:  "Return Symaira Vault unlock authentication status",
+		InputSchema:  objectSchema(nil, map[string]schemaProperty{}),
+		Handler:      (*Server).handleGetAuthStatus,
+		RiskLevel:    RiskLevelLow,
 		ReadOnlyHint: true,
 	})
 	RegisterTool(toolDefinition{
@@ -105,8 +105,8 @@ func init() {
 		InputSchema: objectSchema([]string{"method"}, map[string]schemaProperty{
 			"method": {Type: "string", Description: "Authentication method: passphrase or touchid"},
 		}),
-		Handler:   (*Server).handleSetAuthMethod,
-		RiskLevel: RiskLevelHigh,
+		Handler:         (*Server).handleSetAuthMethod,
+		RiskLevel:       RiskLevelHigh,
 		DestructiveHint: true,
 	})
 }

--- a/internal/mcp/server/tools_autotype.go
+++ b/internal/mcp/server/tools_autotype.go
@@ -80,8 +80,8 @@ func init() {
 			"path":  {Type: "string", Description: "Entry path"},
 			"field": {Type: "string", Description: "Field name to type (default: password)"},
 		}),
-		Handler:   (*Server).handleAutotype,
-		RiskLevel: RiskLevelHigh,
+		Handler:         (*Server).handleAutotype,
+		RiskLevel:       RiskLevelHigh,
 		DestructiveHint: true,
 	})
 }

--- a/internal/mcp/server/tools_autotype.go
+++ b/internal/mcp/server/tools_autotype.go
@@ -82,5 +82,6 @@ func init() {
 		}),
 		Handler:   (*Server).handleAutotype,
 		RiskLevel: RiskLevelHigh,
+		DestructiveHint: true,
 	})
 }

--- a/internal/mcp/server/tools_clipboard.go
+++ b/internal/mcp/server/tools_clipboard.go
@@ -92,8 +92,8 @@ func init() {
 		InputSchema: objectSchema([]string{"path"}, map[string]schemaProperty{
 			"path": {Type: "string", Description: "Entry path"},
 		}),
-		Handler:   (*Server).handleCopyToClipboard,
-		RiskLevel: RiskLevelHigh,
+		Handler:         (*Server).handleCopyToClipboard,
+		RiskLevel:       RiskLevelHigh,
 		DestructiveHint: true,
 	})
 }

--- a/internal/mcp/server/tools_clipboard.go
+++ b/internal/mcp/server/tools_clipboard.go
@@ -94,5 +94,6 @@ func init() {
 		}),
 		Handler:   (*Server).handleCopyToClipboard,
 		RiskLevel: RiskLevelHigh,
+		DestructiveHint: true,
 	})
 }

--- a/internal/mcp/server/tools_delete.go
+++ b/internal/mcp/server/tools_delete.go
@@ -64,8 +64,8 @@ func init() {
 		InputSchema: objectSchema([]string{"path"}, map[string]schemaProperty{
 			"path": {Type: "string", Description: "Entry path to delete"},
 		}),
-		Handler:   (*Server).handleDelete,
-		RiskLevel: RiskLevelCritical,
+		Handler:         (*Server).handleDelete,
+		RiskLevel:       RiskLevelCritical,
 		DestructiveHint: true,
 	})
 	RegisterTool(toolDefinition{
@@ -74,10 +74,10 @@ func init() {
 		InputSchema: objectSchema([]string{"path"}, map[string]schemaProperty{
 			"path": {Type: "string", Description: "Entry path to delete"},
 		}),
-		Handler:    (*Server).handleDelete,
-		Deprecated: true,
-		AliasFor:   "delete_entry",
-		RiskLevel:  RiskLevelCritical,
+		Handler:         (*Server).handleDelete,
+		Deprecated:      true,
+		AliasFor:        "delete_entry",
+		RiskLevel:       RiskLevelCritical,
 		DestructiveHint: true,
 	})
 }

--- a/internal/mcp/server/tools_delete.go
+++ b/internal/mcp/server/tools_delete.go
@@ -66,6 +66,7 @@ func init() {
 		}),
 		Handler:   (*Server).handleDelete,
 		RiskLevel: RiskLevelCritical,
+		DestructiveHint: true,
 	})
 	RegisterTool(toolDefinition{
 		Name:        "symaira_delete",
@@ -77,5 +78,6 @@ func init() {
 		Deprecated: true,
 		AliasFor:   "delete_entry",
 		RiskLevel:  RiskLevelCritical,
+		DestructiveHint: true,
 	})
 }

--- a/internal/mcp/server/tools_execute_api_request.go
+++ b/internal/mcp/server/tools_execute_api_request.go
@@ -483,9 +483,9 @@ func init() {
 			"headers":  {Type: "object", Description: "Additional request headers (optional)"},
 			"timeout":  {Type: "number", Description: "Timeout in seconds (default: 30)"},
 		}),
-		Handler:   (*Server).handleExecuteAPIRequest,
-		Available: executeAPIAvailable,
-		RiskLevel: RiskLevelCritical,
+		Handler:         (*Server).handleExecuteAPIRequest,
+		Available:       executeAPIAvailable,
+		RiskLevel:       RiskLevelCritical,
 		DestructiveHint: true,
 	})
 }

--- a/internal/mcp/server/tools_execute_api_request.go
+++ b/internal/mcp/server/tools_execute_api_request.go
@@ -486,5 +486,6 @@ func init() {
 		Handler:   (*Server).handleExecuteAPIRequest,
 		Available: executeAPIAvailable,
 		RiskLevel: RiskLevelCritical,
+		DestructiveHint: true,
 	})
 }

--- a/internal/mcp/server/tools_execute_api_request_test.go
+++ b/internal/mcp/server/tools_execute_api_request_test.go
@@ -83,14 +83,14 @@ func TestAPITemplateLoadAll(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadAll() error = %v", err)
 	}
-	if len(templates) != 4 {
-		t.Fatalf("LoadAll() returned %d templates, want 4", len(templates))
+	if len(templates) != 5 {
+		t.Fatalf("LoadAll() returned %d templates, want 5", len(templates))
 	}
 	names := make(map[string]bool)
 	for _, tmpl := range templates {
 		names[tmpl.Name] = true
 	}
-	for _, name := range []string{"github", "openai", "anthropic", "slack"} {
+	for _, name := range []string{"github", "openai", "anthropic", "slack", "perplexity"} {
 		if !names[name] {
 			t.Errorf("LoadAll() missing template %q", name)
 		}

--- a/internal/mcp/server/tools_execute_with_secret.go
+++ b/internal/mcp/server/tools_execute_with_secret.go
@@ -280,5 +280,6 @@ func init() {
 		}),
 		Handler:   (*Server).handleExecuteWithSecret,
 		RiskLevel: RiskLevelHigh,
+		DestructiveHint: true,
 	})
 }

--- a/internal/mcp/server/tools_execute_with_secret.go
+++ b/internal/mcp/server/tools_execute_with_secret.go
@@ -278,8 +278,8 @@ func init() {
 			"env_vars":    {Type: "object", Description: "Additional non-secret environment variables"},
 			"timeout":     {Type: "number", Description: "Timeout in seconds (default: 30)"},
 		}),
-		Handler:   (*Server).handleExecuteWithSecret,
-		RiskLevel: RiskLevelHigh,
+		Handler:         (*Server).handleExecuteWithSecret,
+		RiskLevel:       RiskLevelHigh,
 		DestructiveHint: true,
 	})
 }

--- a/internal/mcp/server/tools_find.go
+++ b/internal/mcp/server/tools_find.go
@@ -67,8 +67,8 @@ func init() {
 		InputSchema: objectSchema([]string{"query"}, map[string]schemaProperty{
 			"query": {Type: "string", Description: "Search query"},
 		}),
-		Handler:   (*Server).handleFind,
-		RiskLevel: RiskLevelLow,
+		Handler:      (*Server).handleFind,
+		RiskLevel:    RiskLevelLow,
 		ReadOnlyHint: true,
 	})
 }

--- a/internal/mcp/server/tools_find.go
+++ b/internal/mcp/server/tools_find.go
@@ -69,5 +69,6 @@ func init() {
 		}),
 		Handler:   (*Server).handleFind,
 		RiskLevel: RiskLevelLow,
+		ReadOnlyHint: true,
 	})
 }

--- a/internal/mcp/server/tools_generate.go
+++ b/internal/mcp/server/tools_generate.go
@@ -45,5 +45,6 @@ func init() {
 		}),
 		Handler:   (*Server).handleGenerate,
 		RiskLevel: RiskLevelLow,
+		ReadOnlyHint: true,
 	})
 }

--- a/internal/mcp/server/tools_generate.go
+++ b/internal/mcp/server/tools_generate.go
@@ -43,8 +43,8 @@ func init() {
 			"length":  {Type: "number", Description: "Password length"},
 			"symbols": {Type: "boolean", Description: "Include symbols. Default: true."},
 		}),
-		Handler:   (*Server).handleGenerate,
-		RiskLevel: RiskLevelLow,
+		Handler:      (*Server).handleGenerate,
+		RiskLevel:    RiskLevelLow,
 		ReadOnlyHint: true,
 	})
 }

--- a/internal/mcp/server/tools_get.go
+++ b/internal/mcp/server/tools_get.go
@@ -308,6 +308,7 @@ func init() {
 		}),
 		Handler:   (*Server).handleGet,
 		RiskLevel: RiskLevelMedium,
+		ReadOnlyHint: true,
 	})
 	RegisterTool(toolDefinition{
 		Name:        "get_entry_value",
@@ -317,6 +318,7 @@ func init() {
 		}),
 		Handler:   (*Server).handleGetValue,
 		RiskLevel: RiskLevelHigh,
+		ReadOnlyHint: true,
 	})
 	RegisterTool(toolDefinition{
 		Name:        "get_entry_metadata",
@@ -326,5 +328,6 @@ func init() {
 		}),
 		Handler:   (*Server).handleGetMetadata,
 		RiskLevel: RiskLevelMedium,
+		ReadOnlyHint: true,
 	})
 }

--- a/internal/mcp/server/tools_get.go
+++ b/internal/mcp/server/tools_get.go
@@ -306,8 +306,8 @@ func init() {
 			"path":          {Type: "string", Description: "Entry path"},
 			"include_value": {Type: "boolean", Description: "When true, returns the full entry with secret values. Default: false."},
 		}),
-		Handler:   (*Server).handleGet,
-		RiskLevel: RiskLevelMedium,
+		Handler:      (*Server).handleGet,
+		RiskLevel:    RiskLevelMedium,
 		ReadOnlyHint: true,
 	})
 	RegisterTool(toolDefinition{
@@ -316,8 +316,8 @@ func init() {
 		InputSchema: objectSchema([]string{"path"}, map[string]schemaProperty{
 			"path": {Type: "string", Description: "Entry path"},
 		}),
-		Handler:   (*Server).handleGetValue,
-		RiskLevel: RiskLevelHigh,
+		Handler:      (*Server).handleGetValue,
+		RiskLevel:    RiskLevelHigh,
 		ReadOnlyHint: true,
 	})
 	RegisterTool(toolDefinition{
@@ -326,8 +326,8 @@ func init() {
 		InputSchema: objectSchema([]string{"path"}, map[string]schemaProperty{
 			"path": {Type: "string", Description: "Entry path"},
 		}),
-		Handler:   (*Server).handleGetMetadata,
-		RiskLevel: RiskLevelMedium,
+		Handler:      (*Server).handleGetMetadata,
+		RiskLevel:    RiskLevelMedium,
 		ReadOnlyHint: true,
 	})
 }

--- a/internal/mcp/server/tools_health.go
+++ b/internal/mcp/server/tools_health.go
@@ -24,11 +24,11 @@ func (s *Server) handleHealth(ctx context.Context, req mcp.CallToolRequest) (*mc
 
 func init() {
 	RegisterTool(toolDefinition{
-		Name:        "health",
-		Description: "Return Symaira Vault MCP server health information",
-		InputSchema: objectSchema(nil, map[string]schemaProperty{}),
-		Handler:     (*Server).handleHealth,
-		RiskLevel:   RiskLevelLow,
+		Name:         "health",
+		Description:  "Return Symaira Vault MCP server health information",
+		InputSchema:  objectSchema(nil, map[string]schemaProperty{}),
+		Handler:      (*Server).handleHealth,
+		RiskLevel:    RiskLevelLow,
 		ReadOnlyHint: true,
 	})
 }

--- a/internal/mcp/server/tools_health.go
+++ b/internal/mcp/server/tools_health.go
@@ -29,5 +29,6 @@ func init() {
 		InputSchema: objectSchema(nil, map[string]schemaProperty{}),
 		Handler:     (*Server).handleHealth,
 		RiskLevel:   RiskLevelLow,
+		ReadOnlyHint: true,
 	})
 }

--- a/internal/mcp/server/tools_list.go
+++ b/internal/mcp/server/tools_list.go
@@ -88,5 +88,6 @@ func init() {
 		}),
 		Handler:   (*Server).handleList,
 		RiskLevel: RiskLevelLow,
+		ReadOnlyHint: true,
 	})
 }

--- a/internal/mcp/server/tools_list.go
+++ b/internal/mcp/server/tools_list.go
@@ -86,8 +86,8 @@ func init() {
 			"prefix":          {Type: "string", Description: "Path prefix to filter"},
 			"include_details": {Type: "boolean", Description: "When true, returns metadata for each entry. Default: true."},
 		}),
-		Handler:   (*Server).handleList,
-		RiskLevel: RiskLevelLow,
+		Handler:      (*Server).handleList,
+		RiskLevel:    RiskLevelLow,
 		ReadOnlyHint: true,
 	})
 }

--- a/internal/mcp/server/tools_perplexity.go
+++ b/internal/mcp/server/tools_perplexity.go
@@ -92,7 +92,7 @@ type perplexityAskResult struct {
 	Context   []string `json:"context,omitempty"`
 }
 
-func (s *Server) resolvePerplexityAPIKey(ctx context.Context) (string, error) {
+func (s *Server) resolvePerplexityAPIKey(_ context.Context) (string, error) {
 	if s.vault != nil && s.vault.Config != nil && s.vault.Config.MCP != nil &&
 		s.vault.Config.MCP.Perplexity != nil && s.vault.Config.MCP.Perplexity.APIKey != "" {
 		return s.vault.Config.MCP.Perplexity.APIKey, nil

--- a/internal/mcp/server/tools_perplexity.go
+++ b/internal/mcp/server/tools_perplexity.go
@@ -1,0 +1,322 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	mcp "github.com/danieljustus/symaira-vault/internal/mcp"
+	"github.com/danieljustus/symaira-vault/internal/metrics"
+	vaultpkg "github.com/danieljustus/symaira-vault/internal/vault"
+)
+
+const (
+	perplexityDefaultBaseURL   = "https://api.perplexity.ai"
+	perplexityChatEndpoint     = "/chat/completions"
+	perplexityDefaultModel     = "sonar-pro"
+	perplexityDefaultTimeout   = 60
+	perplexityDefaultRateLimit = 10
+	perplexityMaxTokens        = 2048
+	perplexityAPIKeyEntry      = "perplexity"
+)
+
+type perplexityRateLimiter struct {
+	mu      sync.Mutex
+	count   int
+	resetAt time.Time
+}
+
+var globalPerplexityRL = &perplexityRateLimiter{}
+
+func (rl *perplexityRateLimiter) Allow(maxPerMin int) bool {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+	now := time.Now()
+	if now.After(rl.resetAt) {
+		rl.count = 0
+		rl.resetAt = now.Add(time.Minute)
+	}
+	rl.count++
+	return rl.count <= maxPerMin
+}
+
+type perplexityMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type perplexityChatRequest struct {
+	Model       string               `json:"model"`
+	Messages    []perplexityMessage  `json:"messages"`
+	MaxTokens   int                  `json:"max_tokens,omitempty"`
+}
+
+type perplexityChatChoice struct {
+	Index        int                 `json:"index"`
+	Message      perplexityMessage   `json:"message"`
+	FinishReason string              `json:"finish_reason"`
+}
+
+type perplexityUsage struct {
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+	TotalTokens      int `json:"total_tokens"`
+}
+
+type perplexityChatResponse struct {
+	ID        string                 `json:"id"`
+	Model     string                 `json:"model"`
+	Choices   []perplexityChatChoice `json:"choices"`
+	Citations []string               `json:"citations"`
+	Usage     perplexityUsage        `json:"usage,omitempty"`
+}
+
+type perplexitySearchResult struct {
+	Query     string   `json:"query"`
+	Answer    string   `json:"answer"`
+	Model     string   `json:"model,omitempty"`
+	Citations []string `json:"citations,omitempty"`
+}
+
+type perplexityAskResult struct {
+	Question  string   `json:"question"`
+	Answer    string   `json:"answer"`
+	Model     string   `json:"model,omitempty"`
+	Citations []string `json:"citations,omitempty"`
+	Context   []string `json:"context,omitempty"`
+}
+
+func (s *Server) resolvePerplexityAPIKey(ctx context.Context) (string, error) {
+	if s.vault != nil && s.vault.Config != nil && s.vault.Config.MCP != nil &&
+		s.vault.Config.MCP.Perplexity != nil && s.vault.Config.MCP.Perplexity.APIKey != "" {
+		return s.vault.Config.MCP.Perplexity.APIKey, nil
+	}
+
+	entry, err := vaultpkg.ReadEntry(s.vault.Dir, perplexityAPIKeyEntry, s.vault.Identity)
+	if err != nil {
+		return "", fmt.Errorf("perplexity API key not found: try adding a vault entry %q with a credential field, or set mcp.perplexity.api_key in config", perplexityAPIKeyEntry)
+	}
+	for _, key := range []string{"credential", "token", "password", "api_key"} {
+		if v, ok := entry.Data[key]; ok {
+			if vStr, ok := v.(string); ok && vStr != "" {
+				return vStr, nil
+			}
+		}
+	}
+	return "", fmt.Errorf("perplexity vault entry %q exists but no credential field found (expected: credential, token, password, or api_key)", perplexityAPIKeyEntry)
+}
+
+func (s *Server) getPerplexityBaseURL() string {
+	if s.vault != nil && s.vault.Config != nil && s.vault.Config.MCP != nil &&
+		s.vault.Config.MCP.Perplexity != nil && s.vault.Config.MCP.Perplexity.BaseURL != "" {
+		return s.vault.Config.MCP.Perplexity.BaseURL
+	}
+	return perplexityDefaultBaseURL
+}
+
+func (s *Server) getPerplexityRateLimit() int {
+	if s.vault != nil && s.vault.Config != nil && s.vault.Config.MCP != nil &&
+		s.vault.Config.MCP.Perplexity != nil && s.vault.Config.MCP.Perplexity.RateLimitPerMin > 0 {
+		return s.vault.Config.MCP.Perplexity.RateLimitPerMin
+	}
+	return perplexityDefaultRateLimit
+}
+
+func (s *Server) callPerplexityChat(ctx context.Context, apiKey, baseURL, model string, messages []perplexityMessage) (*perplexityChatResponse, error) {
+	rateLimit := s.getPerplexityRateLimit()
+	if !globalPerplexityRL.Allow(rateLimit) {
+		return nil, fmt.Errorf("perplexity rate limit exceeded: max %d requests per minute", rateLimit)
+	}
+
+	reqBody := perplexityChatRequest{
+		Model:     model,
+		Messages:  messages,
+		MaxTokens: perplexityMaxTokens,
+	}
+	bodyBytes, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+
+	url := strings.TrimRight(baseURL, "/") + perplexityChatEndpoint
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(bodyBytes))
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", "Bearer "+apiKey)
+	httpReq.Header.Set("Accept", "application/json")
+
+	client := &http.Client{Timeout: perplexityDefaultTimeout * time.Second}
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("perplexity API call failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 1024*1024))
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("perplexity API returned status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var chatResp perplexityChatResponse
+	if err := json.Unmarshal(respBody, &chatResp); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+
+	return &chatResp, nil
+}
+
+func (s *Server) handlePerplexitySearch(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	query, err := req.RequireString("query")
+	if err != nil {
+		s.logAudit(ctx, "perplexity_search", "<invalid>", false)
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	apiKey, err := s.resolvePerplexityAPIKey(ctx)
+	if err != nil {
+		s.logAudit(ctx, "perplexity_search", "<api-key-error>", false)
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	baseURL := s.getPerplexityBaseURL()
+
+	messages := []perplexityMessage{
+		{Role: "system", Content: "You are a search assistant. Synthesize search results for the user's query. Provide accurate, up-to-date information with citations where applicable. Be concise and direct."},
+		{Role: "user", Content: query},
+	}
+
+	resp, apiErr := s.callPerplexityChat(ctx, apiKey, baseURL, perplexityDefaultModel, messages)
+	if apiErr != nil {
+		s.logAudit(ctx, "perplexity_search", fmt.Sprintf("query=%q, error=%v", query, apiErr), false)
+		metrics.RecordMCPRequest("perplexity_search", s.agent.Name, "error", 0)
+		return mcp.NewToolResultError(fmt.Sprintf("Perplexity search failed: %v", apiErr)), nil
+	}
+
+	if len(resp.Choices) == 0 {
+		s.logAudit(ctx, "perplexity_search", fmt.Sprintf("query=%q, error=empty-response", query), false)
+		metrics.RecordMCPRequest("perplexity_search", s.agent.Name, "error", 0)
+		return mcp.NewToolResultError("Perplexity returned an empty response"), nil
+	}
+
+	answer := resp.Choices[0].Message.Content
+
+	result := perplexitySearchResult{
+		Query:     query,
+		Answer:    answer,
+		Model:     resp.Model,
+		Citations: resp.Citations,
+	}
+
+	s.logAudit(ctx, "perplexity_search", fmt.Sprintf("query=%q, model=%s, citations=%d", query, resp.Model, len(resp.Citations)), true)
+	metrics.RecordMCPRequest("perplexity_search", s.agent.Name, "success", 0)
+
+	resultJSON, marshalErr := json.Marshal(result)
+	if marshalErr != nil {
+		return nil, marshalErr
+	}
+
+	return mcp.NewToolResultText(string(resultJSON)), nil
+}
+
+func (s *Server) handlePerplexityAsk(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	question, err := req.RequireString("question")
+	if err != nil {
+		s.logAudit(ctx, "perplexity_ask", "<invalid>", false)
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	apiKey, err := s.resolvePerplexityAPIKey(ctx)
+	if err != nil {
+		s.logAudit(ctx, "perplexity_ask", "<api-key-error>", false)
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	baseURL := s.getPerplexityBaseURL()
+	contextEntries := req.GetString("context", "")
+
+	systemPrompt := "You are a helpful AI assistant. Answer the user's question clearly and accurately. Provide citations for your answers where applicable."
+	var contextParts []string
+	if contextEntries != "" {
+		systemPrompt = "You are a helpful AI assistant with access to the user's vault entries as context. Use the provided vault context to answer the user's question. If the vault context is insufficient, supplement with your own knowledge and cite sources. Provide citations for your answers where applicable."
+		contextParts = strings.Split(contextEntries, "\n")
+	}
+
+	userMessage := question
+	if contextEntries != "" {
+		userMessage = fmt.Sprintf("Context from vault entries:\n%s\n\nQuestion: %s", contextEntries, question)
+	}
+
+	messages := []perplexityMessage{
+		{Role: "system", Content: systemPrompt},
+		{Role: "user", Content: userMessage},
+	}
+
+	resp, apiErr := s.callPerplexityChat(ctx, apiKey, baseURL, perplexityDefaultModel, messages)
+	if apiErr != nil {
+		s.logAudit(ctx, "perplexity_ask", fmt.Sprintf("question=%q, error=%v", question, apiErr), false)
+		metrics.RecordMCPRequest("perplexity_ask", s.agent.Name, "error", 0)
+		return mcp.NewToolResultError(fmt.Sprintf("Perplexity ask failed: %v", apiErr)), nil
+	}
+
+	if len(resp.Choices) == 0 {
+		s.logAudit(ctx, "perplexity_ask", fmt.Sprintf("question=%q, error=empty-response", question), false)
+		metrics.RecordMCPRequest("perplexity_ask", s.agent.Name, "error", 0)
+		return mcp.NewToolResultError("Perplexity returned an empty response"), nil
+	}
+
+	answer := resp.Choices[0].Message.Content
+
+	result := perplexityAskResult{
+		Question:  question,
+		Answer:    answer,
+		Model:     resp.Model,
+		Citations: resp.Citations,
+		Context:   contextParts,
+	}
+
+	s.logAudit(ctx, "perplexity_ask", fmt.Sprintf("question=%q, model=%s, citations=%d, context=%t", question, resp.Model, len(resp.Citations), contextEntries != ""), true)
+	metrics.RecordMCPRequest("perplexity_ask", s.agent.Name, "success", 0)
+
+	resultJSON, marshalErr := json.Marshal(result)
+	if marshalErr != nil {
+		return nil, marshalErr
+	}
+
+	return mcp.NewToolResultText(string(resultJSON)), nil
+}
+
+func init() {
+	RegisterTool(toolDefinition{
+		Name:        "perplexity_search",
+		Description: "Search the web using Perplexity AI. Returns synthesized search results with citations from the web.",
+		InputSchema: objectSchema([]string{"query"}, map[string]schemaProperty{
+			"query": {Type: "string", Description: "Natural language search query"},
+		}),
+		Handler:      (*Server).handlePerplexitySearch,
+		RiskLevel:    RiskLevelLow,
+		ReadOnlyHint: true,
+	})
+	RegisterTool(toolDefinition{
+		Name:        "perplexity_ask",
+		Description: "Ask Perplexity AI a question with optional vault entry context. Returns an AI-generated answer with citations.",
+		InputSchema: objectSchema([]string{"question"}, map[string]schemaProperty{
+			"question": {Type: "string", Description: "Question to ask Perplexity AI"},
+			"context":  {Type: "string", Description: "Optional context from vault entries to include in the question"},
+		}),
+		Handler:      (*Server).handlePerplexityAsk,
+		RiskLevel:    RiskLevelLow,
+		ReadOnlyHint: true,
+	})
+}

--- a/internal/mcp/server/tools_perplexity.go
+++ b/internal/mcp/server/tools_perplexity.go
@@ -52,15 +52,15 @@ type perplexityMessage struct {
 }
 
 type perplexityChatRequest struct {
-	Model       string               `json:"model"`
-	Messages    []perplexityMessage  `json:"messages"`
-	MaxTokens   int                  `json:"max_tokens,omitempty"`
+	Model     string              `json:"model"`
+	Messages  []perplexityMessage `json:"messages"`
+	MaxTokens int                 `json:"max_tokens,omitempty"`
 }
 
 type perplexityChatChoice struct {
-	Index        int                 `json:"index"`
-	Message      perplexityMessage   `json:"message"`
-	FinishReason string              `json:"finish_reason"`
+	Index        int               `json:"index"`
+	Message      perplexityMessage `json:"message"`
+	FinishReason string            `json:"finish_reason"`
 }
 
 type perplexityUsage struct {

--- a/internal/mcp/server/tools_perplexity_test.go
+++ b/internal/mcp/server/tools_perplexity_test.go
@@ -42,11 +42,11 @@ func newTestPerplexityServer(t *testing.T, searchResponse bool) *httptest.Server
 		}
 
 		resp := map[string]any{
-			"id":      "test-chat-id",
-			"model":   "sonar-pro",
+			"id":    "test-chat-id",
+			"model": "sonar-pro",
 			"choices": []map[string]any{
 				{
-					"index":        0,
+					"index":         0,
 					"finish_reason": "stop",
 					"message": map[string]any{
 						"role":    "assistant",

--- a/internal/mcp/server/tools_perplexity_test.go
+++ b/internal/mcp/server/tools_perplexity_test.go
@@ -1,0 +1,692 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"filippo.io/age"
+
+	"github.com/danieljustus/symaira-vault/internal/config"
+	mcp "github.com/danieljustus/symaira-vault/internal/mcp"
+)
+
+func newTestPerplexityServer(t *testing.T, searchResponse bool) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("method = %q, want POST", r.Method)
+		}
+		if r.URL.Path != "/chat/completions" {
+			t.Errorf("path = %q, want /chat/completions", r.URL.Path)
+		}
+		if r.Header.Get("Authorization") != "Bearer test-perplexity-key" {
+			t.Errorf("Authorization = %q, want Bearer test-perplexity-key", r.Header.Get("Authorization"))
+		}
+		if r.Header.Get("Content-Type") != "application/json" {
+			t.Errorf("Content-Type = %q, want application/json", r.Header.Get("Content-Type"))
+		}
+
+		var reqBody map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+			t.Errorf("decode request body: %v", err)
+		}
+
+		answer := "The capital of France is Paris."
+		if searchResponse {
+			answer = "Paris is the capital of France, located in the north-central part of the country."
+		}
+
+		resp := map[string]any{
+			"id":      "test-chat-id",
+			"model":   "sonar-pro",
+			"choices": []map[string]any{
+				{
+					"index":        0,
+					"finish_reason": "stop",
+					"message": map[string]any{
+						"role":    "assistant",
+						"content": answer,
+					},
+				},
+			},
+			"citations": []string{"https://en.wikipedia.org/wiki/Paris", "https://www.britannica.com/place/Paris"},
+			"usage": map[string]any{
+				"prompt_tokens":     50,
+				"completion_tokens": 100,
+				"total_tokens":      150,
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+}
+
+func TestHandlePerplexitySearch_Success(t *testing.T) {
+	ts := newTestPerplexityServer(t, true)
+	defer ts.Close()
+
+	vaultDir, identity := mockVaultWithEntry(t, "perplexity", map[string]any{
+		"credential": "test-perplexity-key",
+	})
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:         "test",
+		AllowedPaths: []string{"*"},
+		CanWrite:     config.BoolPtr(false),
+		ApprovalMode: config.StrPtr("none"),
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+	srv.vault.Config = &config.Config{
+		MCP: &config.MCPConfig{
+			Perplexity: &config.PerplexityConfig{
+				BaseURL:         ts.URL,
+				RateLimitPerMin: 100,
+			},
+		},
+	}
+
+	globalPerplexityRL = &perplexityRateLimiter{}
+
+	req := mcp.CallToolRequest{
+		Arguments: map[string]any{"query": "What is the capital of France?"},
+	}
+
+	result, err := srv.handlePerplexitySearch(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handlePerplexitySearch() error = %v", err)
+	}
+	if result == nil {
+		t.Fatal("handlePerplexitySearch() returned nil result")
+	}
+	if result.IsError {
+		t.Fatalf("handlePerplexitySearch() returned error: %s", result.Text)
+	}
+
+	var output perplexitySearchResult
+	if err := json.Unmarshal([]byte(result.Text), &output); err != nil {
+		t.Fatalf("parse result: %v", err)
+	}
+	if output.Query != "What is the capital of France?" {
+		t.Errorf("query = %q, want %q", output.Query, "What is the capital of France?")
+	}
+	if output.Answer == "" {
+		t.Error("answer should not be empty")
+	}
+	if !strings.Contains(output.Answer, "Paris") {
+		t.Errorf("answer = %q, want to contain 'Paris'", output.Answer)
+	}
+	if len(output.Citations) == 0 {
+		t.Error("expected citations")
+	}
+	if output.Model == "" {
+		t.Error("model should not be empty")
+	}
+}
+
+func TestHandlePerplexitySearch_MissingQuery(t *testing.T) {
+	vaultDir, identity := mockVaultWithEntry(t, "perplexity", map[string]any{
+		"credential": "test-key",
+	})
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:         "test",
+		AllowedPaths: []string{"*"},
+		CanWrite:     config.BoolPtr(false),
+		ApprovalMode: config.StrPtr("none"),
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+	srv.vault.Config = &config.Config{
+		MCP: &config.MCPConfig{
+			Perplexity: &config.PerplexityConfig{
+				BaseURL: "http://localhost:9999",
+			},
+		},
+	}
+
+	req := mcp.CallToolRequest{
+		Arguments: map[string]any{},
+	}
+
+	result, err := srv.handlePerplexitySearch(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handlePerplexitySearch() error = %v", err)
+	}
+	if result == nil {
+		t.Fatal("handlePerplexitySearch() returned nil result")
+	}
+	if !result.IsError {
+		t.Error("handlePerplexitySearch() expected error result for missing query")
+	}
+}
+
+func TestHandlePerplexitySearch_MissingAPIKey(t *testing.T) {
+	vaultDir, identity := mockVaultWithEntry(t, "other-entry", map[string]any{
+		"password": "some-value",
+	})
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:         "test",
+		AllowedPaths: []string{"*"},
+		CanWrite:     config.BoolPtr(false),
+		ApprovalMode: config.StrPtr("none"),
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+	srv.vault.Config = &config.Config{
+		MCP: &config.MCPConfig{
+			Perplexity: &config.PerplexityConfig{
+				BaseURL: "http://localhost:9999",
+			},
+		},
+	}
+
+	req := mcp.CallToolRequest{
+		Arguments: map[string]any{"query": "test query"},
+	}
+
+	result, err := srv.handlePerplexitySearch(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handlePerplexitySearch() error = %v", err)
+	}
+	if result == nil {
+		t.Fatal("handlePerplexitySearch() returned nil result")
+	}
+	if !result.IsError {
+		t.Error("handlePerplexitySearch() expected error for missing API key")
+	}
+	if !strings.Contains(result.Text, "API key") {
+		t.Errorf("error = %q, want to contain 'API key'", result.Text)
+	}
+}
+
+func TestHandlePerplexitySearch_APIKeyFromConfig(t *testing.T) {
+	ts := newTestPerplexityServer(t, true)
+	defer ts.Close()
+
+	vaultDir := t.TempDir()
+	identity, err := age.GenerateX25519Identity()
+	if err != nil {
+		t.Fatalf("generate identity: %v", err)
+	}
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:         "test",
+		AllowedPaths: []string{"*"},
+		CanWrite:     config.BoolPtr(false),
+		ApprovalMode: config.StrPtr("none"),
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+	srv.vault.Config = &config.Config{
+		MCP: &config.MCPConfig{
+			Perplexity: &config.PerplexityConfig{
+				APIKey:          "test-perplexity-key",
+				BaseURL:         ts.URL,
+				RateLimitPerMin: 100,
+			},
+		},
+	}
+
+	globalPerplexityRL = &perplexityRateLimiter{}
+
+	req := mcp.CallToolRequest{
+		Arguments: map[string]any{"query": "What is the capital of France?"},
+	}
+
+	result, err := srv.handlePerplexitySearch(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handlePerplexitySearch() error = %v", err)
+	}
+	if result == nil {
+		t.Fatal("handlePerplexitySearch() returned nil result")
+	}
+	if result.IsError {
+		t.Fatalf("handlePerplexitySearch() returned error: %s", result.Text)
+	}
+
+	var output perplexitySearchResult
+	if err := json.Unmarshal([]byte(result.Text), &output); err != nil {
+		t.Fatalf("parse result: %v", err)
+	}
+	if output.Query != "What is the capital of France?" {
+		t.Errorf("query = %q, want %q", output.Query, "What is the capital of France?")
+	}
+	if output.Answer == "" {
+		t.Error("answer should not be empty")
+	}
+}
+
+func TestHandlePerplexityAsk_Success(t *testing.T) {
+	ts := newTestPerplexityServer(t, false)
+	defer ts.Close()
+
+	vaultDir, identity := mockVaultWithEntry(t, "perplexity", map[string]any{
+		"credential": "test-perplexity-key",
+	})
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:         "test",
+		AllowedPaths: []string{"*"},
+		CanWrite:     config.BoolPtr(false),
+		ApprovalMode: config.StrPtr("none"),
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+	srv.vault.Config = &config.Config{
+		MCP: &config.MCPConfig{
+			Perplexity: &config.PerplexityConfig{
+				BaseURL:         ts.URL,
+				RateLimitPerMin: 100,
+			},
+		},
+	}
+
+	globalPerplexityRL = &perplexityRateLimiter{}
+
+	req := mcp.CallToolRequest{
+		Arguments: map[string]any{"question": "What is the capital of France?"},
+	}
+
+	result, err := srv.handlePerplexityAsk(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handlePerplexityAsk() error = %v", err)
+	}
+	if result == nil {
+		t.Fatal("handlePerplexityAsk() returned nil result")
+	}
+	if result.IsError {
+		t.Fatalf("handlePerplexityAsk() returned error: %s", result.Text)
+	}
+
+	var output perplexityAskResult
+	if err := json.Unmarshal([]byte(result.Text), &output); err != nil {
+		t.Fatalf("parse result: %v", err)
+	}
+	if output.Question != "What is the capital of France?" {
+		t.Errorf("question = %q, want %q", output.Question, "What is the capital of France?")
+	}
+	if output.Answer == "" {
+		t.Error("answer should not be empty")
+	}
+	if !strings.Contains(output.Answer, "Paris") {
+		t.Errorf("answer = %q, want to contain 'Paris'", output.Answer)
+	}
+	if len(output.Citations) == 0 {
+		t.Error("expected citations")
+	}
+	if output.Model == "" {
+		t.Error("model should not be empty")
+	}
+}
+
+func TestHandlePerplexityAsk_WithContext(t *testing.T) {
+	ts := newTestPerplexityServer(t, false)
+	defer ts.Close()
+
+	vaultDir, identity := mockVaultWithEntry(t, "perplexity", map[string]any{
+		"credential": "test-perplexity-key",
+	})
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:         "test",
+		AllowedPaths: []string{"*"},
+		CanWrite:     config.BoolPtr(false),
+		ApprovalMode: config.StrPtr("none"),
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+	srv.vault.Config = &config.Config{
+		MCP: &config.MCPConfig{
+			Perplexity: &config.PerplexityConfig{
+				BaseURL:         ts.URL,
+				RateLimitPerMin: 100,
+			},
+		},
+	}
+
+	globalPerplexityRL = &perplexityRateLimiter{}
+
+	req := mcp.CallToolRequest{
+		Arguments: map[string]any{
+			"question": "What services does AWS provide?",
+			"context":  "AWS provides cloud computing services including EC2, S3, Lambda.",
+		},
+	}
+
+	result, err := srv.handlePerplexityAsk(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handlePerplexityAsk() error = %v", err)
+	}
+	if result == nil {
+		t.Fatal("handlePerplexityAsk() returned nil result")
+	}
+	if result.IsError {
+		t.Fatalf("handlePerplexityAsk() returned error: %s", result.Text)
+	}
+
+	var output perplexityAskResult
+	if err := json.Unmarshal([]byte(result.Text), &output); err != nil {
+		t.Fatalf("parse result: %v", err)
+	}
+	if output.Question != "What services does AWS provide?" {
+		t.Errorf("question = %q, want %q", output.Question, "What services does AWS provide?")
+	}
+	if len(output.Context) == 0 {
+		t.Error("expected context in result")
+	}
+	if output.Answer == "" {
+		t.Error("answer should not be empty")
+	}
+}
+
+func TestHandlePerplexityAsk_MissingQuestion(t *testing.T) {
+	vaultDir, identity := mockVaultWithEntry(t, "perplexity", map[string]any{
+		"credential": "test-key",
+	})
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:         "test",
+		AllowedPaths: []string{"*"},
+		CanWrite:     config.BoolPtr(false),
+		ApprovalMode: config.StrPtr("none"),
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+	srv.vault.Config = &config.Config{
+		MCP: &config.MCPConfig{
+			Perplexity: &config.PerplexityConfig{
+				BaseURL: "http://localhost:9999",
+			},
+		},
+	}
+
+	req := mcp.CallToolRequest{
+		Arguments: map[string]any{},
+	}
+
+	result, err := srv.handlePerplexityAsk(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handlePerplexityAsk() error = %v", err)
+	}
+	if result == nil {
+		t.Fatal("handlePerplexityAsk() returned nil result")
+	}
+	if !result.IsError {
+		t.Error("handlePerplexityAsk() expected error result for missing question")
+	}
+}
+
+func TestPerplexitySearchToolRegistered(t *testing.T) {
+	defs := toolDefinitions()
+	foundSearch := false
+	foundAsk := false
+	for _, def := range defs {
+		if def.Name == "perplexity_search" {
+			foundSearch = true
+			if def.RiskLevel != RiskLevelLow {
+				t.Errorf("perplexity_search RiskLevel = %v, want RiskLevelLow", def.RiskLevel)
+			}
+			if !def.ReadOnlyHint {
+				t.Error("perplexity_search should have ReadOnlyHint true")
+			}
+		}
+		if def.Name == "perplexity_ask" {
+			foundAsk = true
+			if def.RiskLevel != RiskLevelLow {
+				t.Errorf("perplexity_ask RiskLevel = %v, want RiskLevelLow", def.RiskLevel)
+			}
+			if !def.ReadOnlyHint {
+				t.Error("perplexity_ask should have ReadOnlyHint true")
+			}
+		}
+	}
+	if !foundSearch {
+		t.Error("perplexity_search tool not registered in tool definitions")
+	}
+	if !foundAsk {
+		t.Error("perplexity_ask tool not registered in tool definitions")
+	}
+}
+
+func TestPerplexityRateLimiter(t *testing.T) {
+	rl := &perplexityRateLimiter{}
+	if !rl.Allow(5) {
+		t.Error("expected first request to be allowed")
+	}
+	if !rl.Allow(5) {
+		t.Error("expected second request to be allowed")
+	}
+	for i := 0; i < 3; i++ {
+		if !rl.Allow(5) {
+			t.Errorf("expected request %d to be allowed", i+3)
+		}
+	}
+	if rl.Allow(5) {
+		t.Error("expected 6th request to be denied (limit is 5)")
+	}
+}
+
+func TestPerplexityRateLimiter_Reset(t *testing.T) {
+	rl := &perplexityRateLimiter{}
+	rl.count = 5
+	rl.resetAt = time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+	now := time.Date(2020, 1, 1, 0, 2, 0, 0, time.UTC)
+
+	rl.mu.Lock()
+	if now.After(rl.resetAt) {
+		rl.count = 0
+		rl.resetAt = now.Add(time.Minute)
+	}
+	rl.mu.Unlock()
+
+	if !rl.Allow(5) {
+		t.Error("expected request after reset to be allowed")
+	}
+}
+
+func TestResolvePerplexityAPIKey_FromVault(t *testing.T) {
+	vaultDir, identity := mockVaultWithEntry(t, "perplexity", map[string]any{
+		"credential": "vault-key-123",
+	})
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:         "test",
+		AllowedPaths: []string{"*"},
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+
+	key, err := srv.resolvePerplexityAPIKey(context.Background())
+	if err != nil {
+		t.Fatalf("resolvePerplexityAPIKey() error = %v", err)
+	}
+	if key != "vault-key-123" {
+		t.Errorf("key = %q, want %q", key, "vault-key-123")
+	}
+}
+
+func TestResolvePerplexityAPIKey_FromConfig(t *testing.T) {
+	vaultDir := t.TempDir()
+	identity, err := age.GenerateX25519Identity()
+	if err != nil {
+		t.Fatalf("generate identity: %v", err)
+	}
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:         "test",
+		AllowedPaths: []string{"*"},
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+	srv.vault.Config = &config.Config{
+		MCP: &config.MCPConfig{
+			Perplexity: &config.PerplexityConfig{
+				APIKey: "config-key-456",
+			},
+		},
+	}
+
+	key, err := srv.resolvePerplexityAPIKey(context.Background())
+	if err != nil {
+		t.Fatalf("resolvePerplexityAPIKey() error = %v", err)
+	}
+	if key != "config-key-456" {
+		t.Errorf("key = %q, want %q", key, "config-key-456")
+	}
+}
+
+func TestResolvePerplexityAPIKey_Missing(t *testing.T) {
+	vaultDir := t.TempDir()
+	identity, err := age.GenerateX25519Identity()
+	if err != nil {
+		t.Fatalf("generate identity: %v", err)
+	}
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:         "test",
+		AllowedPaths: []string{"*"},
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+
+	_, err = srv.resolvePerplexityAPIKey(context.Background())
+	if err == nil {
+		t.Fatal("resolvePerplexityAPIKey() expected error for missing key")
+	}
+	if !strings.Contains(err.Error(), "API key") {
+		t.Errorf("error = %q, want to contain 'API key'", err.Error())
+	}
+}
+
+func TestGetPerplexityBaseURL_Default(t *testing.T) {
+	vaultDir := t.TempDir()
+	identity, err := age.GenerateX25519Identity()
+	if err != nil {
+		t.Fatalf("generate identity: %v", err)
+	}
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name: "test",
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+
+	url := srv.getPerplexityBaseURL()
+	if url != "https://api.perplexity.ai" {
+		t.Errorf("base URL = %q, want %q", url, "https://api.perplexity.ai")
+	}
+}
+
+func TestGetPerplexityBaseURL_ConfigOverride(t *testing.T) {
+	vaultDir := t.TempDir()
+	identity, err := age.GenerateX25519Identity()
+	if err != nil {
+		t.Fatalf("generate identity: %v", err)
+	}
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name: "test",
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+	srv.vault.Config = &config.Config{
+		MCP: &config.MCPConfig{
+			Perplexity: &config.PerplexityConfig{
+				BaseURL: "https://custom.perplexity.example.com",
+			},
+		},
+	}
+
+	url := srv.getPerplexityBaseURL()
+	if url != "https://custom.perplexity.example.com" {
+		t.Errorf("base URL = %q, want %q", url, "https://custom.perplexity.example.com")
+	}
+}
+
+func TestPerplexitySearch_RateLimited(t *testing.T) {
+	ts := newTestPerplexityServer(t, true)
+	defer ts.Close()
+
+	vaultDir, identity := mockVaultWithEntry(t, "perplexity", map[string]any{
+		"credential": "test-perplexity-key",
+	})
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:         "test",
+		AllowedPaths: []string{"*"},
+		CanWrite:     config.BoolPtr(false),
+		ApprovalMode: config.StrPtr("none"),
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+	srv.vault.Config = &config.Config{
+		MCP: &config.MCPConfig{
+			Perplexity: &config.PerplexityConfig{
+				BaseURL:         ts.URL,
+				RateLimitPerMin: 1,
+			},
+		},
+	}
+
+	globalPerplexityRL = &perplexityRateLimiter{}
+
+	req1 := mcp.CallToolRequest{
+		Arguments: map[string]any{"query": "first query"},
+	}
+	result1, err := srv.handlePerplexitySearch(context.Background(), req1)
+	if err != nil {
+		t.Fatalf("first request error = %v", err)
+	}
+	if result1 == nil {
+		t.Fatal("first request returned nil result")
+	}
+	if result1.IsError {
+		t.Fatalf("first request returned error: %s", result1.Text)
+	}
+
+	req2 := mcp.CallToolRequest{
+		Arguments: map[string]any{"query": "second query"},
+	}
+	result2, err := srv.handlePerplexitySearch(context.Background(), req2)
+	if err != nil {
+		t.Fatalf("second request error = %v", err)
+	}
+	if result2 == nil {
+		t.Fatal("second request returned nil result")
+	}
+	if !result2.IsError {
+		t.Fatal("expected rate limit error on second request")
+	}
+	if !strings.Contains(result2.Text, "rate limit") {
+		t.Errorf("error = %q, want to contain 'rate limit'", result2.Text)
+	}
+}
+
+func TestPerplexityAPIError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error": "invalid_api_key"}`))
+	}))
+	defer ts.Close()
+
+	vaultDir, identity := mockVaultWithEntry(t, "perplexity", map[string]any{
+		"credential": "bad-key",
+	})
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:         "test",
+		AllowedPaths: []string{"*"},
+		CanWrite:     config.BoolPtr(false),
+		ApprovalMode: config.StrPtr("none"),
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+	srv.vault.Config = &config.Config{
+		MCP: &config.MCPConfig{
+			Perplexity: &config.PerplexityConfig{
+				BaseURL:         ts.URL,
+				RateLimitPerMin: 100,
+			},
+		},
+	}
+
+	globalPerplexityRL = &perplexityRateLimiter{}
+
+	req := mcp.CallToolRequest{
+		Arguments: map[string]any{"query": "test"},
+	}
+
+	result, err := srv.handlePerplexitySearch(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handlePerplexitySearch() error = %v", err)
+	}
+	if result == nil {
+		t.Fatal("handlePerplexitySearch() returned nil result")
+	}
+	if !result.IsError {
+		t.Fatal("expected error result for API error")
+	}
+	if !strings.Contains(result.Text, "401") && !strings.Contains(result.Text, "Unauthorized") {
+		t.Errorf("error = %q, want to contain error details", result.Text)
+	}
+}

--- a/internal/mcp/server/tools_request_credential.go
+++ b/internal/mcp/server/tools_request_credential.go
@@ -39,9 +39,9 @@ func init() {
 			"field":  {Type: "string", Description: "Field name, e.g. \"token\", \"password\", \"api_key\""},
 			"reason": {Type: "string", Description: "Short human-readable reason shown in the dialog (why does the agent need this?)"},
 		}),
-		Handler:   (*Server).handleRequestCredential,
-		Available: secureInputToolAvailable,
-		RiskLevel: RiskLevelCritical,
+		Handler:         (*Server).handleRequestCredential,
+		Available:       secureInputToolAvailable,
+		RiskLevel:       RiskLevelCritical,
 		DestructiveHint: true,
 	})
 }

--- a/internal/mcp/server/tools_request_credential.go
+++ b/internal/mcp/server/tools_request_credential.go
@@ -42,5 +42,6 @@ func init() {
 		Handler:   (*Server).handleRequestCredential,
 		Available: secureInputToolAvailable,
 		RiskLevel: RiskLevelCritical,
+		DestructiveHint: true,
 	})
 }

--- a/internal/mcp/server/tools_run.go
+++ b/internal/mcp/server/tools_run.go
@@ -165,5 +165,6 @@ func init() {
 		}),
 		Handler:   (*Server).handleRunCommand,
 		RiskLevel: RiskLevelHigh,
+		DestructiveHint: true,
 	})
 }

--- a/internal/mcp/server/tools_run.go
+++ b/internal/mcp/server/tools_run.go
@@ -163,8 +163,8 @@ func init() {
 			"working_dir": {Type: "string", Description: "Working directory for the command"},
 			"timeout":     {Type: "number", Description: "Timeout in seconds (default: 30)"},
 		}),
-		Handler:   (*Server).handleRunCommand,
-		RiskLevel: RiskLevelHigh,
+		Handler:         (*Server).handleRunCommand,
+		RiskLevel:       RiskLevelHigh,
 		DestructiveHint: true,
 	})
 }

--- a/internal/mcp/server/tools_sanitize.go
+++ b/internal/mcp/server/tools_sanitize.go
@@ -72,8 +72,8 @@ func init() {
 			"mask_with_op_refs": {Type: "boolean", Description: "Replace vault-known secrets with op:// references"},
 			"mask":              {Type: "string", Description: "Custom mask string (default: ***)"},
 		}),
-		Handler:   (*Server).handleSanitizeOutput,
-		RiskLevel: RiskLevelLow,
+		Handler:      (*Server).handleSanitizeOutput,
+		RiskLevel:    RiskLevelLow,
 		ReadOnlyHint: true,
 	})
 }

--- a/internal/mcp/server/tools_sanitize.go
+++ b/internal/mcp/server/tools_sanitize.go
@@ -74,5 +74,6 @@ func init() {
 		}),
 		Handler:   (*Server).handleSanitizeOutput,
 		RiskLevel: RiskLevelLow,
+		ReadOnlyHint: true,
 	})
 }

--- a/internal/mcp/server/tools_search.go
+++ b/internal/mcp/server/tools_search.go
@@ -133,5 +133,6 @@ func init() {
 		}),
 		Handler:   (*Server).handleSearch,
 		RiskLevel: RiskLevelLow,
+		ReadOnlyHint: true,
 	})
 }

--- a/internal/mcp/server/tools_search.go
+++ b/internal/mcp/server/tools_search.go
@@ -131,8 +131,8 @@ func init() {
 			"intent": {Type: "string", Description: "Natural language intent or keyword to search for"},
 			"return": {Type: "string", Description: "Output format: \"spec\" (full tool specs) or \"names\" (just tool names). Default: \"spec\"."},
 		}),
-		Handler:   (*Server).handleSearch,
-		RiskLevel: RiskLevelLow,
+		Handler:      (*Server).handleSearch,
+		RiskLevel:    RiskLevelLow,
 		ReadOnlyHint: true,
 	})
 }

--- a/internal/mcp/server/tools_search_openai.go
+++ b/internal/mcp/server/tools_search_openai.go
@@ -1,0 +1,158 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"path"
+	"strings"
+	"time"
+
+	mcp "github.com/danieljustus/symaira-vault/internal/mcp"
+	"github.com/danieljustus/symaira-vault/internal/metrics"
+	vaultpkg "github.com/danieljustus/symaira-vault/internal/vault"
+)
+
+type openAISearchResult struct {
+	ID      string `json:"id"`
+	Title   string `json:"title"`
+	URL     string `json:"url"`
+	Content string `json:"content,omitempty"`
+}
+
+type openAISearchResponse struct {
+	Results []openAISearchResult `json:"results"`
+}
+
+type openAIFetchResponse struct {
+	ID       string         `json:"id"`
+	Title    string         `json:"title"`
+	URL      string         `json:"url"`
+	Metadata map[string]any `json:"metadata,omitempty"`
+	Values   map[string]any `json:"values,omitempty"`
+}
+
+func entryURL(path string) string {
+	return "symvault://entry/" + path
+}
+
+func entryTitle(p string) string {
+	_, name := path.Split(p)
+	if name == "" {
+		return p
+	}
+	return name
+}
+
+func (s *Server) handleSearchOpenAI(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	query, err := req.RequireString("query")
+	if err != nil {
+		s.logAudit(ctx, "search_openai", "<invalid>", false)
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	matches, err := s.findEntries(ctx, query)
+	if err != nil {
+		s.logAudit(ctx, "search_openai", query, false)
+		return nil, err
+	}
+
+	s.logAudit(ctx, "search_openai", query, true)
+
+	results := make([]openAISearchResult, 0, len(matches))
+	for _, m := range matches {
+		sanitizedPath := globalChokepoint.SanitizeForMCP(m.Path)
+		result := openAISearchResult{
+			ID:    sanitizedPath,
+			Title: globalChokepoint.SanitizeForMCP(entryTitle(m.Path)),
+			URL:   entryURL(sanitizedPath),
+		}
+		if len(m.Fields) > 0 {
+			result.Content = "Matching fields: " + strings.Join(m.Fields, ", ")
+		}
+		results = append(results, result)
+	}
+
+	structured := openAISearchResponse{Results: results}
+
+	textJSON, err := json.Marshal(results)
+	if err != nil {
+		return nil, err
+	}
+
+	return mcp.NewToolResultStructured(string(textJSON), structured), nil
+}
+
+func (s *Server) handleFetchOpenAI(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	id, err := req.RequireString("id")
+	if err != nil {
+		s.logAudit(ctx, "fetch_openai", "<invalid>", false)
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	if !s.checkScope(id) {
+		s.logAudit(ctx, "fetch_openai", id, false)
+		metrics.RecordAuthDenial("scope_denied", s.agent.Name)
+		return mcp.NewToolResultError(fmt.Sprintf("access denied: path %q outside allowed scope", id)), nil
+	}
+
+	_, span := metrics.StartSpan(ctx, "vault.ReadEntry")
+	entry, vaultErr := vaultpkg.ReadEntry(s.vault.Dir, id, s.vault.Identity)
+	span.End()
+	if vaultErr != nil {
+		s.logAudit(ctx, "fetch_openai", id, false)
+		metrics.RecordVaultOperation("read", "error")
+		return vaultServiceErrorResult(vaultErr)
+	}
+
+	s.logAudit(ctx, "fetch_openai", id, true)
+	metrics.RecordVaultOperation("read", "success")
+
+	sanitizedPath := globalChokepoint.SanitizeForMCP(id)
+
+	response := openAIFetchResponse{
+		ID:    sanitizedPath,
+		Title: globalChokepoint.SanitizeForMCP(entryTitle(id)),
+		URL:   entryURL(sanitizedPath),
+		Metadata: map[string]any{
+			"created": entry.Metadata.Created.Format(time.RFC3339),
+			"updated": entry.Metadata.Updated.Format(time.RFC3339),
+			"version": entry.Metadata.Version,
+			"type":    entry.SecretMetadata.Type,
+		},
+	}
+
+	if s.canReadValues() && len(entry.Data) > 0 {
+		response.Values = entry.Data
+	}
+
+	textJSON, marshalErr := json.Marshal(response)
+	if marshalErr != nil {
+		return nil, marshalErr
+	}
+
+	return mcp.NewToolResultStructured(string(textJSON), response), nil
+}
+
+func init() {
+	RegisterTool(toolDefinition{
+		Name:        "search",
+		Description: "Search vault entries by query. Returns results with id, title, and url for each matching entry.",
+		InputSchema: objectSchema([]string{"query"}, map[string]schemaProperty{
+			"query": {Type: "string", Description: "Search query to match against entry paths and field values"},
+		}),
+		Handler:      (*Server).handleSearchOpenAI,
+		RiskLevel:    RiskLevelLow,
+		ReadOnlyHint: true,
+	})
+	RegisterTool(toolDefinition{
+		Name:        "fetch",
+		Description: "Fetch a vault entry by path/id. Returns the full entry content with metadata and values.",
+		InputSchema: objectSchema([]string{"id"}, map[string]schemaProperty{
+			"id": {Type: "string", Description: "Entry path or id to fetch (e.g., 'github' or 'work/aws')"},
+		}),
+		Handler:      (*Server).handleFetchOpenAI,
+		RiskLevel:    RiskLevelLow,
+		ReadOnlyHint: true,
+	})
+}

--- a/internal/mcp/server/tools_search_openai_test.go
+++ b/internal/mcp/server/tools_search_openai_test.go
@@ -1,0 +1,561 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/danieljustus/symaira-vault/internal/config"
+	mcp "github.com/danieljustus/symaira-vault/internal/mcp"
+)
+
+func TestHandleSearchOpenAI_Success(t *testing.T) {
+	vaultDir, identity := mockVault(t)
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:         "test",
+		AllowedPaths: []string{"*"},
+		CanWrite:     config.BoolPtr(false),
+		ApprovalMode: config.StrPtr("none"),
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+
+	req := mcp.CallToolRequest{
+		Arguments: map[string]any{"query": "test"},
+	}
+
+	result, err := srv.handleSearchOpenAI(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleSearchOpenAI() error = %v", err)
+	}
+	if result == nil {
+		t.Fatal("handleSearchOpenAI() returned nil result")
+	}
+	if result.IsError {
+		t.Fatalf("handleSearchOpenAI() returned error: %s", result.Text)
+	}
+	if result.StructuredContent == nil {
+		t.Fatal("handleSearchOpenAI() returned nil StructuredContent")
+	}
+
+	structured, ok := result.StructuredContent.(openAISearchResponse)
+	if !ok {
+		t.Fatalf("StructuredContent type = %T, want openAISearchResponse", result.StructuredContent)
+	}
+	if len(structured.Results) == 0 {
+		t.Fatal("expected at least one search result")
+	}
+	found := false
+	for _, r := range structured.Results {
+		if r.ID == "github" {
+			found = true
+			if r.Title == "" {
+				t.Error("result title should not be empty")
+			}
+			if r.URL == "" {
+				t.Error("result url should not be empty")
+			}
+			if !strings.HasPrefix(r.URL, "symvault://") {
+				t.Errorf("result url = %q, want symvault:// prefix", r.URL)
+			}
+			break
+		}
+	}
+	if !found {
+		t.Error("expected to find github entry in search results")
+	}
+
+	var textResults []openAISearchResult
+	if err := json.Unmarshal([]byte(result.Text), &textResults); err != nil {
+		t.Fatalf("parse result text: %v", err)
+	}
+	if len(textResults) != len(structured.Results) {
+		t.Errorf("text results count = %d, structured count = %d", len(textResults), len(structured.Results))
+	}
+}
+
+func TestHandleSearchOpenAI_MissingQuery(t *testing.T) {
+	vaultDir, identity := mockVault(t)
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:         "test",
+		AllowedPaths: []string{"*"},
+		CanWrite:     config.BoolPtr(false),
+		ApprovalMode: config.StrPtr("none"),
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+
+	req := mcp.CallToolRequest{
+		Arguments: map[string]any{},
+	}
+
+	result, err := srv.handleSearchOpenAI(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleSearchOpenAI() error = %v", err)
+	}
+	if result == nil {
+		t.Fatal("handleSearchOpenAI() returned nil result")
+	}
+	if !result.IsError {
+		t.Error("handleSearchOpenAI() expected error result for missing query")
+	}
+}
+
+func TestHandleSearchOpenAI_FiltersByScope(t *testing.T) {
+	vaultDir, identity := mockVault(t)
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:         "test",
+		AllowedPaths: []string{"work/"},
+		CanWrite:     config.BoolPtr(false),
+		ApprovalMode: config.StrPtr("none"),
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+
+	req := mcp.CallToolRequest{
+		Arguments: map[string]any{"query": "test"},
+	}
+
+	result, err := srv.handleSearchOpenAI(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleSearchOpenAI() error = %v", err)
+	}
+	if result == nil {
+		t.Fatal("handleSearchOpenAI() returned nil result")
+	}
+	if result.IsError {
+		t.Fatalf("handleSearchOpenAI() returned error: %s", result.Text)
+	}
+
+	structured, ok := result.StructuredContent.(openAISearchResponse)
+	if !ok {
+		t.Fatalf("StructuredContent type = %T, want openAISearchResponse", result.StructuredContent)
+	}
+	for _, r := range structured.Results {
+		if r.ID == "github" {
+			t.Error("github should not be in results due to scope filtering")
+		}
+	}
+}
+
+func TestHandleSearchOpenAI_NoResults(t *testing.T) {
+	vaultDir, identity := mockVault(t)
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:         "test",
+		AllowedPaths: []string{"*"},
+		CanWrite:     config.BoolPtr(false),
+		ApprovalMode: config.StrPtr("none"),
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+
+	req := mcp.CallToolRequest{
+		Arguments: map[string]any{"query": "zzzzz_nomatch"},
+	}
+
+	result, err := srv.handleSearchOpenAI(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleSearchOpenAI() error = %v", err)
+	}
+	if result == nil {
+		t.Fatal("handleSearchOpenAI() returned nil result")
+	}
+	if result.IsError {
+		t.Fatalf("handleSearchOpenAI() returned error: %s", result.Text)
+	}
+
+	structured, ok := result.StructuredContent.(openAISearchResponse)
+	if !ok {
+		t.Fatalf("StructuredContent type = %T, want openAISearchResponse", result.StructuredContent)
+	}
+	if len(structured.Results) != 0 {
+		t.Errorf("expected no results, got %d", len(structured.Results))
+	}
+}
+
+func TestHandleFetchOpenAI_Success(t *testing.T) {
+	vaultDir, identity := mockVault(t)
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:         "test",
+		AllowedPaths: []string{"*"},
+		CanWrite:     config.BoolPtr(false),
+		CanReadValues: config.BoolPtr(true),
+		ApprovalMode: config.StrPtr("none"),
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+
+	req := mcp.CallToolRequest{
+		Arguments: map[string]any{"id": "github"},
+	}
+
+	result, err := srv.handleFetchOpenAI(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleFetchOpenAI() error = %v", err)
+	}
+	if result == nil {
+		t.Fatal("handleFetchOpenAI() returned nil result")
+	}
+	if result.IsError {
+		t.Fatalf("handleFetchOpenAI() returned error: %s", result.Text)
+	}
+	if result.StructuredContent == nil {
+		t.Fatal("handleFetchOpenAI() returned nil StructuredContent")
+	}
+
+	structured, ok := result.StructuredContent.(openAIFetchResponse)
+	if !ok {
+		t.Fatalf("StructuredContent type = %T, want openAIFetchResponse", result.StructuredContent)
+	}
+	if structured.ID != "github" {
+		t.Errorf("id = %q, want github", structured.ID)
+	}
+	if structured.Title == "" {
+		t.Error("title should not be empty")
+	}
+	if !strings.HasPrefix(structured.URL, "symvault://") {
+		t.Errorf("url = %q, want symvault:// prefix", structured.URL)
+	}
+	if structured.Metadata == nil {
+		t.Fatal("expected metadata in response")
+	}
+	if v, ok := structured.Metadata["version"]; !ok || v == nil {
+		t.Error("expected version in metadata")
+	}
+	if structured.Values == nil {
+		t.Fatal("expected values in response when canReadValues is true")
+	}
+	if _, ok := structured.Values["password"]; !ok {
+		t.Error("expected password field in values")
+	}
+
+	var textResponse openAIFetchResponse
+	if err := json.Unmarshal([]byte(result.Text), &textResponse); err != nil {
+		t.Fatalf("parse result text: %v", err)
+	}
+	if textResponse.ID != structured.ID {
+		t.Errorf("text id = %q, want %q", textResponse.ID, structured.ID)
+	}
+}
+
+func TestHandleFetchOpenAI_NoValues(t *testing.T) {
+	vaultDir, identity := mockVault(t)
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:         "test",
+		AllowedPaths: []string{"*"},
+		CanWrite:     config.BoolPtr(false),
+		CanReadValues: config.BoolPtr(false),
+		ApprovalMode: config.StrPtr("none"),
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+
+	req := mcp.CallToolRequest{
+		Arguments: map[string]any{"id": "github"},
+	}
+
+	result, err := srv.handleFetchOpenAI(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleFetchOpenAI() error = %v", err)
+	}
+	if result == nil {
+		t.Fatal("handleFetchOpenAI() returned nil result")
+	}
+	if result.IsError {
+		t.Fatalf("handleFetchOpenAI() returned error: %s", result.Text)
+	}
+
+	structured, ok := result.StructuredContent.(openAIFetchResponse)
+	if !ok {
+		t.Fatalf("StructuredContent type = %T, want openAIFetchResponse", result.StructuredContent)
+	}
+	if structured.Values != nil {
+		t.Error("expected nil values when canReadValues is false")
+	}
+	if structured.Metadata == nil {
+		t.Error("expected metadata even without value access")
+	}
+}
+
+func TestHandleFetchOpenAI_MissingID(t *testing.T) {
+	vaultDir, identity := mockVault(t)
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:         "test",
+		AllowedPaths: []string{"*"},
+		CanWrite:     config.BoolPtr(false),
+		ApprovalMode: config.StrPtr("none"),
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+
+	req := mcp.CallToolRequest{
+		Arguments: map[string]any{},
+	}
+
+	result, err := srv.handleFetchOpenAI(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleFetchOpenAI() error = %v", err)
+	}
+	if result == nil {
+		t.Fatal("handleFetchOpenAI() returned nil result")
+	}
+	if !result.IsError {
+		t.Error("handleFetchOpenAI() expected error result for missing id")
+	}
+}
+
+func TestHandleFetchOpenAI_NotFound(t *testing.T) {
+	vaultDir, identity := mockVault(t)
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:         "test",
+		AllowedPaths: []string{"*"},
+		CanWrite:     config.BoolPtr(false),
+		ApprovalMode: config.StrPtr("none"),
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+
+	req := mcp.CallToolRequest{
+		Arguments: map[string]any{"id": "nonexistent"},
+	}
+
+	result, err := srv.handleFetchOpenAI(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleFetchOpenAI() error = %v", err)
+	}
+	if result == nil || !result.IsError {
+		t.Fatal("handleFetchOpenAI() expected error result for nonexistent entry")
+	}
+}
+
+func TestHandleFetchOpenAI_OutsideScope(t *testing.T) {
+	vaultDir, identity := mockVault(t)
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:         "test",
+		AllowedPaths: []string{"work/"},
+		CanWrite:     config.BoolPtr(false),
+		ApprovalMode: config.StrPtr("none"),
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+
+	req := mcp.CallToolRequest{
+		Arguments: map[string]any{"id": "github"},
+	}
+
+	result, err := srv.handleFetchOpenAI(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleFetchOpenAI() error = %v", err)
+	}
+	if result == nil {
+		t.Fatal("handleFetchOpenAI() returned nil result")
+	}
+	if !result.IsError {
+		t.Fatal("handleFetchOpenAI() expected error result for out-of-scope path")
+	}
+	if !strings.Contains(result.Text, "outside allowed scope") {
+		t.Errorf("error = %q, want 'outside allowed scope'", result.Text)
+	}
+}
+
+func TestCallToolResultPayload_StructuredContent(t *testing.T) {
+	structured := map[string]any{"results": []map[string]any{
+		{"id": "test", "title": "Test", "url": "symvault://entry/test"},
+	}}
+	result := mcp.NewToolResultStructured(`[{"id":"test","title":"Test","url":"symvault://entry/test"}]`, structured)
+
+	payload := callToolResultPayload(result)
+
+	if payload["structuredContent"] == nil {
+		t.Fatal("expected structuredContent in payload")
+	}
+
+	sc, ok := payload["structuredContent"].(map[string]any)
+	if !ok {
+		t.Fatalf("structuredContent type = %T, want map[string]any", payload["structuredContent"])
+	}
+	results, ok := sc["results"].([]map[string]any)
+	if !ok {
+		t.Fatalf("results type = %T, want []map[string]any", sc["results"])
+	}
+	if len(results) != 1 {
+		t.Errorf("expected 1 result, got %d", len(results))
+	}
+	if results[0]["id"] != "test" {
+		t.Errorf("result id = %v, want test", results[0]["id"])
+	}
+
+	content, ok := payload["content"].([]map[string]any)
+	if !ok {
+		t.Fatal("expected content in payload")
+	}
+	if len(content) == 0 {
+		t.Fatal("expected non-empty content")
+	}
+	if content[0]["type"] != "text" {
+		t.Errorf("content type = %v, want text", content[0]["type"])
+	}
+
+	if payload["isError"] != false {
+		t.Error("expected isError to be false")
+	}
+}
+
+func TestEntryURL(t *testing.T) {
+	tests := []struct {
+		path string
+		want string
+	}{
+		{"github", "symvault://entry/github"},
+		{"work/aws", "symvault://entry/work/aws"},
+		{"nested/deep/path", "symvault://entry/nested/deep/path"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			got := entryURL(tt.path)
+			if got != tt.want {
+				t.Errorf("entryURL(%q) = %q, want %q", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEntryTitle(t *testing.T) {
+	tests := []struct {
+		path string
+		want string
+	}{
+		{"github", "github"},
+		{"work/aws", "aws"},
+		{"nested/deep/path", "path"},
+		{"single", "single"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			got := entryTitle(tt.path)
+			if got != tt.want {
+				t.Errorf("entryTitle(%q) = %q, want %q", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSearchToolRegistered(t *testing.T) {
+	defs := toolDefinitions()
+	foundSearch := false
+	foundFetch := false
+	for _, def := range defs {
+		if def.Name == "search" {
+			foundSearch = true
+			if def.RiskLevel != RiskLevelLow {
+				t.Errorf("search tool RiskLevel = %v, want RiskLevelLow", def.RiskLevel)
+			}
+			if !def.ReadOnlyHint {
+				t.Error("search tool should have ReadOnlyHint true")
+			}
+		}
+		if def.Name == "fetch" {
+			foundFetch = true
+			if def.RiskLevel != RiskLevelLow {
+				t.Errorf("fetch tool RiskLevel = %v, want RiskLevelLow", def.RiskLevel)
+			}
+			if !def.ReadOnlyHint {
+				t.Error("fetch tool should have ReadOnlyHint true")
+			}
+		}
+	}
+	if !foundSearch {
+		t.Error("search tool not registered in tool definitions")
+	}
+	if !foundFetch {
+		t.Error("fetch tool not registered in tool definitions")
+	}
+}
+
+func TestFetchOpenAI_ValuesRespectCanReadValues(t *testing.T) {
+	vaultDir, identity := mockVault(t)
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:          "test",
+		AllowedPaths:  []string{"*"},
+		CanWrite:      config.BoolPtr(false),
+		CanReadValues: config.BoolPtr(false),
+		ApprovalMode:  config.StrPtr("none"),
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+
+	req := mcp.CallToolRequest{
+		Arguments: map[string]any{"id": "github"},
+	}
+
+	result, err := srv.handleFetchOpenAI(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleFetchOpenAI() error = %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handleFetchOpenAI() returned error: %s", result.Text)
+	}
+
+	structured, ok := result.StructuredContent.(openAIFetchResponse)
+	if !ok {
+		t.Fatalf("StructuredContent type = %T, want openAIFetchResponse", result.StructuredContent)
+	}
+	if structured.Values != nil {
+		t.Error("Values should be nil when canReadValues is false")
+	}
+	if structured.Metadata == nil {
+		t.Error("Metadata should be present even without value access")
+	}
+}
+
+func TestExecuteTool_SearchOpenAI(t *testing.T) {
+	vaultDir, identity := mockVault(t)
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:         "test",
+		AllowedPaths: []string{"*"},
+		CanWrite:     config.BoolPtr(false),
+		ApprovalMode: config.StrPtr("none"),
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+
+	args, _ := json.Marshal(map[string]any{"query": "test"})
+	rawArgs := json.RawMessage(args)
+	result, err := srv.executeTool(context.Background(), "search", rawArgs)
+	if err != nil {
+		t.Fatalf("executeTool(search) error = %v", err)
+	}
+
+	content, ok := result["content"].([]map[string]any)
+	if !ok {
+		t.Fatal("result content has unexpected type")
+	}
+	if len(content) == 0 {
+		t.Fatal("expected content in result")
+	}
+
+	if _, ok := result["structuredContent"]; !ok {
+		t.Error("expected structuredContent in result")
+	}
+}
+
+func TestExecuteTool_FetchOpenAI(t *testing.T) {
+	vaultDir, identity := mockVault(t)
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:         "test",
+		AllowedPaths: []string{"*"},
+		CanWrite:     config.BoolPtr(false),
+		CanReadValues: config.BoolPtr(true),
+		ApprovalMode: config.StrPtr("none"),
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+
+	args, _ := json.Marshal(map[string]any{"id": "github"})
+	rawArgs := json.RawMessage(args)
+	result, err := srv.executeTool(context.Background(), "fetch", rawArgs)
+	if err != nil {
+		t.Fatalf("executeTool(fetch) error = %v", err)
+	}
+
+	content, ok := result["content"].([]map[string]any)
+	if !ok {
+		t.Fatal("result content has unexpected type")
+	}
+	if len(content) == 0 {
+		t.Fatal("expected content in result")
+	}
+
+	if _, ok := result["structuredContent"]; !ok {
+		t.Error("expected structuredContent in result")
+	}
+}

--- a/internal/mcp/server/tools_search_openai_test.go
+++ b/internal/mcp/server/tools_search_openai_test.go
@@ -173,11 +173,11 @@ func TestHandleSearchOpenAI_NoResults(t *testing.T) {
 func TestHandleFetchOpenAI_Success(t *testing.T) {
 	vaultDir, identity := mockVault(t)
 	srv := newTestServerWithVault(t, config.AgentProfile{
-		Name:         "test",
-		AllowedPaths: []string{"*"},
-		CanWrite:     config.BoolPtr(false),
+		Name:          "test",
+		AllowedPaths:  []string{"*"},
+		CanWrite:      config.BoolPtr(false),
 		CanReadValues: config.BoolPtr(true),
-		ApprovalMode: config.StrPtr("none"),
+		ApprovalMode:  config.StrPtr("none"),
 	}, "stdio", vaultDir)
 	srv.vault.Identity = identity
 
@@ -237,11 +237,11 @@ func TestHandleFetchOpenAI_Success(t *testing.T) {
 func TestHandleFetchOpenAI_NoValues(t *testing.T) {
 	vaultDir, identity := mockVault(t)
 	srv := newTestServerWithVault(t, config.AgentProfile{
-		Name:         "test",
-		AllowedPaths: []string{"*"},
-		CanWrite:     config.BoolPtr(false),
+		Name:          "test",
+		AllowedPaths:  []string{"*"},
+		CanWrite:      config.BoolPtr(false),
 		CanReadValues: config.BoolPtr(false),
-		ApprovalMode: config.StrPtr("none"),
+		ApprovalMode:  config.StrPtr("none"),
 	}, "stdio", vaultDir)
 	srv.vault.Identity = identity
 
@@ -532,11 +532,11 @@ func TestExecuteTool_SearchOpenAI(t *testing.T) {
 func TestExecuteTool_FetchOpenAI(t *testing.T) {
 	vaultDir, identity := mockVault(t)
 	srv := newTestServerWithVault(t, config.AgentProfile{
-		Name:         "test",
-		AllowedPaths: []string{"*"},
-		CanWrite:     config.BoolPtr(false),
+		Name:          "test",
+		AllowedPaths:  []string{"*"},
+		CanWrite:      config.BoolPtr(false),
 		CanReadValues: config.BoolPtr(true),
-		ApprovalMode: config.StrPtr("none"),
+		ApprovalMode:  config.StrPtr("none"),
 	}, "stdio", vaultDir)
 	srv.vault.Identity = identity
 

--- a/internal/mcp/server/tools_secure_input.go
+++ b/internal/mcp/server/tools_secure_input.go
@@ -121,5 +121,6 @@ func init() {
 		Handler:   (*Server).handleSecureInput,
 		Available: secureInputToolAvailable,
 		RiskLevel: RiskLevelCritical,
+		DestructiveHint: true,
 	})
 }

--- a/internal/mcp/server/tools_secure_input.go
+++ b/internal/mcp/server/tools_secure_input.go
@@ -118,9 +118,9 @@ func init() {
 			"field":       {Type: "string", Description: "Field name to store the value under"},
 			"description": {Type: "string", Description: "Optional description shown to the user in the prompt"},
 		}),
-		Handler:   (*Server).handleSecureInput,
-		Available: secureInputToolAvailable,
-		RiskLevel: RiskLevelCritical,
+		Handler:         (*Server).handleSecureInput,
+		Available:       secureInputToolAvailable,
+		RiskLevel:       RiskLevelCritical,
 		DestructiveHint: true,
 	})
 }

--- a/internal/mcp/server/tools_set.go
+++ b/internal/mcp/server/tools_set.go
@@ -175,8 +175,8 @@ func init() {
 			"value": {Type: "string", Description: "Field value"},
 			"force": {Type: "boolean", Description: "Skip password strength validation. Default: false."},
 		}),
-		Handler:   (*Server).handleSet,
-		RiskLevel: RiskLevelCritical,
+		Handler:         (*Server).handleSet,
+		RiskLevel:       RiskLevelCritical,
 		DestructiveHint: true,
 	})
 }

--- a/internal/mcp/server/tools_set.go
+++ b/internal/mcp/server/tools_set.go
@@ -177,5 +177,6 @@ func init() {
 		}),
 		Handler:   (*Server).handleSet,
 		RiskLevel: RiskLevelCritical,
+		DestructiveHint: true,
 	})
 }

--- a/internal/mcp/server/tools_sharing.go
+++ b/internal/mcp/server/tools_sharing.go
@@ -228,6 +228,7 @@ func init() {
 		}),
 		Handler:   (*Server).handleRequestShare,
 		RiskLevel: RiskLevelMedium,
+		DestructiveHint: true,
 	})
 	RegisterTool(toolDefinition{
 		Name:        "approve_share",
@@ -237,6 +238,7 @@ func init() {
 		}),
 		Handler:   (*Server).handleApproveShare,
 		RiskLevel: RiskLevelHigh,
+		DestructiveHint: true,
 	})
 	RegisterTool(toolDefinition{
 		Name:        "revoke_share",
@@ -246,6 +248,7 @@ func init() {
 		}),
 		Handler:   (*Server).handleRevokeShare,
 		RiskLevel: RiskLevelHigh,
+		DestructiveHint: true,
 	})
 	RegisterTool(toolDefinition{
 		Name:        "list_shares",
@@ -258,5 +261,6 @@ func init() {
 		}),
 		Handler:   (*Server).handleListShares,
 		RiskLevel: RiskLevelLow,
+		ReadOnlyHint: true,
 	})
 }

--- a/internal/mcp/server/tools_sharing.go
+++ b/internal/mcp/server/tools_sharing.go
@@ -226,8 +226,8 @@ func init() {
 			"secret_field": {Type: "string", Description: "Specific field to share (optional, shares entire entry if omitted)"},
 			"ttl":          {Type: "string", Description: "Time-to-live duration (e.g., \"1h\", \"30m\"). Share expires after this duration."},
 		}),
-		Handler:   (*Server).handleRequestShare,
-		RiskLevel: RiskLevelMedium,
+		Handler:         (*Server).handleRequestShare,
+		RiskLevel:       RiskLevelMedium,
 		DestructiveHint: true,
 	})
 	RegisterTool(toolDefinition{
@@ -236,8 +236,8 @@ func init() {
 		InputSchema: objectSchema([]string{"grant_id"}, map[string]schemaProperty{
 			"grant_id": {Type: "string", Description: "ID of the share grant to approve"},
 		}),
-		Handler:   (*Server).handleApproveShare,
-		RiskLevel: RiskLevelHigh,
+		Handler:         (*Server).handleApproveShare,
+		RiskLevel:       RiskLevelHigh,
 		DestructiveHint: true,
 	})
 	RegisterTool(toolDefinition{
@@ -246,8 +246,8 @@ func init() {
 		InputSchema: objectSchema([]string{"grant_id"}, map[string]schemaProperty{
 			"grant_id": {Type: "string", Description: "ID of the share grant to revoke"},
 		}),
-		Handler:   (*Server).handleRevokeShare,
-		RiskLevel: RiskLevelHigh,
+		Handler:         (*Server).handleRevokeShare,
+		RiskLevel:       RiskLevelHigh,
 		DestructiveHint: true,
 	})
 	RegisterTool(toolDefinition{
@@ -259,8 +259,8 @@ func init() {
 			"to_agent":    {Type: "string", Description: "Filter by target agent name"},
 			"secret_path": {Type: "string", Description: "Filter by secret path"},
 		}),
-		Handler:   (*Server).handleListShares,
-		RiskLevel: RiskLevelLow,
+		Handler:      (*Server).handleListShares,
+		RiskLevel:    RiskLevelLow,
 		ReadOnlyHint: true,
 	})
 }

--- a/internal/mcp/server/tools_template.go
+++ b/internal/mcp/server/tools_template.go
@@ -132,8 +132,8 @@ func init() {
 			"secret_refs":   {Type: "object", Description: "Map of template variable names to vault references"},
 			"dry_run":       {Type: "boolean", Description: "Show template with masked values. Default: false"},
 		}),
-		Handler:   (*Server).handleGenerateTemplate,
-		RiskLevel: RiskLevelMedium,
+		Handler:      (*Server).handleGenerateTemplate,
+		RiskLevel:    RiskLevelMedium,
 		ReadOnlyHint: true,
 	})
 }

--- a/internal/mcp/server/tools_template.go
+++ b/internal/mcp/server/tools_template.go
@@ -134,5 +134,6 @@ func init() {
 		}),
 		Handler:   (*Server).handleGenerateTemplate,
 		RiskLevel: RiskLevelMedium,
+		ReadOnlyHint: true,
 	})
 }

--- a/internal/mcp/server/tools_totp.go
+++ b/internal/mcp/server/tools_totp.go
@@ -197,5 +197,6 @@ func init() {
 		Handler:   (*Server).handleGenerateTOTP,
 		Available: generateTOTPAvailable,
 		RiskLevel: RiskLevelHigh,
+		ReadOnlyHint: true,
 	})
 }

--- a/internal/mcp/server/tools_totp.go
+++ b/internal/mcp/server/tools_totp.go
@@ -194,9 +194,9 @@ func init() {
 			"destination": {Type: "string", Description: "Where to send the code: \"clipboard\" (default, not returned), \"autotype\" (type directly), \"return\" (return in response, requires approval)"},
 			"return_code": {Type: "boolean", Description: "Must be true when destination=\"return\""},
 		}),
-		Handler:   (*Server).handleGenerateTOTP,
-		Available: generateTOTPAvailable,
-		RiskLevel: RiskLevelHigh,
+		Handler:      (*Server).handleGenerateTOTP,
+		Available:    generateTOTPAvailable,
+		RiskLevel:    RiskLevelHigh,
 		ReadOnlyHint: true,
 	})
 }

--- a/internal/mcp/server/tools_unseal.go
+++ b/internal/mcp/server/tools_unseal.go
@@ -130,5 +130,6 @@ func init() {
 		}),
 		Handler:   (*Server).handleSecretUnseal,
 		RiskLevel: RiskLevelHigh,
+		ReadOnlyHint: true,
 	})
 }

--- a/internal/mcp/server/tools_unseal.go
+++ b/internal/mcp/server/tools_unseal.go
@@ -128,8 +128,8 @@ func init() {
 		InputSchema: objectSchema([]string{"handle"}, map[string]schemaProperty{
 			"handle": {Type: "string", Description: "Secret handle to unseal (e.g. op://github/password)"},
 		}),
-		Handler:   (*Server).handleSecretUnseal,
-		RiskLevel: RiskLevelHigh,
+		Handler:      (*Server).handleSecretUnseal,
+		RiskLevel:    RiskLevelHigh,
 		ReadOnlyHint: true,
 	})
 }

--- a/internal/mcp/server/tools_whoami.go
+++ b/internal/mcp/server/tools_whoami.go
@@ -183,11 +183,11 @@ func (s *Server) handleWhoami(ctx context.Context, req mcp.CallToolRequest) (*mc
 
 func init() {
 	RegisterTool(toolDefinition{
-		Name:        "symaira_whoami",
-		Description: "Return the agent profile, available/unavailable tools, quotas, and vault status",
-		InputSchema: objectSchema(nil, map[string]schemaProperty{}),
-		Handler:     (*Server).handleWhoami,
-		RiskLevel:   RiskLevelLow,
+		Name:         "symaira_whoami",
+		Description:  "Return the agent profile, available/unavailable tools, quotas, and vault status",
+		InputSchema:  objectSchema(nil, map[string]schemaProperty{}),
+		Handler:      (*Server).handleWhoami,
+		RiskLevel:    RiskLevelLow,
 		ReadOnlyHint: true,
 	})
 }

--- a/internal/mcp/server/tools_whoami.go
+++ b/internal/mcp/server/tools_whoami.go
@@ -188,5 +188,6 @@ func init() {
 		InputSchema: objectSchema(nil, map[string]schemaProperty{}),
 		Handler:     (*Server).handleWhoami,
 		RiskLevel:   RiskLevelLow,
+		ReadOnlyHint: true,
 	})
 }

--- a/internal/mcp/serverbootstrap/http.go
+++ b/internal/mcp/serverbootstrap/http.go
@@ -4,6 +4,8 @@ package serverbootstrap
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"net"
@@ -351,10 +353,14 @@ func RunHTTPServerOnListener(ctx context.Context, listener net.Listener, v *vaul
 
 	tlsCert := ""
 	tlsKey := ""
+	tlsCAFile := ""
+	mtlsEnabled := false
 	allowInsecure := false
 	if v != nil && v.Config != nil && v.Config.MCP != nil {
 		tlsCert = strings.TrimSpace(v.Config.MCP.TLSCertFile)
 		tlsKey = strings.TrimSpace(v.Config.MCP.TLSKeyFile)
+		tlsCAFile = strings.TrimSpace(v.Config.MCP.TLSClientCAFile)
+		mtlsEnabled = v.Config.MCP.MTLSEnabled
 		allowInsecure = v.Config.MCP.AllowInsecureBind
 	}
 
@@ -408,7 +414,30 @@ func RunHTTPServerOnListener(ctx context.Context, listener net.Listener, v *vaul
 
 	var serveErr error
 	if tlsEnabled {
-		serveErr = server.ServeTLS(listener, tlsCert, tlsKey)
+		if mtlsEnabled && tlsCAFile != "" {
+			caCert, readErr := os.ReadFile(tlsCAFile)
+			if readErr != nil {
+				return fmt.Errorf("read client CA certificate: %w", readErr)
+			}
+			caCertPool := x509.NewCertPool()
+			if !caCertPool.AppendCertsFromPEM(caCert) {
+				return fmt.Errorf("parse client CA certificate: no valid PEM block found in %q", tlsCAFile)
+			}
+			cert, loadErr := tls.LoadX509KeyPair(tlsCert, tlsKey)
+			if loadErr != nil {
+				return fmt.Errorf("load server TLS key pair: %w", loadErr)
+			}
+			tlsConfig := &tls.Config{
+				Certificates: []tls.Certificate{cert},
+				ClientAuth:   tls.RequireAndVerifyClientCert,
+				ClientCAs:    caCertPool,
+				MinVersion:   tls.VersionTLS12,
+			}
+			tlsListener := tls.NewListener(listener, tlsConfig)
+			serveErr = server.Serve(tlsListener)
+		} else {
+			serveErr = server.ServeTLS(listener, tlsCert, tlsKey)
+		}
 	} else {
 		serveErr = server.Serve(listener)
 	}

--- a/internal/mcp/serverbootstrap/serverbootstrap_test.go
+++ b/internal/mcp/serverbootstrap/serverbootstrap_test.go
@@ -5,11 +5,15 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
 	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/json"
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"math/big"
 	"net"
 	"net/http"
 	"net/url"
@@ -1184,4 +1188,208 @@ func TestGenerateSelfSignedCert_ECDSA_P256(t *testing.T) {
 	if !foundLoopback {
 		t.Error("expected IPAddresses to contain loopback address")
 	}
+}
+
+func generateTestCA(t *testing.T) (certPEM, keyPEM []byte) {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate CA key: %v", err)
+	}
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		t.Fatalf("generate CA serial: %v", err)
+	}
+	template := &x509.Certificate{
+		SerialNumber: serial,
+		Subject: pkix.Name{
+			CommonName:   "Test CA",
+			Organization: []string{"Test"},
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		MaxPathLen:            0,
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatalf("create CA cert: %v", err)
+	}
+	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	privBytes, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		t.Fatalf("marshal CA key: %v", err)
+	}
+	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privBytes})
+	return certPEM, keyPEM
+}
+
+func generateTestCert(t *testing.T, caCertPEM, caKeyPEM []byte, cn string) (certPEM, keyPEM []byte) {
+	t.Helper()
+	caBlock, _ := pem.Decode(caCertPEM)
+	if caBlock == nil {
+		t.Fatal("decode CA cert PEM")
+	}
+	caCert, err := x509.ParseCertificate(caBlock.Bytes)
+	if err != nil {
+		t.Fatalf("parse CA cert: %v", err)
+	}
+	caBlock, _ = pem.Decode(caKeyPEM)
+	if caBlock == nil {
+		t.Fatal("decode CA key PEM")
+	}
+	caKey, err := x509.ParsePKCS8PrivateKey(caBlock.Bytes)
+	if err != nil {
+		t.Fatalf("parse CA key: %v", err)
+	}
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		t.Fatalf("generate serial: %v", err)
+	}
+	template := &x509.Certificate{
+		SerialNumber: serial,
+		Subject: pkix.Name{
+			CommonName:   cn,
+			Organization: []string{"Test"},
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  false,
+		DNSNames:              []string{"localhost"},
+		IPAddresses:           []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1")},
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, template, caCert, &priv.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	privBytes, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		t.Fatalf("marshal key: %v", err)
+	}
+	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privBytes})
+	return certPEM, keyPEM
+}
+
+func writeCert(t *testing.T, dir, name string, pemData []byte) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, pemData, 0o644); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+	return path
+}
+
+func writeKey(t *testing.T, dir, name string, pemData []byte) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, pemData, 0o600); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+	return path
+}
+
+func TestRunHTTPServer_MTLS(t *testing.T) {
+	caCertPEM, caKeyPEM := generateTestCA(t)
+	serverCertPEM, serverKeyPEM := generateTestCert(t, caCertPEM, caKeyPEM, "server")
+	clientCertPEM, clientKeyPEM := generateTestCert(t, caCertPEM, caKeyPEM, "client")
+	wrongCACertPEM, wrongCAKeyPEM := generateTestCA(t)
+	wrongClientCertPEM, wrongClientKeyPEM := generateTestCert(t, wrongCACertPEM, wrongCAKeyPEM, "wrong-client")
+
+	tmpDir := t.TempDir()
+	caFile := writeCert(t, tmpDir, "ca.pem", caCertPEM)
+	serverCertFile := writeCert(t, tmpDir, "server.pem", serverCertPEM)
+	serverKeyFile := writeKey(t, tmpDir, "server.key", serverKeyPEM)
+
+	v := newTestVault(t)
+	v.Config.MCP = &config.MCPConfig{
+		TLSCertFile:     serverCertFile,
+		TLSKeyFile:      serverKeyFile,
+		TLSClientCAFile: caFile,
+		MTLSEnabled:     true,
+	}
+
+	port := reserveFreePort(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	waitForServer := runHTTPServerAsync(ctx, t, "127.0.0.1", port, v, server.New)
+	defer func() {
+		cancel()
+		waitForServer()
+	}()
+
+	caCertPool := x509.NewCertPool()
+	if !caCertPool.AppendCertsFromPEM(caCertPEM) {
+		t.Fatal("append CA cert to pool")
+	}
+
+	clientTLSCert, err := tls.X509KeyPair(clientCertPEM, clientKeyPEM)
+	if err != nil {
+		t.Fatalf("load client key pair: %v", err)
+	}
+
+	baseURL := fmt.Sprintf("https://127.0.0.1:%d", port)
+
+	t.Run("valid client cert succeeds", func(t *testing.T) {
+		client := &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{
+					Certificates: []tls.Certificate{clientTLSCert},
+					RootCAs:      caCertPool,
+				},
+			},
+			Timeout: 5 * time.Second,
+		}
+		resp, err := client.Get(baseURL + "/health")
+		if err != nil {
+			t.Fatalf("mTLS request failed: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("health status = %d, want %d", resp.StatusCode, http.StatusOK)
+		}
+	})
+
+	t.Run("no client cert is rejected", func(t *testing.T) {
+		client := &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{
+					RootCAs: caCertPool,
+				},
+			},
+			Timeout: 5 * time.Second,
+		}
+		_, err := client.Get(baseURL + "/health")
+		if err == nil {
+			t.Error("expected error without client cert, got nil")
+		}
+	})
+
+	t.Run("wrong client cert is rejected", func(t *testing.T) {
+		wrongCert, certErr := tls.X509KeyPair(wrongClientCertPEM, wrongClientKeyPEM)
+		if certErr != nil {
+			t.Fatalf("load wrong client key pair: %v", certErr)
+		}
+		client := &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{
+					Certificates: []tls.Certificate{wrongCert},
+					RootCAs:      caCertPool,
+				},
+			},
+			Timeout: 5 * time.Second,
+		}
+		_, err := client.Get(baseURL + "/health")
+		if err == nil {
+			t.Error("expected error with wrong client cert, got nil")
+		}
+	})
 }

--- a/internal/mcp/serverbootstrap/serverbootstrap_test.go
+++ b/internal/mcp/serverbootstrap/serverbootstrap_test.go
@@ -1367,8 +1367,9 @@ func TestRunHTTPServer_MTLS(t *testing.T) {
 			},
 			Timeout: 5 * time.Second,
 		}
-		_, err := client.Get(baseURL + "/health")
+		resp, err := client.Get(baseURL + "/health")
 		if err == nil {
+			resp.Body.Close()
 			t.Error("expected error without client cert, got nil")
 		}
 	})
@@ -1387,8 +1388,9 @@ func TestRunHTTPServer_MTLS(t *testing.T) {
 			},
 			Timeout: 5 * time.Second,
 		}
-		_, err := client.Get(baseURL + "/health")
+		resp, err := client.Get(baseURL + "/health")
 		if err == nil {
+			resp.Body.Close()
 			t.Error("expected error with wrong client cert, got nil")
 		}
 	})

--- a/internal/mcp/toolhash.go
+++ b/internal/mcp/toolhash.go
@@ -11,9 +11,11 @@ import (
 // ToolHashDef is a minimal representation of a tool used for computing
 // a content-hash of the tool registry.
 type ToolHashDef struct {
-	Name        string
-	Description string
-	InputSchema map[string]any
+	Name            string
+	Description     string
+	InputSchema     map[string]any
+	ReadOnlyHint    bool
+	DestructiveHint bool
 }
 
 // ComputeToolRegistryHash returns a SHA-256 hex digest of the given tool
@@ -29,7 +31,7 @@ func ComputeToolRegistryHash(defs []ToolHashDef) string {
 		if err != nil {
 			schemaJSON = []byte("{}")
 		}
-		_, _ = fmt.Fprintf(h, "%s|%s|%s\n", def.Name, def.Description, schemaJSON)
+		_, _ = fmt.Fprintf(h, "%s|%s|%s|%v|%v\n", def.Name, def.Description, schemaJSON, def.ReadOnlyHint, def.DestructiveHint)
 	}
 	return hex.EncodeToString(h.Sum(nil))
 }

--- a/scripts/build-mcpb.sh
+++ b/scripts/build-mcpb.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+#
+# build-mcpb.sh — Package a symvault binary into a .mcpb MCP Bundle
+#
+# Usage:
+#   scripts/build-mcpb.sh --version <version> --os <goos> --arch <goarch> [--binary <path>]
+#
+# Without --binary the script searches dist/ for the matching goreleaser output.
+#
+# Output: dist/symvault_<version>_<os>_<arch>.mcpb
+#
+# .mcpb is a ZIP archive containing:
+#   manifest.json  — MCP Bundle manifest (v0.3)
+#   server/
+#     symvault     — Binary (or symvault.exe on Windows)
+
+set -euo pipefail
+
+NAME="${NAME:-symvault}"
+VERSION="${VERSION:-dev}"
+GOOS="${GOOS:-}"
+GOARCH="${GOARCH:-}"
+BINARY_PATH=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --name) NAME="$2"; shift 2 ;;
+    --version) VERSION="$2"; shift 2 ;;
+    --os) GOOS="$2"; shift 2 ;;
+    --arch) GOARCH="$2"; shift 2 ;;
+    --binary) BINARY_PATH="$2"; shift 2 ;;
+    *) echo "Unknown argument: $1"; exit 1 ;;
+  esac
+done
+
+if [ -z "$GOOS" ] || [ -z "$GOARCH" ]; then
+  echo "Usage: $0 --version <ver> --os <goos> --arch <goarch> [--binary <path>]"
+  exit 1
+fi
+
+DIST_DIR="${DIST_DIR:-dist}"
+
+BINARY_NAME="$NAME"
+[ "$GOOS" = "windows" ] && BINARY_NAME="${NAME}.exe"
+
+if [ -z "$BINARY_PATH" ]; then
+  BINARY_PATH=$(find "$DIST_DIR" -maxdepth 2 -type f -name "$BINARY_NAME" -path "*/${GOOS}_${GOARCH}*" | head -1 || true)
+  if [ -z "$BINARY_PATH" ]; then
+    echo "ERROR: Binary not found for ${GOOS}/${GOARCH} in ${DIST_DIR}" >&2
+    exit 1
+  fi
+elif [ ! -f "$BINARY_PATH" ]; then
+  echo "ERROR: Binary not found at $BINARY_PATH" >&2
+  exit 1
+fi
+
+VERSION_CLEAN="${VERSION#v}"
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+cat > "$TMPDIR/manifest.json" <<ENDMARKER
+{
+  "manifest_version": "0.3",
+  "name": "symvault",
+  "version": "${VERSION_CLEAN}",
+  "description": "Secure password manager MCP server",
+  "author": {"name": "danieljustus"},
+  "server": {
+    "type": "binary",
+    "entry_point": "server/${BINARY_NAME}",
+    "mcp_config": {
+      "command": "\${__dirname}/server/${BINARY_NAME}",
+      "args": ["serve", "--stdio"]
+    }
+  }
+}
+ENDMARKER
+
+mkdir -p "$TMPDIR/server"
+cp "$BINARY_PATH" "$TMPDIR/server/$BINARY_NAME"
+chmod +x "$TMPDIR/server/$BINARY_NAME"
+
+MCPB_FILE="${DIST_DIR}/${NAME}_${VERSION_CLEAN}_${GOOS}_${GOARCH}.mcpb"
+(cd "$TMPDIR" && zip -q -r "$MCPB_FILE" .)
+
+echo "Created: $MCPB_FILE"


### PR DESCRIPTION
Bundles fixes for multiple open issues. The list below grows as commits land; every linked issue will close automatically on merge.

<!-- closes-list-start -->
- Closes #297 feat: Add MCP tool security annotations (readOnlyHint, destructiveHint) for Connectors Directory compliance
- Closes #298 feat: Fix Docker containerization and integrate into CI/CD pipeline
- Closes #296 feat: Add mTLS support for OpenAI connector verification
- Closes #295 feat: Implement ChatGPT Company Knowledge Compatibility Schema (search/fetch tools)
- Closes #294 feat: Package symvault as MCP Bundle (.mcpb) for Claude Desktop
- Closes #299 feat: Perplexity Agent API integration (inverted REST approach)
<!-- closes-list-end -->