### PR TITLE
Fix TouchID timeouts and allow locked MCP stdio startup

### DIFF
--- a/cmd/mcp/serve.go
+++ b/cmd/mcp/serve.go
@@ -40,4 +40,5 @@ func init() {
 	ServeCmd.Flags().String("tls-cert", "", "TLS certificate file path (overrides config)")
 	ServeCmd.Flags().String("tls-key", "", "TLS key file path (overrides config)")
 	ServeCmd.Flags().String("tls-ca", "", "CA certificate file path for mTLS client verification (enables mTLS)")
+	ServeCmd.Flags().Bool("allow-locked", false, "Allow the MCP server to start even when the vault is locked (stdio mode only)")
 }

--- a/cmd/mcp/serve_deps.go
+++ b/cmd/mcp/serve_deps.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"sync"
@@ -45,6 +46,14 @@ func IsLocalhostBind(bind string) bool {
 
 var ServeUnlockVault = cli.UnlockVault
 
+func isVaultLockedError(err error) bool {
+	var cliErr *errorspkg.CLIError
+	if errors.As(err, &cliErr) {
+		return cliErr.Code == errorspkg.ExitLocked
+	}
+	return false
+}
+
 func confirmServeInsecure() (bool, error) {
 	fmt.Fprintf(os.Stderr, "Bind MCP server without TLS? Bearer tokens will travel in cleartext and are vulnerable to loopback sniffing by local processes. [y/N] ")
 	reader := bufio.NewReader(os.Stdin)
@@ -86,6 +95,13 @@ func runServe(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("read tls-ca flag: %w", err)
 	}
+	allowLocked, err := cmd.Flags().GetBool("allow-locked")
+	if err != nil {
+		return fmt.Errorf("read allow-locked flag: %w", err)
+	}
+	if allowLocked && !stdioFlag {
+		return fmt.Errorf("--allow-locked is only supported in --stdio mode")
+	}
 	if bind == "" {
 		return fmt.Errorf("--bind must not be empty; use '127.0.0.1' for localhost-only")
 	}
@@ -108,7 +124,12 @@ func runServe(cmd *cobra.Command, args []string) error {
 			vault, err = ServeUnlockVault(vaultDir, !stdioFlag)
 		}
 		if err != nil {
-			return err
+			if allowLocked && stdioFlag && isVaultLockedError(err) {
+				cliout.Warnf("Vault is locked; starting MCP server in read-only mode. Run 'symvault unlock' to enable vault tools.")
+				vault = nil
+			} else {
+				return err
+			}
 		}
 	}
 	// Apply CLI TLS flag overrides to the vault config so they take

--- a/internal/cli/unlock.go
+++ b/internal/cli/unlock.go
@@ -78,7 +78,9 @@ func resolveUnlockPassphrase(vaultDir string, interactive bool, cfg *configpkg.C
 	passphraseFromBiometric := false
 	if err != nil || len(passphrase) == 0 {
 		if cfg.EffectiveAuthMethod() == configpkg.AuthMethodTouchID {
-			if biometricPassphrase, biometricErr := SessionLoadBiometric(context.Background(), vaultDir); biometricErr == nil && len(biometricPassphrase) > 0 {
+			biometricCtx, biometricCancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer biometricCancel()
+			if biometricPassphrase, biometricErr := SessionLoadBiometric(biometricCtx, vaultDir); biometricErr == nil && len(biometricPassphrase) > 0 {
 				passphrase = biometricPassphrase
 				passphraseFromBiometric = true
 			}

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -513,6 +513,9 @@ func TestAutoCommitWithOptionsWithCustomAuthor(t *testing.T) {
 func TestAutoCommitWithOptionsDefaultAuthor(t *testing.T) {
 	dir := t.TempDir()
 
+	// Isolate from user's global git config so the fallback defaults are used.
+	t.Setenv("HOME", t.TempDir())
+
 	if err := Init(dir); err != nil {
 		t.Fatalf("Init() error = %v", err)
 	}

--- a/internal/mcp/server/protocol.go
+++ b/internal/mcp/server/protocol.go
@@ -212,7 +212,7 @@ func (h *ProtocolHandler) handleToolsCall(ctx context.Context, msg *transport.Me
 	}
 
 	if h.tools == nil {
-		return transport.NewErrorResponse(msg.ID, transport.ErrCodeInternalError, "Tools not available", nil), nil
+		return transport.NewErrorResponse(msg.ID, transport.ErrCodeInternalError, "vault locked: run 'symvault unlock' first", nil), nil
 	}
 
 	var params struct {

--- a/internal/session/touchid_darwin.go
+++ b/internal/session/touchid_darwin.go
@@ -147,10 +147,13 @@ int touch_id_load_passphrase(char *service_c, char *account_c, char *reason_c, c
 		authResult = success ? 1 : 0;
 		dispatch_semaphore_signal(semaphore);
 	}];
-	dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
+	long waitResult = dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, 30 * NSEC_PER_SEC));
 	[semaphore release];
 	[laCtx release];
 
+	if (waitResult != 0) {
+		return errSecAuthFailed;
+	}
 	if (authResult != 1) {
 		return errSecAuthFailed;
 	}


### PR DESCRIPTION
Bundles fixes for multiple open issues. The list below grows as commits land; every linked issue will close automatically on merge.

<!-- closes-list-start -->
- Closes #313 mcp/serve: dispatch_semaphore_wait(DISPATCH_TIME_FOREVER) in TouchID C-Code blockiert MCP-Start bei fehlender GUI-Session
- Closes #314 mcp/serve: context.Background() in resolveUnlockPassphrase macht TouchID-Timeout unwirksam
- Closes #315 mcp/serve: stdio-Modus sollte für readonly-Agents ohne Vault-Unseal starten können
<!-- closes-list-end -->