### PR TITLE
test(vault): flush manifest updates before TempDir cleanup in concurrent merge test

### DIFF
--- a/internal/vault/lock_test.go
+++ b/internal/vault/lock_test.go
@@ -111,6 +111,8 @@ func TestConcurrentMergeEntry(t *testing.T) {
 	if got.Data["field_c"] != "value_c" {
 		t.Errorf("field_c missing: got %v", got.Data["field_c"])
 	}
+
+	FlushManifestUpdates()
 }
 
 func TestAcquireWriteLockDefaultTimeout(t *testing.T) {


### PR DESCRIPTION
TestConcurrentMergeEntry queued fire-and-forget manifest updates but
never flushed them. The background worker still held files open when
t.TempDir() ran cleanup, causing 'directory not empty' on macOS CI.
