### PR TITLE
Use HKDF-SHA256 for search index key derivation (+3 more)

### DIFF
--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -23,6 +23,7 @@ type VaultConfig struct {
 	Argon2idMemory     int           `yaml:"argon2id_memory,omitempty"`
 	Argon2idThreads    int           `yaml:"argon2id_threads,omitempty"`
 	ListingCacheTTL    time.Duration `yaml:"listing_cache_ttl,omitempty"`
+	ManifestGeneration int           `yaml:"manifest_generation,omitempty"`
 }
 
 // GitConfig holds git-related configuration for automatic commits and pushes.

--- a/internal/vault/entry.go
+++ b/internal/vault/entry.go
@@ -443,12 +443,16 @@ func WriteEntry(vaultDir, path string, entry *Entry, identity *age.X25519Identit
 		span.SetStatus(codes.Error, err.Error())
 		return err
 	}
+	queueManifestUpdate(vaultDir, path, ciphertext, identity)
+	if cfg.Vault != nil {
+		cfg.Vault.ManifestGeneration++
+	}
+	FlushManifestUpdates()
 	if err := ReleaseLock(lockFile); err != nil {
 		span.SetStatus(codes.Error, err.Error())
 		return err
 	}
 	lockFile = nil
-	queueManifestUpdate(vaultDir, path, ciphertext, identity)
 	if err := globalIndex.UpdateEntry(vaultDir, path, identity); err != nil {
 		span.SetStatus(codes.Error, err.Error())
 	}
@@ -502,12 +506,16 @@ func DeleteEntry(vaultDir, path string, identity *age.X25519Identity) error {
 			span.SetStatus(codes.Error, err.Error())
 			return err
 		}
+		queueManifestRemove(vaultDir, path, identity)
+		if cfg.Vault != nil {
+			cfg.Vault.ManifestGeneration++
+		}
+		FlushManifestUpdates()
 		if err := ReleaseLock(lockFile); err != nil {
 			span.SetStatus(codes.Error, err.Error())
 			return err
 		}
 		lockFile = nil
-		queueManifestRemove(vaultDir, path, identity)
 		globalIndex.RemoveEntry(path)
 		InvalidateListCache("")
 		return nil
@@ -523,12 +531,16 @@ func DeleteEntry(vaultDir, path string, identity *age.X25519Identity) error {
 			return err
 		}
 	}
+	queueManifestRemove(vaultDir, path, identity)
+	if cfg.Vault != nil {
+		cfg.Vault.ManifestGeneration++
+	}
+	FlushManifestUpdates()
 	if err := ReleaseLock(lockFile); err != nil {
 		span.SetStatus(codes.Error, err.Error())
 		return err
 	}
 	lockFile = nil
-	queueManifestRemove(vaultDir, path, identity)
 	globalIndex.RemoveEntry(path)
 	InvalidateListCache("")
 	return nil

--- a/internal/vault/manifest.go
+++ b/internal/vault/manifest.go
@@ -26,10 +26,11 @@ type ManifestEntry struct {
 
 // Manifest tracks integrity of all .age entry files in the vault.
 type Manifest struct {
-	Version int                      `json:"version"`
-	Created time.Time                `json:"created"`
-	Updated time.Time                `json:"updated"`
-	Entries map[string]ManifestEntry `json:"entries"`
+	Version    int                      `json:"version"`
+	Generation int                      `json:"generation"`
+	Created    time.Time                `json:"created"`
+	Updated    time.Time                `json:"updated"`
+	Entries    map[string]ManifestEntry `json:"entries"`
 }
 
 // ManifestVerifyResult contains the outcome of a full manifest integrity check.
@@ -74,6 +75,7 @@ func writeManifest(vaultDir string, m *Manifest, identity *age.X25519Identity) e
 	if m.Version == 0 {
 		m.Version = 1
 	}
+	m.Generation++
 	m.Updated = time.Now().UTC()
 
 	plaintext, err := json.Marshal(m)

--- a/internal/vault/manifest_updater.go
+++ b/internal/vault/manifest_updater.go
@@ -41,7 +41,7 @@ var (
 // Every update/remove operation resets this timer. When the timer fires all
 // accumulated changes for the affected vault are flushed in a single read-
 // modify-write cycle.
-const manifestFlushInterval = 200 * time.Millisecond
+const manifestFlushInterval = 50 * time.Millisecond
 
 // pendingVaultState tracks accumulated manifest changes for a single vault
 // directory. All fields are accessed only from the worker goroutine.

--- a/internal/vault/search.go
+++ b/internal/vault/search.go
@@ -144,16 +144,24 @@ type listCacheEntry struct {
 	vaultDirHash   string
 }
 
+const (
+	defaultListCacheTTL = 300 * time.Second
+	minListCacheTTL     = 30 * time.Second
+	maxListCacheTTL     = 10 * time.Minute
+)
+
 // listCache provides TTL-cached path listings to avoid repetitive directory walks.
 // It invalidates entries when the underlying directories' modification times change.
+// The TTL adapts based on hit rate: extends when hit rate > 90%, shrinks when < 50%.
 var listCache = struct {
 	mu    sync.RWMutex
 	items map[string]listCacheEntry
-	// TTL is the cache duration. It is a variable (not const) so tests can override it.
-	ttl time.Duration
+	ttl   time.Duration
+	_hits uint64
+	_miss uint64
 }{
 	items: make(map[string]listCacheEntry),
-	ttl:   300 * time.Second,
+	ttl:   defaultListCacheTTL,
 }
 
 // getDirMtime returns the modification time of a directory, or zero if unavailable.
@@ -189,30 +197,72 @@ func computeDirHash(dir string) string {
 	return hex.EncodeToString(h.Sum(nil))
 }
 
+func adaptListCacheTTL() {
+	hits := atomic.LoadUint64(&listCache._hits)
+	miss := atomic.LoadUint64(&listCache._miss)
+	total := hits + miss
+	if total < 100 {
+		return
+	}
+	effectiveMax := maxListCacheTTL
+	if configuredListCacheTTL > 0 && configuredListCacheTTL < effectiveMax {
+		effectiveMax = configuredListCacheTTL
+	}
+	ratio := float64(hits) / float64(total)
+	listCache.mu.Lock()
+	if ratio > 0.9 && listCache.ttl < effectiveMax {
+		listCache.ttl *= 2
+		if listCache.ttl > effectiveMax {
+			listCache.ttl = effectiveMax
+		}
+	} else if ratio < 0.5 && listCache.ttl > minListCacheTTL {
+		listCache.ttl /= 2
+		if listCache.ttl < minListCacheTTL {
+			listCache.ttl = minListCacheTTL
+		}
+	}
+	listCache.mu.Unlock()
+	atomic.StoreUint64(&listCache._hits, 0)
+	atomic.StoreUint64(&listCache._miss, 0)
+}
+
 // cachedList returns cached paths if valid, or nil if cache miss / expired / invalidated.
 func cachedList(vaultDir string) []string {
 	listCache.mu.RLock()
 	entry, ok := listCache.items[vaultDir]
 	listCache.mu.RUnlock()
 	if !ok {
+		atomic.AddUint64(&listCache._miss, 1)
+		adaptListCacheTTL()
 		return nil
 	}
 	if time.Since(entry.createdAt) > listCache.ttl {
+		atomic.AddUint64(&listCache._miss, 1)
+		adaptListCacheTTL()
 		return nil
 	}
-	// Validate mtimes: if either directory changed since caching, invalidate
 	if !getDirMtime(entriesDir(vaultDir)).Equal(entry.entriesMtime) {
+		atomic.AddUint64(&listCache._miss, 1)
+		adaptListCacheTTL()
 		return nil
 	}
 	if !getDirMtime(vaultDir).Equal(entry.vaultMtime) {
+		atomic.AddUint64(&listCache._miss, 1)
+		adaptListCacheTTL()
 		return nil
 	}
 	if computeDirHash(entriesDir(vaultDir)) != entry.entriesDirHash {
+		atomic.AddUint64(&listCache._miss, 1)
+		adaptListCacheTTL()
 		return nil
 	}
 	if computeDirHash(vaultDir) != entry.vaultDirHash {
+		atomic.AddUint64(&listCache._miss, 1)
+		adaptListCacheTTL()
 		return nil
 	}
+	atomic.AddUint64(&listCache._hits, 1)
+	adaptListCacheTTL()
 	return entry.paths
 }
 
@@ -230,13 +280,20 @@ func storeListCache(vaultDir string, paths []string) {
 	listCache.mu.Unlock()
 }
 
+var configuredListCacheTTL time.Duration
+
 // SetListCacheTTL overrides the default list cache TTL. Pass 0 to disable
 // caching. Typically called from vault initialization with the configured
-// vault.listing_cache_ttl value.
+// vault.listing_cache_ttl value. The adaptive TTL will not grow past this value.
 func SetListCacheTTL(ttl time.Duration) {
 	listCache.mu.Lock()
-	listCache.ttl = ttl
+	if ttl <= 0 {
+		listCache.ttl = 0
+	} else {
+		listCache.ttl = ttl
+	}
 	listCache.mu.Unlock()
+	configuredListCacheTTL = ttl
 }
 
 // InvalidateListCache removes the cached entry list for vaultDir.

--- a/internal/vault/search_index.go
+++ b/internal/vault/search_index.go
@@ -71,7 +71,6 @@ type indexDoc struct {
 	Salt []byte `json:"s,omitempty"`
 }
 
-
 var globalIndex EncryptedIndex
 
 // Build constructs the encrypted search index by scanning all entries in the
@@ -96,8 +95,8 @@ func (idx *EncryptedIndex) Build(vaultDir string, identity *age.X25519Identity) 
 	}
 
 	salt := make([]byte, indexSaltLen)
-	if _, err := rand.Read(salt); err != nil {
-		return err
+	if _, randErr := rand.Read(salt); randErr != nil {
+		return randErr
 	}
 	doc.Salt = salt
 

--- a/internal/vault/search_index.go
+++ b/internal/vault/search_index.go
@@ -1,9 +1,11 @@
 package vault
 
 import (
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/json"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -11,6 +13,7 @@ import (
 	"unicode"
 
 	"filippo.io/age"
+	"golang.org/x/crypto/hkdf"
 
 	vaultcrypto "github.com/danieljustus/symaira-vault/internal/crypto"
 )
@@ -37,6 +40,7 @@ import (
 type EncryptedIndex struct {
 	mu         sync.RWMutex
 	ciphertext []byte            // encrypted serialized index
+	salt       []byte            // 16-byte HKDF salt (nil for legacy)
 	vaultDir   string            // vault directory the index covers
 	idHash     [sha256.Size]byte // sha256 of identity for change detection
 }
@@ -62,7 +66,11 @@ type indexDoc struct {
 	// EntryCount is the number of entries in the vault when the index was built.
 	// Used for stale detection — if the count differs, the index is rebuilt.
 	EntryCount int `json:"c,omitempty"`
+	// Salt is the random salt for HKDF-based index key derivation.
+	// Empty for legacy indices (pre-v0.4.1) that used raw SHA-256 keying.
+	Salt []byte `json:"s,omitempty"`
 }
+
 
 var globalIndex EncryptedIndex
 
@@ -86,6 +94,12 @@ func (idx *EncryptedIndex) Build(vaultDir string, identity *age.X25519Identity) 
 		TokenIndex: make(map[string]map[string]struct{}),
 		EntryCount: len(paths),
 	}
+
+	salt := make([]byte, indexSaltLen)
+	if _, err := rand.Read(salt); err != nil {
+		return err
+	}
+	doc.Salt = salt
 
 	for _, entryPath := range paths {
 		entry, readErr := ReadEntry(vaultDir, entryPath, identity)
@@ -114,7 +128,7 @@ func (idx *EncryptedIndex) Build(vaultDir string, identity *age.X25519Identity) 
 	}
 	defer vaultcrypto.Wipe(plaintext)
 
-	key := deriveIndexKey(identity)
+	key := deriveIndexKey(identity, salt)
 	defer vaultcrypto.Wipe(key)
 
 	ciphertext, err := vaultcrypto.EncryptWithKey(plaintext, key)
@@ -126,6 +140,7 @@ func (idx *EncryptedIndex) Build(vaultDir string, identity *age.X25519Identity) 
 
 	idx.mu.Lock()
 	idx.ciphertext = ciphertext
+	idx.salt = salt
 	idx.vaultDir = vaultDir
 	idx.idHash = idHash
 	idx.mu.Unlock()
@@ -151,6 +166,7 @@ func (idx *EncryptedIndex) MatchEntries(vaultDir string, identity *age.X25519Ide
 	idx.mu.RLock()
 	ct := idx.ciphertext
 	idHash := idx.idHash
+	storedSalt := idx.salt
 	idx.mu.RUnlock()
 
 	if ct == nil {
@@ -162,7 +178,7 @@ func (idx *EncryptedIndex) MatchEntries(vaultDir string, identity *age.X25519Ide
 		return nil, errors.New("identity changed")
 	}
 
-	key := deriveIndexKey(identity)
+	key := deriveIndexKey(identity, storedSalt)
 	defer vaultcrypto.Wipe(key)
 
 	plaintext, err := vaultcrypto.DecryptWithKey(ct, key)
@@ -226,6 +242,7 @@ func (idx *EncryptedIndex) Invalidate() {
 	idx.mu.Lock()
 	vaultDir := idx.vaultDir
 	idx.ciphertext = nil
+	idx.salt = nil
 	idx.vaultDir = ""
 	idx.idHash = [sha256.Size]byte{}
 	idx.mu.Unlock()
@@ -246,13 +263,14 @@ func (idx *EncryptedIndex) UpdateEntry(vaultDir, path string, identity *age.X255
 		return nil
 	}
 
-	key := deriveIndexKey(identity)
+	storedSalt := idx.salt
+	key := deriveIndexKey(identity, storedSalt)
 	defer vaultcrypto.Wipe(key)
 
 	plaintext, err := vaultcrypto.DecryptWithKey(idx.ciphertext, key)
 	if err != nil {
-		// Corrupt index — clear and let it rebuild lazily
 		idx.ciphertext = nil
+		idx.salt = nil
 		idx.vaultDir = ""
 		idx.idHash = [sha256.Size]byte{}
 		return nil
@@ -262,6 +280,7 @@ func (idx *EncryptedIndex) UpdateEntry(vaultDir, path string, identity *age.X255
 	var doc indexDoc
 	if err = json.Unmarshal(plaintext, &doc); err != nil {
 		idx.ciphertext = nil
+		idx.salt = nil
 		idx.vaultDir = ""
 		idx.idHash = [sha256.Size]byte{}
 		return nil
@@ -317,15 +336,17 @@ func (idx *EncryptedIndex) RemoveEntry(path string) {
 	identity := currentSearchIdentity()
 	if identity == nil {
 		idx.ciphertext = nil
+		idx.salt = nil
 		return
 	}
 
-	key := deriveIndexKey(identity)
+	key := deriveIndexKey(identity, idx.salt)
 	defer vaultcrypto.Wipe(key)
 
 	plaintext, err := vaultcrypto.DecryptWithKey(idx.ciphertext, key)
 	if err != nil {
 		idx.ciphertext = nil
+		idx.salt = nil
 		return
 	}
 	defer vaultcrypto.Wipe(plaintext)
@@ -357,9 +378,12 @@ func (idx *EncryptedIndex) RemoveEntry(path string) {
 	idx.ciphertext = newCiphertext
 }
 
+const indexFormatVersion = byte(0x01)
+
 func (idx *EncryptedIndex) saveToDisk(vaultDir string) error {
 	idx.mu.RLock()
 	ct := idx.ciphertext
+	storedSalt := idx.salt
 	idx.mu.RUnlock()
 
 	if ct == nil {
@@ -367,12 +391,16 @@ func (idx *EncryptedIndex) saveToDisk(vaultDir string) error {
 	}
 
 	indexPath := indexFilePath(vaultDir)
-	return os.WriteFile(indexPath, ct, 0600)
+	data := make([]byte, 0, 1+len(storedSalt)+len(ct))
+	data = append(data, indexFormatVersion)
+	data = append(data, storedSalt...)
+	data = append(data, ct...)
+	return os.WriteFile(indexPath, data, 0600)
 }
 
 func (idx *EncryptedIndex) loadFromDisk(vaultDir string, identity *age.X25519Identity) error {
 	indexPath := indexFilePath(vaultDir)
-	ct, err := os.ReadFile(indexPath) // #nosec G304 — indexPath is filepath.Join(vaultDir, ".search-index"). Callers pass Vault.Dir from Open, which validates the directory via validateVaultDir(), and the filename is hardcoded.
+	raw, err := os.ReadFile(indexPath) // #nosec G304 — indexPath is filepath.Join(vaultDir, ".search-index"). Callers pass Vault.Dir from Open, which validates the directory via validateVaultDir(), and the filename is hardcoded.
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return nil
@@ -380,11 +408,28 @@ func (idx *EncryptedIndex) loadFromDisk(vaultDir string, identity *age.X25519Ide
 		return err
 	}
 
-	key := deriveIndexKey(identity)
+	var salt []byte
+	var ct []byte
+
+	if len(raw) > 1 && raw[0] == indexFormatVersion {
+		if len(raw) < 1+indexSaltLen+1 {
+			_ = os.Remove(indexPath)
+			return errors.New("truncated search index")
+		}
+		salt = raw[1 : 1+indexSaltLen]
+		ct = raw[1+indexSaltLen:]
+	} else {
+		ct = raw
+	}
+
+	key := deriveIndexKey(identity, salt)
 	defer vaultcrypto.Wipe(key)
 
 	plaintext, err := vaultcrypto.DecryptWithKey(ct, key)
-	if err != nil {
+	if err != nil && len(salt) == 0 {
+		_ = os.Remove(indexPath)
+		return err
+	} else if err != nil {
 		_ = os.Remove(indexPath)
 		return err
 	}
@@ -410,9 +455,14 @@ func (idx *EncryptedIndex) loadFromDisk(vaultDir string, identity *age.X25519Ide
 
 	idx.mu.Lock()
 	idx.ciphertext = ct
+	idx.salt = salt
 	idx.vaultDir = vaultDir
 	idx.idHash = idHash
 	idx.mu.Unlock()
+
+	if len(salt) == 0 {
+		_ = idx.saveToDisk(vaultDir)
+	}
 
 	return nil
 }
@@ -449,11 +499,23 @@ func collectStringValues(dst *[]string, data any) {
 }
 
 // deriveIndexKey derives a 32-byte symmetric encryption key from the vault
-// identity using SHA-256 of the identity string.
-func deriveIndexKey(identity *age.X25519Identity) []byte {
-	h := sha256.Sum256([]byte(identity.String()))
-	return h[:]
+// identity using HKDF-SHA256 with a per-index random salt and an info label.
+// Legacy indices without a salt use raw SHA-256 for backward compatibility.
+func deriveIndexKey(identity *age.X25519Identity, salt []byte) []byte {
+	identityBytes := []byte(identity.String())
+	if len(salt) == 0 {
+		h := sha256.Sum256(identityBytes)
+		return h[:]
+	}
+	kdf := hkdf.New(sha256.New, identityBytes, salt, []byte("symvault-search-index-v1"))
+	key := make([]byte, 32)
+	if _, err := io.ReadFull(kdf, key); err != nil {
+		panic("hkdf read failed: " + err.Error())
+	}
+	return key
 }
+
+const indexSaltLen = 16
 
 // tokenize splits a lowercased string into individual tokens on whitespace and
 // punctuation boundaries. Consecutive delimiters produce no empty tokens.

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -105,9 +105,19 @@ func Open(vaultDir string, identity *age.X25519Identity) (*Vault, error) {
 		}
 		markLegacyMigrationDone(vaultDir)
 	}
-	// Rebuild manifest only when missing (fresh vaults or missing manifest file).
+	// Flush any pending manifest updates before checking consistency.
+	FlushManifestUpdates()
+
+	// Check manifest consistency: rebuild if missing, or if the manifest is stale
+	// (config generation counter > manifest generation counter, indicating unflushed
+	// writes from a prior crash).
 	if _, err := os.Stat(filepath.Join(vaultDir, manifestFileName)); os.IsNotExist(err) {
 		_ = RebuildManifest(vaultDir, identity) // best-effort
+	} else if cfg.Vault != nil && cfg.Vault.ManifestGeneration > 0 {
+		m, loadErr := LoadManifest(vaultDir, identity)
+		if loadErr == nil && m.Generation < cfg.Vault.ManifestGeneration {
+			_ = RebuildManifest(vaultDir, identity) // best-effort
+		}
 	}
 	if _, err := os.Stat(filepath.Join(vaultDir, ".git")); err == nil {
 		if err := git.CreateGitignore(vaultDir); err != nil {


### PR DESCRIPTION
Bundles fixes for multiple open issues. Every linked issue will close automatically on merge.

<!-- closes-list-start -->
- Closes #330 Search index key derivation lacks KDF stretching
- Closes #332 Async manifest write window creates integrity risk on crash
- Closes #349 Manifest debounce adds 200ms latency to every write operation
- Closes #350 List cache TTL is static; could be adaptive
<!-- closes-list-end -->