### PR TITLE
fix(clipboard): auto-clear after `symvault get` never fires (+7 more)

### DIFF
--- a/cmd/crud/add.go
+++ b/cmd/crud/add.go
@@ -100,7 +100,7 @@ func runAdd(cmd *cobra.Command, args []string) error {
 			return errorspkg.WriteFailed(err, "cannot create entry")
 		}
 
-		if err := v.AutoCommit(fmt.Sprintf("Add %s", name)); err != nil {
+		if err := v.AutoCommitEntry(fmt.Sprintf("Add %s", name), name); err != nil {
 			cliout.Warnf("Warning: auto-commit failed: %v", err)
 		}
 		cli.PrintQuietAware("Entry created: %s\n", name)

--- a/cmd/crud/edit.go
+++ b/cmd/crud/edit.go
@@ -1,18 +1,15 @@
 package crud
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 
 	cli "github.com/danieljustus/symaira-vault/internal/cli"
 
 	"github.com/spf13/cobra"
 
 	errorspkg "github.com/danieljustus/symaira-vault/internal/errors"
-	"github.com/danieljustus/symaira-vault/internal/secrets"
+	"github.com/danieljustus/symaira-vault/internal/secureedit"
 	"github.com/danieljustus/symaira-vault/internal/ui/cliout"
 	vaultpkg "github.com/danieljustus/symaira-vault/internal/vault"
 )
@@ -20,7 +17,7 @@ import (
 var EditorFlag string
 
 // OSCreateTemp is overridable in tests for permission verification.
-var OSCreateTemp = os.CreateTemp
+var OSCreateTemp = secureedit.CreateTemp
 
 var editCmd = &cobra.Command{
 	Use:     "edit <name>",
@@ -55,64 +52,14 @@ The editor is determined by the --editor flag or EDITOR environment variable (de
 				editor = "vi"
 			}
 
-			// Validate editor exists in PATH before executing (G204 mitigation)
-			if _, lookErr := exec.LookPath(editor); lookErr != nil {
-				return errorspkg.Wrap(errorspkg.ExitGeneralError, errorspkg.ErrKindNone, lookErr, "editor %q not found in PATH", editor)
-			}
-
-			var tmpFile *os.File
-			tmpFile, err = OSCreateTemp("", "symvault-edit-*.json")
+			secureedit.CreateTemp = OSCreateTemp
+			defer func() { secureedit.CreateTemp = os.CreateTemp }()
+			updatedEntry, err := secureedit.EditEntry(entry, editor, secureedit.DefaultStreams())
 			if err != nil {
-				return errorspkg.WriteFailed(err, "cannot create temp file")
-			}
-			if err = os.Chmod(tmpFile.Name(), 0o600); err != nil {
-				_ = tmpFile.Close()
-				_ = os.Remove(tmpFile.Name())
-				return errorspkg.WriteFailed(err, "cannot set temp file permissions")
-			}
-			defer func() { _ = os.Remove(tmpFile.Name()) }()
-
-			encoder := json.NewEncoder(tmpFile)
-			encoder.SetIndent("", "  ")
-			if encErr := encoder.Encode(entry); encErr != nil {
-				_ = tmpFile.Close()
-				return errorspkg.WriteFailed(encErr, "cannot encode entry")
-			}
-			if closeErr := tmpFile.Close(); closeErr != nil {
-				return errorspkg.WriteFailed(closeErr, "cannot close temp file")
+				return errorspkg.Wrap(errorspkg.ExitGeneralError, errorspkg.ErrKindNone, err, "edit entry")
 			}
 
-			//#nosec G204 -- editor path validated via exec.LookPath above
-			editorCmd := exec.Command(editor, tmpFile.Name())
-			secrets.PrepareCmd(editorCmd)
-			editorCmd.Stdin = os.Stdin
-			editorCmd.Stdout = os.Stdout
-			editorCmd.Stderr = os.Stderr
-
-			if runErr := editorCmd.Run(); runErr != nil {
-				return errorspkg.Wrap(errorspkg.ExitGeneralError, errorspkg.ErrKindNone, runErr, "editor failed")
-			}
-
-			content, err := os.ReadFile(tmpFile.Name())
-			if err != nil {
-				return errorspkg.ReadFailed(err, "cannot read edited file")
-			}
-
-			content = bytes.TrimSpace(content)
-			if len(content) == 0 {
-				return fmt.Errorf("empty file, changes discarded")
-			}
-
-			var updatedEntry vaultpkg.Entry
-			if err := json.Unmarshal(content, &updatedEntry); err != nil {
-				return errorspkg.Wrap(errorspkg.ExitGeneralError, errorspkg.ErrKindNone, err, "invalid JSON")
-			}
-
-			if updatedEntry.Data == nil {
-				updatedEntry.Data = map[string]any{}
-			}
-
-			if err := vs.WriteEntry(name, &updatedEntry); err != nil {
+			if err := vs.WriteEntry(name, updatedEntry); err != nil {
 				return errorspkg.WriteFailed(err, "cannot save entry")
 			}
 

--- a/cmd/crud/edit.go
+++ b/cmd/crud/edit.go
@@ -63,7 +63,7 @@ The editor is determined by the --editor flag or EDITOR environment variable (de
 				return errorspkg.WriteFailed(err, "cannot save entry")
 			}
 
-			if err := v.AutoCommit(fmt.Sprintf("Edit %s", name)); err != nil {
+			if err := v.AutoCommitEntry(fmt.Sprintf("Edit %s", name), name); err != nil {
 				cliout.Warnf("Warning: auto-commit failed: %v", err)
 			}
 			cli.PrintQuietAware("Entry updated: %s\n", name)

--- a/cmd/crud/get.go
+++ b/cmd/crud/get.go
@@ -23,8 +23,10 @@ import (
 )
 
 var (
-	GetPrint     bool
-	GetClipboard = clipboardapp.DefaultClipboard
+	GetPrint                 bool
+	GetClipboard             = clipboardapp.DefaultClipboard
+	GetAutoClearDurationFunc = GetAutoClearDuration
+	StartAutoClear           = clipboardapp.StartAutoClear
 )
 
 type totpOutput struct {
@@ -159,13 +161,13 @@ var getCmd = &cobra.Command{
 					}
 					cliout.Hintf("[copied to clipboard]")
 
-					autoClearDuration := GetAutoClearDuration()
+					autoClearDuration := GetAutoClearDurationFunc()
 					if autoClearDuration > 0 {
 						cancelCh := make(chan struct{})
 						go clipboardapp.Countdown(autoClearDuration, func(remaining int) {
 							fmt.Fprintf(os.Stderr, "\r[clearing clipboard in %ds] ", remaining)
 						}, cancelCh)
-						go clipboardapp.StartAutoClear(autoClearDuration, func() {
+						StartAutoClear(autoClearDuration, func() {
 							close(cancelCh)
 							copied := strValue
 							if clearErr := GetClipboard().Copy(""); clearErr != nil {

--- a/cmd/crud/get.go
+++ b/cmd/crud/get.go
@@ -133,7 +133,7 @@ var getCmd = &cobra.Command{
 				// 2. --print flag: always print to stdout
 				// 3. Not a TTY: print to stdout (for scripts/pipes)
 				// 4. TTY + no --print: copy to clipboard (default)
-				// 5. Config override: clipboard.printByDefault=false restores old behavior
+				// 5. Config override: clipboard.copyByDefault=false restores old behavior
 
 				if cli.OutputFormat != "text" {
 					if printErr := cli.PrintResult(strValue); printErr != nil {
@@ -145,12 +145,15 @@ var getCmd = &cobra.Command{
 				shouldPrint := GetPrint || !cli.IsTerminalFunc(int(os.Stdout.Fd()))
 				if !shouldPrint {
 					// Check config override
-					vaultDir, _ := cli.VaultPath()
-					if vaultDir != "" {
-						cfg, _ := configpkg.Load(vaultDir + "/config.yaml")
-						if cfg != nil && cfg.Clipboard != nil && !cfg.Clipboard.PrintByDefault {
-							shouldPrint = true
+					cfg := v.Config
+					if cfg == nil {
+						vaultDir := vs.VaultDir()
+						if vaultDir != "" {
+							cfg, _ = configpkg.Load(vaultDir + "/config.yaml")
 						}
+					}
+					if cfg != nil && cfg.Clipboard != nil && !cfg.Clipboard.CopyByDefault {
+						shouldPrint = true
 					}
 				}
 

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -54,7 +54,7 @@ var generateCmd = &cobra.Command{
 					}
 				}
 
-				if err := v.AutoCommit(fmt.Sprintf("Generate password for %s", genStore)); err != nil {
+				if err := v.AutoCommitEntry(fmt.Sprintf("Generate password for %s", genStore), genStore); err != nil {
 					return fmt.Errorf("auto-commit failed: %w", err)
 				}
 

--- a/cmd/get_test.go
+++ b/cmd/get_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	crud "github.com/danieljustus/symaira-vault/cmd/crud"
+	cli "github.com/danieljustus/symaira-vault/internal/cli"
 	clipboardapp "github.com/danieljustus/symaira-vault/internal/clipboard"
 	"github.com/danieljustus/symaira-vault/internal/config"
 	vaultpkg "github.com/danieljustus/symaira-vault/internal/vault"
@@ -20,10 +21,10 @@ func TestGetAutoClearDuration(t *testing.T) {
 		if runtime.GOOS == "windows" {
 			t.Skip("skipping on windows: HOME env behavior differs")
 		}
-		origVault := vault
+		origVault := cli.Vault
 		origFlagChanged := vaultFlag.Changed
 		defer func() {
-			vault = origVault
+			cli.Vault = origVault
 			vaultFlag.Changed = origFlagChanged
 		}()
 
@@ -32,9 +33,9 @@ func TestGetAutoClearDuration(t *testing.T) {
 		_ = os.Unsetenv("HOME")
 		_ = os.Unsetenv("OPENPASS_VAULT")
 
-		vault = "~/.symvault"
+		cli.Vault = "~/.symvault"
 
-		duration := getAutoClearDuration()
+		duration := crud.GetAutoClearDuration()
 		if duration != 30 {
 			t.Errorf("duration = %d, want 30", duration)
 		}
@@ -42,16 +43,16 @@ func TestGetAutoClearDuration(t *testing.T) {
 
 	t.Run("returns default when config file missing", func(t *testing.T) {
 		tmpDir := t.TempDir()
-		origVault := vault
+		origVault := cli.Vault
 		origFlagChanged := vaultFlag.Changed
 		defer func() {
-			vault = origVault
+			cli.Vault = origVault
 			vaultFlag.Changed = origFlagChanged
 		}()
 
-		vault = tmpDir
+		cli.Vault = tmpDir
 
-		duration := getAutoClearDuration()
+		duration := crud.GetAutoClearDuration()
 		if duration != 30 {
 			t.Errorf("duration = %d, want 30", duration)
 		}
@@ -68,16 +69,16 @@ func TestGetAutoClearDuration(t *testing.T) {
 			t.Fatalf("write config: %v", err)
 		}
 
-		origVault := vault
+		origVault := cli.Vault
 		origFlagChanged := vaultFlag.Changed
 		defer func() {
-			vault = origVault
+			cli.Vault = origVault
 			vaultFlag.Changed = origFlagChanged
 		}()
 
-		vault = tmpDir
+		cli.Vault = tmpDir
 
-		duration := getAutoClearDuration()
+		duration := crud.GetAutoClearDuration()
 		if duration != 30 {
 			t.Errorf("duration = %d, want 30", duration)
 		}
@@ -94,16 +95,16 @@ func TestGetAutoClearDuration(t *testing.T) {
 			t.Fatalf("write config: %v", err)
 		}
 
-		origVault := vault
+		origVault := cli.Vault
 		origFlagChanged := vaultFlag.Changed
 		defer func() {
-			vault = origVault
+			cli.Vault = origVault
 			vaultFlag.Changed = origFlagChanged
 		}()
 
-		vault = tmpDir
+		cli.Vault = tmpDir
 
-		duration := getAutoClearDuration()
+		duration := crud.GetAutoClearDuration()
 		if duration != 60 {
 			t.Errorf("duration = %d, want 60", duration)
 		}
@@ -122,16 +123,16 @@ func TestGetAutoClearDurationFromConfig(t *testing.T) {
 			t.Fatalf("write config: %v", err)
 		}
 
-		origVault := vault
+		origVault := cli.Vault
 		origFlagChanged := vaultFlag.Changed
 		defer func() {
-			vault = origVault
+			cli.Vault = origVault
 			vaultFlag.Changed = origFlagChanged
 		}()
 
-		vault = tmpDir
+		cli.Vault = tmpDir
 
-		duration := getAutoClearDuration()
+		duration := crud.GetAutoClearDuration()
 		if duration != 0 {
 			t.Errorf("duration = %d, want 0", duration)
 		}
@@ -148,16 +149,16 @@ func TestGetAutoClearDurationFromConfig(t *testing.T) {
 			t.Fatalf("write config: %v", err)
 		}
 
-		origVault := vault
+		origVault := cli.Vault
 		origFlagChanged := vaultFlag.Changed
 		defer func() {
-			vault = origVault
+			cli.Vault = origVault
 			vaultFlag.Changed = origFlagChanged
 		}()
 
-		vault = tmpDir
+		cli.Vault = tmpDir
 
-		duration := getAutoClearDuration()
+		duration := crud.GetAutoClearDuration()
 		if duration != 120 {
 			t.Errorf("duration = %d, want 120", duration)
 		}
@@ -343,10 +344,12 @@ func TestCmdGet_FieldTTY_DefaultClipboard(t *testing.T) {
 	defer setupVaultFlag(t, vaultDir)()
 	clipboardapp.SetClipboard(clipboardapp.NewNullClipboard())
 	t.Cleanup(func() { clipboardapp.SetClipboard(nil) })
+	crud.GetAutoClearDurationFunc = func() int { return 0 }
+	t.Cleanup(func() { crud.GetAutoClearDurationFunc = crud.GetAutoClearDuration })
 
-	oldIsTerminal := isTerminalFunc
-	isTerminalFunc = func(int) bool { return true }
-	defer func() { isTerminalFunc = oldIsTerminal }()
+	oldIsTerminal := cli.IsTerminalFunc
+	cli.IsTerminalFunc = func(int) bool { return true }
+	defer func() { cli.IsTerminalFunc = oldIsTerminal }()
 
 	var stdout string
 	var execErr error
@@ -372,6 +375,55 @@ func TestCmdGet_FieldTTY_DefaultClipboard(t *testing.T) {
 	}
 }
 
+func TestCmdGet_FieldTTY_AutoClearRunsBeforeReturn(t *testing.T) {
+	vaultDir, passphrase := initVault(t)
+	if err := os.WriteFile(filepath.Join(vaultDir, "config.yaml"), []byte("clipboard:\n  auto_clear_duration: 1\n"), 0o600); err != nil {
+		t.Fatalf("enable clipboard auto-clear: %v", err)
+	}
+	identity, _ := vaultpkg.OpenWithPassphrase(vaultDir, passphrase)
+	entry := &vaultpkg.Entry{Data: map[string]any{"password": "clear-before-return"}}
+	_ = vaultpkg.WriteEntry(vaultDir, "clear-entry", entry, identity.Identity)
+	setPassEnv(t, string(passphrase))
+	defer setupVaultFlag(t, vaultDir)()
+	clipboardapp.SetClipboard(clipboardapp.NewNullClipboard())
+	t.Cleanup(func() { clipboardapp.SetClipboard(nil) })
+	crud.GetAutoClearDurationFunc = func() int { return 1 }
+	t.Cleanup(func() { crud.GetAutoClearDurationFunc = crud.GetAutoClearDuration })
+
+	oldIsTerminal := cli.IsTerminalFunc
+	cli.IsTerminalFunc = func(int) bool { return true }
+	defer func() { cli.IsTerminalFunc = oldIsTerminal }()
+
+	cleared := false
+	crud.StartAutoClear = func(duration int, clearFn func(), cancelCh <-chan struct{}) {
+		if duration != 1 {
+			t.Fatalf("duration = %d, want 1", duration)
+		}
+		clearFn()
+		cleared = true
+	}
+	t.Cleanup(func() { crud.StartAutoClear = clipboardapp.StartAutoClear })
+
+	var execErr error
+	captureStderr(func() {
+		captureStdout(func() {
+			rootCmd.SetArgs([]string{"--vault", vaultDir, "get", "clear-entry.password"})
+			execErr = rootCmd.Execute()
+			rootCmd.SetArgs(nil)
+		})
+	})
+	if execErr != nil {
+		t.Fatalf("get command failed: %v", execErr)
+	}
+	if !cleared {
+		t.Fatal("auto-clear callback did not run before command returned")
+	}
+	copied, _ := clipboardapp.DefaultClipboard().Read()
+	if copied != "" {
+		t.Fatalf("clipboard = %q, want cleared", copied)
+	}
+}
+
 func TestCmdGet_FieldPipe_DefaultPrint(t *testing.T) {
 	vaultDir, passphrase := initVault(t)
 	identity, _ := vaultpkg.OpenWithPassphrase(vaultDir, passphrase)
@@ -380,9 +432,9 @@ func TestCmdGet_FieldPipe_DefaultPrint(t *testing.T) {
 	setPassEnv(t, string(passphrase))
 	defer setupVaultFlag(t, vaultDir)()
 
-	oldIsTerminal := isTerminalFunc
-	isTerminalFunc = func(int) bool { return false }
-	defer func() { isTerminalFunc = oldIsTerminal }()
+	oldIsTerminal := cli.IsTerminalFunc
+	cli.IsTerminalFunc = func(int) bool { return false }
+	defer func() { cli.IsTerminalFunc = oldIsTerminal }()
 
 	out := execWithStdout("--vault", vaultDir, "get", "pipe-entry.password")
 	if strings.TrimSpace(out) != "pipe-pass-456" {
@@ -398,9 +450,9 @@ func TestCmdGet_FieldPrintFlag_OverridesTTY(t *testing.T) {
 	setPassEnv(t, string(passphrase))
 	defer setupVaultFlag(t, vaultDir)()
 
-	oldIsTerminal := isTerminalFunc
-	isTerminalFunc = func(int) bool { return true }
-	defer func() { isTerminalFunc = oldIsTerminal }()
+	oldIsTerminal := cli.IsTerminalFunc
+	cli.IsTerminalFunc = func(int) bool { return true }
+	defer func() { cli.IsTerminalFunc = oldIsTerminal }()
 
 	out := execWithStdout("--vault", vaultDir, "get", "print-entry.password", "--print")
 	if strings.TrimSpace(out) != "print-pass-789" {

--- a/cmd/get_test.go
+++ b/cmd/get_test.go
@@ -424,6 +424,46 @@ func TestCmdGet_FieldTTY_AutoClearRunsBeforeReturn(t *testing.T) {
 	}
 }
 
+func TestCmdGet_FieldTTY_CopyByDefaultFalsePrints(t *testing.T) {
+	vaultDir, passphrase := initVault(t)
+	identity, _ := vaultpkg.OpenWithPassphrase(vaultDir, passphrase)
+	if err := os.WriteFile(filepath.Join(vaultDir, "config.yaml"), []byte("clipboard:\n  copyByDefault: false\n  auto_clear_duration: 0\n"), 0o600); err != nil {
+		t.Fatalf("write clipboard config: %v", err)
+	}
+	entry := &vaultpkg.Entry{Data: map[string]any{"password": "copy-default-disabled"}}
+	_ = vaultpkg.WriteEntry(vaultDir, "copy-config-entry", entry, identity.Identity)
+	setPassEnv(t, string(passphrase))
+	oldVaultFlagChanged := cli.VaultFlag.Changed
+	cli.VaultFlag.Changed = false
+	t.Cleanup(func() { cli.VaultFlag.Changed = oldVaultFlagChanged })
+	t.Setenv("OPENPASS_VAULT", vaultDir)
+	crud.GetAutoClearDurationFunc = func() int { return 0 }
+	t.Cleanup(func() { crud.GetAutoClearDurationFunc = crud.GetAutoClearDuration })
+	resolvedVaultDir, err := cli.VaultPath()
+	if err != nil {
+		t.Fatalf("VaultPath() error = %v", err)
+	}
+	if resolvedVaultDir != vaultDir {
+		t.Fatalf("VaultPath() = %q, want %q", resolvedVaultDir, vaultDir)
+	}
+	cfg, err := config.Load(filepath.Join(vaultDir, "config.yaml"))
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if cfg.Clipboard == nil || cfg.Clipboard.CopyByDefault {
+		t.Fatalf("CopyByDefault = %v, want false", cfg.Clipboard)
+	}
+
+	oldIsTerminal := cli.IsTerminalFunc
+	cli.IsTerminalFunc = func(int) bool { return true }
+	defer func() { cli.IsTerminalFunc = oldIsTerminal }()
+
+	out := execWithStdout("get", "copy-config-entry.password")
+	if strings.TrimSpace(out) != "copy-default-disabled" {
+		t.Fatalf("stdout = %q, want copy-default-disabled", out)
+	}
+}
+
 func TestCmdGet_FieldPipe_DefaultPrint(t *testing.T) {
 	vaultDir, passphrase := initVault(t)
 	identity, _ := vaultpkg.OpenWithPassphrase(vaultDir, passphrase)

--- a/cmd/test_state_test.go
+++ b/cmd/test_state_test.go
@@ -74,6 +74,8 @@ func resetCommandFlagGlobals() {
 	genSymbols = false
 	genStore = ""
 	crud.GetClipboard = clipboardapp.DefaultClipboard
+	crud.GetAutoClearDurationFunc = crud.GetAutoClearDuration
+	crud.StartAutoClear = clipboardapp.StartAutoClear
 	cli.OutputFormat = "text"
 }
 

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -124,6 +124,9 @@ update:
 clipboard:
   # Seconds before copied secrets are cleared. Set 0 to disable auto-clear.
   auto_clear_duration: 30
+  # Copy field values to the clipboard by default on a TTY.
+  # Set false to print to stdout unless --print is already supplied.
+  copyByDefault: true
 
 # Custom PII/secret scan patterns for the output sanitizer.
 # These are merged with built-in defaults and compiled at runtime.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -118,6 +118,7 @@ Keychain item when Touch ID is enabled.
 | Option | Default | Description |
 |--------|---------|-------------|
 | `auto_clear_duration` | `30` | Seconds before copied secrets are cleared; `0` disables auto-clear |
+| `copyByDefault` | `true` | Copy field values to the clipboard by default on a TTY; set `false` to print to stdout |
 
 ## Logging Config Options
 

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -203,6 +203,12 @@ MCP server could in principle alter them. See backlog item O-10.
   (`map[issuer:GitHub secret:JBSW...]`).
 - **No fmt-leaks.** `Untrusted` panics in fmt verbs so accidental
   `Sprintf("%v", secret)` is impossible to land in production.
+- **Pseudonymized list cache stripping.** When `pseudonymize_paths` is
+  enabled, the list cache stores paths and only non-secret entry data.
+  Entries containing password, secret, token, key, OTP, or PIN-style field
+  names are omitted from cached entry data, so later value searches
+  re-decrypt the single matching entry instead of retaining those secrets
+  in heap memory for the cache TTL.
 
 ### In-memory passphrase security and Go runtime constraints
 

--- a/internal/config/config_merge.go
+++ b/internal/config/config_merge.go
@@ -4,8 +4,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sync/atomic"
 	"time"
 )
+
+var clipboardPrintByDefaultWarningEmitted atomic.Bool
 
 func mergeStringPtr(dst, src *string) *string {
 	if src != nil {
@@ -415,8 +418,13 @@ func mergeClipboardConfig(raw *ClipboardConfig, sf map[string]bool) *ClipboardCo
 	if sf["auto_clear_duration"] {
 		defaults.AutoClearDuration = raw.AutoClearDuration
 	}
-	if sf["printByDefault"] {
-		defaults.PrintByDefault = raw.PrintByDefault
+	if sf["copyByDefault"] {
+		defaults.CopyByDefault = raw.CopyByDefault
+	} else if sf["printByDefault"] {
+		if !clipboardPrintByDefaultWarningEmitted.Swap(true) {
+			fmt.Fprintln(os.Stderr, "Warning: clipboard.printByDefault is deprecated; use clipboard.copyByDefault instead")
+		}
+		defaults.CopyByDefault = raw.PrintByDefault
 	}
 	return &defaults
 }

--- a/internal/config/config_save.go
+++ b/internal/config/config_save.go
@@ -134,7 +134,7 @@ func (c *Config) SaveTo(path string) error {
 	if c.Clipboard != nil {
 		raw.Clipboard = &ClipboardConfig{
 			AutoClearDuration: c.Clipboard.AutoClearDuration,
-			PrintByDefault:    c.Clipboard.PrintByDefault,
+			CopyByDefault:     c.Clipboard.CopyByDefault,
 		}
 	}
 	if c.Audit != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -1253,6 +1254,60 @@ func TestLoad_ClipboardWithAutoClearDuration(t *testing.T) {
 	}
 	if cfg.Clipboard.AutoClearDuration != 0 {
 		t.Errorf("Clipboard.AutoClearDuration = %d, want 0 (disabled)", cfg.Clipboard.AutoClearDuration)
+	}
+}
+
+func TestLoad_ClipboardCopyByDefault(t *testing.T) {
+	yaml := `clipboard:
+  copyByDefault: false
+`
+	path := writeTempFile(t, []byte(yaml))
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.Clipboard == nil {
+		t.Fatal("Clipboard should not be nil")
+	}
+	if cfg.Clipboard.CopyByDefault {
+		t.Fatal("Clipboard.CopyByDefault = true, want false")
+	}
+}
+
+func TestLoad_ClipboardPrintByDefaultDeprecatedAlias(t *testing.T) {
+	clipboardPrintByDefaultWarningEmitted.Store(false)
+	t.Cleanup(func() { clipboardPrintByDefaultWarningEmitted.Store(false) })
+
+	yaml := `clipboard:
+  printByDefault: false
+`
+	path := writeTempFile(t, []byte(yaml))
+
+	origStderr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("stderr pipe: %v", err)
+	}
+	os.Stderr = w
+
+	cfg, loadErr := Load(path)
+	_ = w.Close()
+	os.Stderr = origStderr
+	output, readErr := io.ReadAll(r)
+	if readErr != nil {
+		t.Fatalf("read stderr: %v", readErr)
+	}
+	if loadErr != nil {
+		t.Fatalf("Load() error = %v", loadErr)
+	}
+	if cfg.Clipboard == nil {
+		t.Fatal("Clipboard should not be nil")
+	}
+	if cfg.Clipboard.CopyByDefault {
+		t.Fatal("Clipboard.CopyByDefault = true, want false from deprecated alias")
+	}
+	if !strings.Contains(string(output), "clipboard.printByDefault is deprecated") {
+		t.Fatalf("stderr = %q, want deprecation warning", string(output))
 	}
 }
 
@@ -2778,7 +2833,7 @@ func TestRoundTrip_AllFieldsSet(t *testing.T) {
 		},
 		Clipboard: &ClipboardConfig{
 			AutoClearDuration: 45,
-			PrintByDefault:    false,
+			CopyByDefault:     false,
 		},
 		Audit: &AuditConfig{
 			MaxFileSize: 50 * 1024 * 1024,

--- a/internal/config/dottedpath.go
+++ b/internal/config/dottedpath.go
@@ -109,6 +109,7 @@ func KnownConfigKeys() []string {
 		// Clipboard
 		"clipboard",
 		"clipboard.auto_clear_duration",
+		"clipboard.copyByDefault",
 
 		// Audit
 		"audit",

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -82,6 +82,7 @@ type UpdateConfig struct {
 // ClipboardConfig holds clipboard-related configuration.
 type ClipboardConfig struct {
 	AutoClearDuration int  `yaml:"auto_clear_duration,omitempty"`
+	CopyByDefault     bool `yaml:"copyByDefault,omitempty"`
 	PrintByDefault    bool `yaml:"printByDefault,omitempty"`
 }
 
@@ -169,7 +170,7 @@ func defaultUpdateConfig() UpdateConfig {
 func defaultClipboardConfig() ClipboardConfig {
 	return ClipboardConfig{
 		AutoClearDuration: 30,
-		PrintByDefault:    true,
+		CopyByDefault:     true,
 	}
 }
 
@@ -392,8 +393,8 @@ func MergeFromClipboard(dst *ClipboardConfig, src ClipboardConfig) {
 	if src.AutoClearDuration > 0 {
 		dst.AutoClearDuration = src.AutoClearDuration
 	}
-	if src.PrintByDefault {
-		dst.PrintByDefault = true
+	if src.CopyByDefault {
+		dst.CopyByDefault = true
 	}
 }
 

--- a/internal/config/schema_test.go
+++ b/internal/config/schema_test.go
@@ -295,6 +295,9 @@ func TestDefaultClipboardConfig(t *testing.T) {
 	if cfg.AutoClearDuration != 30 {
 		t.Errorf("AutoClearDuration should be 30, got %d", cfg.AutoClearDuration)
 	}
+	if !cfg.CopyByDefault {
+		t.Error("CopyByDefault should default to true")
+	}
 }
 
 func TestMergeFromClipboardConfig(t *testing.T) {

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -63,10 +63,11 @@ type SyncResult struct {
 
 // CommitOptions holds options for committing
 type CommitOptions struct {
-	Message  string
-	Template string
-	Author   string
-	Email    string
+	Message       string
+	Template      string
+	Author        string
+	Email         string
+	AffectedPaths []string
 }
 
 // DefaultCommitTemplate is the default commit message template
@@ -165,21 +166,28 @@ func AutoCommitWithOptions(vaultDir string, opts CommitOptions) error {
 		return gitignoreErr
 	}
 
-	if addErr := w.AddWithOptions(&gogit.AddOptions{All: true}); addErr != nil {
-		return addErr
+	if len(opts.AffectedPaths) > 0 {
+		if addErr := stageAffectedPaths(repo, w, vaultDir, opts.AffectedPaths); addErr != nil {
+			return addErr
+		}
+	} else {
+		if addErr := w.AddWithOptions(&gogit.AddOptions{All: true}); addErr != nil {
+			return addErr
+		}
 	}
 
 	status, statusErr := w.Status()
 	if statusErr != nil {
 		return nil
 	}
-	if unstageErr := unstageProtectedRuntimeArtifacts(repo, w, status); unstageErr != nil {
+	unstaged, unstageErr := unstageProtectedRuntimeArtifacts(repo, w, status)
+	if unstageErr != nil {
 		return unstageErr
 	}
-
-	status, statusErr = w.Status()
-	if statusErr != nil {
-		return nil
+	for _, path := range unstaged {
+		fileStatus := status[path]
+		fileStatus.Staging = gogit.Unmodified
+		status[path] = fileStatus
 	}
 	if !hasStagedChanges(status) {
 		return nil
@@ -265,7 +273,61 @@ func hasStagedChanges(status gogit.Status) bool {
 	return false
 }
 
-func unstageProtectedRuntimeArtifacts(repo *gogit.Repository, w *gogit.Worktree, status gogit.Status) error {
+func stageAffectedPaths(repo *gogit.Repository, w *gogit.Worktree, vaultDir string, paths []string) error {
+	seen := make(map[string]bool, len(paths)+1)
+	for _, path := range append(paths, ".gitignore") {
+		normalized, ok, err := normalizeAffectedPath(path)
+		if err != nil {
+			return err
+		}
+		if !ok || seen[normalized] || isProtectedRuntimePath(normalized) {
+			continue
+		}
+		seen[normalized] = true
+
+		fullPath := filepath.Join(vaultDir, filepath.FromSlash(normalized))
+		if _, err := os.Lstat(fullPath); err != nil {
+			if os.IsNotExist(err) {
+				if removeErr := removeFromIndex(repo, normalized); removeErr != nil {
+					return removeErr
+				}
+				continue
+			}
+			return err
+		}
+		if err := w.AddWithOptions(&gogit.AddOptions{Path: normalized, SkipStatus: true}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func normalizeAffectedPath(path string) (string, bool, error) {
+	if filepath.IsAbs(path) {
+		return "", false, fmt.Errorf("affected path %q must be relative", path)
+	}
+	normalized := filepath.ToSlash(filepath.Clean(path))
+	if normalized == "." || normalized == "" {
+		return "", false, nil
+	}
+	if normalized == ".." || strings.HasPrefix(normalized, "../") {
+		return "", false, fmt.Errorf("affected path %q escapes repository", path)
+	}
+	return normalized, true, nil
+}
+
+func removeFromIndex(repo *gogit.Repository, path string) error {
+	idx, err := repo.Storer.Index()
+	if err != nil {
+		return err
+	}
+	if _, err := idx.Remove(path); err != nil {
+		return nil
+	}
+	return repo.Storer.SetIndex(idx)
+}
+
+func unstageProtectedRuntimeArtifacts(repo *gogit.Repository, w *gogit.Worktree, status gogit.Status) ([]string, error) {
 	var staged []string
 	for path, fileStatus := range status {
 		if !isProtectedRuntimePath(path) {
@@ -276,21 +338,21 @@ func unstageProtectedRuntimeArtifacts(repo *gogit.Repository, w *gogit.Worktree,
 		}
 	}
 	if len(staged) == 0 {
-		return nil
+		return nil, nil
 	}
 
 	if _, err := repo.Head(); err == nil {
-		return w.Reset(&gogit.ResetOptions{Mode: gogit.MixedReset, Files: staged})
+		return staged, w.Reset(&gogit.ResetOptions{Mode: gogit.MixedReset, Files: staged})
 	}
 
 	idx, err := repo.Storer.Index()
 	if err != nil {
-		return err
+		return nil, err
 	}
 	for _, path := range staged {
 		_, _ = idx.Remove(path)
 	}
-	return repo.Storer.SetIndex(idx)
+	return staged, repo.Storer.SetIndex(idx)
 }
 
 func isProtectedRuntimePath(path string) bool {
@@ -458,8 +520,13 @@ func classifyPushError(err error) *PushError {
 
 // AutoCommitAndPush performs auto-commit and optionally auto-push
 func AutoCommitAndPush(vaultDir string, message string, autoPush bool) error {
+	return AutoCommitAndPushWithOptions(vaultDir, CommitOptions{Message: message}, autoPush)
+}
+
+// AutoCommitAndPushWithOptions performs auto-commit with options and optionally auto-push.
+func AutoCommitAndPushWithOptions(vaultDir string, opts CommitOptions, autoPush bool) error {
 	// Perform commit
-	if err := AutoCommit(vaultDir, message); err != nil {
+	if err := AutoCommitWithOptions(vaultDir, opts); err != nil {
 		return fmt.Errorf("commit failed: %w", err)
 	}
 

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -252,6 +252,132 @@ func TestAutoCommitDoesNotCommitRuntimeArtifacts(t *testing.T) {
 	}
 }
 
+func TestAutoCommitWithOptionsAffectedPathsStagesOnlyKnownPath(t *testing.T) {
+	dir := t.TempDir()
+	if err := Init(dir); err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "entries"), 0o700); err != nil {
+		t.Fatalf("mkdir entries: %v", err)
+	}
+
+	writeFile(t, dir, "entries/a.age", []byte("a-1"))
+	writeFile(t, dir, "entries/b.age", []byte("b-1"))
+	if err := AutoCommit(dir, "initial"); err != nil {
+		t.Fatalf("AutoCommit() error = %v", err)
+	}
+
+	writeFile(t, dir, "entries/a.age", []byte("a-2"))
+	writeFile(t, dir, "entries/b.age", []byte("b-2"))
+	if err := AutoCommitWithOptions(dir, CommitOptions{
+		Message:       "update a",
+		AffectedPaths: []string{"entries/a.age"},
+	}); err != nil {
+		t.Fatalf("AutoCommitWithOptions() error = %v", err)
+	}
+
+	repo, err := gogit.PlainOpen(dir)
+	if err != nil {
+		t.Fatalf("open repo: %v", err)
+	}
+	ref, err := repo.Head()
+	if err != nil {
+		t.Fatalf("repo.Head(): %v", err)
+	}
+	commit, err := repo.CommitObject(ref.Hash())
+	if err != nil {
+		t.Fatalf("CommitObject(): %v", err)
+	}
+	aFile, err := commit.File("entries/a.age")
+	if err != nil {
+		t.Fatalf("commit missing entries/a.age: %v", err)
+	}
+	aContents, err := aFile.Contents()
+	if err != nil {
+		t.Fatalf("read committed a: %v", err)
+	}
+	if aContents != "a-2" {
+		t.Fatalf("committed a = %q, want a-2", aContents)
+	}
+	bFile, err := commit.File("entries/b.age")
+	if err != nil {
+		t.Fatalf("commit missing entries/b.age: %v", err)
+	}
+	bContents, err := bFile.Contents()
+	if err != nil {
+		t.Fatalf("read committed b: %v", err)
+	}
+	if bContents != "b-1" {
+		t.Fatalf("committed b = %q, want unchanged b-1", bContents)
+	}
+
+	w, err := repo.Worktree()
+	if err != nil {
+		t.Fatalf("Worktree(): %v", err)
+	}
+	status, err := w.Status()
+	if err != nil {
+		t.Fatalf("Status(): %v", err)
+	}
+	if got := status.File("entries/b.age").Worktree; got == gogit.Unmodified {
+		t.Fatalf("entries/b.age worktree status = %v, want modified", got)
+	}
+}
+
+func TestAutoCommitWithOptionsAffectedPathsStagesDeletionOnly(t *testing.T) {
+	dir := t.TempDir()
+	if err := Init(dir); err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "entries"), 0o700); err != nil {
+		t.Fatalf("mkdir entries: %v", err)
+	}
+
+	writeFile(t, dir, "entries/a.age", []byte("a-1"))
+	writeFile(t, dir, "entries/b.age", []byte("b-1"))
+	if err := AutoCommit(dir, "initial"); err != nil {
+		t.Fatalf("AutoCommit() error = %v", err)
+	}
+
+	if err := os.Remove(filepath.Join(dir, "entries/a.age")); err != nil {
+		t.Fatalf("remove entries/a.age: %v", err)
+	}
+	writeFile(t, dir, "entries/b.age", []byte("b-2"))
+	if err := AutoCommitWithOptions(dir, CommitOptions{
+		Message:       "delete a",
+		AffectedPaths: []string{"entries/a.age"},
+	}); err != nil {
+		t.Fatalf("AutoCommitWithOptions() error = %v", err)
+	}
+
+	repo, err := gogit.PlainOpen(dir)
+	if err != nil {
+		t.Fatalf("open repo: %v", err)
+	}
+	ref, err := repo.Head()
+	if err != nil {
+		t.Fatalf("repo.Head(): %v", err)
+	}
+	commit, err := repo.CommitObject(ref.Hash())
+	if err != nil {
+		t.Fatalf("CommitObject(): %v", err)
+	}
+	if _, err := commit.File("entries/a.age"); err == nil {
+		t.Fatal("entries/a.age should be deleted in commit")
+	}
+	bFile, err := commit.File("entries/b.age")
+	if err != nil {
+		t.Fatalf("commit missing entries/b.age: %v", err)
+	}
+	bContents, err := bFile.Contents()
+	if err != nil {
+		t.Fatalf("read committed b: %v", err)
+	}
+	if bContents != "b-1" {
+		t.Fatalf("committed b = %q, want unchanged b-1", bContents)
+	}
+}
+
 func TestAutoCommitAndPush_NoAutoPush(t *testing.T) {
 	local := t.TempDir()
 	if err := Init(local); err != nil {
@@ -1565,8 +1691,12 @@ func TestUnstageProtectedRuntimeArtifactsDirect(t *testing.T) {
 		t.Fatalf("Status(): %v", err)
 	}
 
-	if err := unstageProtectedRuntimeArtifacts(repo, w, status); err != nil {
+	unstaged, err := unstageProtectedRuntimeArtifacts(repo, w, status)
+	if err != nil {
 		t.Fatalf("unstageProtectedRuntimeArtifacts(): %v", err)
+	}
+	if len(unstaged) != 1 || unstaged[0] != "mcp-token" {
+		t.Fatalf("unstaged = %v, want [mcp-token]", unstaged)
 	}
 
 	status2, err := w.Status()
@@ -1606,8 +1736,12 @@ func TestUnstageProtectedRuntimeArtifactsNoHead(t *testing.T) {
 		t.Fatalf("Status(): %v", err)
 	}
 
-	if err := unstageProtectedRuntimeArtifacts(repo, w, status); err != nil {
+	unstaged, err := unstageProtectedRuntimeArtifacts(repo, w, status)
+	if err != nil {
 		t.Fatalf("unstageProtectedRuntimeArtifacts(): %v", err)
+	}
+	if len(unstaged) != 1 || unstaged[0] != "mcp-token" {
+		t.Fatalf("unstaged = %v, want [mcp-token]", unstaged)
 	}
 
 	status2, err := w.Status()

--- a/internal/secureedit/secureedit.go
+++ b/internal/secureedit/secureedit.go
@@ -1,0 +1,163 @@
+package secureedit
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/danieljustus/symaira-vault/internal/secrets"
+	vaultpkg "github.com/danieljustus/symaira-vault/internal/vault"
+)
+
+type Streams struct {
+	Stdin  io.Reader
+	Stdout io.Writer
+	Stderr io.Writer
+}
+
+var CreateTemp = os.CreateTemp
+
+func DefaultStreams() Streams {
+	return Streams{
+		Stdin:  os.Stdin,
+		Stdout: os.Stdout,
+		Stderr: os.Stderr,
+	}
+}
+
+func EditEntry(entry *vaultpkg.Entry, preferredEditor string, streams Streams) (*vaultpkg.Entry, error) {
+	if entry == nil {
+		return nil, fmt.Errorf("nil entry")
+	}
+
+	tmp, err := CreateTemp("", "symvault-edit-*.json")
+	if err != nil {
+		return nil, fmt.Errorf("create temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer func() { _ = SecureDeleteFile(tmpPath) }()
+
+	if err := os.Chmod(tmpPath, 0o600); err != nil {
+		_ = tmp.Close()
+		return nil, fmt.Errorf("set temp file permissions: %w", err)
+	}
+
+	encoder := json.NewEncoder(tmp)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(entry); err != nil {
+		_ = tmp.Close()
+		return nil, fmt.Errorf("encode entry: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return nil, fmt.Errorf("close temp file: %w", err)
+	}
+
+	editor, err := ResolveEditor(preferredEditor)
+	if err != nil {
+		return nil, err
+	}
+
+	//#nosec G204 -- editor path validated via exec.LookPath in ResolveEditor.
+	cmd := exec.Command(editor, tmpPath)
+	secrets.PrepareCmd(cmd)
+	cmd.Stdin = streams.Stdin
+	cmd.Stdout = streams.Stdout
+	cmd.Stderr = streams.Stderr
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("editor failed: %w", err)
+	}
+
+	data, err := os.ReadFile(filepath.Clean(tmpPath)) //#nosec G304 -- tmpPath was created by this process.
+	if err != nil {
+		return nil, fmt.Errorf("read edited file: %w", err)
+	}
+	data = bytes.TrimSpace(data)
+	if len(data) == 0 {
+		return nil, fmt.Errorf("empty file, changes discarded")
+	}
+
+	var edited vaultpkg.Entry
+	if err := json.Unmarshal(data, &edited); err != nil {
+		return nil, fmt.Errorf("invalid JSON: %w", err)
+	}
+	if edited.Data == nil {
+		edited.Data = map[string]any{}
+	}
+	return &edited, nil
+}
+
+func ResolveEditor(preferred string) (string, error) {
+	if preferred != "" {
+		return resolveEditorPath(preferred)
+	}
+
+	if envEditor := os.Getenv("EDITOR"); envEditor != "" {
+		return resolveEditorPath(envEditor)
+	}
+
+	candidates := []string{"vim", "nano", "vi"}
+	for _, candidate := range candidates {
+		if path, err := exec.LookPath(candidate); err == nil {
+			return path, nil
+		}
+	}
+	return "", fmt.Errorf("no editor found on PATH (tried %v); set $EDITOR to a valid editor", candidates)
+}
+
+func resolveEditorPath(editor string) (string, error) {
+	path, err := exec.LookPath(editor)
+	if err != nil {
+		return "", fmt.Errorf("editor %q not found in PATH", editor)
+	}
+	return path, nil
+}
+
+func SecureDeleteFile(path string) error {
+	f, err := os.OpenFile(path, os.O_WRONLY, 0) //#nosec G304 -- path comes from CreateTemp in EditEntry.
+	if err != nil {
+		_ = os.Remove(path)
+		return err
+	}
+	defer func() { _ = f.Close() }()
+
+	fi, err := f.Stat()
+	if err != nil {
+		_ = f.Close()
+		_ = os.Remove(path)
+		return err
+	}
+
+	zeros := make([]byte, 4096)
+	remaining := fi.Size()
+	for remaining > 0 {
+		chunk := zeros
+		if remaining < int64(len(chunk)) {
+			chunk = chunk[:remaining]
+		}
+		n, err := f.Write(chunk)
+		if err != nil {
+			_ = f.Close()
+			_ = os.Remove(path)
+			return err
+		}
+		if n == 0 {
+			_ = f.Close()
+			_ = os.Remove(path)
+			return io.ErrShortWrite
+		}
+		remaining -= int64(n)
+	}
+
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		_ = os.Remove(path)
+		return err
+	}
+
+	_ = f.Close()
+	return os.Remove(path)
+}

--- a/internal/secureedit/secureedit.go
+++ b/internal/secureedit/secureedit.go
@@ -1,3 +1,5 @@
+// Package secureedit provides secure editing and deletion of temporary files
+// used during the interactive entry editing workflow.
 package secureedit
 
 import (
@@ -41,18 +43,18 @@ func EditEntry(entry *vaultpkg.Entry, preferredEditor string, streams Streams) (
 	tmpPath := tmp.Name()
 	defer func() { _ = SecureDeleteFile(tmpPath) }()
 
-	if err := os.Chmod(tmpPath, 0o600); err != nil {
+	if err = os.Chmod(tmpPath, 0o600); err != nil {
 		_ = tmp.Close()
 		return nil, fmt.Errorf("set temp file permissions: %w", err)
 	}
 
 	encoder := json.NewEncoder(tmp)
 	encoder.SetIndent("", "  ")
-	if err := encoder.Encode(entry); err != nil {
+	if err = encoder.Encode(entry); err != nil {
 		_ = tmp.Close()
 		return nil, fmt.Errorf("encode entry: %w", err)
 	}
-	if err := tmp.Close(); err != nil {
+	if err = tmp.Close(); err != nil {
 		return nil, fmt.Errorf("close temp file: %w", err)
 	}
 
@@ -67,7 +69,7 @@ func EditEntry(entry *vaultpkg.Entry, preferredEditor string, streams Streams) (
 	cmd.Stdin = streams.Stdin
 	cmd.Stdout = streams.Stdout
 	cmd.Stderr = streams.Stderr
-	if err := cmd.Run(); err != nil {
+	if err = cmd.Run(); err != nil {
 		return nil, fmt.Errorf("editor failed: %w", err)
 	}
 

--- a/internal/secureedit/secureedit_test.go
+++ b/internal/secureedit/secureedit_test.go
@@ -1,0 +1,51 @@
+package secureedit
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	vaultpkg "github.com/danieljustus/symaira-vault/internal/vault"
+)
+
+func TestEditEntrySecurelyDeletesTempFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell editor fixture is Unix-only")
+	}
+
+	origCreateTemp := CreateTemp
+	var tmpPath string
+	CreateTemp = func(dir, pattern string) (*os.File, error) {
+		f, err := origCreateTemp(dir, pattern)
+		if err == nil {
+			tmpPath = f.Name()
+		}
+		return f, err
+	}
+	t.Cleanup(func() { CreateTemp = origCreateTemp })
+
+	editor := filepath.Join(t.TempDir(), "editor")
+	script := `#!/bin/sh
+cat > "$1" <<'EOF'
+{"data":{"password":"edited"}}
+EOF
+`
+	if err := os.WriteFile(editor, []byte(script), 0o755); err != nil {
+		t.Fatalf("write editor: %v", err)
+	}
+
+	edited, err := EditEntry(&vaultpkg.Entry{Data: map[string]any{"password": "original"}}, editor, Streams{})
+	if err != nil {
+		t.Fatalf("EditEntry() error = %v", err)
+	}
+	if edited.Data["password"] != "edited" {
+		t.Fatalf("password = %v, want edited", edited.Data["password"])
+	}
+	if tmpPath == "" {
+		t.Fatal("temp path was not captured")
+	}
+	if _, err := os.Stat(tmpPath); !os.IsNotExist(err) {
+		t.Fatalf("temp file still exists after edit: %v", err)
+	}
+}

--- a/internal/ui/tui.go
+++ b/internal/ui/tui.go
@@ -2,11 +2,8 @@
 package ui
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
-	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -19,7 +16,7 @@ import (
 
 	clipboardapp "github.com/danieljustus/symaira-vault/internal/clipboard"
 	vaultcrypto "github.com/danieljustus/symaira-vault/internal/crypto"
-	"github.com/danieljustus/symaira-vault/internal/secrets"
+	"github.com/danieljustus/symaira-vault/internal/secureedit"
 	render "github.com/danieljustus/symaira-vault/internal/ui/render"
 	theme "github.com/danieljustus/symaira-vault/internal/ui/theme"
 	vaultpkg "github.com/danieljustus/symaira-vault/internal/vault"
@@ -846,118 +843,17 @@ func editEntryCmd(vault *vaultpkg.Vault, path string) tea.Cmd {
 			return entryEditedMsg{path: path, err: err}
 		}
 
-		tmp, err := os.CreateTemp("", "symvault-*.json")
+		edited, err := secureedit.EditEntry(entry, os.Getenv("EDITOR"), secureedit.DefaultStreams())
 		if err != nil {
 			return entryEditedMsg{path: path, err: err}
 		}
-		tmpPath := tmp.Name()
-		defer func() { _ = secureDeleteFile(tmpPath) }()
-
-		encoder := json.NewEncoder(tmp)
-		encoder.SetIndent("", "  ")
-		if encErr := encoder.Encode(entry); encErr != nil {
-			_ = tmp.Close()
-			return entryEditedMsg{path: path, err: encErr}
-		}
-		if closeErr := tmp.Close(); closeErr != nil {
-			return entryEditedMsg{path: path, err: closeErr}
-		}
-
-		editor, editorErr := resolveEditor(os.Getenv("EDITOR"))
-		if editorErr != nil {
-			return entryEditedMsg{path: path, err: editorErr}
-		}
-		cmd := exec.Command(editor, tmpPath) //#nosec G204 G702 -- editor path resolved via exec.LookPath above.
-		secrets.PrepareCmd(cmd)
-		cmd.Stdin = os.Stdin
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-		if runErr := cmd.Run(); runErr != nil {
-			return entryEditedMsg{path: path, err: fmt.Errorf("run editor: %w", runErr)}
-		}
-
-		data, err := os.ReadFile(filepath.Clean(tmpPath)) //#nosec G304 -- tmpPath was created by this process.
-		if err != nil {
-			return entryEditedMsg{path: path, err: err}
-		}
-		var edited vaultpkg.Entry
-		if err := json.Unmarshal(data, &edited); err != nil {
-			return entryEditedMsg{path: path, err: fmt.Errorf("parse edited entry: %w", err)}
-		}
-		if edited.Data == nil {
-			return entryEditedMsg{path: path, err: fmt.Errorf("edited entry must contain data")}
-		}
-		if err := vaultpkg.WriteEntryWithRecipients(vault.Dir, path, &edited, vault.Identity); err != nil {
+		if err := vaultpkg.WriteEntryWithRecipients(vault.Dir, path, edited, vault.Identity); err != nil {
 			return entryEditedMsg{path: path, err: err}
 		}
 		_ = vault.AutoCommit(fmt.Sprintf("Edit %s", path))
 		vault.Cache.Invalidate()
 		return entryEditedMsg{path: path}
 	}
-}
-
-// resolveEditor returns an absolute path to a usable editor binary. It tries
-// the user-provided value (typically $EDITOR) first, then falls back to a
-// short list of common editors. Returns an error if none are found on PATH.
-func resolveEditor(preferred string) (string, error) {
-	candidates := make([]string, 0, 4)
-	if preferred != "" {
-		candidates = append(candidates, preferred)
-	}
-	candidates = append(candidates, "vim", "nano", "vi")
-	for _, c := range candidates {
-		if path, err := exec.LookPath(c); err == nil {
-			return path, nil
-		}
-	}
-	return "", fmt.Errorf("no editor found on PATH (tried %v); set $EDITOR to a valid editor", candidates)
-}
-
-// secureDeleteFile overwrites the file at path with zeros, syncs it, and
-// then removes it. If overwriting fails, removal is still attempted to
-// avoid leaving temporary files behind.
-func secureDeleteFile(path string) error {
-	f, err := os.OpenFile(path, os.O_WRONLY, 0) //#nosec G304 -- path comes from tmp.Name() in the same function
-	if err != nil {
-		// Cannot open, but still try to remove.
-		_ = os.Remove(path)
-		return err
-	}
-	defer func() { _ = f.Close() }()
-
-	fi, err := f.Stat()
-	if err != nil {
-		_ = f.Close()
-		_ = os.Remove(path)
-		return err
-	}
-
-	size := fi.Size()
-	zeros := make([]byte, 4096)
-	remaining := size
-	for remaining > 0 {
-		chunk := zeros
-		if remaining < int64(len(chunk)) {
-			chunk = chunk[:remaining]
-		}
-		n, werr := f.Write(chunk)
-		if werr != nil {
-			_ = f.Close()
-			_ = os.Remove(path)
-			return werr
-		}
-		remaining -= int64(n)
-	}
-
-	if serr := f.Sync(); serr != nil {
-		_ = f.Close()
-		_ = os.Remove(path)
-		return serr
-	}
-
-	// Close before remove on some platforms (Windows).
-	_ = f.Close()
-	return os.Remove(path)
 }
 
 func fuzzyMatch(query, value string) bool {

--- a/internal/ui/tui.go
+++ b/internal/ui/tui.go
@@ -830,7 +830,7 @@ func deleteEntryCmd(vault *vaultpkg.Vault, path string) tea.Cmd {
 		if err != nil {
 			return entryDeletedMsg{path: path, err: err}
 		}
-		_ = vault.AutoCommit(fmt.Sprintf("Delete %s", path))
+		_ = vault.AutoCommitEntry(fmt.Sprintf("Delete %s", path), path)
 		vault.Cache.Invalidate()
 		return entryDeletedMsg{path: path}
 	}
@@ -850,7 +850,7 @@ func editEntryCmd(vault *vaultpkg.Vault, path string) tea.Cmd {
 		if err := vaultpkg.WriteEntryWithRecipients(vault.Dir, path, edited, vault.Identity); err != nil {
 			return entryEditedMsg{path: path, err: err}
 		}
-		_ = vault.AutoCommit(fmt.Sprintf("Edit %s", path))
+		_ = vault.AutoCommitEntry(fmt.Sprintf("Edit %s", path), path)
 		vault.Cache.Invalidate()
 		return entryEditedMsg{path: path}
 	}

--- a/internal/ui/tui.go
+++ b/internal/ui/tui.go
@@ -56,9 +56,15 @@ const (
 )
 
 type entryLoadedMsg struct {
-	path  string
-	entry *vaultpkg.Entry
-	err   error
+	requestID uint64
+	path      string
+	entry     *vaultpkg.Entry
+	err       error
+}
+
+type entryLoadRequestedMsg struct {
+	requestID uint64
+	path      string
 }
 
 type entriesLoadedMsg struct {
@@ -118,6 +124,7 @@ type TUIModel struct {
 	revealed       bool
 	help           bool
 	loading        bool
+	detailRequest  uint64
 
 	sortMode  int // 0=name-asc, 1=name-desc, 2=updated-asc, 3=updated-desc
 	filterTag string
@@ -135,6 +142,7 @@ type TUIModel struct {
 
 var (
 	writeClipboard = clipboard.WriteAll
+	detailDebounce = 100 * time.Millisecond
 
 	appStyle = lipgloss.NewStyle().Padding(1, 2)
 
@@ -213,17 +221,23 @@ func (m TUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.applyFilter()
 		m.status = fmt.Sprintf("%d entries", len(m.entries))
 		return m, m.loadSelectedEntry()
+	case entryLoadRequestedMsg:
+		if msg.requestID != m.detailRequest || msg.path != m.selectedPath() {
+			return m, nil
+		}
+		return m, loadEntryCmd(m.vault, msg.path, msg.requestID)
 	case entryLoadedMsg:
+		if msg.requestID != m.detailRequest || msg.path != m.selectedPath() {
+			return m, nil
+		}
 		if msg.err != nil {
 			m.err = msg.err
 			m.status = "Could not read entry"
 			return m, nil
 		}
-		if msg.path == m.selectedPath() {
-			m.entry = msg.entry
-			m.entryFor = msg.path
-			m.err = nil
-		}
+		m.entry = msg.entry
+		m.entryFor = msg.path
+		m.err = nil
 		return m, nil
 	case copiedMsg:
 		if msg.err != nil {
@@ -428,23 +442,23 @@ func (m TUIModel) handleKey(msg tea.KeyMsg) (TUIModel, tea.Cmd) {
 		if m.selected > 0 {
 			m.selected--
 			m.clipboardSeconds = 0
-			return m, m.loadSelectedEntry()
+			return m, m.debounceSelectedEntry()
 		}
 	case "down", "j":
 		if m.selected < len(m.filtered)-1 {
 			m.selected++
 			m.clipboardSeconds = 0
-			return m, m.loadSelectedEntry()
+			return m, m.debounceSelectedEntry()
 		}
 	case "home":
 		m.selected = 0
 		m.clipboardSeconds = 0
-		return m, m.loadSelectedEntry()
+		return m, m.debounceSelectedEntry()
 	case "end":
 		if len(m.filtered) > 0 {
 			m.selected = len(m.filtered) - 1
 			m.clipboardSeconds = 0
-			return m, m.loadSelectedEntry()
+			return m, m.debounceSelectedEntry()
 		}
 	case "enter":
 		return m, m.copySelectedPassword()
@@ -570,12 +584,33 @@ func (m TUIModel) sortLabel() string {
 	}
 }
 
-func (m TUIModel) loadSelectedEntry() tea.Cmd {
+func (m *TUIModel) loadSelectedEntry() tea.Cmd {
+	return m.scheduleSelectedEntryLoad(0)
+}
+
+func (m *TUIModel) debounceSelectedEntry() tea.Cmd {
+	return m.scheduleSelectedEntryLoad(detailDebounce)
+}
+
+func (m *TUIModel) scheduleSelectedEntryLoad(delay time.Duration) tea.Cmd {
 	path := m.selectedPath()
 	if path == "" {
+		m.entry = nil
+		m.entryFor = ""
 		return nil
 	}
-	return loadEntryCmd(m.vault, path)
+	if m.entryFor != path {
+		m.entry = nil
+		m.entryFor = ""
+	}
+	m.detailRequest++
+	requestID := m.detailRequest
+	if delay <= 0 {
+		return loadEntryCmd(m.vault, path, requestID)
+	}
+	return tea.Tick(delay, func(time.Time) tea.Msg {
+		return entryLoadRequestedMsg{requestID: requestID, path: path}
+	})
 }
 
 func (m TUIModel) selectedPath() string {
@@ -763,15 +798,15 @@ func loadEntriesCmd(vault *vaultpkg.Vault) tea.Cmd {
 	}
 }
 
-func loadEntryCmd(vault *vaultpkg.Vault, path string) tea.Cmd {
+func loadEntryCmd(vault *vaultpkg.Vault, path string, requestID uint64) tea.Cmd {
 	return func() (msg tea.Msg) {
 		defer func() {
 			if r := recover(); r != nil {
-				msg = entryLoadedMsg{path: path, err: fmt.Errorf("panic loading entry %s: %v", path, r)}
+				msg = entryLoadedMsg{requestID: requestID, path: path, err: fmt.Errorf("panic loading entry %s: %v", path, r)}
 			}
 		}()
 		entry, err := vaultpkg.ReadEntry(vault.Dir, path, vault.Identity)
-		return entryLoadedMsg{path: path, entry: entry, err: err}
+		return entryLoadedMsg{requestID: requestID, path: path, entry: entry, err: err}
 	}
 }
 

--- a/internal/ui/tui.go
+++ b/internal/ui/tui.go
@@ -94,6 +94,10 @@ type clipboardClearedMsg struct {
 	err error
 }
 
+type clipboardQuitClearedMsg struct {
+	err error
+}
+
 type clipboardTickMsg struct{}
 
 type logMsg struct {
@@ -133,6 +137,8 @@ type TUIModel struct {
 }
 
 var (
+	writeClipboard = clipboard.WriteAll
+
 	appStyle = lipgloss.NewStyle().Padding(1, 2)
 
 	borderStyle = lipgloss.NewStyle().
@@ -277,6 +283,13 @@ func (m TUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.clipboardSeconds = 0
 		m.status = "Clipboard cleared"
 		return m, nil
+	case clipboardQuitClearedMsg:
+		m.clipboardSeconds = 0
+		if msg.err != nil {
+			m.err = msg.err
+			m.status = "Clipboard clear failed"
+		}
+		return m, tea.Quit
 	case clipboardTickMsg:
 		if m.clipboardSeconds > 0 {
 			m.clipboardSeconds--
@@ -335,7 +348,7 @@ func (m TUIModel) handleKey(msg tea.KeyMsg) (TUIModel, tea.Cmd) {
 			m.filterInput.Blur()
 			return m, m.loadSelectedEntry()
 		case keyQuit:
-			return m, tea.Quit
+			return m, m.quitCmd()
 		}
 
 		var cmd tea.Cmd
@@ -360,7 +373,7 @@ func (m TUIModel) handleKey(msg tea.KeyMsg) (TUIModel, tea.Cmd) {
 			m.applyFilter()
 			return m, m.loadSelectedEntry()
 		case keyQuit:
-			return m, tea.Quit
+			return m, m.quitCmd()
 		}
 
 		var cmd tea.Cmd
@@ -386,14 +399,14 @@ func (m TUIModel) handleKey(msg tea.KeyMsg) (TUIModel, tea.Cmd) {
 			m.status = "Canceled"
 			return m, nil
 		case keyQuit:
-			return m, tea.Quit
+			return m, m.quitCmd()
 		}
 		return m, nil
 	}
 
 	switch msg.String() {
 	case "q", keyQuit:
-		return m, tea.Quit
+		return m, m.quitCmd()
 	case "?":
 		m.help = !m.help
 		return m, nil
@@ -453,6 +466,13 @@ func (m TUIModel) handleKey(msg tea.KeyMsg) (TUIModel, tea.Cmd) {
 	}
 
 	return m, nil
+}
+
+func (m TUIModel) quitCmd() tea.Cmd {
+	if m.clipboardSeconds <= 0 {
+		return tea.Quit
+	}
+	return clearClipboardBeforeQuitCmd()
 }
 
 func (m *TUIModel) applyFilter() {
@@ -769,7 +789,7 @@ func copyTextCmd(text, message string, cleanup func()) tea.Cmd {
 }
 
 func copyTextMsg(text, message string) tea.Msg {
-	if err := clipboard.WriteAll(text); err != nil {
+	if err := writeClipboard(text); err != nil {
 		return copiedMsg{err: fmt.Errorf("copy to clipboard: %w", err)}
 	}
 	return copiedMsg{message: message}
@@ -780,11 +800,17 @@ func clearClipboardCmd(seconds int) tea.Cmd {
 		done := make(chan struct{})
 		var clearErr error
 		clipboardapp.StartAutoClear(seconds, func() {
-			clearErr = clipboard.WriteAll("")
+			clearErr = writeClipboard("")
 			close(done)
 		}, nil)
 		<-done
 		return clipboardClearedMsg{err: clearErr}
+	}
+}
+
+func clearClipboardBeforeQuitCmd() tea.Cmd {
+	return func() tea.Msg {
+		return clipboardQuitClearedMsg{err: writeClipboard("")}
 	}
 }
 

--- a/internal/ui/tui_test.go
+++ b/internal/ui/tui_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"filippo.io/age"
+	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/danieljustus/symaira-vault/internal/testutil"
 	vaultpkg "github.com/danieljustus/symaira-vault/internal/vault"
@@ -91,6 +92,60 @@ func TestTUIModelHandlesListError(t *testing.T) {
 
 	if newM.err == nil {
 		t.Error("expected error to be set")
+	}
+}
+
+func TestTUIModelClearsClipboardBeforeQuitWhenCopyPending(t *testing.T) {
+	origWriteClipboard := writeClipboard
+	t.Cleanup(func() { writeClipboard = origWriteClipboard })
+
+	tests := []struct {
+		name string
+		mode mode
+		key  tea.KeyMsg
+	}{
+		{name: "normal q", mode: modeNormal, key: tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}}},
+		{name: "normal ctrl-c", mode: modeNormal, key: tea.KeyMsg{Type: tea.KeyCtrlC}},
+		{name: "filter ctrl-c", mode: modeFilter, key: tea.KeyMsg{Type: tea.KeyCtrlC}},
+		{name: "tag filter ctrl-c", mode: modeTagFilter, key: tea.KeyMsg{Type: tea.KeyCtrlC}},
+		{name: "confirm delete ctrl-c", mode: modeConfirmDelete, key: tea.KeyMsg{Type: tea.KeyCtrlC}},
+		{name: "confirm edit ctrl-c", mode: modeConfirmEdit, key: tea.KeyMsg{Type: tea.KeyCtrlC}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			writes := []string{}
+			writeClipboard = func(text string) error {
+				writes = append(writes, text)
+				return nil
+			}
+
+			m := NewTUIModel(&vaultpkg.Vault{})
+			m.mode = tt.mode
+			m.clipboardSeconds = 10
+
+			_, cmd := m.handleKey(tt.key)
+			if cmd == nil {
+				t.Fatal("expected quit path to clear clipboard before quitting")
+			}
+
+			msg := cmd()
+			if _, ok := msg.(clipboardQuitClearedMsg); !ok {
+				t.Fatalf("message = %T, want clipboardQuitClearedMsg", msg)
+			}
+			if len(writes) != 1 || writes[0] != "" {
+				t.Fatalf("clipboard writes = %#v, want one clear write", writes)
+			}
+
+			newModel, quitCmd := m.Update(msg)
+			newM := newModel.(TUIModel)
+			if newM.clipboardSeconds != 0 {
+				t.Fatalf("clipboardSeconds = %d, want 0", newM.clipboardSeconds)
+			}
+			if quitCmd == nil {
+				t.Fatal("expected quit command after clipboard clear")
+			}
+		})
 	}
 }
 

--- a/internal/ui/tui_test.go
+++ b/internal/ui/tui_test.go
@@ -4,6 +4,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+	"time"
 
 	"filippo.io/age"
 	tea "github.com/charmbracelet/bubbletea"
@@ -65,6 +66,72 @@ func TestTUIModelLoadsEntries(t *testing.T) {
 
 	if len(newM.filtered) != 3 {
 		t.Errorf("expected 3 filtered entries, got %d", len(newM.filtered))
+	}
+}
+
+func TestTUIModelDebouncesCursorDetailLoads(t *testing.T) {
+	origDebounce := detailDebounce
+	detailDebounce = time.Hour
+	t.Cleanup(func() { detailDebounce = origDebounce })
+
+	m := NewTUIModel(&vaultpkg.Vault{})
+	m.loading = false
+	m.entries = []string{"a", "b", "c"}
+	m.filtered = append([]string(nil), m.entries...)
+
+	next, cmd := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	if cmd == nil {
+		t.Fatal("expected first cursor move to schedule detail load")
+	}
+	if next.selected != 1 || next.detailRequest != 1 {
+		t.Fatalf("after first move selected=%d request=%d, want selected=1 request=1", next.selected, next.detailRequest)
+	}
+
+	next, cmd = next.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	if cmd == nil {
+		t.Fatal("expected second cursor move to schedule detail load")
+	}
+	if next.selected != 2 || next.detailRequest != 2 {
+		t.Fatalf("after second move selected=%d request=%d, want selected=2 request=2", next.selected, next.detailRequest)
+	}
+
+	model, cmd := next.Update(entryLoadRequestedMsg{requestID: 1, path: "b"})
+	if cmd != nil {
+		t.Fatal("stale debounced request should not start a decrypt")
+	}
+
+	model, cmd = model.(TUIModel).Update(entryLoadRequestedMsg{requestID: 2, path: "c"})
+	if cmd == nil {
+		t.Fatal("current debounced request should start a decrypt")
+	}
+}
+
+func TestTUIModelIgnoresStaleEntryLoads(t *testing.T) {
+	m := NewTUIModel(&vaultpkg.Vault{})
+	m.loading = false
+	m.entries = []string{"a", "b"}
+	m.filtered = append([]string(nil), m.entries...)
+	m.selected = 1
+	m.detailRequest = 2
+
+	staleEntry := &vaultpkg.Entry{Data: map[string]any{"password": "stale"}}
+	model, cmd := m.Update(entryLoadedMsg{requestID: 1, path: "a", entry: staleEntry})
+	if cmd != nil {
+		t.Fatal("stale loaded entry should not return a command")
+	}
+	next := model.(TUIModel)
+	if next.entry != nil || next.entryFor != "" {
+		t.Fatalf("stale entry updated detail pane: entry=%v entryFor=%q", next.entry, next.entryFor)
+	}
+
+	currentEntry := &vaultpkg.Entry{Data: map[string]any{"password": "current"}}
+	model, cmd = next.Update(entryLoadedMsg{requestID: 2, path: "b", entry: currentEntry})
+	if cmd != nil {
+		t.Fatal("current loaded entry should not return a command")
+	}
+	next = model.(TUIModel)
+	if next.entry != currentEntry || next.entryFor != "b" {
+		t.Fatalf("current entry not applied: entry=%v entryFor=%q", next.entry, next.entryFor)
 	}
 }
 

--- a/internal/ui/tui_test.go
+++ b/internal/ui/tui_test.go
@@ -100,7 +100,7 @@ func TestTUIModelDebouncesCursorDetailLoads(t *testing.T) {
 		t.Fatal("stale debounced request should not start a decrypt")
 	}
 
-	model, cmd = model.(TUIModel).Update(entryLoadRequestedMsg{requestID: 2, path: "c"})
+	_, cmd = model.(TUIModel).Update(entryLoadRequestedMsg{requestID: 2, path: "c"})
 	if cmd == nil {
 		t.Fatal("current debounced request should start a decrypt")
 	}

--- a/internal/vault/cache.go
+++ b/internal/vault/cache.go
@@ -241,8 +241,8 @@ func (c *VaultCache) SetListCacheTTL(ttl time.Duration) {
 	} else {
 		c.listCacheTTL = ttl
 	}
-	c.listCacheMu.Unlock()
 	c.configuredTTL = ttl
+	c.listCacheMu.Unlock()
 }
 
 // SetConfigCacheSize sets the maximum number of cached vault configs.
@@ -299,12 +299,12 @@ func (c *VaultCache) adaptListCacheTTL() {
 	if total < 100 {
 		return
 	}
+	ratio := float64(hits) / float64(total)
+	c.listCacheMu.Lock()
 	effectiveMax := maxListCacheTTL
 	if c.configuredTTL > 0 && c.configuredTTL < effectiveMax {
 		effectiveMax = c.configuredTTL
 	}
-	ratio := float64(hits) / float64(total)
-	c.listCacheMu.Lock()
 	if ratio > 0.9 && c.listCacheTTL < effectiveMax {
 		c.listCacheTTL *= 2
 		if c.listCacheTTL > effectiveMax {
@@ -329,20 +329,23 @@ func (c *VaultCache) cachedList(vaultDir string) []string {
 	}
 	c.listCacheMu.RLock()
 	elem, ok := c.listCacheIndex[vaultDir]
-	c.listCacheMu.RUnlock()
 	if !ok {
+		c.listCacheMu.RUnlock()
 		atomic.AddUint64(&c.listCacheMisses, 1)
 		c.adaptListCacheTTL()
 		return nil
 	}
 	payload, ok := elem.Value.(*listCachePayload)
 	if !ok {
+		c.listCacheMu.RUnlock()
 		atomic.AddUint64(&c.listCacheMisses, 1)
 		c.adaptListCacheTTL()
 		return nil
 	}
 	entry := payload.entry
-	if time.Since(entry.createdAt) > c.listCacheTTL {
+	ttl := c.listCacheTTL
+	c.listCacheMu.RUnlock()
+	if time.Since(entry.createdAt) > ttl {
 		atomic.AddUint64(&c.listCacheMisses, 1)
 		c.adaptListCacheTTL()
 		return nil

--- a/internal/vault/cache.go
+++ b/internal/vault/cache.go
@@ -80,8 +80,11 @@ type listCachePayload struct {
 }
 
 // pseudonymizedCacheEntry holds cached pseudonymized list results.
-// Unlike listCacheEntry, it also stores decrypted entry data so that
+// Unlike listCacheEntry, it may also store decrypted entry data so that
 // FindWithOptions can reuse entries already decrypted during listing.
+// Secret-bearing entries are deliberately omitted from entries so callers
+// fall back to a single-entry decrypt instead of retaining those values in
+// heap memory for the cache TTL.
 type pseudonymizedCacheEntry struct {
 	paths        []string
 	entries      map[string]map[string]any

--- a/internal/vault/entry_test.go
+++ b/internal/vault/entry_test.go
@@ -861,6 +861,46 @@ func TestListWithPseudonymizedEntries(t *testing.T) {
 	}
 }
 
+func TestPseudonymizedListCacheOmitsSecretBearingEntries(t *testing.T) {
+	vaultDir := t.TempDir()
+	writePseudonymizeConfig(t, vaultDir)
+	id := testutil.TempIdentity(t)
+
+	listCacheFor(vaultDir).Invalidate()
+	globalIndex.Invalidate()
+
+	mustWriteEntry(t, vaultDir, id, "github.com/user", map[string]interface{}{
+		"username": "alice",
+		"password": "clip-secret-value",
+		"totp": map[string]interface{}{
+			"secret": "JBSWY3DPEHPK3PXP",
+		},
+	})
+	mustWriteEntry(t, vaultDir, id, "public/profile", map[string]interface{}{
+		"username": "bob",
+		"url":      "https://example.com",
+	})
+
+	if _, err := List(vaultDir, "", id); err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+
+	if got := listCacheFor(vaultDir).cachedPseudonymizedEntry(vaultDir, id, "github.com/user"); got != nil {
+		t.Fatalf("secret-bearing entry cached as %#v, want nil", got)
+	}
+	if got := listCacheFor(vaultDir).cachedPseudonymizedEntry(vaultDir, id, "public/profile"); got == nil {
+		t.Fatal("non-secret entry was not cached")
+	}
+
+	matches, err := FindWithOptions(vaultDir, "clip-secret-value", FindOptions{MaxWorkers: 1}, id)
+	if err != nil {
+		t.Fatalf("FindWithOptions() error = %v", err)
+	}
+	if len(matches) != 1 || matches[0].Path != "github.com/user" {
+		t.Fatalf("FindWithOptions() = %#v, want github.com/user", matches)
+	}
+}
+
 func TestListWithPseudonymizedEntriesAndPrefix(t *testing.T) {
 	vaultDir := t.TempDir()
 

--- a/internal/vault/search.go
+++ b/internal/vault/search.go
@@ -412,7 +412,9 @@ func listPseudonymizedWithIdentity(vaultDir, prefix string, identity *age.X25519
 		}
 		paths = append(paths, result.entryPath)
 		if result.data != nil {
-			cachedEntries[result.entryPath] = result.data
+			if cachedData := pseudonymCacheSafeData(result.data); cachedData != nil {
+				cachedEntries[result.entryPath] = cachedData
+			}
 		}
 	}
 
@@ -425,6 +427,54 @@ func listPseudonymizedWithIdentity(vaultDir, prefix string, identity *age.X25519
 	metrics.RecordVaultOperationDuration("list_pseudonymized", time.Since(start))
 	metrics.RecordVaultEntryCount(vaultDir, len(paths))
 	return paths, nil
+}
+
+func pseudonymCacheSafeData(data map[string]any) map[string]any {
+	if len(data) == 0 {
+		return nil
+	}
+	cloned, stripped := cloneWithoutSensitiveFields("", data)
+	if stripped {
+		return nil
+	}
+	return cloned
+}
+
+func cloneWithoutSensitiveFields(prefix string, data map[string]any) (map[string]any, bool) {
+	cloned := make(map[string]any, len(data))
+	stripped := false
+	for key, value := range data {
+		field := key
+		if prefix != "" {
+			field = prefix + "." + key
+		}
+		if isSensitiveCacheField(field) {
+			stripped = true
+			continue
+		}
+		switch typed := value.(type) {
+		case map[string]any:
+			nested, nestedStripped := cloneWithoutSensitiveFields(field, typed)
+			if nestedStripped {
+				stripped = true
+				continue
+			}
+			cloned[key] = nested
+		default:
+			cloned[key] = value
+		}
+	}
+	return cloned, stripped
+}
+
+func isSensitiveCacheField(field string) bool {
+	field = strings.ToLower(field)
+	return strings.Contains(field, "pass") ||
+		strings.Contains(field, "secret") ||
+		strings.Contains(field, "token") ||
+		strings.Contains(field, "key") ||
+		strings.Contains(field, "otp") ||
+		strings.Contains(field, "pin")
 }
 
 // listViaManifest returns entry paths from the manifest when available and

--- a/internal/vault/service.go
+++ b/internal/vault/service.go
@@ -179,7 +179,7 @@ func (DefaultOperationService) UpsertEntry(v *Vault, path string, data map[strin
 		return errorspkg.ReadFailed(readErr, "cannot read entry %s: %v", path, readErr)
 	}
 
-	if err := v.AutoCommit(fmt.Sprintf("Update %s", path)); err != nil {
+	if err := v.AutoCommitEntry(fmt.Sprintf("Update %s", path), path); err != nil {
 		slog.Default().Warn("auto-commit failed", "error", err)
 	}
 	v.Cache.Invalidate()
@@ -202,7 +202,7 @@ func (DefaultOperationService) WriteEntry(v *Vault, path string, entry *Entry) e
 		return errorspkg.WriteFailed(err, "cannot write entry %s: %v", path, err)
 	}
 
-	if err := v.AutoCommit(fmt.Sprintf("Update %s", path)); err != nil {
+	if err := v.AutoCommitEntry(fmt.Sprintf("Update %s", path), path); err != nil {
 		slog.Default().Warn("auto-commit failed", "error", err)
 	}
 	v.Cache.Invalidate()
@@ -217,7 +217,7 @@ func (DefaultOperationService) DeleteEntry(v *Vault, path string) error {
 		return errorspkg.WriteFailed(err, "cannot delete entry %s: %v", path, err)
 	}
 
-	if err := v.AutoCommit(fmt.Sprintf("Delete %s", path)); err != nil {
+	if err := v.AutoCommitEntry(fmt.Sprintf("Delete %s", path), path); err != nil {
 		slog.Default().Warn("auto-commit failed", "error", err)
 	}
 	v.Cache.Invalidate()

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -314,6 +314,22 @@ func (v *Vault) ValidateIdentity(identity *age.X25519Identity) error {
 }
 
 func (v *Vault) AutoCommit(message string) error {
+	return v.AutoCommitPaths(message)
+}
+
+func (v *Vault) AutoCommitEntry(message, path string) error {
+	if v == nil {
+		return errors.New("vault is nil")
+	}
+	entryPath := EntryPath(v, path)
+	relPath, err := filepath.Rel(v.Dir, entryPath)
+	if err != nil {
+		return err
+	}
+	return v.AutoCommitPaths(message, filepath.ToSlash(relPath))
+}
+
+func (v *Vault) AutoCommitPaths(message string, affectedPaths ...string) error {
 	if v == nil {
 		return errors.New("vault is nil")
 	}
@@ -328,7 +344,10 @@ func (v *Vault) AutoCommit(message string) error {
 	if commitMessage == "" {
 		commitMessage = "Update from Symaira Vault"
 	}
-	return git.AutoCommitAndPush(v.Dir, commitMessage, autoPush)
+	return git.AutoCommitAndPushWithOptions(v.Dir, git.CommitOptions{
+		Message:       commitMessage,
+		AffectedPaths: affectedPaths,
+	}, autoPush)
 }
 
 func normalizeConfig(cfg *vaultconfig.Config) {


### PR DESCRIPTION
Bundles fixes for multiple open issues. The list below grows as commits land; every linked issue will close automatically on merge.

<!-- closes-list-start -->
- Closes #396 fix(clipboard): auto-clear after `symvault get` never fires - process exits before goroutines run
- Closes #397 fix(tui): quitting the TUI leaves clipboard contents uncleared
- Closes #398 fix(vault): pseudonymized list cache retains decrypted secret fields for 5 minutes
- Closes #401 fix(vault): data races on TTL fields in VaultCache
- Closes #399 fix(config): `clipboard.printByDefault` semantics are inverted and undocumented
- Closes #400 refactor: deduplicate editor round-trip and unify on secure temp-file deletion
- Closes #402 perf(git): auto-commit stages all files and computes worktree status twice per write
- Closes #403 perf(tui): entry detail pane decrypts on every cursor keystroke without debounce
<!-- closes-list-end -->
