### PR TITLE
Document commercial boundary

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,16 @@
 
 Thank you for your interest in contributing to Symaira Vault! This document provides guidelines and instructions for contributing.
 
+## License and Commercial Boundary
+
+Contributions to this public repository are made under the MIT License used by
+Symaira Vault self-hosted. The self-hosted product must remain buildable,
+testable, and runnable without any private commercial code.
+
+Commercial hosted-service code is kept in a separate private repository. See
+`docs/commercial-boundary.md` for the boundary between the public self-hosted
+core and the private cloud layer.
+
 ## Development Setup
 
 ### Quick Setup (Recommended)

--- a/docs/commercial-boundary.md
+++ b/docs/commercial-boundary.md
@@ -1,0 +1,29 @@
+# Commercial Boundary
+
+Symaira Vault self-hosted remains free and open source under the MIT License.
+
+The public repository contains the self-hosted core, CLI, runtime behavior,
+documentation, and release artifacts that users can run independently. Public
+contributions to this repository are accepted under the repository license.
+
+Commercial hosted-service code lives outside this repository. That private Pro
+layer may provide managed hosting, tenant operations, billing, support workflows,
+cloud deployment automation, compliance operations, and monitoring.
+
+## Rules
+
+- Keep self-hosted functionality free and MIT-licensed in this repository.
+- Do not require private code to build, test, or run the public self-hosted
+  product.
+- Do not copy private Pro code into the public repository.
+- Do not copy public `internal/` packages into the private Pro repository.
+- When the hosted service needs a new core capability, implement and release it
+  publicly here first, then let the private Pro repository consume the tagged
+  runtime artifact.
+
+## Versioning Note
+
+The current Symaira Vault release line is `v0.x`. Historical OpenPass releases
+such as `v4.0.0` remain part of the old release history and must not be treated
+as the current Symaira Vault release target. The next planned core milestone is
+`v0.4.1`.


### PR DESCRIPTION
## Summary
- document that self-hosted Symaira Vault remains MIT-licensed and independent from private commercial code
- add a contribution note for the public MIT boundary
- call out historical OpenPass major tags so they are not treated as the current Symaira Vault release line

## Verification
- git diff --cached --check
- docs-only change; no code tests run