### PR TITLE
fix(ci): dynamic exe discovery in Windows smoke test

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -392,7 +392,14 @@ jobs:
           $tag = "${{ steps.tag.outputs.tag }}"
           $version = $tag -replace '^v',''
           Expand-Archive -Path "symaira-vault_${version}_windows_amd64.zip" -DestinationPath .\symvault-tmp -Force
-          .\symvault-tmp\symaira-vault_${version}_windows_amd64\symvault.exe version
+          $exe = Get-ChildItem -Path .\symvault-tmp -Recurse -Filter "symvault.exe" | Select-Object -First 1 -ExpandProperty FullName
+          if (-not $exe) {
+            Write-Error "symvault.exe not found after extraction"
+            Get-ChildItem -Path .\symvault-tmp -Recurse | Format-Table FullName
+            exit 1
+          }
+          Write-Host "Found exe at: $exe"
+          & $exe version
 
       - name: Smoke test - init vault
         shell: pwsh
@@ -401,7 +408,11 @@ jobs:
           $version = $tag -replace '^v',''
           $tmpdir = Join-Path $env:TEMP "test-vault-$(Get-Random)"
           New-Item -ItemType Directory -Path $tmpdir | Out-Null
-          $exe = ".\symvault-tmp\symaira-vault_${version}_windows_amd64\symvault.exe"
+          $exe = Get-ChildItem -Path .\symvault-tmp -Recurse -Filter "symvault.exe" | Select-Object -First 1 -ExpandProperty FullName
+          if (-not $exe) {
+            Write-Error "symvault.exe not found after extraction"
+            exit 1
+          }
           "test-passphrase-123" | & $exe init --vault "$tmpdir"
           Remove-Item -Path $tmpdir -Recurse -Force -ErrorAction SilentlyContinue
 


### PR DESCRIPTION
## Summary

Expand-Archive on the Windows GitHub Actions runner may produce a different directory structure than expected. Replace hardcoded path lookup with  to find .

## Problem

The Windows smoke test has been failing since v0.4.0 due to a hardcoded path assumption after  extraction. The extraction creates the expected directory but PowerShell can't resolve the exe at the hardcoded path.

## Fix

- Use  to dynamically find the extracted binary
- Add diagnostic output listing extracted files if not found
- Both the version check and init vault steps now use dynamic discovery

## Testing

- All other smoke tests (Linux, macOS, deb, homebrew, mcpb) pass
- This fix will be verified when the release workflow re-runs on tag push

Closes #413