### PR TITLE
ci(release): pass binary path to build-mcpb.sh from GoReleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -29,7 +29,7 @@ builds:
     binary: symvault
     hooks:
       post:
-        - 'scripts/build-mcpb.sh --version "{{ .Version }}" --os "{{ .Os }}" --arch "{{ .Arch }}"'
+        - 'scripts/build-mcpb.sh --version "{{ .Version }}" --os "{{ .Os }}" --arch "{{ .Arch }}" --binary "{{ .Path }}"'
     env:
       - CGO_ENABLED=0
       - GOWORK=off
@@ -56,7 +56,7 @@ builds:
     binary: symvault
     hooks:
       post:
-        - 'scripts/build-mcpb.sh --version "{{ .Version }}" --os "{{ .Os }}" --arch "{{ .Arch }}"'
+        - 'scripts/build-mcpb.sh --version "{{ .Version }}" --os "{{ .Os }}" --arch "{{ .Arch }}" --binary "{{ .Path }}"'
     env:
       - CGO_ENABLED=1
       - GOWORK=off


### PR DESCRIPTION
Fixes the release workflow failure where build-mcpb.sh could not find the compiled binary in dist/.\n\nChanges:\n- Pass the exact binary path using GoReleaser's {{ .Path }} template variable\n- Removes the need for build-mcpb.sh to search dist/ directory\n\nThis ensures the MCP Bundle (.mcpb) packaging step works correctly across all platforms.