### PR TITLE
refactor(vault): eliminate global mutable state for search identity

### DIFF
--- a/cmd/crud/find.go
+++ b/cmd/crud/find.go
@@ -25,7 +25,7 @@ func searchWorkers(vaultDir string, cfg *configpkg.Config) int {
 		return cfg.Vault.SearchWorkers
 	}
 
-	entries, _ := vaultpkg.List(vaultDir, "")
+	entries, _ := vaultpkg.List(vaultDir, "", nil)
 	entryCount := len(entries)
 	cpuCount := runtime.GOMAXPROCS(0)
 

--- a/cmd/import_test.go
+++ b/cmd/import_test.go
@@ -27,7 +27,7 @@ func TestImportCommandDryRunDoesNotWriteEntries(t *testing.T) {
 	output := runImportCommand(t, string(passphrase), "--vault", vaultDir, "import", "csv", csvImportFixture(t), "--dry-run")
 
 	v := importTestVault(t, vaultDir, string(passphrase))
-	entries, err := vaultpkg.List(v.Dir, "")
+	entries, err := vaultpkg.List(v.Dir, "", nil)
 	if err != nil {
 		t.Fatalf("list entries: %v", err)
 	}
@@ -245,7 +245,7 @@ func TestImportQuarantinePath(t *testing.T) {
 
 	// Verify entries are stored under quarantine/<import-id>/
 	v := importTestVault(t, vaultDir, string(passphrase))
-	quarantined, err := vaultpkg.List(v.Dir, "quarantine/")
+	quarantined, err := vaultpkg.List(v.Dir, "quarantine/", nil)
 	if err != nil {
 		t.Fatalf("list quarantine entries: %v", err)
 	}
@@ -400,7 +400,7 @@ func TestImportReviewPromote(t *testing.T) {
 	assertCSVImportedEntries(t, v, "")
 
 	// Quarantine prefix should be empty
-	quarantined, err := vaultpkg.List(v.Dir, "quarantine/")
+	quarantined, err := vaultpkg.List(v.Dir, "quarantine/", nil)
 	if err != nil {
 		t.Fatalf("list quarantine: %v", err)
 	}
@@ -471,7 +471,7 @@ func TestImportReviewPromoteSkipsExisting(t *testing.T) {
 	}
 
 	// Quarantine entry should still exist (not deleted)
-	quarantined, err := vaultpkg.List(v.Dir, "quarantine/")
+	quarantined, err := vaultpkg.List(v.Dir, "quarantine/", nil)
 	if err != nil {
 		t.Fatalf("list quarantine: %v", err)
 	}
@@ -547,7 +547,7 @@ func TestImportReviewPromoteOverwrite(t *testing.T) {
 	}
 
 	// Quarantine should be empty
-	quarantined, err := vaultpkg.List(v.Dir, "quarantine/")
+	quarantined, err := vaultpkg.List(v.Dir, "quarantine/", nil)
 	if err != nil {
 		t.Fatalf("list quarantine: %v", err)
 	}

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -25,7 +25,6 @@ import (
 
 	vaultcrypto "github.com/danieljustus/symaira-vault/internal/crypto"
 	"github.com/danieljustus/symaira-vault/internal/envutil"
-	vaultpkg "github.com/danieljustus/symaira-vault/internal/vault"
 )
 
 const (
@@ -227,7 +226,7 @@ func New(agentName string, vaultDir string) (*Logger, error) {
 		return nil, fmt.Errorf("open audit log: %w", err)
 	}
 
-	ks := NewKeystore(cleanAuditDir, vaultpkg.CurrentSearchIdentity())
+	ks := NewKeystore(cleanAuditDir, nil)
 	hmacKey, err := ks.LoadOrCreateHMACKey()
 	if err != nil {
 		_ = file.Close()

--- a/internal/cli/completion.go
+++ b/internal/cli/completion.go
@@ -50,7 +50,7 @@ func entryPathSuggestions(toComplete string) ([]string, cobra.ShellCompDirective
 	}
 
 	prefix := strings.TrimSpace(toComplete)
-	paths, err := vaultpkg.List(vaultDir, "")
+	paths, err := vaultpkg.List(vaultDir, "", v.Identity)
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}

--- a/internal/health/doctor_crypto.go
+++ b/internal/health/doctor_crypto.go
@@ -207,25 +207,18 @@ func checkKDFModern(vaultDir string, _ Options) Result {
 func checkPasswordStrength(vaultDir string, _ Options) Result {
 	r := Result{ID: "password.strength", Name: "Weak password detection"}
 
-	identity := vault.CurrentSearchIdentity()
-	if identity == nil {
+	paths, err := vault.List(vaultDir, "", nil)
+	if err != nil {
 		r.Status = StatusWarn
 		r.Message = msgSessionNeeded
 		r.Hint = hintSessionNeeded
 		return r
 	}
 
-	paths, err := vault.List(vaultDir, "")
-	if err != nil {
-		r.Status = StatusWarn
-		r.Message = "cannot list entries: " + err.Error()
-		return r
-	}
-
 	var weakCount int
 	var examplePaths []string
 	for _, path := range paths {
-		entry, err := vault.ReadEntry(vaultDir, path, identity)
+		entry, err := vault.ReadEntry(vaultDir, path, nil)
 		if err != nil {
 			continue
 		}
@@ -265,24 +258,17 @@ func checkPasswordStrength(vaultDir string, _ Options) Result {
 func checkPasswordReuse(vaultDir string, _ Options) Result {
 	r := Result{ID: "password.reuse", Name: "Password reuse detection"}
 
-	identity := vault.CurrentSearchIdentity()
-	if identity == nil {
+	paths, err := vault.List(vaultDir, "", nil)
+	if err != nil {
 		r.Status = StatusWarn
 		r.Message = msgSessionNeeded
 		r.Hint = "run `symvault unlock` to decrypt entries for password reuse analysis"
 		return r
 	}
 
-	paths, err := vault.List(vaultDir, "")
-	if err != nil {
-		r.Status = StatusWarn
-		r.Message = "cannot list entries: " + err.Error()
-		return r
-	}
-
 	hashToPaths := make(map[string][]string)
 	for _, path := range paths {
-		entry, err := vault.ReadEntry(vaultDir, path, identity)
+		entry, err := vault.ReadEntry(vaultDir, path, nil)
 		if err != nil {
 			continue
 		}

--- a/internal/health/doctor_mcp.go
+++ b/internal/health/doctor_mcp.go
@@ -14,7 +14,6 @@ import (
 	configpkg "github.com/danieljustus/symaira-vault/internal/config"
 	auth "github.com/danieljustus/symaira-vault/internal/mcp/auth"
 	"github.com/danieljustus/symaira-vault/internal/update"
-	"github.com/danieljustus/symaira-vault/internal/vault"
 )
 
 func checkMCPTokens(vaultDir string, _ Options) Result {
@@ -73,7 +72,7 @@ func checkAuditLog(vaultDir string, _ Options) Result {
 	}
 
 	// HMAC key is shared across all audit logs in the vault directory.
-	ks := audit.NewKeystore(vaultDir, vault.CurrentSearchIdentity())
+	ks := audit.NewKeystore(vaultDir, nil)
 	key, keyErr := ks.LoadHMACKey()
 	if keyErr != nil {
 		r.Status = StatusWarn

--- a/internal/health/doctor_vault.go
+++ b/internal/health/doctor_vault.go
@@ -222,15 +222,13 @@ func checkManifestIntegrity(vaultDir string, _ Options) Result {
 		return r
 	}
 
-	identity := vault.CurrentSearchIdentity()
-	if identity == nil {
+	result, err := vault.VerifyManifestIntegrity(vaultDir, nil)
+	if err != nil {
 		r.Status = StatusWarn
 		r.Message = msgSessionNeeded
 		r.Hint = "run `symvault unlock` to decrypt your identity for manifest verification"
 		return r
 	}
-
-	result, err := vault.VerifyManifestIntegrity(vaultDir, identity)
 	if err != nil {
 		r.Status = StatusWarn
 		r.Message = "cannot verify manifest: " + err.Error()

--- a/internal/health/doctor_vault.go
+++ b/internal/health/doctor_vault.go
@@ -229,12 +229,6 @@ func checkManifestIntegrity(vaultDir string, _ Options) Result {
 		r.Hint = "run `symvault unlock` to decrypt your identity for manifest verification"
 		return r
 	}
-	if err != nil {
-		r.Status = StatusWarn
-		r.Message = "cannot verify manifest: " + err.Error()
-		r.Hint = "run `symvault verify` to regenerate manifest"
-		return r
-	}
 
 	var issues []string
 	if len(result.Tampered) > 0 {

--- a/internal/mcp/server/tools_find.go
+++ b/internal/mcp/server/tools_find.go
@@ -53,7 +53,7 @@ func (s *Server) findEntries(ctx context.Context, query string) ([]vaultpkg.Matc
 		redactPatterns = s.agent.EffectiveRedactFields("find_entries")
 	}
 
-	return vaultpkg.FindWithOptions(s.vault.Dir, query, vaultpkg.FindOptions{
+	return s.vault.FindWithOptions(query, vaultpkg.FindOptions{
 		MaxWorkers:          workers,
 		ScopeFilter:         s.checkScope,
 		RedactFieldPatterns: redactPatterns,

--- a/internal/mcp/server/tools_whoami.go
+++ b/internal/mcp/server/tools_whoami.go
@@ -169,7 +169,7 @@ func (s *Server) handleWhoami(ctx context.Context, req mcp.CallToolRequest) (*mc
 		Unavailable: unavailable,
 	}
 
-	paths, listErr := vaultpkg.List(s.vault.Dir, "")
+	paths, listErr := vaultpkg.List(s.vault.Dir, "", s.vault.Identity)
 	if listErr == nil {
 		info.Vault.EntriesCount = len(paths)
 	}

--- a/internal/ui/tui.go
+++ b/internal/ui/tui.go
@@ -737,7 +737,7 @@ func loadEntriesCmd(vault *vaultpkg.Vault) tea.Cmd {
 				msg = entriesLoadedMsg{err: fmt.Errorf("panic loading entries: %v", r)}
 			}
 		}()
-		entries, err := vaultpkg.List(vault.Dir, "")
+		entries, err := vaultpkg.List(vault.Dir, "", vault.Identity)
 		if err != nil {
 			return entriesLoadedMsg{err: err}
 		}

--- a/internal/ui/tui_test.go
+++ b/internal/ui/tui_test.go
@@ -45,7 +45,7 @@ func TestTUIModelLoadsEntries(t *testing.T) {
 		t.Error("expected model to be in loading state")
 	}
 
-	entriesList, err := vaultpkg.List(vault.Dir, "")
+	entriesList, err := vaultpkg.List(vault.Dir, "", vault.Identity)
 	if err != nil {
 		t.Fatalf("vaultpkg.List() error = %v", err)
 	}
@@ -109,7 +109,7 @@ func TestLoadEntriesCmdIntegration(t *testing.T) {
 		Identity: id,
 	}
 
-	entries, err := vaultpkg.List(vault.Dir, "")
+	entries, err := vaultpkg.List(vault.Dir, "", vault.Identity)
 	if err != nil {
 		t.Fatalf("List error = %v", err)
 	}

--- a/internal/vault/coverage_expansion_test.go
+++ b/internal/vault/coverage_expansion_test.go
@@ -125,9 +125,10 @@ func TestInvalidateConfigCache(t *testing.T) {
 }
 
 func TestCurrentSearchIdentity_InitialNil(t *testing.T) {
-	id := currentSearchIdentity()
+	var v *Vault
+	id := v.CurrentSearchIdentity()
 	if id != nil {
-		t.Error("currentSearchIdentity() should be nil initially")
+		t.Error("CurrentSearchIdentity() on nil vault should return nil")
 	}
 }
 

--- a/internal/vault/coverage_test.go
+++ b/internal/vault/coverage_test.go
@@ -133,22 +133,10 @@ func TestGetRecipientNilVaultPointer(t *testing.T) {
 	}
 }
 
-// TestRememberSearchIdentityNilSkips covers the nil-identity early return.
-func TestRememberSearchIdentityNilSkips(t *testing.T) {
-	// Should not panic and should not overwrite existing identity
-	id := testutil.TempIdentity(t)
-	rememberSearchIdentity(id)
-	rememberSearchIdentity(nil)
-	got := currentSearchIdentity()
-	if got == nil {
-		t.Error("rememberSearchIdentity(nil) should not overwrite existing identity")
-	}
-}
-
 // TestFindListError covers the List error return path in Find.
 func TestFindListError(t *testing.T) {
 	// vaultDir does not exist → List will fail → FindWithOptions returns error
-	_, err := FindWithOptions("/nonexistent/vault/dir/that/does/not/exist", "query", FindOptions{MaxWorkers: 0})
+	_, err := FindWithOptions("/nonexistent/vault/dir/that/does/not/exist", "query", FindOptions{MaxWorkers: 0}, nil)
 	if err == nil {
 		t.Fatal("FindWithOptions() error = nil, want error when vault dir does not exist")
 	}
@@ -255,11 +243,10 @@ func TestCollectFieldMatchesDeeplyNested(t *testing.T) {
 func TestFindReturnsEmptyForNoMatches(t *testing.T) {
 	vaultDir := t.TempDir()
 	id := testutil.TempIdentity(t)
-	rememberSearchIdentity(id)
 
 	mustWriteEntryCoverage(t, vaultDir, id, "github.com/user", map[string]interface{}{"username": "alice"})
 
-	got, err := FindWithOptions(vaultDir, "nomatch", FindOptions{MaxWorkers: 0})
+	got, err := FindWithOptions(vaultDir, "nomatch", FindOptions{MaxWorkers: 0}, id)
 	if err != nil {
 		t.Fatalf("Find() error = %v", err)
 	}
@@ -272,11 +259,10 @@ func TestFindReturnsEmptyForNoMatches(t *testing.T) {
 func TestFindWithOptionsReturnsEmptyForNoMatches(t *testing.T) {
 	vaultDir := t.TempDir()
 	id := testutil.TempIdentity(t)
-	rememberSearchIdentity(id)
 
 	mustWriteEntryCoverage(t, vaultDir, id, "github.com/user", map[string]interface{}{"username": "alice"})
 
-	got, err := FindWithOptions(vaultDir, "nomatch", FindOptions{MaxWorkers: 4})
+	got, err := FindWithOptions(vaultDir, "nomatch", FindOptions{MaxWorkers: 4}, id)
 	if err != nil {
 		t.Fatalf("FindWithOptions() error = %v", err)
 	}
@@ -289,11 +275,10 @@ func TestFindWithOptionsReturnsEmptyForNoMatches(t *testing.T) {
 func TestFindWithUnicodeQuery(t *testing.T) {
 	vaultDir := t.TempDir()
 	id := testutil.TempIdentity(t)
-	rememberSearchIdentity(id)
 
 	mustWriteEntryCoverage(t, vaultDir, id, "test/entry", map[string]interface{}{"data": "日本語テスト"})
 
-	got, err := FindWithOptions(vaultDir, "日本語", FindOptions{MaxWorkers: 0})
+	got, err := FindWithOptions(vaultDir, "日本語", FindOptions{MaxWorkers: 0}, id)
 	if err != nil {
 		t.Fatalf("Find() error = %v", err)
 	}
@@ -306,14 +291,13 @@ func TestFindWithUnicodeQuery(t *testing.T) {
 func TestFindPathMatchesBeforeFieldSearch(t *testing.T) {
 	vaultDir := t.TempDir()
 	id := testutil.TempIdentity(t)
-	rememberSearchIdentity(id)
 
 	mustWriteEntryCoverage(t, vaultDir, id, "github.com/user", map[string]interface{}{
 		"username": "alice",
 		"password": "secret123",
 	})
 
-	got, err := FindWithOptions(vaultDir, "github", FindOptions{MaxWorkers: 0})
+	got, err := FindWithOptions(vaultDir, "github", FindOptions{MaxWorkers: 0}, id)
 	if err != nil {
 		t.Fatalf("Find() error = %v", err)
 	}
@@ -329,14 +313,13 @@ func TestFindPathMatchesBeforeFieldSearch(t *testing.T) {
 func TestFindWithOptionsPathMatchesBeforeFieldSearch(t *testing.T) {
 	vaultDir := t.TempDir()
 	id := testutil.TempIdentity(t)
-	rememberSearchIdentity(id)
 
 	mustWriteEntryCoverage(t, vaultDir, id, "github.com/user", map[string]interface{}{
 		"username": "alice",
 		"password": "secret123",
 	})
 
-	got, err := FindWithOptions(vaultDir, "github", FindOptions{MaxWorkers: 4})
+	got, err := FindWithOptions(vaultDir, "github", FindOptions{MaxWorkers: 4}, id)
 	if err != nil {
 		t.Fatalf("FindWithOptions() error = %v", err)
 	}
@@ -398,9 +381,7 @@ func TestInitWriteFileError(t *testing.T) {
 
 // TestFindWithOptionsListError covers List error path in FindWithOptions.
 func TestFindWithOptionsListError(t *testing.T) {
-	searchIdentity.Store(nil)
-
-	_, err := FindWithOptions("/nonexistent/path", "query", FindOptions{MaxWorkers: 4})
+	_, err := FindWithOptions("/nonexistent/path", "query", FindOptions{MaxWorkers: 4}, nil)
 	if err == nil {
 		t.Fatal("FindWithOptions() error = nil, want error for nonexistent vault")
 	}
@@ -408,7 +389,7 @@ func TestFindWithOptionsListError(t *testing.T) {
 
 // TestListNonExistentVault covers List with nonexistent vault.
 func TestListNonExistentVault(t *testing.T) {
-	_, err := List("/nonexistent/vault", "")
+	_, err := List("/nonexistent/vault", "", nil)
 	if err == nil {
 		t.Fatal("List() error = nil, want error for nonexistent vault")
 	}
@@ -416,7 +397,7 @@ func TestListNonExistentVault(t *testing.T) {
 
 // TestListWithPrefixNonExistentVault covers List with nonexistent vault and prefix.
 func TestListWithPrefixNonExistentVault(t *testing.T) {
-	_, err := List("/nonexistent/vault", "prefix")
+	_, err := List("/nonexistent/vault", "prefix", nil)
 	if err == nil {
 		t.Fatal("List() error = nil, want error for nonexistent vault")
 	}
@@ -452,14 +433,13 @@ func TestOpenWithPassphraseFileNotFound(t *testing.T) {
 func TestFindNoPathMatchesDecryptsAll(t *testing.T) {
 	vaultDir := t.TempDir()
 	id := testutil.TempIdentity(t)
-	rememberSearchIdentity(id)
 
 	mustWriteEntryCoverage(t, vaultDir, id, "github.com/user", map[string]interface{}{
 		"username": "alice",
 		"password": "secret123",
 	})
 
-	got, err := FindWithOptions(vaultDir, "secret", FindOptions{MaxWorkers: 0})
+	got, err := FindWithOptions(vaultDir, "secret", FindOptions{MaxWorkers: 0}, id)
 	if err != nil {
 		t.Fatalf("Find() error = %v", err)
 	}
@@ -475,13 +455,12 @@ func TestFindNoPathMatchesDecryptsAll(t *testing.T) {
 func TestFindMatchesMultipleEntries(t *testing.T) {
 	vaultDir := t.TempDir()
 	id := testutil.TempIdentity(t)
-	rememberSearchIdentity(id)
 
 	mustWriteEntryCoverage(t, vaultDir, id, "github.com/user", map[string]interface{}{"username": "alice"})
 	mustWriteEntryCoverage(t, vaultDir, id, "github.com/work", map[string]interface{}{"username": "bob"})
 	mustWriteEntryCoverage(t, vaultDir, id, "gitlab.com/user", map[string]interface{}{"username": "carol"})
 
-	got, err := FindWithOptions(vaultDir, "github", FindOptions{MaxWorkers: 0})
+	got, err := FindWithOptions(vaultDir, "github", FindOptions{MaxWorkers: 0}, id)
 	if err != nil {
 		t.Fatalf("FindWithOptions() error = %v", err)
 	}
@@ -494,13 +473,12 @@ func TestFindMatchesMultipleEntries(t *testing.T) {
 func TestFindWithOptionsMatchesMultipleEntries(t *testing.T) {
 	vaultDir := t.TempDir()
 	id := testutil.TempIdentity(t)
-	rememberSearchIdentity(id)
 
 	mustWriteEntryCoverage(t, vaultDir, id, "github.com/user", map[string]interface{}{"username": "alice"})
 	mustWriteEntryCoverage(t, vaultDir, id, "github.com/work", map[string]interface{}{"username": "bob"})
 	mustWriteEntryCoverage(t, vaultDir, id, "gitlab.com/user", map[string]interface{}{"username": "carol"})
 
-	got, err := FindWithOptions(vaultDir, "github", FindOptions{MaxWorkers: 4})
+	got, err := FindWithOptions(vaultDir, "github", FindOptions{MaxWorkers: 4}, id)
 	if err != nil {
 		t.Fatalf("FindWithOptions() error = %v", err)
 	}

--- a/internal/vault/entry.go
+++ b/internal/vault/entry.go
@@ -253,7 +253,6 @@ func ReadEntry(vaultDir, path string, identity *age.X25519Identity) (*Entry, err
 	if identity == nil {
 		return nil, errors.New("nil identity")
 	}
-	rememberSearchIdentity(identity)
 
 	_, span := metrics.StartSpan(context.Background(), "vault.ReadEntry",
 		attribute.String("operation", "read"),
@@ -408,7 +407,6 @@ func WriteEntry(vaultDir, path string, entry *Entry, identity *age.X25519Identit
 	if identity == nil {
 		return errors.New("nil identity")
 	}
-	rememberSearchIdentity(identity)
 
 	_, span := metrics.StartSpan(context.Background(), "vault.WriteEntry",
 		attribute.String("operation", "write"),
@@ -517,7 +515,7 @@ func DeleteEntry(vaultDir, path string, identity *age.X25519Identity) error {
 			return err
 		}
 		lockFile = nil
-		globalIndex.RemoveEntry(path)
+		globalIndex.RemoveEntry(path, identity)
 		InvalidateListCache("")
 		return nil
 	}
@@ -542,7 +540,7 @@ func DeleteEntry(vaultDir, path string, identity *age.X25519Identity) error {
 		return err
 	}
 	lockFile = nil
-	globalIndex.RemoveEntry(path)
+	globalIndex.RemoveEntry(path, identity)
 	InvalidateListCache("")
 	return nil
 }

--- a/internal/vault/entry_test.go
+++ b/internal/vault/entry_test.go
@@ -771,7 +771,6 @@ func TestWriteAndReadEntryWithPseudonymization(t *testing.T) {
 	writePseudonymizeConfig(t, vaultDir)
 
 	id := testutil.TempIdentity(t)
-	rememberSearchIdentity(id)
 
 	entry := &Entry{
 		Data: map[string]any{
@@ -818,7 +817,6 @@ func TestDeleteEntryWithPseudonymization(t *testing.T) {
 	writePseudonymizeConfig(t, vaultDir)
 
 	id := testutil.TempIdentity(t)
-	rememberSearchIdentity(id)
 
 	entry := &Entry{Data: map[string]any{"x": 1}}
 	if err := WriteEntry(vaultDir, "github.com/user", entry, id); err != nil {
@@ -847,13 +845,12 @@ func TestListWithPseudonymizedEntries(t *testing.T) {
 	writePseudonymizeConfig(t, vaultDir)
 
 	id := testutil.TempIdentity(t)
-	rememberSearchIdentity(id)
 
 	mustWriteEntry(t, vaultDir, id, "github.com/user", map[string]interface{}{"username": "alice"})
 	mustWriteEntry(t, vaultDir, id, "github.com/work", map[string]interface{}{"username": "bob"})
 	mustWriteEntry(t, vaultDir, id, "personal/email", map[string]interface{}{"username": "carol"})
 
-	got, err := List(vaultDir, "")
+	got, err := List(vaultDir, "", id)
 	if err != nil {
 		t.Fatalf("List() error = %v", err)
 	}
@@ -870,13 +867,12 @@ func TestListWithPseudonymizedEntriesAndPrefix(t *testing.T) {
 	writePseudonymizeConfig(t, vaultDir)
 
 	id := testutil.TempIdentity(t)
-	rememberSearchIdentity(id)
 
 	mustWriteEntry(t, vaultDir, id, "github.com/user", map[string]interface{}{"username": "alice"})
 	mustWriteEntry(t, vaultDir, id, "github.com/work", map[string]interface{}{"username": "bob"})
 	mustWriteEntry(t, vaultDir, id, "personal/email", map[string]interface{}{"username": "carol"})
 
-	got, err := List(vaultDir, "github.com")
+	got, err := List(vaultDir, "github.com", id)
 	if err != nil {
 		t.Fatalf("List() error = %v", err)
 	}
@@ -914,7 +910,6 @@ func TestGetEntryMetadataWithPseudonymization(t *testing.T) {
 	writePseudonymizeConfig(t, vaultDir)
 
 	id := testutil.TempIdentity(t)
-	rememberSearchIdentity(id)
 
 	entry := &Entry{
 		Data: map[string]any{"username": "alice", "password": "s3cr3t"},

--- a/internal/vault/passphrase_test.go
+++ b/internal/vault/passphrase_test.go
@@ -48,7 +48,7 @@ func TestListSkipsIdentityMetadata(t *testing.T) {
 		t.Fatalf("WriteEntry() error = %v", err)
 	}
 
-	entries, err := List(vaultDir, "")
+	entries, err := List(vaultDir, "", nil)
 	if err != nil {
 		t.Fatalf("List() error = %v", err)
 	}

--- a/internal/vault/search.go
+++ b/internal/vault/search.go
@@ -431,40 +431,13 @@ func storePseudonymizedListCache(vaultDir string, identity *age.X25519Identity, 
 	pseudonymizedCache.mu.Unlock()
 }
 
-// searchIdentity holds the cached decryption identity for search operations.
-//
-// DESIGN DECISION: Global State vs Per-Vault Context
-//
-// This is intentionally global state because:
-//  1. Symaira Vault operates with a single active vault per process
-//  2. The identity is session-scoped (tied to unlock duration), not vault-scoped
-//  3. atomic.Pointer provides lock-free thread-safe access verified by `go test -race`
-//  4. Per-vault caching would add complexity without clear benefit for single-vault usage
-//
-// Tradeoffs accepted:
-//   - Parallel vault access in tests requires careful sequencing
-//   - Multiple vaults in same process share cache (invalid for Symaira Vault use case)
-//
-// Future: If multi-vault support is needed, add vaultDir key to a map[VaultDir]*Identity.
-var searchIdentity atomic.Pointer[age.X25519Identity]
-
-func rememberSearchIdentity(identity *age.X25519Identity) {
-	if identity == nil {
-		return
+// CurrentSearchIdentity returns the cached decryption identity from the vault,
+// or nil if no vault identity is available (e.g., vault not opened).
+func (v *Vault) CurrentSearchIdentity() *age.X25519Identity {
+	if v == nil {
+		return nil
 	}
-	searchIdentity.Store(identity)
-}
-
-func currentSearchIdentity() *age.X25519Identity {
-	return searchIdentity.Load()
-}
-
-// CurrentSearchIdentity returns the cached decryption identity, or nil if
-// no identity has been cached yet (e.g., vault not unlocked in this session).
-// This is used by health checks to verify manifest integrity without requiring
-// the user to re-enter their passphrase.
-func CurrentSearchIdentity() *age.X25519Identity {
-	return currentSearchIdentity()
+	return v.searchIdentity.Load()
 }
 
 // SearchWorkerCount returns the number of concurrent decryption workers
@@ -494,17 +467,20 @@ func SearchWorkerCount(configured int) int {
 // MCP sessions. The cache invalidates automatically when directory mtimes change.
 // When pseudonymization is enabled, entries are decrypted to extract the plaintext
 // path from the entry data.
-func List(vaultDir string, prefix string) ([]string, error) {
+func List(vaultDir string, prefix string, identity *age.X25519Identity) ([]string, error) {
 	cfg, err := loadVaultConfig(vaultDir)
 	if err != nil {
 		return nil, err
 	}
 	if isPseudonymizeEnabled(cfg) {
+		if identity == nil {
+			return nil, fmt.Errorf("identity required for pseudonymized vault listing")
+		}
 		workers := 0
 		if cfg != nil && cfg.Vault != nil {
 			workers = cfg.Vault.SearchWorkers
 		}
-		return listPseudonymized(vaultDir, prefix, workers)
+		return listPseudonymized(vaultDir, prefix, identity, workers)
 	}
 
 	// Check cache when listing the entire vault (prefix == "").
@@ -520,7 +496,7 @@ func List(vaultDir string, prefix string) ([]string, error) {
 	// directory walk. Falls back to walk on any error (missing manifest,
 	// no identity, decrypt failure).
 	if prefix == "" {
-		if paths := listViaManifest(vaultDir); paths != nil {
+		if paths := listViaManifest(vaultDir, identity); paths != nil {
 			storeListCache(vaultDir, paths)
 			return paths, nil
 		}
@@ -564,8 +540,8 @@ func List(vaultDir string, prefix string) ([]string, error) {
 //
 // Uses a bounded worker pool for parallel decryption and caches results
 // (including decrypted entry data) for reuse by FindWithOptions.
-func listPseudonymized(vaultDir, prefix string, configuredWorkers int) ([]string, error) {
-	return listPseudonymizedWithIdentity(vaultDir, prefix, currentSearchIdentity(), configuredWorkers)
+func listPseudonymized(vaultDir, prefix string, identity *age.X25519Identity, configuredWorkers int) ([]string, error) {
+	return listPseudonymizedWithIdentity(vaultDir, prefix, identity, configuredWorkers)
 }
 
 func listPseudonymizedWithIdentity(vaultDir, prefix string, identity *age.X25519Identity, configuredWorkers int) ([]string, error) {
@@ -703,8 +679,7 @@ func listPseudonymizedWithIdentity(vaultDir, prefix string, identity *age.X25519
 
 // listViaManifest returns entry paths from the manifest when available and
 // valid. Returns nil on any error so callers fall back to directory walk.
-func listViaManifest(vaultDir string) []string {
-	identity := currentSearchIdentity()
+func listViaManifest(vaultDir string, identity *age.X25519Identity) []string {
 	if identity == nil {
 		return nil
 	}
@@ -788,11 +763,11 @@ func isRedactedField(field string, patterns []string) bool {
 // FindWithOptions searches vault entries with configurable options.
 // It supports both sequential and concurrent decryption, and optional
 // scope filtering before decrypt.
-// Uses the global searchIdentity for backward compatibility; prefer Vault.FindWithOptions.
+// Prefer Vault.FindWithOptions which passes identity from the vault instance.
 //
 //nolint:gocyclo // Search orchestration: listing, filtering, decryption, ranking
-func FindWithOptions(vaultDir string, query string, opts FindOptions) ([]Match, error) {
-	return findWithOptionsIdentity(vaultDir, query, opts, currentSearchIdentity())
+func FindWithOptions(vaultDir string, query string, opts FindOptions, identity *age.X25519Identity) ([]Match, error) {
+	return findWithOptionsIdentity(vaultDir, query, opts, identity)
 }
 
 func findWithOptionsIdentity(vaultDir string, query string, opts FindOptions, identity *age.X25519Identity) ([]Match, error) {
@@ -801,14 +776,11 @@ func findWithOptionsIdentity(vaultDir string, query string, opts FindOptions, id
 		metrics.RecordVaultOperationDuration("search", time.Since(start))
 	}()
 
-	paths, err := List(vaultDir, "")
+	paths, err := List(vaultDir, "", identity)
 	if err != nil {
 		return nil, err
 	}
 
-	if identity == nil {
-		identity = currentSearchIdentity()
-	}
 	if identity == nil {
 		return nil, fmt.Errorf("no search identity available")
 	}
@@ -963,9 +935,6 @@ func hasField(fields []string, want string) bool {
 // stored string values contain the query as a substring. On any error the
 // original slice is returned unchanged, preserving correct behavior.
 func filterPathsUsingIndex(vaultDir string, candidates []string, needle string, identity *age.X25519Identity) []string {
-	if identity == nil {
-		identity = currentSearchIdentity()
-	}
 	if identity == nil {
 		return candidates
 	}

--- a/internal/vault/search_bench_test.go
+++ b/internal/vault/search_bench_test.go
@@ -114,7 +114,7 @@ func benchmarkList(b *testing.B, numEntries int) {
 	b.ReportAllocs()
 
 	for i := 0; i < b.N; i++ {
-		paths, err := List(vaultDir, "")
+		paths, err := List(vaultDir, "", identity)
 		if err != nil {
 			b.Fatalf("List failed: %v", err)
 		}
@@ -128,7 +128,6 @@ func benchmarkFindPathOnly(b *testing.B, numEntries int) {
 	vaultDir := b.TempDir()
 	identity := generateTestIdentity(b)
 	createTestEntries(b, vaultDir, identity, numEntries)
-	rememberSearchIdentity(identity)
 
 	// Find a path number that exists in all vault sizes (use 50 for 100-entry vaults)
 	pathQuery := fmt.Sprintf("entry-%05d", min(50, numEntries-1))
@@ -138,7 +137,7 @@ func benchmarkFindPathOnly(b *testing.B, numEntries int) {
 
 	for i := 0; i < b.N; i++ {
 		// Query that matches path - uses fast path (no decryption)
-		matches, err := FindWithOptions(vaultDir, pathQuery, FindOptions{MaxWorkers: 0})
+		matches, err := FindWithOptions(vaultDir, pathQuery, FindOptions{MaxWorkers: 0}, identity)
 		if err != nil {
 			b.Fatalf("Find failed: %v", err)
 		}
@@ -152,7 +151,6 @@ func benchmarkFindFieldSearch(b *testing.B, numEntries int) {
 	vaultDir := b.TempDir()
 	identity := generateTestIdentity(b)
 	createTestEntries(b, vaultDir, identity, numEntries)
-	rememberSearchIdentity(identity)
 
 	fieldQuery := fmt.Sprintf("secret-password-%05d", min(50, numEntries-1))
 
@@ -160,7 +158,7 @@ func benchmarkFindFieldSearch(b *testing.B, numEntries int) {
 	b.ReportAllocs()
 
 	for i := 0; i < b.N; i++ {
-		matches, err := FindWithOptions(vaultDir, fieldQuery, FindOptions{MaxWorkers: 0})
+		matches, err := FindWithOptions(vaultDir, fieldQuery, FindOptions{MaxWorkers: 0}, identity)
 		if err != nil {
 			b.Fatalf("Find failed: %v", err)
 		}
@@ -174,7 +172,6 @@ func benchmarkFindWithOptions(b *testing.B, numEntries int, maxWorkers int) {
 	vaultDir := b.TempDir()
 	identity := generateTestIdentity(b)
 	createTestEntries(b, vaultDir, identity, numEntries)
-	rememberSearchIdentity(identity)
 
 	fieldQuery := fmt.Sprintf("secret-password-%05d", min(50, numEntries-1))
 
@@ -182,7 +179,7 @@ func benchmarkFindWithOptions(b *testing.B, numEntries int, maxWorkers int) {
 	b.ReportAllocs()
 
 	for i := 0; i < b.N; i++ {
-		matches, err := FindWithOptions(vaultDir, fieldQuery, FindOptions{MaxWorkers: maxWorkers})
+		matches, err := FindWithOptions(vaultDir, fieldQuery, FindOptions{MaxWorkers: maxWorkers}, identity)
 		if err != nil {
 			b.Fatalf("FindWithOptions failed: %v", err)
 		}
@@ -220,11 +217,9 @@ func benchmarkIndexBuild(b *testing.B, numEntries int) {
 	vaultDir := b.TempDir()
 	identity := generateTestIdentity(b)
 	createTestEntries(b, vaultDir, identity, numEntries)
-	rememberSearchIdentity(identity)
-	b.Cleanup(func() { searchIdentity.Store(nil) })
 
 	// Pre-warm list cache by listing once
-	_, err := List(vaultDir, "")
+	_, err := List(vaultDir, "", identity)
 	if err != nil {
 		b.Fatalf("List failed: %v", err)
 	}
@@ -247,13 +242,11 @@ func benchmarkFindFieldSearchIndexHot(b *testing.B, numEntries int) {
 	vaultDir := b.TempDir()
 	identity := generateTestIdentity(b)
 	createTestEntries(b, vaultDir, identity, numEntries)
-	rememberSearchIdentity(identity)
-	b.Cleanup(func() { searchIdentity.Store(nil) })
 
 	fieldQuery := fmt.Sprintf("secret-password-%05d", min(50, numEntries-1))
 
 	// First search warms the index (build + search)
-	_, err := FindWithOptions(vaultDir, fieldQuery, FindOptions{MaxWorkers: 0})
+	_, err := FindWithOptions(vaultDir, fieldQuery, FindOptions{MaxWorkers: 0}, identity)
 	if err != nil {
 		b.Fatalf("Warmup FindWithOptions failed: %v", err)
 	}
@@ -269,7 +262,7 @@ func benchmarkFindFieldSearchIndexHot(b *testing.B, numEntries int) {
 	b.ReportAllocs()
 
 	for i := 0; i < b.N; i++ {
-		matches, err := FindWithOptions(vaultDir, fieldQuery, FindOptions{MaxWorkers: 0})
+		matches, err := FindWithOptions(vaultDir, fieldQuery, FindOptions{MaxWorkers: 0}, identity)
 		if err != nil {
 			b.Fatalf("FindWithOptions failed: %v", err)
 		}

--- a/internal/vault/search_index.go
+++ b/internal/vault/search_index.go
@@ -83,7 +83,7 @@ func (idx *EncryptedIndex) Build(vaultDir string, identity *age.X25519Identity) 
 	// would miss them.
 	InvalidateListCache(vaultDir)
 
-	paths, err := List(vaultDir, "")
+	paths, err := List(vaultDir, "", identity)
 	if err != nil {
 		return err
 	}
@@ -324,7 +324,7 @@ func (idx *EncryptedIndex) UpdateEntry(vaultDir, path string, identity *age.X255
 
 // RemoveEntry removes a single path from the encrypted index.
 // If the index is not built, this is a no-op.
-func (idx *EncryptedIndex) RemoveEntry(path string) {
+func (idx *EncryptedIndex) RemoveEntry(path string, identity *age.X25519Identity) {
 	idx.mu.Lock()
 	defer idx.mu.Unlock()
 
@@ -332,7 +332,6 @@ func (idx *EncryptedIndex) RemoveEntry(path string) {
 		return
 	}
 
-	identity := currentSearchIdentity()
 	if identity == nil {
 		idx.ciphertext = nil
 		idx.salt = nil
@@ -440,7 +439,7 @@ func (idx *EncryptedIndex) loadFromDisk(vaultDir string, identity *age.X25519Ide
 		return err
 	}
 
-	paths, listErr := List(vaultDir, "")
+	paths, listErr := List(vaultDir, "", identity)
 	if listErr != nil {
 		_ = os.Remove(indexPath)
 		return listErr

--- a/internal/vault/search_index_test.go
+++ b/internal/vault/search_index_test.go
@@ -27,8 +27,6 @@ func TestEncryptedIndexBuildAndMatch(t *testing.T) {
 		"password": "s3cr3t-aws",
 	})
 
-	rememberSearchIdentity(identity)
-	t.Cleanup(func() { searchIdentity.Store(nil) })
 
 	idx := &EncryptedIndex{}
 	if err := idx.Build(vaultDir, identity); err != nil {
@@ -106,8 +104,6 @@ func TestEncryptedIndexInvalidate(t *testing.T) {
 		"username": "alice",
 	})
 
-	rememberSearchIdentity(identity)
-	t.Cleanup(func() { searchIdentity.Store(nil) })
 
 	idx := &EncryptedIndex{}
 	if err := idx.Build(vaultDir, identity); err != nil {
@@ -142,8 +138,6 @@ func TestEncryptedIndexRebuildAfterWrite(t *testing.T) {
 		"username": "alice",
 	})
 
-	rememberSearchIdentity(identity)
-	t.Cleanup(func() { searchIdentity.Store(nil) })
 
 	if err := globalIndex.Build(vaultDir, identity); err != nil {
 		t.Fatalf("Build() error = %v", err)
@@ -176,8 +170,6 @@ func TestEncryptedIndexGlobalInvalidate(t *testing.T) {
 	vaultDir := t.TempDir()
 	identity := testutil.TempIdentity(t)
 	mustWriteEntry(t, vaultDir, identity, "test/path", map[string]interface{}{"key": "value"})
-	rememberSearchIdentity(identity)
-	t.Cleanup(func() { searchIdentity.Store(nil) })
 
 	if err := globalIndex.Build(vaultDir, identity); err != nil {
 		t.Fatalf("Build() error = %v", err)
@@ -206,10 +198,8 @@ func TestEncryptedIndexIntegrationWithFind(t *testing.T) {
 		"email": "bob@example.com",
 	})
 
-	rememberSearchIdentity(identity)
-	t.Cleanup(func() { searchIdentity.Store(nil) })
 
-	got, err := FindWithOptions(vaultDir, "alice", FindOptions{MaxWorkers: 0})
+	got, err := FindWithOptions(vaultDir, "alice", FindOptions{MaxWorkers: 0}, identity)
 	if err != nil {
 		t.Fatalf("FindWithOptions() error = %v", err)
 	}
@@ -221,7 +211,7 @@ func TestEncryptedIndexIntegrationWithFind(t *testing.T) {
 		t.Fatal("globalIndex should be built after first FindWithOptions")
 	}
 
-	got2, err := FindWithOptions(vaultDir, "bob@example.com", FindOptions{MaxWorkers: 0})
+	got2, err := FindWithOptions(vaultDir, "bob@example.com", FindOptions{MaxWorkers: 0}, identity)
 	if err != nil {
 		t.Fatalf("FindWithOptions() error = %v", err)
 	}
@@ -244,8 +234,6 @@ func TestEncryptedIndexWithNestedData(t *testing.T) {
 		},
 	})
 
-	rememberSearchIdentity(identity)
-	t.Cleanup(func() { searchIdentity.Store(nil) })
 
 	idx := &EncryptedIndex{}
 	if err := idx.Build(vaultDir, identity); err != nil {
@@ -284,8 +272,6 @@ func TestEncryptedIndexUnreadableEntry(t *testing.T) {
 		t.Fatalf("WriteFile error = %v", err)
 	}
 
-	rememberSearchIdentity(identity)
-	t.Cleanup(func() { searchIdentity.Store(nil) })
 
 	idx := &EncryptedIndex{}
 	if err := idx.Build(vaultDir, identity); err != nil {
@@ -311,10 +297,8 @@ func TestFindAfterWriteInvalidatesIndex(t *testing.T) {
 		"data": "original-data",
 	})
 
-	rememberSearchIdentity(identity)
-	t.Cleanup(func() { searchIdentity.Store(nil) })
 
-	_, err := FindWithOptions(vaultDir, "original", FindOptions{MaxWorkers: 0})
+	_, err := FindWithOptions(vaultDir, "original", FindOptions{MaxWorkers: 0}, identity)
 	if err != nil {
 		t.Fatalf("FindWithOptions() error = %v", err)
 	}
@@ -331,7 +315,7 @@ func TestFindAfterWriteInvalidatesIndex(t *testing.T) {
 		t.Fatal("Index should remain built after incremental update")
 	}
 
-	results, err := FindWithOptions(vaultDir, "data", FindOptions{MaxWorkers: 0})
+	results, err := FindWithOptions(vaultDir, "data", FindOptions{MaxWorkers: 0}, identity)
 	if err != nil {
 		t.Fatalf("FindWithOptions() error = %v", err)
 	}
@@ -350,8 +334,6 @@ func TestEncryptedIndexSubstringMatching(t *testing.T) {
 		"email":       "alice@example.com",
 	})
 
-	rememberSearchIdentity(identity)
-	t.Cleanup(func() { searchIdentity.Store(nil) })
 
 	idx := &EncryptedIndex{}
 	if err := idx.Build(vaultDir, identity); err != nil {
@@ -375,8 +357,6 @@ func TestEncryptedIndexCaseInsensitive(t *testing.T) {
 		"host": "MyDB.Example.com",
 	})
 
-	rememberSearchIdentity(identity)
-	t.Cleanup(func() { searchIdentity.Store(nil) })
 
 	idx := &EncryptedIndex{}
 	if err := idx.Build(vaultDir, identity); err != nil {
@@ -401,10 +381,8 @@ func TestFindAfterDeleteInvalidatesIndex(t *testing.T) {
 	mustWriteEntry(t, vaultDir, identity, "keep/entry", map[string]interface{}{"value": "important"})
 	mustWriteEntry(t, vaultDir, identity, "delete/entry", map[string]interface{}{"value": "gone"})
 
-	rememberSearchIdentity(identity)
-	t.Cleanup(func() { searchIdentity.Store(nil) })
 
-	results, err := FindWithOptions(vaultDir, "entry", FindOptions{MaxWorkers: 0})
+	results, err := FindWithOptions(vaultDir, "entry", FindOptions{MaxWorkers: 0}, identity)
 	if err != nil {
 		t.Fatalf("FindWithOptions() error = %v", err)
 	}
@@ -420,7 +398,7 @@ func TestFindAfterDeleteInvalidatesIndex(t *testing.T) {
 		t.Fatal("Index should be invalidated after delete")
 	}
 
-	results, err = FindWithOptions(vaultDir, "entry", FindOptions{MaxWorkers: 0})
+	results, err = FindWithOptions(vaultDir, "entry", FindOptions{MaxWorkers: 0}, identity)
 	if err != nil {
 		t.Fatalf("FindWithOptions() error = %v", err)
 	}
@@ -442,10 +420,8 @@ func TestFindAfterMergeInvalidatesIndex(t *testing.T) {
 		"initial": "value",
 	})
 
-	rememberSearchIdentity(identity)
-	t.Cleanup(func() { searchIdentity.Store(nil) })
 
-	_, err := FindWithOptions(vaultDir, "initial", FindOptions{MaxWorkers: 0})
+	_, err := FindWithOptions(vaultDir, "initial", FindOptions{MaxWorkers: 0}, identity)
 	if err != nil {
 		t.Fatalf("FindWithOptions() error = %v", err)
 	}
@@ -463,7 +439,7 @@ func TestFindAfterMergeInvalidatesIndex(t *testing.T) {
 		t.Fatal("Index should remain built after incremental update")
 	}
 
-	results, err := FindWithOptions(vaultDir, "newvalue", FindOptions{MaxWorkers: 0})
+	results, err := FindWithOptions(vaultDir, "newvalue", FindOptions{MaxWorkers: 0}, identity)
 	if err != nil {
 		t.Fatalf("FindWithOptions() error = %v", err)
 	}
@@ -484,8 +460,6 @@ func TestEncryptedIndexSearchableAfterBuild(t *testing.T) {
 		})
 	}
 
-	rememberSearchIdentity(identity)
-	t.Cleanup(func() { searchIdentity.Store(nil) })
 
 	idx := &EncryptedIndex{}
 	if err := idx.Build(vaultDir, identity); err != nil {
@@ -514,8 +488,6 @@ func TestEncryptedIndexPersistence(t *testing.T) {
 		"password": "s3cr3t",
 	})
 
-	rememberSearchIdentity(identity)
-	t.Cleanup(func() { searchIdentity.Store(nil) })
 
 	idx := &EncryptedIndex{}
 	if err := idx.Build(vaultDir, identity); err != nil {
@@ -554,8 +526,6 @@ func TestEncryptedIndexStaleDetection(t *testing.T) {
 		"data": "value-one",
 	})
 
-	rememberSearchIdentity(identity)
-	t.Cleanup(func() { searchIdentity.Store(nil) })
 
 	idx := &EncryptedIndex{}
 	if err := idx.Build(vaultDir, identity); err != nil {
@@ -591,8 +561,6 @@ func TestEncryptedIndexInvalidationRemovesFile(t *testing.T) {
 		"key": "value",
 	})
 
-	rememberSearchIdentity(identity)
-	t.Cleanup(func() { searchIdentity.Store(nil) })
 
 	idx := &EncryptedIndex{}
 	if err := idx.Build(vaultDir, identity); err != nil {
@@ -621,8 +589,6 @@ func TestEncryptedIndexFilterPathsUsingIndexLoadsFromDisk(t *testing.T) {
 		"username": "alice",
 	})
 
-	rememberSearchIdentity(identity)
-	t.Cleanup(func() { searchIdentity.Store(nil) })
 
 	// Build the index (this also saves to disk)
 	if err := globalIndex.Build(vaultDir, identity); err != nil {

--- a/internal/vault/search_index_test.go
+++ b/internal/vault/search_index_test.go
@@ -27,7 +27,6 @@ func TestEncryptedIndexBuildAndMatch(t *testing.T) {
 		"password": "s3cr3t-aws",
 	})
 
-
 	idx := &EncryptedIndex{}
 	if err := idx.Build(vaultDir, identity); err != nil {
 		t.Fatalf("Build() error = %v", err)
@@ -104,7 +103,6 @@ func TestEncryptedIndexInvalidate(t *testing.T) {
 		"username": "alice",
 	})
 
-
 	idx := &EncryptedIndex{}
 	if err := idx.Build(vaultDir, identity); err != nil {
 		t.Fatalf("Build() error = %v", err)
@@ -137,7 +135,6 @@ func TestEncryptedIndexRebuildAfterWrite(t *testing.T) {
 	mustWriteEntry(t, vaultDir, identity, "github.com/user", map[string]interface{}{
 		"username": "alice",
 	})
-
 
 	if err := globalIndex.Build(vaultDir, identity); err != nil {
 		t.Fatalf("Build() error = %v", err)
@@ -198,7 +195,6 @@ func TestEncryptedIndexIntegrationWithFind(t *testing.T) {
 		"email": "bob@example.com",
 	})
 
-
 	got, err := FindWithOptions(vaultDir, "alice", FindOptions{MaxWorkers: 0}, identity)
 	if err != nil {
 		t.Fatalf("FindWithOptions() error = %v", err)
@@ -233,7 +229,6 @@ func TestEncryptedIndexWithNestedData(t *testing.T) {
 			map[string]interface{}{"name": "admin", "role": "owner"},
 		},
 	})
-
 
 	idx := &EncryptedIndex{}
 	if err := idx.Build(vaultDir, identity); err != nil {
@@ -272,7 +267,6 @@ func TestEncryptedIndexUnreadableEntry(t *testing.T) {
 		t.Fatalf("WriteFile error = %v", err)
 	}
 
-
 	idx := &EncryptedIndex{}
 	if err := idx.Build(vaultDir, identity); err != nil {
 		t.Fatalf("Build() error = %v", err)
@@ -296,7 +290,6 @@ func TestFindAfterWriteInvalidatesIndex(t *testing.T) {
 	mustWriteEntry(t, vaultDir, identity, "entry/one", map[string]interface{}{
 		"data": "original-data",
 	})
-
 
 	_, err := FindWithOptions(vaultDir, "original", FindOptions{MaxWorkers: 0}, identity)
 	if err != nil {
@@ -334,7 +327,6 @@ func TestEncryptedIndexSubstringMatching(t *testing.T) {
 		"email":       "alice@example.com",
 	})
 
-
 	idx := &EncryptedIndex{}
 	if err := idx.Build(vaultDir, identity); err != nil {
 		t.Fatalf("Build() error = %v", err)
@@ -356,7 +348,6 @@ func TestEncryptedIndexCaseInsensitive(t *testing.T) {
 	mustWriteEntry(t, vaultDir, identity, "test/entry", map[string]interface{}{
 		"host": "MyDB.Example.com",
 	})
-
 
 	idx := &EncryptedIndex{}
 	if err := idx.Build(vaultDir, identity); err != nil {
@@ -380,7 +371,6 @@ func TestFindAfterDeleteInvalidatesIndex(t *testing.T) {
 
 	mustWriteEntry(t, vaultDir, identity, "keep/entry", map[string]interface{}{"value": "important"})
 	mustWriteEntry(t, vaultDir, identity, "delete/entry", map[string]interface{}{"value": "gone"})
-
 
 	results, err := FindWithOptions(vaultDir, "entry", FindOptions{MaxWorkers: 0}, identity)
 	if err != nil {
@@ -419,7 +409,6 @@ func TestFindAfterMergeInvalidatesIndex(t *testing.T) {
 	mustWriteEntry(t, vaultDir, identity, "test/entry", map[string]interface{}{
 		"initial": "value",
 	})
-
 
 	_, err := FindWithOptions(vaultDir, "initial", FindOptions{MaxWorkers: 0}, identity)
 	if err != nil {
@@ -460,7 +449,6 @@ func TestEncryptedIndexSearchableAfterBuild(t *testing.T) {
 		})
 	}
 
-
 	idx := &EncryptedIndex{}
 	if err := idx.Build(vaultDir, identity); err != nil {
 		t.Fatalf("Build() error = %v", err)
@@ -487,7 +475,6 @@ func TestEncryptedIndexPersistence(t *testing.T) {
 		"username": "alice",
 		"password": "s3cr3t",
 	})
-
 
 	idx := &EncryptedIndex{}
 	if err := idx.Build(vaultDir, identity); err != nil {
@@ -526,7 +513,6 @@ func TestEncryptedIndexStaleDetection(t *testing.T) {
 		"data": "value-one",
 	})
 
-
 	idx := &EncryptedIndex{}
 	if err := idx.Build(vaultDir, identity); err != nil {
 		t.Fatalf("Build() error = %v", err)
@@ -561,7 +547,6 @@ func TestEncryptedIndexInvalidationRemovesFile(t *testing.T) {
 		"key": "value",
 	})
 
-
 	idx := &EncryptedIndex{}
 	if err := idx.Build(vaultDir, identity); err != nil {
 		t.Fatalf("Build() error = %v", err)
@@ -589,7 +574,6 @@ func TestEncryptedIndexFilterPathsUsingIndexLoadsFromDisk(t *testing.T) {
 		"username": "alice",
 	})
 
-
 	// Build the index (this also saves to disk)
 	if err := globalIndex.Build(vaultDir, identity); err != nil {
 		t.Fatalf("Build() error = %v", err)
@@ -611,7 +595,7 @@ func TestEncryptedIndexFilterPathsUsingIndexLoadsFromDisk(t *testing.T) {
 	}
 
 	// filterPathsUsingIndex should load from disk
-	results := filterPathsUsingIndex(vaultDir, []string{"github.com/user"}, "alice", nil)
+	results := filterPathsUsingIndex(vaultDir, []string{"github.com/user"}, "alice", identity)
 	if len(results) != 1 {
 		t.Fatalf("filterPathsUsingIndex() = %d results, want 1", len(results))
 	}

--- a/internal/vault/search_test.go
+++ b/internal/vault/search_test.go
@@ -292,8 +292,7 @@ func TestFindWithNoIdentity(t *testing.T) {
 
 	mustWriteEntry(t, vaultDir, id, "github.com/user", map[string]interface{}{"username": "alice"})
 
-
-	_, err := FindWithOptions(vaultDir, "github", FindOptions{MaxWorkers: 0}, id)
+	_, err := FindWithOptions(vaultDir, "github", FindOptions{MaxWorkers: 0}, nil)
 	if err == nil {
 		t.Fatal("expected error when no search identity is available")
 	}
@@ -390,7 +389,7 @@ func TestFindConcurrentNoIdentity(t *testing.T) {
 	t.Cleanup(func() {
 	})
 
-	_, err := FindWithOptions(vaultDir, "github", FindOptions{MaxWorkers: 4}, id)
+	_, err := FindWithOptions(vaultDir, "github", FindOptions{MaxWorkers: 4}, nil)
 	if err == nil {
 		t.Fatal("expected error when no search identity is available")
 	}

--- a/internal/vault/search_test.go
+++ b/internal/vault/search_test.go
@@ -23,7 +23,7 @@ func TestListReturnsAllEntriesWithoutPrefix(t *testing.T) {
 	mustWriteEntry(t, vaultDir, id, "github.com/work", map[string]interface{}{"username": "bob"})
 	mustWriteEntry(t, vaultDir, id, "personal/email", map[string]interface{}{"username": "carol"})
 
-	got, err := List(vaultDir, "")
+	got, err := List(vaultDir, "", nil)
 	if err != nil {
 		t.Fatalf("List() error = %v", err)
 	}
@@ -37,7 +37,6 @@ func TestListReturnsAllEntriesWithoutPrefix(t *testing.T) {
 func BenchmarkListPseudonymized(b *testing.B) {
 	vaultDir := b.TempDir()
 	id := testutil.TempIdentity(b)
-	rememberSearchIdentity(id)
 
 	cfg := vaultconfig.Default()
 	cfg.VaultDir = vaultDir
@@ -63,7 +62,7 @@ func BenchmarkListPseudonymized(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		InvalidateListCache(vaultDir)
-		paths, err := List(vaultDir, "")
+		paths, err := List(vaultDir, "", nil)
 		if err != nil {
 			b.Fatalf("List() error = %v", err)
 		}
@@ -76,7 +75,6 @@ func BenchmarkListPseudonymized(b *testing.B) {
 func BenchmarkListPseudonymizedCached(b *testing.B) {
 	vaultDir := b.TempDir()
 	id := testutil.TempIdentity(b)
-	rememberSearchIdentity(id)
 
 	cfg := vaultconfig.Default()
 	cfg.VaultDir = vaultDir
@@ -95,13 +93,13 @@ func BenchmarkListPseudonymizedCached(b *testing.B) {
 	}
 
 	// Warm the cache.
-	if _, err := List(vaultDir, ""); err != nil {
+	if _, err := List(vaultDir, "", nil); err != nil {
 		b.Fatalf("List() warm-up error = %v", err)
 	}
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		paths, err := List(vaultDir, "")
+		paths, err := List(vaultDir, "", nil)
 		if err != nil {
 			b.Fatalf("List() error = %v", err)
 		}
@@ -119,7 +117,7 @@ func TestListReturnsSortedResults(t *testing.T) {
 	mustWriteEntry(t, vaultDir, id, "alpha/first", map[string]interface{}{"username": "a"})
 	mustWriteEntry(t, vaultDir, id, "middle/item", map[string]interface{}{"username": "m"})
 
-	got, err := List(vaultDir, "")
+	got, err := List(vaultDir, "", nil)
 	if err != nil {
 		t.Fatalf("List() error = %v", err)
 	}
@@ -145,7 +143,7 @@ func TestListIncludesLegacyRootEntries(t *testing.T) {
 		t.Fatalf("move entry to legacy path: %v", err)
 	}
 
-	got, err := List(vaultDir, "")
+	got, err := List(vaultDir, "", nil)
 	if err != nil {
 		t.Fatalf("List() error = %v", err)
 	}
@@ -163,7 +161,7 @@ func TestFindMatchesPaths(t *testing.T) {
 	mustWriteEntry(t, vaultDir, id, "github.com/user", map[string]interface{}{"username": "alice"})
 	mustWriteEntry(t, vaultDir, id, "personal/email", map[string]interface{}{"username": "bob"})
 
-	got, err := FindWithOptions(vaultDir, "github", FindOptions{MaxWorkers: 0})
+	got, err := FindWithOptions(vaultDir, "github", FindOptions{MaxWorkers: 0}, id)
 	if err != nil {
 		t.Fatalf("Find() error = %v", err)
 	}
@@ -188,7 +186,7 @@ func TestFindMatchesFieldValues(t *testing.T) {
 		"password": "s3cr3t",
 	})
 
-	got, err := FindWithOptions(vaultDir, "s3cr", FindOptions{MaxWorkers: 0})
+	got, err := FindWithOptions(vaultDir, "s3cr", FindOptions{MaxWorkers: 0}, id)
 	if err != nil {
 		t.Fatalf("Find() error = %v", err)
 	}
@@ -216,7 +214,7 @@ func TestFindReturnsFieldNamesThatMatched(t *testing.T) {
 		},
 	})
 
-	got, err := FindWithOptions(vaultDir, "alpha", FindOptions{MaxWorkers: 0})
+	got, err := FindWithOptions(vaultDir, "alpha", FindOptions{MaxWorkers: 0}, id)
 	if err != nil {
 		t.Fatalf("Find() error = %v", err)
 	}
@@ -236,7 +234,7 @@ func TestFindIsCaseInsensitive(t *testing.T) {
 
 	mustWriteEntry(t, vaultDir, id, "GitHub.Com/User", map[string]interface{}{"username": "Alice"})
 
-	got, err := FindWithOptions(vaultDir, "gItHuB", FindOptions{MaxWorkers: 0})
+	got, err := FindWithOptions(vaultDir, "gItHuB", FindOptions{MaxWorkers: 0}, id)
 	if err != nil {
 		t.Fatalf("Find() error = %v", err)
 	}
@@ -268,23 +266,23 @@ func containsString(values []string, want string) bool {
 func TestCurrentSearchIdentity(t *testing.T) {
 	id := testutil.TempIdentity(t)
 
-	rememberSearchIdentity(id)
+	v := &Vault{}
+	v.searchIdentity.Store(id)
 
-	got := currentSearchIdentity()
+	got := v.CurrentSearchIdentity()
 	if got == nil {
-		t.Fatal("currentSearchIdentity should return the stored identity")
+		t.Fatal("CurrentSearchIdentity should return the stored identity")
 	}
 	if got.String() != id.String() {
-		t.Errorf("currentSearchIdentity = %q, want %q", got.String(), id.String())
+		t.Errorf("CurrentSearchIdentity = %q, want %q", got.String(), id.String())
 	}
 }
 
 func TestCurrentSearchIdentityNil(t *testing.T) {
-	searchIdentity.Store(nil)
-
-	got := currentSearchIdentity()
+	v := &Vault{}
+	got := v.CurrentSearchIdentity()
 	if got != nil {
-		t.Error("currentSearchIdentity should return nil when no identity is set")
+		t.Error("CurrentSearchIdentity should return nil when no identity is set")
 	}
 }
 
@@ -294,9 +292,8 @@ func TestFindWithNoIdentity(t *testing.T) {
 
 	mustWriteEntry(t, vaultDir, id, "github.com/user", map[string]interface{}{"username": "alice"})
 
-	searchIdentity.Store(nil)
 
-	_, err := FindWithOptions(vaultDir, "github", FindOptions{MaxWorkers: 0})
+	_, err := FindWithOptions(vaultDir, "github", FindOptions{MaxWorkers: 0}, id)
 	if err == nil {
 		t.Fatal("expected error when no search identity is available")
 	}
@@ -313,7 +310,7 @@ func TestFindMatchesNestedArrayFields(t *testing.T) {
 		},
 	})
 
-	got, err := FindWithOptions(vaultDir, "alice", FindOptions{MaxWorkers: 0})
+	got, err := FindWithOptions(vaultDir, "alice", FindOptions{MaxWorkers: 0}, id)
 	if err != nil {
 		t.Fatalf("Find() error = %v", err)
 	}
@@ -332,7 +329,7 @@ func TestFindWithEmptyQuery(t *testing.T) {
 
 	mustWriteEntry(t, vaultDir, id, "github.com/user", map[string]interface{}{"username": "alice"})
 
-	got, err := FindWithOptions(vaultDir, "", FindOptions{MaxWorkers: 0})
+	got, err := FindWithOptions(vaultDir, "", FindOptions{MaxWorkers: 0}, id)
 	if err != nil {
 		t.Fatalf("Find() error = %v", err)
 	}
@@ -357,12 +354,12 @@ func TestFindConcurrentMatchesFind(t *testing.T) {
 
 	for _, q := range queries {
 		t.Run(q, func(t *testing.T) {
-			findResults, err := FindWithOptions(vaultDir, q, FindOptions{MaxWorkers: 0})
+			findResults, err := FindWithOptions(vaultDir, q, FindOptions{MaxWorkers: 0}, id)
 			if err != nil {
 				t.Fatalf("Find() error = %v", err)
 			}
 
-			concurrentResults, err := FindWithOptions(vaultDir, q, FindOptions{MaxWorkers: 4})
+			concurrentResults, err := FindWithOptions(vaultDir, q, FindOptions{MaxWorkers: 4}, id)
 			if err != nil {
 				t.Fatalf("FindWithOptions() error = %v", err)
 			}
@@ -390,12 +387,10 @@ func TestFindConcurrentNoIdentity(t *testing.T) {
 
 	mustWriteEntry(t, vaultDir, id, "github.com/user", map[string]interface{}{"username": "alice"})
 
-	searchIdentity.Store(nil)
 	t.Cleanup(func() {
-		rememberSearchIdentity(id)
 	})
 
-	_, err := FindWithOptions(vaultDir, "github", FindOptions{MaxWorkers: 4})
+	_, err := FindWithOptions(vaultDir, "github", FindOptions{MaxWorkers: 4}, id)
 	if err == nil {
 		t.Fatal("expected error when no search identity is available")
 	}
@@ -404,9 +399,8 @@ func TestFindConcurrentNoIdentity(t *testing.T) {
 func TestFindConcurrentEmptyVault(t *testing.T) {
 	vaultDir := t.TempDir()
 	id := testutil.TempIdentity(t)
-	rememberSearchIdentity(id)
 
-	got, err := FindWithOptions(vaultDir, "query", FindOptions{MaxWorkers: 4})
+	got, err := FindWithOptions(vaultDir, "query", FindOptions{MaxWorkers: 4}, id)
 	if err != nil {
 		t.Fatalf("FindWithOptions() error = %v", err)
 	}
@@ -421,7 +415,7 @@ func TestFindConcurrentDefaultsMaxWorkers(t *testing.T) {
 
 	mustWriteEntry(t, vaultDir, id, "github.com/user", map[string]interface{}{"username": "alice"})
 
-	got, err := FindWithOptions(vaultDir, "github", FindOptions{MaxWorkers: 0})
+	got, err := FindWithOptions(vaultDir, "github", FindOptions{MaxWorkers: 0}, id)
 	if err != nil {
 		t.Fatalf("FindWithOptions() error = %v", err)
 	}
@@ -429,7 +423,7 @@ func TestFindConcurrentDefaultsMaxWorkers(t *testing.T) {
 		t.Fatalf("FindWithOptions() with MaxWorkers=0 returned %d results, want 1", len(got))
 	}
 
-	got2, err := FindWithOptions(vaultDir, "github", FindOptions{MaxWorkers: -1})
+	got2, err := FindWithOptions(vaultDir, "github", FindOptions{MaxWorkers: -1}, id)
 	if err != nil {
 		t.Fatalf("FindWithOptions() error = %v", err)
 	}
@@ -446,7 +440,7 @@ func TestListCacheHit(t *testing.T) {
 	mustWriteEntry(t, vaultDir, id, "example.com/admin", map[string]interface{}{"username": "admin"})
 
 	// First call populates cache
-	paths1, err := List(vaultDir, "")
+	paths1, err := List(vaultDir, "", nil)
 	if err != nil {
 		t.Fatalf("List() error = %v", err)
 	}
@@ -455,7 +449,7 @@ func TestListCacheHit(t *testing.T) {
 	}
 
 	// Second call should hit cache
-	paths2, err := List(vaultDir, "")
+	paths2, err := List(vaultDir, "", nil)
 	if err != nil {
 		t.Fatalf("List() cached error = %v", err)
 	}
@@ -471,7 +465,7 @@ func TestListCacheInvalidation(t *testing.T) {
 	mustWriteEntry(t, vaultDir, id, "github.com/user", map[string]interface{}{"username": "alice"})
 
 	// First call populates cache
-	paths1, err := List(vaultDir, "")
+	paths1, err := List(vaultDir, "", nil)
 	if err != nil {
 		t.Fatalf("List() error = %v", err)
 	}
@@ -486,7 +480,7 @@ func TestListCacheInvalidation(t *testing.T) {
 	mustWriteEntry(t, vaultDir, id, "example.com/admin", map[string]interface{}{"username": "admin"})
 
 	// Next call should re-walk and find both entries
-	paths2, err := List(vaultDir, "")
+	paths2, err := List(vaultDir, "", nil)
 	if err != nil {
 		t.Fatalf("List() after invalidate error = %v", err)
 	}
@@ -503,7 +497,7 @@ func TestListCachePrefixBypass(t *testing.T) {
 	mustWriteEntry(t, vaultDir, id, "example.com/admin", map[string]interface{}{"username": "admin"})
 
 	// Prefix queries bypass cache
-	paths, err := List(vaultDir, "github")
+	paths, err := List(vaultDir, "github", nil)
 	if err != nil {
 		t.Fatalf("List() error = %v", err)
 	}
@@ -512,7 +506,7 @@ func TestListCachePrefixBypass(t *testing.T) {
 	}
 
 	// Full listing still uses cache
-	allPaths, err := List(vaultDir, "")
+	allPaths, err := List(vaultDir, "", nil)
 	if err != nil {
 		t.Fatalf("List() error = %v", err)
 	}
@@ -533,7 +527,7 @@ func TestListCacheTTLExpiration(t *testing.T) {
 	defer func() { listCache.ttl = originalTTL }()
 
 	// First call populates cache
-	_, err := List(vaultDir, "")
+	_, err := List(vaultDir, "", nil)
 	if err != nil {
 		t.Fatalf("List() error = %v", err)
 	}
@@ -545,7 +539,7 @@ func TestListCacheTTLExpiration(t *testing.T) {
 	mustWriteEntry(t, vaultDir, id, "example.com/admin", map[string]interface{}{"username": "admin"})
 
 	// Cache should have expired, so we should see both entries
-	paths, err := List(vaultDir, "")
+	paths, err := List(vaultDir, "", nil)
 	if err != nil {
 		t.Fatalf("List() after TTL expiry error = %v", err)
 	}
@@ -560,7 +554,7 @@ func TestListCacheSurvivesMtimeOnlyChange(t *testing.T) {
 
 	mustWriteEntry(t, vaultDir, id, "github.com/user", map[string]interface{}{"username": "alice"})
 
-	beforeTouch, err := List(vaultDir, "")
+	beforeTouch, err := List(vaultDir, "", nil)
 	if err != nil {
 		t.Fatalf("List() error = %v", err)
 	}
@@ -576,7 +570,7 @@ func TestListCacheSurvivesMtimeOnlyChange(t *testing.T) {
 		t.Fatalf("Chtimes(entriesDir) error = %v", terr)
 	}
 
-	afterTouch, err := List(vaultDir, "")
+	afterTouch, err := List(vaultDir, "", nil)
 	if err != nil {
 		t.Fatalf("List() after touch error = %v", err)
 	}
@@ -586,7 +580,7 @@ func TestListCacheSurvivesMtimeOnlyChange(t *testing.T) {
 
 	mustWriteEntry(t, vaultDir, id, "example.com/admin", map[string]interface{}{"username": "admin"})
 
-	afterAdd, err := List(vaultDir, "")
+	afterAdd, err := List(vaultDir, "", nil)
 	if err != nil {
 		t.Fatalf("List() after add error = %v", err)
 	}
@@ -608,7 +602,7 @@ func TestFindWithRedactFieldPatterns(t *testing.T) {
 	got, err := FindWithOptions(vaultDir, "JBSW", FindOptions{
 		MaxWorkers:          0,
 		RedactFieldPatterns: []string{"totp.secret"},
-	})
+	}, id)
 	if err != nil {
 		t.Fatalf("FindWithOptions() error = %v", err)
 	}
@@ -620,7 +614,7 @@ func TestFindWithRedactFieldPatterns(t *testing.T) {
 	gotNoRedact, err := FindWithOptions(vaultDir, "JBSW", FindOptions{
 		MaxWorkers:          0,
 		RedactFieldPatterns: nil,
-	})
+	}, id)
 	if err != nil {
 		t.Fatalf("FindWithOptions(no redact) error = %v", err)
 	}
@@ -632,7 +626,7 @@ func TestFindWithRedactFieldPatterns(t *testing.T) {
 	gotWrong, err := FindWithOptions(vaultDir, "WRONG", FindOptions{
 		MaxWorkers:          0,
 		RedactFieldPatterns: []string{"totp.secret"},
-	})
+	}, id)
 	if err != nil {
 		t.Fatalf("FindWithOptions(wrong query) error = %v", err)
 	}
@@ -655,7 +649,7 @@ func TestFindWithRedactFieldPatternsConcurrent(t *testing.T) {
 	got, err := FindWithOptions(vaultDir, "sk-", FindOptions{
 		MaxWorkers:          4,
 		RedactFieldPatterns: []string{"api.*"},
-	})
+	}, id)
 	if err != nil {
 		t.Fatalf("FindWithOptions(concurrent) error = %v", err)
 	}
@@ -667,7 +661,7 @@ func TestFindWithRedactFieldPatternsConcurrent(t *testing.T) {
 	gotDesc, err := FindWithOptions(vaultDir, "account", FindOptions{
 		MaxWorkers:          4,
 		RedactFieldPatterns: []string{"api.*"},
-	})
+	}, id)
 	if err != nil {
 		t.Fatalf("FindWithOptions(description) error = %v", err)
 	}

--- a/internal/vault/service.go
+++ b/internal/vault/service.go
@@ -179,7 +179,7 @@ func (DefaultOperationService) DeleteEntry(v *Vault, path string) error {
 }
 
 func (DefaultOperationService) ListEntries(v *Vault, prefix string) ([]string, error) {
-	entries, err := List(v.Dir, prefix)
+	entries, err := List(v.Dir, prefix, v.Identity)
 	if err != nil {
 		return nil, errorspkg.ReadFailed(err, "cannot list entries: %v", err)
 	}
@@ -187,7 +187,7 @@ func (DefaultOperationService) ListEntries(v *Vault, prefix string) ([]string, e
 }
 
 func (DefaultOperationService) FindEntries(v *Vault, query string, opts FindOptions) ([]Match, error) {
-	matches, err := FindWithOptions(v.Dir, query, opts)
+	matches, err := FindWithOptions(v.Dir, query, opts, v.Identity)
 	if err != nil {
 		return nil, errorspkg.ReadFailed(err, "search failed: %v", err)
 	}

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 
 	"filippo.io/age"
 	"gopkg.in/yaml.v3"
@@ -38,6 +39,8 @@ type Vault struct {
 	Config         *vaultconfig.Config
 	Dir            string
 	NeedsMigration bool
+
+	searchIdentity atomic.Pointer[age.X25519Identity]
 }
 
 func Init(vaultDir string, identity *age.X25519Identity, cfg *vaultconfig.Config) error {
@@ -95,7 +98,6 @@ func Open(vaultDir string, identity *age.X25519Identity) (*Vault, error) {
 	if err := detectLegacyMode(cfg, vaultDir); err != nil {
 		return nil, fmt.Errorf("detect legacy mode: %w", err)
 	}
-	rememberSearchIdentity(identity)
 	if cfg != nil && cfg.Vault != nil && cfg.Vault.ListingCacheTTL > 0 {
 		SetListCacheTTL(cfg.Vault.ListingCacheTTL)
 	}
@@ -124,7 +126,9 @@ func Open(vaultDir string, identity *age.X25519Identity) (*Vault, error) {
 			return nil, fmt.Errorf("update gitignore: %w", err)
 		}
 	}
-	return &Vault{Dir: vaultDir, Identity: identity, Config: cfg}, nil
+	v := &Vault{Dir: vaultDir, Identity: identity, Config: cfg}
+	v.searchIdentity.Store(identity)
+	return v, nil
 }
 
 const legacyMigrationMarker = ".symvault-migrated"
@@ -396,18 +400,7 @@ func (v *Vault) List(prefix string) ([]string, error) {
 	if v == nil {
 		return nil, errors.New("vault is nil")
 	}
-	cfg, err := loadVaultConfig(v.Dir)
-	if err != nil {
-		return nil, err
-	}
-	if isPseudonymizeEnabled(cfg) {
-		workers := 0
-		if cfg != nil && cfg.Vault != nil {
-			workers = cfg.Vault.SearchWorkers
-		}
-		return listPseudonymizedWithIdentity(v.Dir, prefix, v.Identity, workers)
-	}
-	return List(v.Dir, prefix)
+	return List(v.Dir, prefix, v.Identity)
 }
 
 // FindWithOptions searches this vault's entries using the vault's identity


### PR DESCRIPTION
refactor(vault): eliminate global mutable state for search identity

Move searchIdentity atomic.Pointer from package-level variable to a field
on the Vault struct. Remove rememberSearchIdentity, currentSearchIdentity,
and the standalone CurrentSearchIdentity function. Replace with a method
on Vault that reads from the per-instance cache.

Update all callers of List() and FindWithOptions() to pass identity
explicitly instead of relying on the global cache. Doctor health checks,
audit logger, and UI code now pass nil identity when no vault session
is active, handling the missing-identity case gracefully.

This eliminates a cross-vault identity leakage risk where opening a
second vault would overwrite the first vault's search identity in the
global atomic pointer.

Milestone: v0.4.1

<!-- closes-list-start -->
- Closes #334 Global mutable state risks cross-vault identity leakage
<!-- closes-list-end -->
