### PR TITLE
docs(audit): stabilize audit event schema and retention controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,8 @@ For the full configuration reference, see [docs/configuration.md](docs/configura
 - [Configuration reference](docs/configuration.md)
 - [Agent integration](docs/agent-integration.md)
 - [MCP API](docs/mcp-api.md)
+- [Audit event schema](docs/audit-schema.md)
+- [Audit retention & integrity](docs/audit-retention.md)
 - [Distribution channels](docs/distribution.md)
 - [Troubleshooting](docs/troubleshooting.md)
 - [Architecture](ARCHITECTURE.md)

--- a/docs/audit-retention.md
+++ b/docs/audit-retention.md
@@ -1,0 +1,297 @@
+# Audit Retention & Integrity
+
+**Scope**: Public self-hosted Symaira Vault core. Cloud Pro management is
+separate (see [Cloud Pro Boundary](audit-schema.md#cloud-pro-boundary)).
+
+## Retention Configuration
+
+Symaira Vault audit logs are stored per-agent at
+`~/.symvault/audit-<agent>.log`. The retention system automatically rotates
+logs and prunes old files based on configurable limits.
+
+### Configuration Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `SYMVAULT_AUDIT_MAX_SIZE_MB` | `100` | Maximum log file size in megabytes before rotation |
+| `SYMVAULT_AUDIT_MAX_BACKUPS` | `5` | Maximum number of rotated backup files to retain |
+| `SYMVAULT_AUDIT_MAX_AGE_DAYS` | `30` | Maximum age in days before rotated files are deleted |
+
+Legacy `OPENPASS_AUDIT_*` variants are also accepted for backward
+compatibility. `SYMVAULT_*` takes precedence when both are set.
+
+### Configuration via config.yaml
+
+The audit section in `~/.symvault/config.yaml` can also set these values:
+
+```yaml
+audit:
+  maxFileSize: 200   # MB, overrides env var
+  maxBackups: 10
+  maxAgeDays: 90
+```
+
+Environment variables always take precedence over config file values.
+
+### Setting Values
+
+```bash
+# Set via environment (session)
+export SYMVAULT_AUDIT_MAX_SIZE_MB=200
+export SYMVAULT_AUDIT_MAX_BACKUPS=10
+export SYMVAULT_AUDIT_MAX_AGE_DAYS=90
+
+# Or export in your shell profile (~/.zshrc, ~/.bashrc) for persistence
+```
+
+## Rotation Algorithm
+
+Rotation runs on every new logger creation (when an agent first connects) and
+is checked before every write via `rotateIfNeeded()`.
+
+### Triggers
+
+Rotation is triggered when **either**:
+1. **Size limit**: The current log file exceeds `SYMVAULT_AUDIT_MAX_SIZE_MB`
+   megabytes.
+2. **Age limit**: The current log file's modification time is older than
+   `SYMVAULT_AUDIT_MAX_AGE_DAYS` days.
+
+### Rotation Process
+
+1. The current log file is closed.
+2. It is renamed to `audit-<agent>.log.rotated.<YYYYMMDD-HHMMSS>` in the same
+   directory.
+3. A new empty `audit-<agent>.log` file is opened for append.
+4. If rename fails (e.g. file locked), the rotation is skipped gracefully and
+   writing continues to the same file.
+
+Rotation is thread-safe and does not lose log entries — entries written during
+rotation go to the new file.
+
+### Retention Enforcement
+
+`EnforceRetention()` runs the cleanup policy on rotated files:
+
+1. **Backup count**: If more than `MaxBackups` rotated files exist, the oldest
+   are deleted first until the count is within the limit.
+2. **Age cleanup**: Any rotated file older than `MaxAgeDays` is deleted.
+
+Files are sorted by modification time; the newest files are preserved. This
+means with `MaxBackups=3`, the 3 most recently rotated files survive.
+
+Retention enforcement is called manually via `EnforceRetention()`. It is not
+triggered automatically on every write — callers should invoke it periodically
+or after rotation events.
+
+## Common Retention Policies
+
+### Minimal Retention (limited disk space)
+
+```bash
+export SYMVAULT_AUDIT_MAX_SIZE_MB=50
+export SYMVAULT_AUDIT_MAX_BACKUPS=2
+export SYMVAULT_AUDIT_MAX_AGE_DAYS=7
+```
+
+Disk usage: ~150MB maximum (50MB current + 2×50MB backups).
+
+### Default (recommended)
+
+```bash
+export SYMVAULT_AUDIT_MAX_SIZE_MB=100
+export SYMVAULT_AUDIT_MAX_BACKUPS=5
+export SYMVAULT_AUDIT_MAX_AGE_DAYS=30
+```
+
+Disk usage: ~600MB maximum (100MB current + 5×100MB backups).
+
+### Long-Term Retention (compliance)
+
+```bash
+export SYMVAULT_AUDIT_MAX_SIZE_MB=200
+export SYMVAULT_AUDIT_MAX_BACKUPS=20
+export SYMVAULT_AUDIT_MAX_AGE_DAYS=365
+```
+
+Disk usage: ~4.2GB maximum (200MB current + 20×200MB backups).
+
+### Disable Retention (keep everything)
+
+```bash
+export SYMVAULT_AUDIT_MAX_BACKUPS=0
+export SYMVAULT_AUDIT_MAX_AGE_DAYS=0
+```
+
+> **Warning**: With `MaxBackups=0`, all rotated files are immediately deleted.
+> Use large values like `999999` to effectively disable cleanup while keeping
+> backups.
+
+### Audit Log Health
+
+Check audit log health programmatically:
+
+```go
+status, err := logger.HealthCheck()
+// status.LogFilePath      — path to current log file
+// status.LogFileSize      — current file size in bytes
+// status.TotalAuditSize   — total size of all files (current + rotated)
+// status.LogFileAge       — age of current file (e.g. "2h30m")
+// status.NeedsRotation    — true if rotation is due
+// status.NeedsRetention   — true if cleanup is due
+// status.ErrorCount       — count of ok:false entries in last 100
+// status.WriteAccessible  — true if file is writable
+```
+
+## HMAC Key Management
+
+### Key Storage
+
+The audit HMAC key is a 32-byte random key stored in:
+- **Primary**: OS keyring (service: `symaira`, account: `audit-hmac-key:<vault-dir>`)
+- **Fallback**: File at `~/.symvault/audit-hmac-key` (permissions `0o600`)
+
+The key is generated on first use and loaded on subsequent logger creation.
+
+### Key Rotation
+
+When the HMAC key may have been compromised, rotate it:
+
+```bash
+symvault audit rotate-key
+```
+
+This command:
+1. Generates a new 32-byte random HMAC key using `crypto/rand`.
+2. Archives the current key to `audit-hmac-key.rotated.YYYY-MM-DD` in the
+   vault directory.
+3. Stores the new key in the OS keyring and fallback file.
+4. Future audit entries use the new key for HMAC computation.
+
+**Important**: The archived key file is essential for verifying historical
+audit logs. Back it up alongside your vault.
+
+### Verifying with Archived Keys
+
+After rotation, verify logs with both the current and archived keys:
+
+```bash
+# Verify with current key
+symvault audit verify
+
+# Verify with an archived key
+symvault audit verify --key-file ~/.symvault/audit-hmac-key.rotated.2026-05-28
+```
+
+### Key Loss
+
+If all HMAC keys are lost (no archived copies, OS keyring cleared):
+1. Generate a fresh key: `symvault audit rotate-key`
+2. All future entries use the new HMAC chain
+3. Existing log entries remain readable but their HMACs cannot be verified
+4. Any tampering that occurred before key loss is undetectable
+
+## Integrity Verification
+
+### VerifyLog Function
+
+`VerifyLog()` checks the HMAC chain of an entire audit log file:
+
+```go
+func VerifyLog(logFilePath string, key []byte) (*VerifyResult, error)
+```
+
+**Parameters**:
+- `logFilePath` — Absolute path to the audit log file
+- `key` — The HMAC key bytes (from `Keystore.LoadHMACKey()`)
+
+**Returns**:
+
+```go
+type VerifyResult struct {
+    Valid       bool  // true if ALL entries pass verification
+    Total       int   // total entries parsed from the log
+    Verified    int   // entries with correct HMAC
+    Legacy      int   // entries without HMAC (pre-v0.4 format)
+    Tampered    int   // entries with incorrect HMAC (tampered)
+    FirstBadIdx int   // index of first tampered entry (-1 if none)
+}
+```
+
+### What It Detects
+
+HMAC chain verification detects:
+- **Entry modification** — Any change to an entry's fields (action, path, ok, etc.)
+- **Entry insertion** — New entries inserted between existing entries
+- **Entry deletion** — Removal of entries from the chain
+- **Entry reordering** — Moving entries within the log file
+
+### What It Does Not Detect
+
+- **Truncation at end** — If the last N entries are deleted, the remaining
+  chain is still valid. Mitigate with off-site backup or external monitoring.
+- **Full log replacement** — If the entire log file is replaced with a validly
+  chained alternative. Mitigate with file integrity monitoring or periodic
+  verification snapshots.
+
+### Programmatic Usage
+
+```go
+package main
+
+import (
+    "fmt"
+    "github.com/danieljustus/symaira-vault/internal/audit"
+)
+
+func main() {
+    ks := audit.NewKeystore("/path/to/vault", nil)
+    key, err := ks.LoadHMACKey()
+    if err != nil {
+        panic(err)
+    }
+
+    result, err := audit.VerifyLog("/path/to/vault/audit-claude-code.log", key)
+    if err != nil {
+        panic(err)
+    }
+
+    fmt.Printf("Valid: %v\n", result.Valid)
+    fmt.Printf("Total: %d, Verified: %d, Legacy: %d, Tampered: %d\n",
+        result.Total, result.Verified, result.Legacy, result.Tampered)
+    if result.FirstBadIdx >= 0 {
+        fmt.Printf("First tampered entry at index: %d\n", result.FirstBadIdx)
+    }
+}
+```
+
+### CLI Verification
+
+```bash
+# Verify all agent audit logs
+symvault audit verify
+
+# Verify a specific agent's log
+symvault audit verify --agent claude-code
+
+# Verify with an archived HMAC key
+symvault audit verify --key-file ~/.symvault/audit-hmac-key.rotated.2026-05-28
+```
+
+### Legacy Logs
+
+Entries without an `hmac` field (written before v0.4 or when no HMAC key was
+available) are counted as `Legacy`. They are skipped during verification and do
+not invalidate the chain. When a legacy entry appears, the previous HMAC state
+is reset, so the next HMAC-bearing entry starts a fresh chain.
+
+## Related Documentation
+
+- [Audit Event Schema](audit-schema.md) — Schema, actions, HMAC chain design
+- [Error Tracking Strategy](error-tracking-strategy.md) — Audit system in
+  diagnostic context
+- [Security Policy](../SECURITY.md#audit-logs) — Audit log privacy
+- [Runbook](../docs/runbook.md#audit-log-hmac-key-rotation) — Incident response
+  procedures
+- `internal/audit/audit.go` — Implementation
+- `internal/audit/keystore.go` — HMAC key storage

--- a/docs/audit-schema.md
+++ b/docs/audit-schema.md
@@ -1,0 +1,301 @@
+# Audit Event Schema
+
+**Stability**: Stable for the `v0.x` release line. No breaking changes without a
+major version bump. New optional fields may be added in minor releases.
+
+**Scope**: Public self-hosted Symaira Vault core. Cloud Pro features (SIEM
+export, managed retention, compliance reporting, tenant audit storage) are
+excluded — see [Cloud Pro Boundary](#cloud-pro-boundary).
+
+## Overview
+
+Symaira Vault records a structured audit event for every MCP tool call and CLI
+agent operation. Events are written as JSONL (one JSON object per line) to
+per-agent log files at `~/.symvault/audit-<agent>.log`. Each event carries an
+HMAC integrity hash that chains to the previous entry, enabling tamper
+detection.
+
+## LogEntry Schema
+
+```go
+// internal/audit/audit.go
+type LogEntry struct {
+    Timestamp   string `json:"ts"`              // RFC 3339 UTC timestamp
+    Agent       string `json:"agent"`            // Agent name (e.g. "claude-code")
+    Action      string `json:"action"`           // Action category (see table below)
+    Path        string `json:"path,omitempty"`   // Vault entry path, or "<reason>" for denials
+    Field       string `json:"field,omitempty"`  // Field name only — NEVER contains the value
+    Transport   string `json:"transport,omitempty"` // "stdio" or "http"
+    Reason      string `json:"reason,omitempty"`    // Human-readable failure reason
+    ShareID     string `json:"share_id,omitempty"`  // Share grant ID (sharing events)
+    FromAgent   string `json:"from_agent,omitempty"` // Sharing source agent
+    ToAgent     string `json:"to_agent,omitempty"`   // Sharing target agent
+    ShareAction string `json:"share_action,omitempty"` // Share operation type
+    DurMs       int64  `json:"dur_ms,omitempty"`      // Operation duration in milliseconds
+    TokenID     string `json:"token_id,omitempty"`     // MCP bearer token ID
+    RequestID   string `json:"req_id,omitempty"`       // Unique request identifier
+    SessionID   string `json:"sess_id,omitempty"`      // MCP session identifier
+    HMAC        string `json:"hmac,omitempty"`         // Hex-encoded SHA-256 HMAC (see below)
+    OK          bool   `json:"ok"`                     // true = success, false = denial/error
+}
+```
+
+### Field Semantics
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `ts` | string (RFC 3339) | Always | When the event occurred. Auto-filled if omitted. |
+| `agent` | string | Always | Agent name from `config.yaml` or `SYMVAULT_AGENT`. |
+| `action` | string | Always | Action category. See the [Actions table](#actions). |
+| `path` | string | Conditional | Vault entry path the action targets. May be `<reason>` for denials before path resolution. |
+| `field` | string | Conditional | Field name targeted (e.g. `password`, `totp.secret`). **Field values are never recorded.** |
+| `transport` | string | Conditional | `stdio` for CLI and MCP stdio, `http` for MCP HTTP. |
+| `reason` | string | Conditional | Human-readable reason for failure (`ok: false`). For denials, typically the action name itself (e.g. `scope_denied`, `write_denied`). |
+| `share_id` | string | Optional | Share grant ID for sharing-related events. |
+| `from_agent` | string | Optional | Source agent in a share operation. |
+| `to_agent` | string | Optional | Target agent in a share operation. |
+| `share_action` | string | Optional | Share operation type (e.g. `share_request`, `share_approve`, `share_revoke`). |
+| `dur_ms` | int64 | Optional | Measured operation duration in milliseconds. |
+| `token_id` | string | Optional | MCP bearer token ID from `TokenFromContext`. |
+| `req_id` | string | Optional | Unique request ID from `RequestIDFromContext`. |
+| `sess_id` | string | Optional | MCP session identifier for correlation. |
+| `hmac` | string | Conditional | Hex-encoded SHA-256 HMAC. Present when a key is available. See [HMAC chain](#hmac-integrity-chain). |
+| `ok` | bool | Always | `true` for successful operations, `false` for denials or errors. |
+
+### Redaction Guarantees
+
+The `Field` field records **only field names** — never field values. The audit
+log never contains:
+- Entry field values (passwords, TOTP secrets, API keys, notes)
+- Environment variable values from `run_command` or `execute_with_secret`
+- Response bodies from `execute_api_request`
+- Token secrets or bearer token values
+- Any data classified as a secret by the vault
+
+Path values may contain the entry path (e.g. `secret/github`) because paths are
+metadata, not secrets. Path segments that happen to be passwords (e.g.
+`passwords/bank`) are recorded as-is — the path itself is directory structure,
+not a secret value.
+
+### Transport Types
+
+| Transport | Meaning |
+|-----------|---------|
+| `stdio` | MCP server running in stdio mode (typical for Claude Code, OpenCode, Hermes CLI) |
+| `http` | MCP server running in HTTP mode (bound to 127.0.0.1) |
+
+## Actions
+
+Every audit event has an `action` field that categorizes the operation. The
+following actions are used in the public self-hosted core:
+
+### Entry Operations
+
+| Action | Description | OK=true means |
+|--------|-------------|---------------|
+| `get` | Generic entry retrieval (metadata + fields) | Entry returned |
+| `get_value` | Retrieve a specific field value | Value returned (redacted in audit) |
+| `get_metadata` | Retrieve entry metadata only | Metadata returned |
+| `set` | Create or update an entry field | Write completed |
+| `set_entry_field` | Set a single field via MCP tool | Field set |
+| `delete` | Delete an entry | Entry deleted |
+| `list` | List entries matching a prefix | Entries listed |
+| `find` | Search for entries by query | Results returned |
+| `generate` | Generate a random password | Password generated |
+
+### Authorization & Enforcement
+
+| Action | Description | OK=true means |
+|--------|-------------|---------------|
+| `read` | Read authorization granted | Access allowed |
+| `write` | Write authorization granted | Access allowed |
+| `scope_denied` | Request outside agent allowed paths | — (always false) |
+| `write_denied` | Write request from read-only agent | — (always false) |
+| `approval_required` | Write requires human approval (deny mode) | — (always false) |
+| `policy_denied` | Rejected by policy engine | — (always false) |
+| `policy_prompt` | Policy requires approval prompt | — (always false) |
+| `policy_biometry` | Policy requires biometric verification | — (always false) |
+| `policy_biometry_passed` | Biometric verification succeeded | Biometry passed |
+| `policy_biometry_failed` | Biometric verification failed | — (always false) |
+| `policy_biometry_unavailable` | Biometric verification unavailable | — (always false) |
+| `tool_scope_denied` | Tool outside agent scope | — (always false) |
+| `agent_tool_denied` | Tool blocked by agent tier | — (always false) |
+| `tool_registry_drift` | Tool registered but no handler | — (always false) |
+| `post_call_hook_error` | Post-call hook failed | — (always false) |
+| `approval.<action>.denied` | Approval explicitly denied | — (always false) |
+| `approval.<action>.granted` | Approval granted | Approved |
+| `approval.<action>.requested` | Approval prompt requested | Prompt shown |
+| `approval.<action>.remembered` | Approval remembered from prior grant | Remembered |
+| `quarantine_block` | Entry blocked by quarantine | — (always false) |
+
+### Tool Invocations
+
+| Action | Description | OK=true means |
+|--------|-------------|---------------|
+| `copy_to_clipboard` | Copy value to system clipboard | Copied |
+| `autotype` | Auto-type value into focused app | Typed |
+| `generate_totp` | Generate TOTP code | Code generated |
+| `generate_totp.clipboard` | Generate TOTP and copy to clipboard | Copied |
+| `generate_totp.autotype` | Generate TOTP and auto-type | Typed |
+| `generate_totp.return` | Generate TOTP and return directly | Returned |
+| `run_command` | Execute a command with secrets as env vars | Command completed (exit 0) |
+| `execute_with_secret` | Execute a command with secrets injected | Command completed (exit 0) |
+| `execute_api_request` | Execute an API request via template | Response received (status < 400) |
+| `secret_unseal` | Decrypt and surface an entry value | Unsealed |
+| `secret_unseal_remembered` | Unseal with remembered approval | Unsealed |
+| `secure_input` | Collect credential via native dialog | Collected |
+| `sanitize_output` | Sanitize output for injection patterns | Sanitized |
+| `perplexity_search` | Perplexity API search | Results returned |
+| `perplexity_ask` | Perplexity API ask | Answer returned |
+| `search_openai` | OpenAI web search | Results returned |
+| `fetch_openai` | OpenAI fetch URL | Content retrieved |
+| `template_generated` | Template engine generated output | Generated |
+| `template_written` | Template engine wrote output to file | Written |
+| `template_failed` | Template engine failed | — (always false) |
+
+### Sharing Operations
+
+| Action | Description | OK=true means |
+|--------|-------------|---------------|
+| `share_request` | Request access to another agent's entry | Requested |
+| `share_approve` | Approve a share request | Approved |
+| `share_approve_denied` | Share approval denied | — (always false) |
+| `share_reject` | Reject a share request | Rejected |
+| `share_revoke` | Revoke an existing share | Revoked |
+| `share_list` | List active shares | Listed |
+| `share_grant` | Grant access via share | Granted |
+| `share_expired` | Share grant has expired | — (always false) |
+
+### Authentication & Administration
+
+| Action | Description | OK=true means |
+|--------|-------------|---------------|
+| `auth_failure` | MCP token authentication failed | — (always false) |
+| `auth_config` | Auth method configuration changed | Configured |
+| `auth_config_denied` | Auth config blocked by tier | — (always false) |
+| `auth_method_biometric_failed` | Biometric auth method failed | — (always false) |
+| `rotate-passphrase` | Vault passphrase rotated | Rotated |
+| `token_cleanup` | Expired token cleanup job | Cleaned |
+| `tool_invocation` | Generic tool invocation hook | Invoked |
+
+### Anomaly Detection
+
+| Action | Description | OK=true means |
+|--------|-------------|---------------|
+| `anomaly_<type>` | Anomaly alert from metrics system | Alert recorded |
+
+## OK/Reason Semantics
+
+- `ok: true` — The operation completed successfully. `reason` is typically
+  empty.
+- `ok: false` — The operation was denied or failed. `reason` contains a
+  human-readable explanation. For authorization denials, the `action` name
+  itself is used as the `reason` (e.g. action=`write_denied`, reason=
+  `write_denied`).
+
+For error entries, the `GetErrors()` method on the logger returns a filtered,
+redacted subset containing only `ok: false` entries with `ts`, `action`, and
+`reason`.
+
+## JSONL Format
+
+Audit log files use JSONL (JSON Lines) format:
+- One complete JSON object per line, terminated by `\n`
+- No trailing commas, no array wrapper
+- Each line is a valid, self-contained `LogEntry`
+
+Example file content:
+```jsonl
+{"ts":"2026-04-27T10:30:00Z","agent":"claude-code","action":"get","path":"dev/api-key","transport":"stdio","token_id":"tok_abc123","req_id":"req_001","sess_id":"sess_001","ok":true,"hmac":"a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2"}
+{"ts":"2026-04-27T10:31:00Z","agent":"claude-code","action":"set","path":"secret/key","field":"password","transport":"stdio","token_id":"tok_abc123","req_id":"req_002","sess_id":"sess_001","hmac":"b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3","ok":false,"reason":"write_denied"}
+{"ts":"2026-04-27T10:32:00Z","agent":"claude-code","action":"list","path":"dev/","transport":"stdio","token_id":"tok_abc123","req_id":"req_003","sess_id":"sess_001","ok":true,"hmac":"c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4"}
+```
+
+### Malformed Lines
+
+When reading log files programmatically via `lastNEntries()` or
+`parseTailEntries()`, malformed JSON lines are silently skipped. This means a
+corrupted line in the log does not block reading the remaining valid entries.
+
+## HMAC Integrity Chain
+
+Each audit entry (when an HMAC key is loaded) carries a chained SHA-256 HMAC
+that cryptographically links it to the previous entry. This provides tamper
+detection for the entire log file.
+
+### How It Works
+
+1. An HMAC key (32 bytes, generated by `crypto/rand`) is loaded from the OS
+   keyring or fallback file at `~/.symvault/audit-hmac-key`.
+2. For each new entry, the HMAC is computed as:
+   ```
+   HMAC-SHA256(key, prevHMAC || canonicalJSON(entry))
+   ```
+   where `canonicalJSON(entry)` is the JSON serialization of the entry with the
+   `hmac` field set to empty string.
+3. The resulting HMAC is written as the `hmac` field of the entry and becomes
+   the `prevHMAC` for the next entry.
+4. On logger re-open, the last entry's HMAC is read and used as the initial
+   chain state.
+
+### Integrity Verification
+
+Use `VerifyLog()` to check a log file's integrity:
+
+```go
+result, err := audit.VerifyLog("/path/to/audit-claude-code.log", hmacKey)
+// result.Valid       bool   — true if all entries verify
+// result.Total       int    — total entries parsed
+// result.Verified    int    — entries with valid HMACs
+// result.Legacy      int    — entries without HMAC (pre-v0.4 format)
+// result.Tampered    int    — entries with invalid HMACs
+// result.FirstBadIdx int    — index of first tampered entry (-1 if none)
+```
+
+See [audit-retention.md](audit-retention.md) for the CLI command
+`symvault audit verify` and HMAC key rotation.
+
+## Version Compatibility
+
+The `LogEntry` schema is stable for the `v0.x` release line:
+
+- **No field removal** — Existing fields will not be removed in `v0.x`.
+- **No field renames** — Field names and JSON keys will not change.
+- **Optional field additions** — New `omitempty` fields may be added in minor
+  releases without a breaking change.
+- **JSONL format** — The one-JSON-object-per-line format is permanent.
+- **HMAC scheme** — The chained HMAC-SHA256 scheme is permanent. Key rotation
+  is supported without format changes.
+
+Breaking schema changes, if ever needed, will only arrive with a `v1.0` major
+release and will be documented in the changelog.
+
+## Cloud Pro Boundary
+
+The public self-hosted Symaira Vault core provides local audit logging with
+HMAC integrity verification. The private Symaira Vault Pro repository extends
+audit capabilities with:
+
+- **SIEM export** — Streaming audit events to external SIEM platforms
+- **Managed long-term retention** — Cloud-backed retention policies beyond local
+  rotation
+- **Compliance reporting** — Audit reports for SOC 2, ISO 27001, etc.
+- **Tenant audit storage** — Multi-tenant audit log partitioning and access
+  controls
+- **Centralized audit search** — Cross-agent, cross-vault audit event search
+
+None of these Pro features are included in the public self-hosted product. The
+local audit system documented here is fully functional and useful on its own
+for self-hosted deployments.
+
+## Related Documentation
+
+- [Audit Retention & Integrity](audit-retention.md) — Retention configuration,
+  key rotation, integrity verification
+- [Error Tracking Strategy](error-tracking-strategy.md) — Audit system overview
+  in the error tracking context
+- [Security Policy](../SECURITY.md#audit-logs) — Audit log privacy and
+  configuration
+- [Runbook](../docs/runbook.md#audit-log-hmac-key-rotation) — HMAC key rotation
+  procedures
+- `internal/audit/audit.go` — Implementation

--- a/docs/error-tracking-strategy.md
+++ b/docs/error-tracking-strategy.md
@@ -43,6 +43,8 @@ Symaira Vault maintains comprehensive audit logs for MCP operations:
 - Duration, timestamp, and error reasons (redacted)
 
 See also:
+- [`audit-schema.md`](audit-schema.md) — Stable audit event schema and action reference
+- [`audit-retention.md`](audit-retention.md) — Retention configuration, key rotation, integrity verification
 - `SECURITY.md` § Audit Logs for privacy details
 - `internal/audit/audit.go` for implementation
 

--- a/internal/audit/audit_redaction_test.go
+++ b/internal/audit/audit_redaction_test.go
@@ -1,0 +1,557 @@
+package audit
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestFieldNameOnlyNeverValue verifies that the Field field in audit entries
+// records only field names, never field values. Even when operations target
+// fields with names like "password", the value itself must not appear.
+func TestFieldNameOnlyNeverValue(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	logger, err := New("field-name-test", "")
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	defer func() { _ = logger.Close() }()
+
+	// Log an entry where the Field is "password" (the field name, not the value).
+	// The audit log must NOT contain "supersecret123" (the value).
+	_ = logger.LogEntry(LogEntry{
+		Agent:  "test-agent",
+		Action: "get_value",
+		Path:   "secret/github",
+		Field:  "password",
+		OK:     true,
+	})
+
+	content, err := os.ReadFile(filepath.Join(home, ".symvault", "audit-field-name-test.log"))
+	if err != nil {
+		t.Fatalf("ReadFile error = %v", err)
+	}
+
+	text := string(content)
+
+	// Should have the field name
+	if !strings.Contains(text, "password") {
+		t.Fatal("expected 'password' field name in audit entry")
+	}
+
+	// Must NOT have any value-like content leaked
+	if strings.Contains(text, "supersecret") {
+		t.Fatal("audit log leaked field value 'supersecret'")
+	}
+	if strings.Contains(text, "mysecret") {
+		t.Fatal("audit log leaked field value 'mysecret'")
+	}
+}
+
+// TestNoSecretValuesInPathEntries verifies that entries targeting
+// paths with sensitive-looking names (e.g., "secret/key", "passwords/bank")
+// never accidentally serialize secret values into the audit log.
+func TestNoSecretValuesInPathEntries(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	logger, err := New("path-secret-test", "")
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	defer func() { _ = logger.Close() }()
+
+	sensitivePaths := []string{
+		"secret/key",
+		"passwords/bank",
+		"vault/master",
+		"api/tokens/github",
+		"credentials/admin",
+	}
+
+	for _, p := range sensitivePaths {
+		_ = logger.LogEntry(LogEntry{
+			Agent:  "test-agent",
+			Action: "get",
+			Path:   p,
+			Field:  "value",
+			OK:     true,
+		})
+	}
+
+	content, err := os.ReadFile(filepath.Join(home, ".symvault", "audit-path-secret-test.log"))
+	if err != nil {
+		t.Fatalf("ReadFile error = %v", err)
+	}
+
+	var entries []LogEntry
+	for _, line := range strings.Split(strings.TrimSpace(string(content)), "\n") {
+		var entry LogEntry
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			t.Fatalf("invalid JSON line: %s err=%v", line, err)
+		}
+		entries = append(entries, entry)
+
+		// Each entry must have the Path set but no value fields leaked
+		if entry.Path == "" {
+			t.Fatal("expected Path to be set")
+		}
+		// Verify that the entry JSON contains no suspicious value patterns
+		if strings.Contains(line, `"value":"`) {
+			t.Fatalf("entry with path %q contains potential value leak: %s", entry.Path, line)
+		}
+	}
+
+	if len(entries) != 5 {
+		t.Fatalf("expected 5 entries, got %d", len(entries))
+	}
+}
+
+// TestSecretRedactionFixtureBased tests a predefined set of potentially
+// sensitive LogEntry configurations to verify that no secret values leak
+// into the serialized JSON output.
+func TestSecretRedactionFixtureBased(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	logger, err := New("fixture-test", "")
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	defer func() { _ = logger.Close() }()
+
+	// Fixtures: entries that must NOT contain the listed forbidden patterns
+	fixtures := []struct {
+		name      string
+		entry     LogEntry
+		forbidden []string
+	}{
+		{
+			name: "set password field",
+			entry: LogEntry{
+				Agent:  "test",
+				Action: "set",
+				Path:   "secret/db",
+				Field:  "password",
+				OK:     true,
+			},
+			forbidden: []string{"s3cr3t!", "P@ssw0rd", "drowssap"},
+		},
+		{
+			name: "get totp secret",
+			entry: LogEntry{
+				Agent:  "test",
+				Action: "get",
+				Path:   "secret/github",
+				Field:  "totp.secret",
+				OK:     true,
+			},
+			forbidden: []string{"JBSWY3DPEHPK3PXP", "base32secret"},
+		},
+		{
+			name: "get api key",
+			entry: LogEntry{
+				Agent:  "test",
+				Action: "get_value",
+				Path:   "api/openai",
+				Field:  "api-key",
+				OK:     true,
+			},
+			forbidden: []string{"sk-proj-", "sk-abc123", "Bearer xyz"},
+		},
+		{
+			name: "denied write with path only",
+			entry: LogEntry{
+				Agent:  "test",
+				Action: "write_denied",
+				Path:   "secret/admin",
+				OK:     false,
+				Reason: "write_denied",
+			},
+			forbidden: []string{"adminpass", "root"},
+		},
+		{
+			name: "run command with env vars",
+			entry: LogEntry{
+				Agent:  "test",
+				Action: "run_command",
+				Path:   "curl",
+				OK:     true,
+				DurMs:  150,
+			},
+			forbidden: []string{"API_KEY=", "DATABASE_URL=", "export SECRET"},
+		},
+		{
+			name: "autotype with password path",
+			entry: LogEntry{
+				Agent:  "test",
+				Action: "autotype",
+				Path:   "secret/login",
+				Field:  "password",
+				OK:     true,
+			},
+			forbidden: []string{"letmein", "qwerty123"},
+		},
+		{
+			name: "share with agent metadata",
+			entry: LogEntry{
+				Agent:     "test",
+				Action:    "share_request",
+				Path:      "secret/shared",
+				FromAgent: "alice",
+				ToAgent:   "bob",
+				OK:        true,
+			},
+			forbidden: []string{"shared-secret-value"},
+		},
+		{
+			name: "auth failure",
+			entry: LogEntry{
+				Agent:     "test",
+				Action:    "auth_failure",
+				Transport: "http",
+				OK:        false,
+				Reason:    "invalid_token",
+			},
+			forbidden: []string{"Bearer ", "token:abc", "Authorization:"},
+		},
+	}
+
+	for _, tt := range fixtures {
+		t.Run(tt.name, func(t *testing.T) {
+			_ = logger.LogEntry(tt.entry)
+		})
+	}
+
+	content, err := os.ReadFile(filepath.Join(home, ".symvault", "audit-fixture-test.log"))
+	if err != nil {
+		t.Fatalf("ReadFile error = %v", err)
+	}
+
+	text := string(content)
+
+	for _, tt := range fixtures {
+		for _, forbidden := range tt.forbidden {
+			if strings.Contains(text, forbidden) {
+				t.Errorf("fixture %q: audit log contains forbidden pattern %q", tt.name, forbidden)
+			}
+		}
+	}
+}
+
+// TestAuditLogDoesNotContainJSONValues verifies that the audit log content
+// as raw text does not contain patterns that look like serialized secret values.
+func TestAuditLogDoesNotContainJSONValues(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	logger, err := New("no-values-test", "")
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	defer func() { _ = logger.Close() }()
+
+	// Log many different kinds of entries
+	_ = logger.LogEntry(LogEntry{
+		Agent:  "test",
+		Action: "get_value",
+		Path:   "secret/db",
+		Field:  "password",
+		OK:     true,
+	})
+	_ = logger.LogEntry(LogEntry{
+		Agent:  "test",
+		Action: "set",
+		Path:   "secret/api",
+		Field:  "api_key",
+		OK:     true,
+	})
+	_ = logger.LogEntry(LogEntry{
+		Agent:  "test",
+		Action: "get",
+		Path:   "secret/admin",
+		Field:  "totp.secret",
+		OK:     true,
+	})
+	_ = logger.LogEntry(LogEntry{
+		Agent:  "test",
+		Action: "delete",
+		Path:   "secret/old",
+		OK:     true,
+	})
+
+	content, err := os.ReadFile(filepath.Join(home, ".symvault", "audit-no-values-test.log"))
+	if err != nil {
+		t.Fatalf("ReadFile error = %v", err)
+	}
+
+	// Parse all entries and verify Field only contains names, not values
+	lines := strings.Split(strings.TrimSpace(string(content)), "\n")
+	for i, line := range lines {
+		var entry map[string]any
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			t.Fatalf("invalid JSON on line %d: %v", i, err)
+		}
+
+		// If a "field" key exists, it must only contain names like "password",
+		// "api_key", "totp.secret" — never a value like "<32-chars-base64>"
+		if field, ok := entry["field"]; ok {
+			fieldStr, isString := field.(string)
+			if !isString {
+				t.Fatalf("line %d: field is not a string: %v", i, field)
+			}
+			// Values typically won't contain dots (unlike field paths)
+			// But more importantly: the field should be SHORT, not a value
+			if len(fieldStr) > 100 {
+				t.Errorf("line %d: field string too long (%d chars), likely a value: %s",
+					i, len(fieldStr), fieldStr)
+			}
+		}
+	}
+}
+
+// TestLogEntryJSONSerializationNoValueLeak verifies that LogEntry JSON
+// serialization does not accidentally include field values through any
+// mechanism (e.g., embedded structs, map fields, unexported fields).
+func TestLogEntryJSONSerializationNoValueLeak(t *testing.T) {
+	// Test that the LogEntry struct itself, when serialized, never
+	// accidentally contains value-like patterns
+	entry := LogEntry{
+		Timestamp: "2026-01-01T00:00:00Z",
+		Agent:     "test-agent",
+		Action:    "get_value",
+		Path:      "secret/production/database",
+		Field:     "password",
+		Transport: "stdio",
+		OK:        true,
+		DurMs:     42,
+	}
+
+	data, err := json.Marshal(entry)
+	if err != nil {
+		t.Fatalf("json.Marshal error = %v", err)
+	}
+
+	jsonStr := string(data)
+
+	// JSON must not contain any value indicators
+	forbiddenJSON := []string{
+		`"value":`,
+		`"secret":`,
+		`"plaintext":`,
+		`"password_value":`,
+		`"field_value":`,
+		`"entry_data":`,
+	}
+	for _, pattern := range forbiddenJSON {
+		if strings.Contains(strings.ToLower(jsonStr), strings.ToLower(pattern)) {
+			t.Errorf("serialized LogEntry contains forbidden JSON key: %s", pattern)
+		}
+	}
+
+	// Verify the serialized entry can be deserialized correctly
+	var deserialized LogEntry
+	if err := json.Unmarshal(data, &deserialized); err != nil {
+		t.Fatalf("json.Unmarshal error = %v", err)
+	}
+	if deserialized.Field != "password" {
+		t.Errorf("Field = %s, want password", deserialized.Field)
+	}
+	if deserialized.Path != "secret/production/database" {
+		t.Errorf("Path = %s, want secret/production/database", deserialized.Path)
+	}
+}
+
+// TestSensitivePathPatternsDoesNotLeakValues verifies that even when the
+// path name contains words like "password" or "secret", no actual values
+// leak into the audit output.
+func TestSensitivePathPatternsDoesNotLeakValues(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	logger, err := New("sensitive-path-test", "")
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	defer func() { _ = logger.Close() }()
+
+	// Paths that happen to use sensitive-looking segment names
+	// These are legitimate entry paths, not secret values
+	sensitivePathNames := []string{
+		"passwords/bank-login",
+		"secrets/aws-root",
+		"tokens/github-pat",
+		"keys/ssh/id_rsa",
+		"credentials/vpn",
+	}
+
+	for _, p := range sensitivePathNames {
+		_ = logger.LogEntry(LogEntry{
+			Agent:  "test",
+			Action: "get",
+			Path:   p,
+			OK:     true,
+		})
+	}
+
+	content, err := os.ReadFile(filepath.Join(home, ".symvault", "audit-sensitive-path-test.log"))
+	if err != nil {
+		t.Fatalf("ReadFile error = %v", err)
+	}
+
+	text := string(content)
+
+	// Paths should appear (they are metadata)
+	for _, p := range sensitivePathNames {
+		if !strings.Contains(text, p) {
+			t.Errorf("expected path %q to appear in audit (it's metadata)", p)
+		}
+	}
+
+	// But the audit log must not contain any plausible secret values
+	// These are all content types that would indicate a value leak
+	valueIndicators := []string{
+		"A3TQ2n8xKpL5mR9v",     // random-looking base62
+		"AKIAIOSFODNN7EXAMPLE", // AWS access key pattern
+		"ghp_1234567890abcdef", // GitHub PAT pattern
+		"sk-abcdefghijklmnop",  // OpenAI key pattern
+	}
+	for _, indicator := range valueIndicators {
+		if strings.Contains(text, indicator) {
+			t.Errorf("audit log contains potential secret value indicator: %q", indicator)
+		}
+	}
+}
+
+// TestReasonFieldDoesNotLeakValues verifies that the Reason field
+// (which is human-readable) never accidentally contains secret values
+// or field values from the operation.
+func TestReasonFieldDoesNotLeakValues(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	logger, err := New("reason-test", "")
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	defer func() { _ = logger.Close() }()
+
+	// Log denial entries — reasons should be fixed strings, not variable data
+	failureEntries := []struct {
+		action string
+		path   string
+		reason string
+	}{
+		{"scope_denied", "secret/admin", "scope_denied"},
+		{"write_denied", "secret/db", "write_denied"},
+		{"policy_denied", "secret/vault", "policy_denied"},
+		{"approval_required", "secret/prod", "approval_required"},
+	}
+
+	for _, fe := range failureEntries {
+		_ = logger.LogEntry(LogEntry{
+			Agent:  "test",
+			Action: fe.action,
+			Path:   fe.path,
+			OK:     false,
+			Reason: fe.reason,
+		})
+	}
+
+	content, err := os.ReadFile(filepath.Join(home, ".symvault", "audit-reason-test.log"))
+	if err != nil {
+		t.Fatalf("ReadFile error = %v", err)
+	}
+
+	text := string(content)
+
+	// Reason field should contain only the fixed reason strings
+	for _, fe := range failureEntries {
+		if !strings.Contains(text, fe.reason) {
+			t.Errorf("expected reason %q in audit log", fe.reason)
+		}
+	}
+
+	// Must NOT contain any value-like data in the reason context
+	reasonValueIndicators := []string{
+		"password is",
+		"secret was",
+		"value=",
+		"key=",
+		"token=",
+	}
+	for _, indicator := range reasonValueIndicators {
+		if strings.Contains(strings.ToLower(text), strings.ToLower(indicator)) {
+			t.Errorf("reason field leaked value data: found %q", indicator)
+		}
+	}
+}
+
+// TestConcurrentNoValueLeak runs many concurrent writes with various
+// field names and verifies that all entries only contain names, never values.
+func TestConcurrentNoValueLeak(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	logger, err := New("concurrent-redact-test", "")
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	defer func() { _ = logger.Close() }()
+
+	const goroutines = 5
+	const entriesPer = 20
+	done := make(chan struct{})
+
+	fieldNames := []string{"password", "api_key", "totp.secret", "note", "username"}
+
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			for j := 0; j < entriesPer; j++ {
+				_ = logger.LogEntry(LogEntry{
+					Agent:  "test",
+					Action: "get",
+					Path:   "secret/test",
+					Field:  fieldNames[j%len(fieldNames)],
+					OK:     true,
+				})
+			}
+			done <- struct{}{}
+		}()
+	}
+
+	for range goroutines {
+		<-done
+	}
+
+	content, err := os.ReadFile(filepath.Join(home, ".symvault", "audit-concurrent-redact-test.log"))
+	if err != nil {
+		t.Fatalf("ReadFile error = %v", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(string(content)), "\n")
+	for i, line := range lines {
+		var entry map[string]any
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			t.Fatalf("invalid JSON on line %d: %v", i, err)
+		}
+
+		// field must be a known field name
+		if field, ok := entry["field"]; ok {
+			known := false
+			for _, n := range fieldNames {
+				if field == n {
+					known = true
+					break
+				}
+			}
+			if !known {
+				t.Errorf("line %d: unknown field value %v (expected only field names)", i, field)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Document the stable audit event schema, HMAC integrity chain,
retention configuration, and Cloud Pro scope boundary for
self-hosted users.

<!-- closes-list-start -->
- Closes #308 Stabilize self-hosted audit event schema and local retention controls
<!-- closes-list-end -->
