### PR TITLE
ci(release): fix YAML syntax error in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -227,17 +227,17 @@ jobs:
 
       - name: Verify manifest.json
         run: |
-          python3 -c "
-import json
-with open('mcpb-test/manifest.json') as f:
-    m = json.load(f)
-assert m['manifest_version'] == '0.3'
-assert m['name'] == 'symvault'
-assert m['server']['type'] == 'binary'
-assert m['server']['entry_point'] == 'server/symvault'
-assert m['server']['mcp_config']['args'] == ['serve', '--stdio']
-print('manifest.json validated')
-"
+          python3 <<'EOF'
+          import json
+          with open('mcpb-test/manifest.json') as f:
+              m = json.load(f)
+          assert m['manifest_version'] == '0.3'
+          assert m['name'] == 'symvault'
+          assert m['server']['type'] == 'binary'
+          assert m['server']['entry_point'] == 'server/symvault'
+          assert m['server']['mcp_config']['args'] == ['serve', '--stdio']
+          print('manifest.json validated')
+          EOF
 
       - name: Verify binary works
         run: |


### PR DESCRIPTION
Fixes a YAML parsing error in the release workflow that was causing all workflow runs to fail immediately.\n\nThe Python heredoc in the manifest.json verification step was missing proper indentation, causing the YAML parser to interpret Python code as YAML keys.\n\nChanges:\n- Replace inline python3 -c quoted string with a proper heredoc\n- Ensures the release workflow can parse and execute correctly on tag pushes