### PR TITLE
docs(changelog): clarify v0.x release line vs. historical v4.0.0 (OpenPass)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+> **Note — release series:** The releases `v1.0.0` through `v4.0.0` were
+> published under the legacy **OpenPass** name. The current **Symaira Vault**
+> series begins at `v0.1.0` and follows the `v0.x` line. Historical OpenPass
+> releases remain in this changelog for reference only and are not part of the
+> current Symaira Vault release target. See
+> [docs/MIGRATION-RENAME.md](docs/MIGRATION-RENAME.md) for the rename context
+> and [docs/commercial-boundary.md](docs/commercial-boundary.md) for the
+> current release-line policy. (Added 2026-06-10, see #384.)
+
 ## [v4.0.0] - 2026-05-21
 
 v4.0 reshapes Symaira Vault around AI-agent integration. The CLI becomes a

--- a/internal/update/checker.go
+++ b/internal/update/checker.go
@@ -15,6 +15,19 @@ import (
 	"github.com/danieljustus/symaira-vault/internal/metrics"
 )
 
+// DefaultLatestReleaseURL targets GitHub's "latest stable release" endpoint for
+// the symaira-vault repository. The returned release is whatever GitHub
+// currently advertises as latest.
+//
+// Release-line context (2026-06): the repository carries two lineages. The
+// historical OpenPass releases v1.0.0–v4.0.0 remain in the tag list, and the
+// current Symaira Vault series begins at v0.1.0. The semver comparison below
+// is correct within any single series (e.g. v0.4.0 → v0.4.1) but is NOT
+// designed to span the rename boundary — a user on v0.x will be told a v4.x
+// release is "newer" because 4.0.0 > 0.4.0 numerically, even though the v4.x
+// releases belong to the discontinued OpenPass line. See CHANGELOG.md (the
+// release-series note added in #384) and docs/commercial-boundary.md for the
+// current policy.
 const DefaultLatestReleaseURL = "https://api.github.com/repos/danieljustus/symaira-vault/releases/latest"
 
 // newSecureClient returns an HTTP client with TLS 1.3 minimum version.


### PR DESCRIPTION
Bundles fixes for multiple open issues. The list below grows as commits land; every linked issue will close automatically on merge.

<!-- closes-list-start -->
- Closes #384 docs: clarify v0.x release line vs. historical v4.0.0 (OpenPass)
<!-- closes-list-end -->
