### PR TITLE
ci(release): fix mcpb output path in build-mcpb.sh

### DIFF
--- a/scripts/build-mcpb.sh
+++ b/scripts/build-mcpb.sh
@@ -81,7 +81,12 @@ mkdir -p "$TMPDIR/server"
 cp "$BINARY_PATH" "$TMPDIR/server/$BINARY_NAME"
 chmod +x "$TMPDIR/server/$BINARY_NAME"
 
-MCPB_FILE="${DIST_DIR}/${NAME}_${VERSION_CLEAN}_${GOOS}_${GOARCH}.mcpb"
+if [[ "${DIST_DIR}" = /* ]]; then
+  MCPB_FILE="${DIST_DIR}/${NAME}_${VERSION_CLEAN}_${GOOS}_${GOARCH}.mcpb"
+else
+  MCPB_FILE="$(pwd)/${DIST_DIR}/${NAME}_${VERSION_CLEAN}_${GOOS}_${GOARCH}.mcpb"
+fi
+mkdir -p "$(dirname "$MCPB_FILE")"
 (cd "$TMPDIR" && zip -q -r "$MCPB_FILE" .)
 
 echo "Created: $MCPB_FILE"


### PR DESCRIPTION
Fixes the release workflow failure where zip could not create the .mcpb output file.\n\nThe script was changing to TMPDIR before running zip, causing the relative dist/ path to be resolved against TMPDIR instead of the project root.\n\nChanges:\n- Use absolute path for MCPB_FILE output\n- Ensure parent directory exists before creating zip\n\nThis ensures MCP Bundle packaging works correctly in GoReleaser post-build hooks.