### PR TITLE
Audit log HMAC key is stored inside the vault directory (+6 more)

### DIFF
--- a/cmd/auth/auth_rotate.go
+++ b/cmd/auth/auth_rotate.go
@@ -129,7 +129,7 @@ Optionally re-encrypts all entries with the new passphrase.`,
 			cliout.Warnf("Warning: git auto-commit failed: %v", commitErr)
 		}
 
-		auditLog, auditErr := audit.New("symvault", vaultDir)
+		auditLog, auditErr := audit.New("symvault", vaultDir, v.Identity)
 		if auditErr == nil {
 			if err := auditLog.LogEntry(audit.LogEntry{Action: "rotate-passphrase", OK: true, Timestamp: time.Now().UTC().Format(time.RFC3339)}); err != nil {
 				cliout.Warnf("Warning: audit log write failed: %v", err)

--- a/cmd/crud/get.go
+++ b/cmd/crud/get.go
@@ -92,7 +92,7 @@ var getCmd = &cobra.Command{
 					return errorspkg.ReadFailed(err, "cannot read entry")
 				}
 
-				matches, findErr := cli.FindEntries(v, path, vaultpkg.FindOptions{MaxWorkers: 4})
+				matches, findErr := cli.FindEntries(v, path, vaultpkg.FindOptions{})
 				if findErr != nil {
 					return errorspkg.ReadFailed(findErr, "search entry")
 				}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -39,6 +39,12 @@ func SetVersionInfo(version, commit, date string) {
 
 func AppVersion() string { return cli.AppVersionStr() }
 
+// SniffAndClearEnvPassphrase reads and caches the SYMVAULT_PASSPHRASE env var
+// then unsets it so child processes cannot inherit the raw passphrase.
+func SniffAndClearEnvPassphrase() {
+	cli.SniffAndClearEnvPassphrase()
+}
+
 // printQuietAware prints to stdout unless quiet mode is enabled
 func printQuietAware(format string, args ...interface{}) {
 	cli.PrintQuietAware(format, args...)

--- a/internal/agentctx/context.go
+++ b/internal/agentctx/context.go
@@ -99,7 +99,7 @@ func Load(agentName, vaultDir string) (*AgentContext, error) {
 	// Attempt to create the audit logger; silently continue without it on
 	// failure so agentctx can still function even if audit logging is down.
 	var auditLog *audit.Logger
-	auditLog, _ = audit.New(agentName, vaultDir)
+	auditLog, _ = audit.New(agentName, vaultDir, nil)
 
 	return &AgentContext{
 		profile:   &profile,

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -20,6 +20,8 @@ import (
 	"sync"
 	"time"
 
+	"filippo.io/age"
+
 	configpkg "github.com/danieljustus/symaira-vault/internal/config"
 	"github.com/danieljustus/symaira-vault/internal/logging"
 
@@ -181,7 +183,12 @@ type Logger struct {
 	syncMode   bool
 }
 
-func New(agentName string, vaultDir string) (*Logger, error) {
+// New creates a new audit Logger for the given agent and vault directory.
+// When identity is non-nil (platforms without OS keyring), the HMAC key
+// is encrypted with the vault's age identity so it cannot be forged by an
+// attacker who exfiltrates only the vault directory without the passphrase.
+// On platforms with OS keyring support the identity is ignored.
+func New(agentName string, vaultDir string, identity *age.X25519Identity) (*Logger, error) {
 	if strings.Contains(agentName, "/") || strings.Contains(agentName, "\\") || agentName == ".." || agentName == "." {
 		return nil, errors.New("agent name must not contain path separators or traversal patterns")
 	}
@@ -226,7 +233,7 @@ func New(agentName string, vaultDir string) (*Logger, error) {
 		return nil, fmt.Errorf("open audit log: %w", err)
 	}
 
-	ks := NewKeystore(cleanAuditDir, nil)
+	ks := NewKeystore(cleanAuditDir, identity)
 	hmacKey, err := ks.LoadOrCreateHMACKey()
 	if err != nil {
 		_ = file.Close()

--- a/internal/audit/audit_hmac_test.go
+++ b/internal/audit/audit_hmac_test.go
@@ -14,7 +14,7 @@ func TestHMACChainValidPasses(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	logger, err := New("hmac-valid-test", "")
+	logger, err := New("hmac-valid-test", "", nil)
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -59,7 +59,7 @@ func TestHMACTamperedEntryDetected(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	logger, err := New("hmac-tamper-test", "")
+	logger, err := New("hmac-tamper-test", "", nil)
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -147,7 +147,7 @@ func TestHMACLegacyLogAccepted(t *testing.T) {
 		t.Fatalf("WriteFile error = %v", err)
 	}
 
-	logger, err := New("legacy-test", "")
+	logger, err := New("legacy-test", "", nil)
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -184,7 +184,7 @@ func TestHMACEmptyLog(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	logger, err := New("hmac-empty-test", "")
+	logger, err := New("hmac-empty-test", "", nil)
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -206,7 +206,7 @@ func TestHMACChainContinuity(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	logger, err := New("hmac-chain-test", "")
+	logger, err := New("hmac-chain-test", "", nil)
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -269,7 +269,7 @@ func TestHMACMultipleWrites(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	logger, err := New("hmac-multi-test", "")
+	logger, err := New("hmac-multi-test", "", nil)
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -349,7 +349,7 @@ func TestHMACReopenRetainsChain(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	logger, err := New("hmac-reopen-test", "")
+	logger, err := New("hmac-reopen-test", "", nil)
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -368,7 +368,7 @@ func TestHMACReopenRetainsChain(t *testing.T) {
 	})
 	_ = logger.Close()
 
-	logger2, err := New("hmac-reopen-test", "")
+	logger2, err := New("hmac-reopen-test", "", nil)
 	if err != nil {
 		t.Fatalf("New() error on reopen = %v", err)
 	}
@@ -409,7 +409,7 @@ func TestHMACMixedLegacyAndNew(t *testing.T) {
 		t.Fatalf("WriteFile error = %v", err)
 	}
 
-	logger, err := New("mixed-test", "")
+	logger, err := New("mixed-test", "", nil)
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}

--- a/internal/audit/audit_redaction_test.go
+++ b/internal/audit/audit_redaction_test.go
@@ -15,7 +15,7 @@ func TestFieldNameOnlyNeverValue(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	logger, err := New("field-name-test", "")
+	logger, err := New("field-name-test", "", nil)
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -59,7 +59,7 @@ func TestNoSecretValuesInPathEntries(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	logger, err := New("path-secret-test", "")
+	logger, err := New("path-secret-test", "", nil)
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -118,7 +118,7 @@ func TestSecretRedactionFixtureBased(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	logger, err := New("fixture-test", "")
+	logger, err := New("fixture-test", "", nil)
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -249,7 +249,7 @@ func TestAuditLogDoesNotContainJSONValues(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	logger, err := New("no-values-test", "")
+	logger, err := New("no-values-test", "", nil)
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -373,7 +373,7 @@ func TestSensitivePathPatternsDoesNotLeakValues(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	logger, err := New("sensitive-path-test", "")
+	logger, err := New("sensitive-path-test", "", nil)
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -434,7 +434,7 @@ func TestReasonFieldDoesNotLeakValues(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	logger, err := New("reason-test", "")
+	logger, err := New("reason-test", "", nil)
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -497,7 +497,7 @@ func TestConcurrentNoValueLeak(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	logger, err := New("concurrent-redact-test", "")
+	logger, err := New("concurrent-redact-test", "", nil)
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}

--- a/internal/audit/audit_test.go
+++ b/internal/audit/audit_test.go
@@ -16,7 +16,7 @@ func TestLogEntryWritesJSONL(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	logger, err := New("test-agent", "")
+	logger, err := New("test-agent", "", nil)
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -63,7 +63,7 @@ func TestLogEntryDenialIncludesReason(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	logger, err := New("test-agent", "")
+	logger, err := New("test-agent", "", nil)
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -131,7 +131,7 @@ func TestLogEntryMultipleWrites(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	logger, err := New("multi-write", "")
+	logger, err := New("multi-write", "", nil)
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -169,7 +169,7 @@ func TestLogEntryAutoTimestamp(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	logger, err := New("timestamp-test", "")
+	logger, err := New("timestamp-test", "", nil)
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -201,7 +201,7 @@ func TestLogEntryPreservesProvidedTimestamp(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	logger, err := New("preserved-ts", "")
+	logger, err := New("preserved-ts", "", nil)
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -234,7 +234,7 @@ func TestNewRejectsPathSeparator(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	_, err := New("agent/with/slash", "")
+	_, err := New("agent/with/slash", "", nil)
 	if err == nil {
 		t.Fatal("expected error for agent name with slash")
 	}
@@ -244,7 +244,7 @@ func TestNewRejectsBackslash(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	_, err := New("agent\\with\\backslash", "")
+	_, err := New("agent\\with\\backslash", "", nil)
 	if err == nil {
 		t.Fatal("expected error for agent name with backslash")
 	}
@@ -254,7 +254,7 @@ func TestNewRejectsDotDot(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	_, err := New("..", "")
+	_, err := New("..", "", nil)
 	if err == nil {
 		t.Fatal("expected error for .. agent name")
 	}
@@ -264,7 +264,7 @@ func TestNewRejectsDot(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	_, err := New(".", "")
+	_, err := New(".", "", nil)
 	if err == nil {
 		t.Fatal("expected error for . agent name")
 	}
@@ -274,7 +274,7 @@ func TestNewRejectsDotDotInName(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	_, err := New("my..agent", "")
+	_, err := New("my..agent", "", nil)
 	if err == nil {
 		t.Fatal("expected error for agent name containing ..")
 	}
@@ -287,7 +287,7 @@ func TestNewCreatesAuditDirectory(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	_, err := New("create-dir-test", "")
+	_, err := New("create-dir-test", "", nil)
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -302,7 +302,7 @@ func TestNewCreatesLogFile(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	logger, err := New("logfile-test", "")
+	logger, err := New("logfile-test", "", nil)
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -321,7 +321,7 @@ func TestNewSetsCorrectPermissions(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	logger, err := New("perms-test", "")
+	logger, err := New("perms-test", "", nil)
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -351,7 +351,7 @@ func TestNewUsesUserHomeDirWhenHomeEmpty(t *testing.T) {
 	}()
 
 	// os.UserHomeDir may fail in some environments; skip if so
-	logger, err := New("home-dir-test", "")
+	logger, err := New("home-dir-test", "", nil)
 	if err != nil && strings.Contains(err.Error(), "not defined") {
 		t.Skip("HOME not available in this environment")
 	}
@@ -376,7 +376,7 @@ func TestNewErrorWhenAuditDirNotCreatable(t *testing.T) {
 
 	t.Setenv("HOME", parent)
 
-	_, err := New("dir-fail-agent", "")
+	_, err := New("dir-fail-agent", "", nil)
 	if err == nil {
 		t.Fatal("expected error when audit dir cannot be created, got nil")
 	}
@@ -405,7 +405,7 @@ func TestNewErrorWhenLogFileNotWritable(t *testing.T) {
 	}
 	defer os.Chmod(auditDir, 0o700) //nolint:errcheck
 
-	_, err := New("file-fail-agent", "")
+	_, err := New("file-fail-agent", "", nil)
 	if err == nil {
 		t.Fatal("expected error when log file cannot be opened, got nil")
 	}
@@ -496,7 +496,7 @@ func TestRotateIfNeededSizeLimit(t *testing.T) {
 	ReloadConfig()
 	defer ReloadConfig()
 
-	logger, err := New("size-rotate-test", "")
+	logger, err := New("size-rotate-test", "", nil)
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -535,7 +535,7 @@ func TestRotateIfNeededAgeLimit(t *testing.T) {
 	ReloadConfig()
 	defer ReloadConfig()
 
-	logger, err := New("age-rotate-test", "")
+	logger, err := New("age-rotate-test", "", nil)
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -569,7 +569,7 @@ func TestEnforceRetentionMaxBackups(t *testing.T) {
 	ReloadConfig()
 	defer ReloadConfig()
 
-	logger, err := New("backup-cleanup-test", "")
+	logger, err := New("backup-cleanup-test", "", nil)
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -610,7 +610,7 @@ func TestEnforceRetentionMaxAge(t *testing.T) {
 	ReloadConfig()
 	defer ReloadConfig()
 
-	logger, err := New("age-cleanup-test", "")
+	logger, err := New("age-cleanup-test", "", nil)
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -643,7 +643,7 @@ func TestEnforceRetentionNoFiles(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	logger, err := New("no-backups-test", "")
+	logger, err := New("no-backups-test", "", nil)
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -663,7 +663,7 @@ func TestEnforceRetentionPreservesNewest(t *testing.T) {
 	ReloadConfig()
 	defer ReloadConfig()
 
-	logger, err := New("preserve-newest-test", "")
+	logger, err := New("preserve-newest-test", "", nil)
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -701,7 +701,7 @@ func TestNoLogLossDuringRotation(t *testing.T) {
 	ReloadConfig()
 	defer ReloadConfig()
 
-	logger, err := New("no-loss-test", "")
+	logger, err := New("no-loss-test", "", nil)
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -799,7 +799,7 @@ func TestHealthCheckHealthy(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	logger, err := New("health-test", "")
+	logger, err := New("health-test", "", nil)
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -840,7 +840,7 @@ func TestHealthCheckEmptyLog(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	logger, err := New("empty-health-test", "")
+	logger, err := New("empty-health-test", "", nil)
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -869,7 +869,7 @@ func TestHealthCheckNeedsRotationBySize(t *testing.T) {
 	ReloadConfig()
 	defer ReloadConfig()
 
-	logger, err := New("rotation-health-test", "")
+	logger, err := New("rotation-health-test", "", nil)
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -890,7 +890,7 @@ func TestGetErrorsFiltersErrors(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	logger, err := New("errors-test", "")
+	logger, err := New("errors-test", "", nil)
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -924,7 +924,7 @@ func TestGetErrorsNoErrors(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	logger, err := New("no-errors-test", "")
+	logger, err := New("no-errors-test", "", nil)
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -945,7 +945,7 @@ func TestGetErrorsLimit(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	logger, err := New("limit-errors-test", "")
+	logger, err := New("limit-errors-test", "", nil)
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -977,7 +977,7 @@ func TestLastNEntriesEmptyFile(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	logger, err := New("empty-entries-test", "")
+	logger, err := New("empty-entries-test", "", nil)
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -1040,7 +1040,7 @@ func TestLastNEntriesReturnsCorrectCount(t *testing.T) {
 			home := t.TempDir()
 			t.Setenv("HOME", home)
 
-			logger, err := New("lastn-"+tt.name, "")
+			logger, err := New("lastn-"+tt.name, "", nil)
 			if err != nil {
 				t.Fatalf("New() error = %v", err)
 			}
@@ -1072,7 +1072,7 @@ func TestLastNEntriesMoreThanAvailable(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	logger, err := New("more-entries-test", "")
+	logger, err := New("more-entries-test", "", nil)
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -1096,7 +1096,7 @@ func TestLastNEntriesSkipsMalformedLines(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	logger, err := New("malformed-test", "")
+	logger, err := New("malformed-test", "", nil)
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -1212,7 +1212,7 @@ func TestLogEntryAutoFillsEmptyTimestamp(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	logger, err := New("autofill-ts-test", "")
+	logger, err := New("autofill-ts-test", "", nil)
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -1249,7 +1249,7 @@ func TestNewRejectsDotDotInMiddle(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	_, err := New("agent..name", "")
+	_, err := New("agent..name", "", nil)
 	if err == nil {
 		t.Fatal("expected error for agent name containing ..")
 	}
@@ -1259,7 +1259,7 @@ func TestHealthCheckMultipleErrors(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	logger, err := New("multi-error-test", "")
+	logger, err := New("multi-error-test", "", nil)
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -1286,7 +1286,7 @@ func TestGetErrorsAllOk(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	logger, err := New("all-ok-test", "")
+	logger, err := New("all-ok-test", "", nil)
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -1309,7 +1309,7 @@ func TestGetErrorsAllErrors(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	logger, err := New("all-errors-test", "")
+	logger, err := New("all-errors-test", "", nil)
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -1379,7 +1379,7 @@ func TestLogEntryAllFields(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	logger, err := New("all-fields-test", "")
+	logger, err := New("all-fields-test", "", nil)
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -1443,7 +1443,7 @@ func TestNewValidAgentNames(t *testing.T) {
 	validNames := []string{"claude", "my-agent", "agent_1", "Agent123"}
 	for _, name := range validNames {
 		t.Run(name, func(t *testing.T) {
-			logger, err := New(name, "")
+			logger, err := New(name, "", nil)
 			if err != nil {
 				t.Fatalf("New(%q) error = %v", name, err)
 			}
@@ -1461,7 +1461,7 @@ func TestHealthCheckIncludesRotatedSize(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	logger, err := New("rotated-size-test", "")
+	logger, err := New("rotated-size-test", "", nil)
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -1492,7 +1492,7 @@ func TestLastNEntriesCorruptedJSON(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	logger, err := New("corrupt-json-test", "")
+	logger, err := New("corrupt-json-test", "", nil)
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -1526,7 +1526,7 @@ func TestLastNEntriesMissingFields(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	logger, err := New("missing-fields-test", "")
+	logger, err := New("missing-fields-test", "", nil)
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -1557,7 +1557,7 @@ func TestLastNEntriesEmptyTimestamp(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	logger, err := New("empty-ts-test", "")
+	logger, err := New("empty-ts-test", "", nil)
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -1587,7 +1587,7 @@ func TestConcurrentWrites(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	logger, err := New("concurrent-test", "")
+	logger, err := New("concurrent-test", "", nil)
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -1645,7 +1645,7 @@ func TestConcurrentWritesWithClose(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	logger, err := New("concurrent-close-test", "")
+	logger, err := New("concurrent-close-test", "", nil)
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -1687,7 +1687,7 @@ func TestRotateIfNeededRenameFailure(t *testing.T) {
 	ReloadConfig()
 	defer ReloadConfig()
 
-	logger, err := New("rename-fail-test", "")
+	logger, err := New("rename-fail-test", "", nil)
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -1715,7 +1715,7 @@ func TestMaxLogSizeTrigger(t *testing.T) {
 	ReloadConfig()
 	defer ReloadConfig()
 
-	logger, err := New("max-size-trigger-test", "")
+	logger, err := New("max-size-trigger-test", "", nil)
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -1756,7 +1756,7 @@ func TestLogEntryWriteErrorReturned(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	logger, err := New("write-error-test", "")
+	logger, err := New("write-error-test", "", nil)
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -1784,7 +1784,7 @@ func TestEnforceRetentionStatError(t *testing.T) {
 	ReloadConfig()
 	defer ReloadConfig()
 
-	logger, err := New("stat-error-test", "")
+	logger, err := New("stat-error-test", "", nil)
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -1822,7 +1822,7 @@ func TestEnforceRetentionRemoveError(t *testing.T) {
 	ReloadConfig()
 	defer ReloadConfig()
 
-	logger, err := New("remove-error-test", "")
+	logger, err := New("remove-error-test", "", nil)
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -1854,7 +1854,7 @@ func TestHealthCheckSeekError(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	logger, err := New("seek-error-test", "")
+	logger, err := New("seek-error-test", "", nil)
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -1880,7 +1880,7 @@ func TestLastNEntriesReadFileError(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	logger, err := New("readfile-error-test", "")
+	logger, err := New("readfile-error-test", "", nil)
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -1916,7 +1916,7 @@ func TestNewPathSeparators(t *testing.T) {
 	badNames := []string{"agent/name", "agent\\name"}
 	for _, name := range badNames {
 		t.Run(name, func(t *testing.T) {
-			_, err := New(name, "")
+			_, err := New(name, "", nil)
 			if err == nil {
 				t.Fatalf("expected error for agent name %q", name)
 			}
@@ -1932,7 +1932,7 @@ func TestHealthCheckZeroMaxAge(t *testing.T) {
 	ReloadConfig()
 	defer ReloadConfig()
 
-	logger, err := New("zero-age-test", "")
+	logger, err := New("zero-age-test", "", nil)
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -1954,7 +1954,7 @@ func TestRotateIfNeededFileStatError(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	logger, err := New("stat-error-test", "")
+	logger, err := New("stat-error-test", "", nil)
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -1977,7 +1977,7 @@ func TestRotateIfNeededClosedFileStatError(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	logger, err := New("closed-stat-test", "")
+	logger, err := New("closed-stat-test", "", nil)
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -1995,7 +1995,7 @@ func TestHealthCheckClosedFileStatError(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	logger, err := New("closed-health-test", "")
+	logger, err := New("closed-health-test", "", nil)
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -2056,7 +2056,7 @@ func TestNewOpenFilePermissionDenied(t *testing.T) {
 	}
 	defer os.Chmod(auditDir, 0o700) //nolint:errcheck
 
-	_, err := New("perm-denied-test", "")
+	_, err := New("perm-denied-test", "", nil)
 	if err == nil {
 		t.Fatal("expected error when OpenFile fails")
 	}
@@ -2066,7 +2066,7 @@ func TestEnforceRetentionEmptyDir(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	logger, err := New("empty-dir-test", "")
+	logger, err := New("empty-dir-test", "", nil)
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -2083,7 +2083,7 @@ func TestLastNEntriesFileSizeZero(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	logger, err := New("zero-size-test", "")
+	logger, err := New("zero-size-test", "", nil)
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -2276,7 +2276,7 @@ func TestRotateIfNeededSizeLimit_Symvault(t *testing.T) {
 	ReloadConfig()
 	defer ReloadConfig()
 
-	logger, err := New("size-rotate-symvault-test", "")
+	logger, err := New("size-rotate-symvault-test", "", nil)
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -2316,7 +2316,7 @@ func TestRotateIfNeededAgeLimit_Symvault(t *testing.T) {
 	ReloadConfig()
 	defer ReloadConfig()
 
-	logger, err := New("age-rotate-symvault-test", "")
+	logger, err := New("age-rotate-symvault-test", "", nil)
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -2348,7 +2348,7 @@ func TestHealthCheckNeedsRotationBySize_Symvault(t *testing.T) {
 	ReloadConfig()
 	defer ReloadConfig()
 
-	logger, err := New("rotation-health-symvault-test", "")
+	logger, err := New("rotation-health-symvault-test", "", nil)
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}

--- a/internal/audit/keystore_test.go
+++ b/internal/audit/keystore_test.go
@@ -100,7 +100,7 @@ func TestKeystoreWithAuditLogIntegration(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	logger, err := New("keystore-integ-test", "")
+	logger, err := New("keystore-integ-test", "", nil)
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -127,7 +127,7 @@ func TestKeystoreHMACVerificationAfterKeystoreUse(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	logger, err := New("verify-keystore-test", "")
+	logger, err := New("verify-keystore-test", "", nil)
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}

--- a/internal/cli/passphrase_env.go
+++ b/internal/cli/passphrase_env.go
@@ -1,0 +1,36 @@
+package cli
+
+import (
+	"sync"
+
+	"github.com/danieljustus/symaira-vault/internal/envutil"
+)
+
+var (
+	cachedEnvPassphrase     []byte
+	cachedEnvPassphraseOnce sync.Once
+)
+
+// SniffAndClearEnvPassphrase reads SYMVAULT_PASSPHRASE (and the legacy
+// OPENPASS_PASSPHRASE) from the environment, stores the value in a process-
+// local buffer, and immediately unsets both variables so child processes
+// cannot inherit the raw passphrase.
+//
+// Must be called before any child process is spawned, ideally in main().
+func SniffAndClearEnvPassphrase() {
+	cachedEnvPassphraseOnce.Do(func() {
+		p := envutil.Getenv("SYMVAULT_PASSPHRASE", "OPENPASS_PASSPHRASE")
+		if p != "" {
+			cachedEnvPassphrase = []byte(p)
+		}
+		envutil.Unsetenv("SYMVAULT_PASSPHRASE", "OPENPASS_PASSPHRASE")
+	})
+}
+
+// consumeCachedEnvPassphrase returns the early-cached env passphrase
+// and clears the process-local cache so the bytes are not retained.
+func consumeCachedEnvPassphrase() []byte {
+	p := cachedEnvPassphrase
+	cachedEnvPassphrase = nil
+	return p
+}

--- a/internal/cli/unlock.go
+++ b/internal/cli/unlock.go
@@ -11,6 +11,7 @@ import (
 
 	configpkg "github.com/danieljustus/symaira-vault/internal/config"
 	cryptopkg "github.com/danieljustus/symaira-vault/internal/crypto"
+	"github.com/danieljustus/symaira-vault/internal/envutil"
 	errorspkg "github.com/danieljustus/symaira-vault/internal/errors"
 	"github.com/danieljustus/symaira-vault/internal/metrics"
 	vaultpkg "github.com/danieljustus/symaira-vault/internal/vault"

--- a/internal/cli/unlock.go
+++ b/internal/cli/unlock.go
@@ -11,6 +11,7 @@ import (
 
 	configpkg "github.com/danieljustus/symaira-vault/internal/config"
 	cryptopkg "github.com/danieljustus/symaira-vault/internal/crypto"
+	"github.com/danieljustus/symaira-vault/internal/envutil"
 	errorspkg "github.com/danieljustus/symaira-vault/internal/errors"
 	"github.com/danieljustus/symaira-vault/internal/metrics"
 	vaultpkg "github.com/danieljustus/symaira-vault/internal/vault"
@@ -90,17 +91,21 @@ func resolveUnlockPassphrase(vaultDir string, interactive bool, cfg *configpkg.C
 				passphrase = cached
 				passphraseFromEnv = true
 				WarnEnvPassphrase()
+			} else if p := envutil.Getenv("SYMVAULT_PASSPHRASE", "OPENPASS_PASSPHRASE"); p != "" {
+				passphrase = []byte(p)
+				passphraseFromEnv = true
+				WarnEnvPassphrase()
 			}
 		}
-	}
-	if len(passphrase) == 0 {
-		if !interactive {
-			return nil, false, false, errorspkg.NewCLIError(errorspkg.ExitLocked, lockedMessageForCache(), nil)
-		}
-		var readErr error
-		passphrase, readErr = ReadHiddenInput("Passphrase: ", nil)
-		if readErr != nil {
-			return nil, false, false, errorspkg.NewCLIError(errorspkg.ExitLocked, "read passphrase", readErr)
+		if len(passphrase) == 0 {
+			if !interactive {
+				return nil, false, false, errorspkg.NewCLIError(errorspkg.ExitLocked, lockedMessageForCache(), nil)
+			}
+			var readErr error
+			passphrase, readErr = ReadHiddenInput("Passphrase: ", nil)
+			if readErr != nil {
+				return nil, false, false, errorspkg.NewCLIError(errorspkg.ExitLocked, "read passphrase", readErr)
+			}
 		}
 	}
 	return passphrase, passphraseFromEnv, passphraseFromBiometric, nil

--- a/internal/cli/unlock.go
+++ b/internal/cli/unlock.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"path/filepath"
 	"time"
-	"unsafe"
 
 	"github.com/danieljustus/symaira-vault/internal/ui/cliout"
 
@@ -12,7 +11,6 @@ import (
 
 	configpkg "github.com/danieljustus/symaira-vault/internal/config"
 	cryptopkg "github.com/danieljustus/symaira-vault/internal/crypto"
-	"github.com/danieljustus/symaira-vault/internal/envutil"
 	errorspkg "github.com/danieljustus/symaira-vault/internal/errors"
 	"github.com/danieljustus/symaira-vault/internal/metrics"
 	vaultpkg "github.com/danieljustus/symaira-vault/internal/vault"
@@ -86,18 +84,13 @@ func resolveUnlockPassphrase(vaultDir string, interactive bool, cfg *configpkg.C
 			}
 		}
 		if len(passphrase) == 0 && (cfg == nil || cfg.Security == nil || !cfg.Security.DisableEnvPassphrase) {
-			if envPass := envutil.Getenv("SYMVAULT_PASSPHRASE", "OPENPASS_PASSPHRASE"); envPass != "" {
-				// Use unsafe.Slice to alias the string backing array without a heap copy.
-				// This way the deferred Wipe(passphrase) at the call site clears the only
-				// copy of the passphrase in memory, and the os.Unsetenv does not leave a
-				// lingering string on the heap.
-				// #nosec G103 — intentional: unsafe.Slice avoids heap-copying the passphrase
-				// so that the subsequent Wipe clears the only copy in memory.
-				passphrase = unsafe.Slice(unsafe.StringData(envPass), len(envPass))
+			// Check the early-cached env passphrase first (sniffed in main()
+			// before any child process could inherit it).
+			if cached := consumeCachedEnvPassphrase(); len(cached) > 0 {
+				passphrase = cached
 				passphraseFromEnv = true
 				WarnEnvPassphrase()
 			}
-			envutil.Unsetenv("SYMVAULT_PASSPHRASE", "OPENPASS_PASSPHRASE")
 		}
 	}
 	if len(passphrase) == 0 {

--- a/internal/cli/unlock.go
+++ b/internal/cli/unlock.go
@@ -11,7 +11,6 @@ import (
 
 	configpkg "github.com/danieljustus/symaira-vault/internal/config"
 	cryptopkg "github.com/danieljustus/symaira-vault/internal/crypto"
-	"github.com/danieljustus/symaira-vault/internal/envutil"
 	errorspkg "github.com/danieljustus/symaira-vault/internal/errors"
 	"github.com/danieljustus/symaira-vault/internal/metrics"
 	vaultpkg "github.com/danieljustus/symaira-vault/internal/vault"

--- a/internal/cli/unlock_test.go
+++ b/internal/cli/unlock_test.go
@@ -111,7 +111,9 @@ func TestUnlockVaultWithTTLDoesNotSaveTouchIDItemForUncachedEnvPassphrase(t *tes
 		t.Fatal("SessionSaveBiometric should not be called for uncached env passphrase")
 		return nil
 	}
-	t.Setenv("SYMVAULT_PASSPHRASE", string(passphrase))
+	// Prime the early-cached env passphrase (normally sniffed in main()
+	// before any child process can inherit it).
+	cachedEnvPassphrase = append([]byte(nil), passphrase...)
 
 	v, _, err := UnlockVaultWithTTL(vaultDir, false, 0, false)
 	if err != nil {

--- a/internal/clipboard/clipboard.go
+++ b/internal/clipboard/clipboard.go
@@ -3,6 +3,8 @@ package clipboard
 
 import (
 	"errors"
+	"os"
+	"os/signal"
 	"time"
 )
 
@@ -14,6 +16,9 @@ import (
 var ErrClipboardNotCleared = errors.New("clipboard still contains the copied secret after clear; a clipboard-history manager may have restored it")
 
 // StartAutoClear clears the clipboard after the configured timeout unless canceled.
+// It also registers handlers for SIGINT, SIGTERM, and SIGHUP (on supported
+// platforms) so the clipboard is cleared if the process is terminated before
+// the timer fires.
 func StartAutoClear(duration int, clearFn func(), cancelCh <-chan struct{}) {
 	if duration <= 0 || clearFn == nil {
 		return
@@ -22,10 +27,16 @@ func StartAutoClear(duration int, clearFn func(), cancelCh <-chan struct{}) {
 	timer := time.NewTimer(time.Duration(duration) * time.Second)
 	defer timer.Stop()
 
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, terminationSignals()...)
+	defer signal.Stop(sigCh)
+
 	select {
 	case <-timer.C:
 		clearFn()
 	case <-cancelCh:
+	case <-sigCh:
+		clearFn()
 	}
 }
 

--- a/internal/clipboard/clipboard_signal_unix.go
+++ b/internal/clipboard/clipboard_signal_unix.go
@@ -1,0 +1,12 @@
+//go:build !windows
+
+package clipboard
+
+import (
+	"os"
+	"syscall"
+)
+
+func terminationSignals() []os.Signal {
+	return []os.Signal{os.Interrupt, syscall.SIGTERM, syscall.SIGHUP}
+}

--- a/internal/clipboard/clipboard_signal_windows.go
+++ b/internal/clipboard/clipboard_signal_windows.go
@@ -1,0 +1,12 @@
+//go:build windows
+
+package clipboard
+
+import (
+	"os"
+	"syscall"
+)
+
+func terminationSignals() []os.Signal {
+	return []os.Signal{os.Interrupt, syscall.SIGTERM}
+}

--- a/internal/envutil/envutil.go
+++ b/internal/envutil/envutil.go
@@ -9,9 +9,15 @@ import (
 	"fmt"
 	"os"
 	"sync/atomic"
+
+	"golang.org/x/term"
 )
 
 var deprecateWarn atomic.Uint32
+
+// ForceDeprecationWarning forces the deprecation warning to print even when
+// stderr is not a terminal. Used in tests.
+var ForceDeprecationWarning bool
 
 // Getenv checks the primary environment variable first, then falls back to the
 // legacy variable. Prints a one-shot deprecation warning when a legacy
@@ -22,9 +28,11 @@ func Getenv(primary, legacy string) string {
 	}
 	if v := os.Getenv(legacy); v != "" {
 		if deprecateWarn.CompareAndSwap(0, 1) && len(legacy) > 8 && legacy[:8] == "OPENPASS" {
-			fmt.Fprintf(os.Stderr,
-				"WARNING: %[1]s is deprecated and will be removed 3 releases after 2026-05-26. "+
-					"Use %[2]s instead.\n", legacy, primary)
+			if ForceDeprecationWarning || term.IsTerminal(int(os.Stderr.Fd())) {
+				fmt.Fprintf(os.Stderr,
+					"WARNING: %[1]s is deprecated and will be removed 3 releases after 2026-05-26. "+
+						"Use %[2]s instead.\n", legacy, primary)
+			}
 		}
 		return v
 	}

--- a/internal/envutil/envutil_test.go
+++ b/internal/envutil/envutil_test.go
@@ -90,6 +90,8 @@ func captureStderr(fn func()) string {
 
 func TestGetenvDeprecationWarning(t *testing.T) {
 	t.Run("warns once when legacy var is consumed", func(t *testing.T) {
+		ForceDeprecationWarning = true
+		defer func() { ForceDeprecationWarning = false }()
 		resetDeprecationWarning()
 		os.Unsetenv("SYMVAULT_DEPTEST")
 		t.Setenv("OPENPASS_DEPTEST", "legacy-value")

--- a/internal/health/doctor_test.go
+++ b/internal/health/doctor_test.go
@@ -12,6 +12,7 @@ import (
 	"filippo.io/age"
 
 	"github.com/danieljustus/symaira-vault/internal/health"
+	"github.com/danieljustus/symaira-vault/internal/session"
 	"github.com/danieljustus/symaira-vault/internal/vault"
 )
 
@@ -882,8 +883,13 @@ func TestRunChecks_ManifestIntegrity_AllOK(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Cache identity by opening vault (this calls rememberSearchIdentity).
+	// Cache identity by opening vault.
 	if _, err := vault.OpenWithCachedIdentity(dir, identity); err != nil {
+		t.Fatal(err)
+	}
+
+	// Save identity to session so the health check can load it.
+	if err := session.SaveIdentity(dir, identity.String(), 15*time.Minute); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/health/doctor_vault.go
+++ b/internal/health/doctor_vault.go
@@ -8,7 +8,10 @@ import (
 	"strings"
 	"time"
 
+	"filippo.io/age"
+
 	configpkg "github.com/danieljustus/symaira-vault/internal/config"
+	"github.com/danieljustus/symaira-vault/internal/session"
 	"github.com/danieljustus/symaira-vault/internal/vault"
 )
 
@@ -222,7 +225,15 @@ func checkManifestIntegrity(vaultDir string, _ Options) Result {
 		return r
 	}
 
-	result, err := vault.VerifyManifestIntegrity(vaultDir, nil)
+	identity, err := loadIdentityForVault(vaultDir)
+	if err != nil {
+		r.Status = StatusWarn
+		r.Message = msgSessionNeeded
+		r.Hint = "run `symvault unlock` to decrypt your identity for manifest verification"
+		return r
+	}
+
+	result, err := vault.VerifyManifestIntegrity(vaultDir, identity)
 	if err != nil {
 		r.Status = StatusWarn
 		r.Message = msgSessionNeeded
@@ -255,6 +266,21 @@ func checkManifestIntegrity(vaultDir string, _ Options) Result {
 	r.Status = StatusOK
 	r.Message = fmt.Sprintf("all %d entries verified", result.OK)
 	return r
+}
+
+// loadIdentityForVault attempts to load a cached X25519 identity from the
+// session keyring for the given vault directory. Returns nil when no valid
+// cached identity is available.
+func loadIdentityForVault(vaultDir string) (*age.X25519Identity, error) {
+	cached, err := session.LoadIdentity(vaultDir)
+	if err != nil {
+		return nil, err
+	}
+	identity, err := age.ParseX25519Identity(cached)
+	if err != nil {
+		return nil, err
+	}
+	return identity, nil
 }
 
 func checkVaultSize(vaultDir string, _ Options) Result {

--- a/internal/mcp/server/mcp_test.go
+++ b/internal/mcp/server/mcp_test.go
@@ -14,7 +14,7 @@ import (
 func newTestServer(t *testing.T, profile config.AgentProfile, transport string) *Server {
 	t.Helper()
 
-	auditLog, err := audit.New("test", "")
+	auditLog, err := audit.New("test", "", nil)
 	if err != nil {
 		t.Fatalf("audit.New() error = %v", err)
 	}

--- a/internal/mcp/server/server.go
+++ b/internal/mcp/server/server.go
@@ -137,7 +137,7 @@ func New(v *vault.Vault, agentName string, transport string) (*Server, error) {
 		})
 	}
 
-	auditLog, err := audit.New(agentName, v.Dir)
+	auditLog, err := audit.New(agentName, v.Dir, v.Identity)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/mcp/server/tools_test_helpers.go
+++ b/internal/mcp/server/tools_test_helpers.go
@@ -17,7 +17,7 @@ import (
 func newTestServerWithVault(t *testing.T, profile config.AgentProfile, transport string, vaultDir string) *Server {
 	t.Helper()
 
-	auditLog, err := audit.New("test", "")
+	auditLog, err := audit.New("test", "", nil)
 	if err != nil {
 		t.Fatalf("audit.New() error = %v", err)
 	}

--- a/internal/mcp/serverbootstrap/http.go
+++ b/internal/mcp/serverbootstrap/http.go
@@ -79,7 +79,7 @@ func RunHTTPServerOnListener(ctx context.Context, listener net.Listener, v *vaul
 
 	// Create a dedicated audit logger for token cleanup events before
 	// starting the cleanup goroutine so it can reference the logger.
-	cleanupAuditLog, err := audit.New("token-cleanup", vaultDir)
+	cleanupAuditLog, err := audit.New("token-cleanup", vaultDir, v.Identity)
 	if err != nil {
 		return fmt.Errorf("create token cleanup audit logger: %w", err)
 	}
@@ -105,7 +105,7 @@ func RunHTTPServerOnListener(ctx context.Context, listener net.Listener, v *vaul
 		_ = registry.StartFileWatcher(ctx, 2*time.Second)
 	}
 
-	authAuditLog, err := audit.New("auth-failures", vaultDir)
+	authAuditLog, err := audit.New("auth-failures", vaultDir, v.Identity)
 	if err != nil {
 		return fmt.Errorf("create auth audit logger: %w", err)
 	}

--- a/internal/session/memory_keyring.go
+++ b/internal/session/memory_keyring.go
@@ -33,18 +33,20 @@ func (m *memoryKeyring) Set(service, account, value string) error {
 		m.store = make(map[string][]byte)
 	}
 
+	// Wrap keys and identities have different JSON schemas than storedSession;
+	// round-tripping through storedSession would silently drop fields like
+	// EncryptedIdentity. Store them opaquely.
+	if account == wrapKeyAccount || account == identityAccount {
+		key := service + "|" + account
+		if old, ok := m.store[key]; ok {
+			zeroBytes(old)
+		}
+		m.store[key] = []byte(value)
+		return nil
+	}
+
 	var sess storedSession
 	if err := json.Unmarshal([]byte(value), &sess); err != nil {
-		if account == wrapKeyAccount || account == identityAccount {
-			// Wrap keys and identities are stored opaquely (not re-marshaled
-			// through storedSession to preserve all fields).
-			key := service + "|" + account
-			if old, ok := m.store[key]; ok {
-				zeroBytes(old)
-			}
-			m.store[key] = []byte(value)
-			return nil
-		}
 		return fmt.Errorf("unmarshal session: %w", err)
 	}
 
@@ -105,13 +107,15 @@ func (m *memoryKeyring) Get(service, account string) (string, error) {
 		return "", fmt.Errorf("not found")
 	}
 
+	// Wrap keys and identities have different JSON schemas than storedSession;
+	// round-tripping through storedSession would silently drop fields like
+	// EncryptedIdentity. Return them opaquely.
+	if account == wrapKeyAccount || account == identityAccount {
+		return string(payload), nil
+	}
+
 	var sess storedSession
 	if err := json.Unmarshal(payload, &sess); err != nil {
-		if account == wrapKeyAccount || account == identityAccount {
-			// Wrap keys and identities are stored opaquely (not re-marshaled
-			// through storedSession to preserve all fields).
-			return string(payload), nil
-		}
 		delete(m.store, key)
 		return "", fmt.Errorf("not found")
 	}

--- a/internal/session/memory_keyring.go
+++ b/internal/session/memory_keyring.go
@@ -35,8 +35,9 @@ func (m *memoryKeyring) Set(service, account, value string) error {
 
 	var sess storedSession
 	if err := json.Unmarshal([]byte(value), &sess); err != nil {
-		if account == wrapKeyAccount {
-			// Wrap keys are stored as raw base64 (not session JSON)
+		if account == wrapKeyAccount || account == identityAccount {
+			// Wrap keys and identities are stored opaquely (not re-marshaled
+			// through storedSession to preserve all fields).
 			key := service + "|" + account
 			if old, ok := m.store[key]; ok {
 				zeroBytes(old)
@@ -106,8 +107,9 @@ func (m *memoryKeyring) Get(service, account string) (string, error) {
 
 	var sess storedSession
 	if err := json.Unmarshal(payload, &sess); err != nil {
-		if account == wrapKeyAccount {
-			// Wrap keys are stored as raw base64 (not session JSON)
+		if account == wrapKeyAccount || account == identityAccount {
+			// Wrap keys and identities are stored opaquely (not re-marshaled
+			// through storedSession to preserve all fields).
 			return string(payload), nil
 		}
 		delete(m.store, key)

--- a/internal/session/memory_keyring_test.go
+++ b/internal/session/memory_keyring_test.go
@@ -257,6 +257,52 @@ func TestVaultDirFromService(t *testing.T) {
 	}
 }
 
+func TestMemoryKeyring_Identity_RoundTrip(t *testing.T) {
+	mk := &memoryKeyring{}
+	vaultDir := "/tmp/vault-mem-id"
+
+	// Store wrap key so encryption/decryption works
+	wrapKey := base64.StdEncoding.EncodeToString(testKey())
+	mk.Set("symvault:"+vaultDir, wrapKeyAccount, wrapKey)
+
+	identity := "AGE-SECRET-KEY-1TESTTESTTESTTESTTESTTESTTESTTESTTESTTESTTESTTESTTEST"
+	enc, nonce, err := encryptPassphrase([]byte(identity), testKey())
+	if err != nil {
+		t.Fatalf("setup encrypt failed: %v", err)
+	}
+
+	now := time.Now().UTC()
+	ident := storedIdentity{
+		EncryptedIdentity: enc,
+		Nonce:             nonce,
+		SavedAt:           now,
+		LastAccess:        now,
+		TTL:               int64(time.Hour),
+	}
+	payload, _ := json.Marshal(ident)
+
+	if err := mk.Set("symvault:"+vaultDir, identityAccount, string(payload)); err != nil {
+		t.Fatalf("Set() error = %v", err)
+	}
+
+	got, err := mk.Get("symvault:"+vaultDir, identityAccount)
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+
+	var retrieved storedIdentity
+	if err := json.Unmarshal([]byte(got), &retrieved); err != nil {
+		t.Fatalf("Get() returned invalid JSON: %v", err)
+	}
+
+	if retrieved.EncryptedIdentity != enc {
+		t.Errorf("EncryptedIdentity lost in round-trip: got %q, want %q", retrieved.EncryptedIdentity, enc)
+	}
+	if retrieved.Nonce != nonce {
+		t.Errorf("Nonce lost in round-trip: got %q, want %q", retrieved.Nonce, nonce)
+	}
+}
+
 func TestZeroBytes(t *testing.T) {
 	b := []byte("hello world")
 	zeroBytes(b)

--- a/internal/vault/search.go
+++ b/internal/vault/search.go
@@ -223,7 +223,13 @@ func cachedList(vaultDir string) []string {
 		adaptListCacheTTL()
 		return nil
 	}
-	entry := elem.Value.(*listCachePayload).entry
+	payload, ok := elem.Value.(*listCachePayload)
+	if !ok {
+		atomic.AddUint64(&listCache._miss, 1)
+		adaptListCacheTTL()
+		return nil
+	}
+	entry := payload.entry
 	if time.Since(entry.createdAt) > listCache.ttl {
 		atomic.AddUint64(&listCache._miss, 1)
 		adaptListCacheTTL()
@@ -255,7 +261,11 @@ func storeListCache(vaultDir string, paths []string) {
 	defer listCache.mu.Unlock()
 
 	if elem, ok := listCache.index[vaultDir]; ok {
-		elem.Value.(*listCachePayload).entry = listCacheEntry{
+		payload, ok := elem.Value.(*listCachePayload)
+		if !ok {
+			return
+		}
+		payload.entry = listCacheEntry{
 			paths:        append([]string(nil), paths...),
 			createdAt:    time.Now(),
 			entriesMtime: getDirMtime(entriesDir(vaultDir)),
@@ -268,7 +278,11 @@ func storeListCache(vaultDir string, paths []string) {
 	if listCache.order.Len() >= maxListCacheVaults {
 		oldest := listCache.order.Back()
 		if oldest != nil {
-			oldKey := oldest.Value.(*listCachePayload).key
+			oldPayload, ok := oldest.Value.(*listCachePayload)
+			if !ok {
+				return
+			}
+			oldKey := oldPayload.key
 			delete(listCache.index, oldKey)
 			listCache.order.Remove(oldest)
 		}

--- a/internal/vault/search.go
+++ b/internal/vault/search.go
@@ -111,8 +111,6 @@ package vault
 
 import (
 	"container/list"
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -137,13 +135,12 @@ type Match struct {
 }
 
 // listCacheEntry holds cached List results with invalidation metadata.
+// Invalidation uses directory mtime (O(1)) instead of tree-walking hash.
 type listCacheEntry struct {
-	paths          []string
-	createdAt      time.Time
-	entriesMtime   time.Time
-	vaultMtime     time.Time
-	entriesDirHash string
-	vaultDirHash   string
+	paths        []string
+	createdAt    time.Time
+	entriesMtime time.Time
+	vaultMtime   time.Time
 }
 
 const (
@@ -185,30 +182,6 @@ func getDirMtime(dir string) time.Time {
 		return time.Time{}
 	}
 	return info.ModTime()
-}
-
-func computeDirHash(dir string) string {
-	h := sha256.New()
-	_ = filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
-		if err != nil {
-			return nil
-		}
-		if d.IsDir() {
-			return nil
-		}
-		rel, err := filepath.Rel(dir, path)
-		if err != nil {
-			return nil
-		}
-		h.Write([]byte(rel))
-		info, err := d.Info()
-		if err != nil {
-			return nil
-		}
-		_, _ = fmt.Fprintf(h, "%d|%d", info.Size(), info.ModTime().UnixNano())
-		return nil
-	})
-	return hex.EncodeToString(h.Sum(nil))
 }
 
 func adaptListCacheTTL() {
@@ -266,16 +239,6 @@ func cachedList(vaultDir string) []string {
 		adaptListCacheTTL()
 		return nil
 	}
-	if computeDirHash(entriesDir(vaultDir)) != entry.entriesDirHash {
-		atomic.AddUint64(&listCache._miss, 1)
-		adaptListCacheTTL()
-		return nil
-	}
-	if computeDirHash(vaultDir) != entry.vaultDirHash {
-		atomic.AddUint64(&listCache._miss, 1)
-		adaptListCacheTTL()
-		return nil
-	}
 	atomic.AddUint64(&listCache._hits, 1)
 	adaptListCacheTTL()
 	listCache.mu.Lock()
@@ -293,12 +256,10 @@ func storeListCache(vaultDir string, paths []string) {
 
 	if elem, ok := listCache.index[vaultDir]; ok {
 		elem.Value.(*listCachePayload).entry = listCacheEntry{
-			paths:          append([]string(nil), paths...),
-			createdAt:      time.Now(),
-			entriesMtime:   getDirMtime(entriesDir(vaultDir)),
-			vaultMtime:     getDirMtime(vaultDir),
-			entriesDirHash: computeDirHash(entriesDir(vaultDir)),
-			vaultDirHash:   computeDirHash(vaultDir),
+			paths:        append([]string(nil), paths...),
+			createdAt:    time.Now(),
+			entriesMtime: getDirMtime(entriesDir(vaultDir)),
+			vaultMtime:   getDirMtime(vaultDir),
 		}
 		listCache.order.MoveToFront(elem)
 		return
@@ -316,12 +277,10 @@ func storeListCache(vaultDir string, paths []string) {
 	payload := &listCachePayload{
 		key: vaultDir,
 		entry: listCacheEntry{
-			paths:          append([]string(nil), paths...),
-			createdAt:      time.Now(),
-			entriesMtime:   getDirMtime(entriesDir(vaultDir)),
-			vaultMtime:     getDirMtime(vaultDir),
-			entriesDirHash: computeDirHash(entriesDir(vaultDir)),
-			vaultDirHash:   computeDirHash(vaultDir),
+			paths:        append([]string(nil), paths...),
+			createdAt:    time.Now(),
+			entriesMtime: getDirMtime(entriesDir(vaultDir)),
+			vaultMtime:   getDirMtime(vaultDir),
 		},
 	}
 	elem := listCache.order.PushFront(payload)
@@ -378,13 +337,11 @@ func InvalidateListCache(vaultDir string) {
 // Unlike listCacheEntry, it also stores decrypted entry data so that
 // FindWithOptions can reuse entries already decrypted during listing.
 type pseudonymizedCacheEntry struct {
-	paths          []string
-	entries        map[string]map[string]any // path -> decrypted entry data
-	createdAt      time.Time
-	entriesMtime   time.Time
-	vaultMtime     time.Time
-	entriesDirHash string
-	vaultDirHash   string
+	paths        []string
+	entries      map[string]map[string]any // path -> decrypted entry data
+	createdAt    time.Time
+	entriesMtime time.Time
+	vaultMtime   time.Time
 }
 
 // pseudonymizedCache provides TTL-cached pseudonymized listings keyed by
@@ -424,12 +381,6 @@ func cachedPseudonymizedList(vaultDir string, identity *age.X25519Identity) []st
 	if !getDirMtime(vaultDir).Equal(entry.vaultMtime) {
 		return nil
 	}
-	if computeDirHash(entriesDir(vaultDir)) != entry.entriesDirHash {
-		return nil
-	}
-	if computeDirHash(vaultDir) != entry.vaultDirHash {
-		return nil
-	}
 	return entry.paths
 }
 
@@ -452,12 +403,6 @@ func cachedPseudonymizedEntry(vaultDir string, identity *age.X25519Identity, pat
 	if !getDirMtime(vaultDir).Equal(entry.vaultMtime) {
 		return nil
 	}
-	if computeDirHash(entriesDir(vaultDir)) != entry.entriesDirHash {
-		return nil
-	}
-	if computeDirHash(vaultDir) != entry.vaultDirHash {
-		return nil
-	}
 	return entry.entries[path]
 }
 
@@ -472,13 +417,11 @@ func storePseudonymizedListCache(vaultDir string, identity *age.X25519Identity, 
 	key := pseudonymizedCacheKey(vaultDir, identity)
 	pseudonymizedCache.mu.Lock()
 	pseudonymizedCache.items[key] = pseudonymizedCacheEntry{
-		paths:          append([]string(nil), paths...),
-		entries:        entries,
-		createdAt:      time.Now(),
-		entriesMtime:   getDirMtime(entriesDir(vaultDir)),
-		vaultMtime:     getDirMtime(vaultDir),
-		entriesDirHash: computeDirHash(entriesDir(vaultDir)),
-		vaultDirHash:   computeDirHash(vaultDir),
+		paths:        append([]string(nil), paths...),
+		entries:      entries,
+		createdAt:    time.Now(),
+		entriesMtime: getDirMtime(entriesDir(vaultDir)),
+		vaultMtime:   getDirMtime(vaultDir),
 	}
 	pseudonymizedCache.mu.Unlock()
 }

--- a/internal/vault/search.go
+++ b/internal/vault/search.go
@@ -110,6 +110,7 @@
 package vault
 
 import (
+	"container/list"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -154,15 +155,27 @@ const (
 // listCache provides TTL-cached path listings to avoid repetitive directory walks.
 // It invalidates entries when the underlying directories' modification times change.
 // The TTL adapts based on hit rate: extends when hit rate > 90%, shrinks when < 50%.
+// Cache size is bounded by maxListCacheVaults to prevent unbounded growth in
+// multi-vault or CI scenarios; least-recently-used entries are evicted when full.
+const maxListCacheVaults = 16
+
 var listCache = struct {
 	mu    sync.RWMutex
-	items map[string]listCacheEntry
+	index map[string]*list.Element // vaultDir → list element
+	order *list.List               // LRU order (front = most recent)
 	ttl   time.Duration
 	_hits uint64
 	_miss uint64
 }{
-	items: make(map[string]listCacheEntry),
+	index: make(map[string]*list.Element),
+	order: list.New(),
 	ttl:   defaultListCacheTTL,
+}
+
+// listCachePayload pairs a vault directory key with its cached entry.
+type listCachePayload struct {
+	key   string
+	entry listCacheEntry
 }
 
 // getDirMtime returns the modification time of a directory, or zero if unavailable.
@@ -230,13 +243,14 @@ func adaptListCacheTTL() {
 // cachedList returns cached paths if valid, or nil if cache miss / expired / invalidated.
 func cachedList(vaultDir string) []string {
 	listCache.mu.RLock()
-	entry, ok := listCache.items[vaultDir]
+	elem, ok := listCache.index[vaultDir]
 	listCache.mu.RUnlock()
 	if !ok {
 		atomic.AddUint64(&listCache._miss, 1)
 		adaptListCacheTTL()
 		return nil
 	}
+	entry := elem.Value.(*listCachePayload).entry
 	if time.Since(entry.createdAt) > listCache.ttl {
 		atomic.AddUint64(&listCache._miss, 1)
 		adaptListCacheTTL()
@@ -264,21 +278,54 @@ func cachedList(vaultDir string) []string {
 	}
 	atomic.AddUint64(&listCache._hits, 1)
 	adaptListCacheTTL()
+	listCache.mu.Lock()
+	listCache.order.MoveToFront(elem)
+	listCache.mu.Unlock()
 	return entry.paths
 }
 
 // storeListCache stores the result of a List call for the given vaultDir.
+// When the cache exceeds maxListCacheVaults the least-recently-used entry
+// is evicted.
 func storeListCache(vaultDir string, paths []string) {
 	listCache.mu.Lock()
-	listCache.items[vaultDir] = listCacheEntry{
-		paths:          append([]string(nil), paths...),
-		createdAt:      time.Now(),
-		entriesMtime:   getDirMtime(entriesDir(vaultDir)),
-		vaultMtime:     getDirMtime(vaultDir),
-		entriesDirHash: computeDirHash(entriesDir(vaultDir)),
-		vaultDirHash:   computeDirHash(vaultDir),
+	defer listCache.mu.Unlock()
+
+	if elem, ok := listCache.index[vaultDir]; ok {
+		elem.Value.(*listCachePayload).entry = listCacheEntry{
+			paths:          append([]string(nil), paths...),
+			createdAt:      time.Now(),
+			entriesMtime:   getDirMtime(entriesDir(vaultDir)),
+			vaultMtime:     getDirMtime(vaultDir),
+			entriesDirHash: computeDirHash(entriesDir(vaultDir)),
+			vaultDirHash:   computeDirHash(vaultDir),
+		}
+		listCache.order.MoveToFront(elem)
+		return
 	}
-	listCache.mu.Unlock()
+
+	if listCache.order.Len() >= maxListCacheVaults {
+		oldest := listCache.order.Back()
+		if oldest != nil {
+			oldKey := oldest.Value.(*listCachePayload).key
+			delete(listCache.index, oldKey)
+			listCache.order.Remove(oldest)
+		}
+	}
+
+	payload := &listCachePayload{
+		key: vaultDir,
+		entry: listCacheEntry{
+			paths:          append([]string(nil), paths...),
+			createdAt:      time.Now(),
+			entriesMtime:   getDirMtime(entriesDir(vaultDir)),
+			vaultMtime:     getDirMtime(vaultDir),
+			entriesDirHash: computeDirHash(entriesDir(vaultDir)),
+			vaultDirHash:   computeDirHash(vaultDir),
+		},
+	}
+	elem := listCache.order.PushFront(payload)
+	listCache.index[vaultDir] = elem
 }
 
 var configuredListCacheTTL time.Duration
@@ -303,9 +350,13 @@ func SetListCacheTTL(ttl time.Duration) {
 func InvalidateListCache(vaultDir string) {
 	listCache.mu.Lock()
 	if vaultDir == "" {
-		listCache.items = make(map[string]listCacheEntry)
+		listCache.index = make(map[string]*list.Element)
+		listCache.order.Init()
 	} else {
-		delete(listCache.items, vaultDir)
+		if elem, ok := listCache.index[vaultDir]; ok {
+			delete(listCache.index, vaultDir)
+			listCache.order.Remove(elem)
+		}
 	}
 	listCache.mu.Unlock()
 

--- a/internal/vault/search.go
+++ b/internal/vault/search.go
@@ -98,7 +98,8 @@
 //
 // FindConcurrent uses a bounded worker pool for parallel decryption:
 //   - Same two-pass logic as Find, but decrypts entries concurrently
-//   - Default 4 concurrent workers balances throughput vs memory pressure
+//   - Default worker count derived from runtime.NumCPU() capped at 8,
+//     overridable via config vault.search_workers or FindOptions.MaxWorkers
 //   - Best for field-search queries on large vaults (10k+ entries)
 //
 // Limits:
@@ -813,6 +814,9 @@ func findWithOptionsIdentity(vaultDir string, query string, opts FindOptions, id
 
 	maxWorkers := opts.MaxWorkers
 	if maxWorkers <= 0 {
+		maxWorkers = min(runtime.NumCPU(), 8)
+	}
+	if maxWorkers <= 1 {
 		for _, path := range pathsNeedingDecrypt {
 			data := maybeCachedEntryData(vaultDir, identity, path)
 			if data == nil {

--- a/main.go
+++ b/main.go
@@ -11,6 +11,11 @@ var (
 )
 
 func main() {
+	// Sniff and clear SYMVAULT_PASSPHRASE from the environment before any
+	// child process can inherit it. The cached value is consumed by the
+	// unlock flow in internal/cli.
+	cmd.SniffAndClearEnvPassphrase()
+
 	cmd.SetVersionInfo(version, commit, date)
 	cmd.Execute()
 }


### PR DESCRIPTION
Bundles fixes for multiple open issues. The list below grows as commits land; every linked issue will close automatically on merge.

<!-- closes-list-start -->
- Closes #368 Audit log HMAC key is stored inside the vault directory
- Closes #369 Clipboard auto-clear does not handle process termination signals
- Closes #370 SYMVAULT_PASSPHRASE is visible to child processes before unset
- Closes #372 Deprecation warnings break stdout-parsing scripts
- Closes #376 Search worker pool is hardcoded to 4 workers
- Closes #373 Global listCache has unbounded growth per vault directory
- Closes #375 computeDirHash walks the entire tree on every cache miss
<!-- closes-list-end -->