### PR TITLE
Bind scoped MCP tokens to their agent profile (+3 more)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,5 @@
 name: Bug report
-description: Report a reproducible problem in OpenPass.
+description: Report a reproducible problem in Symaira Vault.
 title: "bug: "
 labels:
   - bug
@@ -11,9 +11,9 @@ body:
   - type: input
     id: version
     attributes:
-      label: OpenPass version
-      description: Run `openpass version` or provide the commit SHA.
-      placeholder: "v1.0.0"
+      label: Symaira Vault version
+      description: Run `symvault version` or provide the commit SHA.
+      placeholder: "v0.4.1"
     validations:
       required: true
   - type: input
@@ -35,7 +35,7 @@ body:
       label: Steps to reproduce
       description: Use a minimal synthetic example. Do not paste real secrets.
       placeholder: |
-        1. Run `openpass ...`
+        1. Run `symvault ...`
         2. Observe ...
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
   - name: Security vulnerability
-    url: https://github.com/danieljustus/OpenPass/security/advisories/new
+    url: https://github.com/danieljustus/symaira-vault/security/advisories/new
     about: Please report suspected vulnerabilities privately. Do not open a public issue for security reports.
   - name: Questions and ideas
-    url: https://github.com/danieljustus/OpenPass/discussions
+    url: https://github.com/danieljustus/symaira-vault/discussions
     about: Use GitHub Discussions for usage questions, design ideas, and early feature proposals.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,5 +1,5 @@
 name: Feature request
-description: Suggest an improvement or new capability for OpenPass.
+description: Suggest an improvement or new capability for Symaira Vault.
 title: "feat: "
 labels:
   - enhancement

--- a/.github/ISSUE_TEMPLATE/installation_problem.yml
+++ b/.github/ISSUE_TEMPLATE/installation_problem.yml
@@ -1,5 +1,5 @@
 name: Installation problem
-description: Report trouble installing or setting up OpenPass.
+description: Report trouble installing or setting up Symaira Vault.
 title: "install: "
 labels:
   - installation
@@ -12,7 +12,7 @@ body:
     id: method
     attributes:
       label: Installation method
-      description: How did you try to install OpenPass?
+      description: How did you try to install Symaira Vault?
       options:
         - Quick install script (curl / PowerShell)
         - Homebrew
@@ -27,9 +27,9 @@ body:
   - type: input
     id: version
     attributes:
-      label: OpenPass version
-      description: If known. Run `openpass version` after installation, or provide the release tag you tried.
-      placeholder: "v2.1.0"
+      label: Symaira Vault version
+      description: If known. Run `symvault version` after installation, or provide the release tag you tried.
+      placeholder: "v0.4.1"
   - type: input
     id: os
     attributes:

--- a/Makefile
+++ b/Makefile
@@ -207,7 +207,7 @@ editors-clean:
 docs-check:
 	@echo "Checking documentation for deprecated terms and incorrect syntax..."
 	@errors=0; \
-	for pattern in "brew install --cask openpass" "mcp-config --agent" "mcp_openpass_openpass"; do \
+	for pattern in "brew install --cask openpass" "mcp-config --agent" "mcp_openpass_openpass" "X-Symaira Vault-Agent"; do \
 		if grep -r "$$pattern" README.md docs homebrew .gitignore --exclude-dir=dist --exclude-dir=coverage --exclude-dir=node_modules 2>/dev/null; then \
 			echo "Found deprecated pattern: $$pattern"; \
 			errors=$$((errors + 1)); \

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,13 +2,14 @@
 
 ## Supported Versions
 
-Symaira Vault v1.0.0 is the first stable release. Security reports are accepted for
-the latest stable 1.x release. Snapshots and local builds are unsupported except
-where a maintainer explicitly requests reproduction details for a current fix.
+Symaira Vault currently follows the public v0.x release line. Security reports
+are accepted for the latest public v0.x release. Snapshots and local builds are
+unsupported except where a maintainer explicitly requests reproduction details
+for a current fix.
 
 | Version                   | Supported         | Notes                                                   |
 | ------------------------- | ----------------- | ------------------------------------------------------- |
-| v1.x                      | :white_check_mark: | Latest stable release line                              |
+| v0.x                      | :white_check_mark: | Current public self-hosted release line                 |
 | Snapshots and local builds | :x:               | Reproduce on the latest stable release before reporting |
 
 ### Stable Security Support
@@ -147,7 +148,7 @@ adoption pattern) and review the [`hermes-safe-adoption.md`](docs/hermes-safe-ad
 - Binds to `127.0.0.1` only (localhost) — not exposed to network
 - Bearer token authentication required
 - Token auto-generated and stored at `<vault>/mcp-token`
-- Agent identified per-request via `X-Symaira Vault-Agent` header
+- Agent identified per-request via `X-Symaira-Agent` header
 - Max request body size: 1MB (requests exceeding this return 413 Request Entity Too Large)
 
 **Security recommendations for HTTP mode:**
@@ -330,7 +331,7 @@ passphrase-based key derivation. While scrypt provides reasonable protection,
 **argon2id** is the industry-standard memory-hard KDF (RFC 9106) and provides
 stronger resistance against GPU/ASIC-based attacks.
 
-#### Current Status (v1.x)
+#### Current Status (v0.x)
 
 | Vault Format | KDF    | Work Factor | Doctor Check         |
 |-------------|--------|-------------|---------------------|

--- a/cmd/admin/backup.go
+++ b/cmd/admin/backup.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"compress/gzip"
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -189,7 +190,7 @@ func RestoreBackup(archivePath, vaultDir string) error {
 
 	for {
 		header, err := tr.Next()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		if err != nil {

--- a/cmd/admin/backup.go
+++ b/cmd/admin/backup.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -15,7 +16,13 @@ import (
 	"github.com/spf13/cobra"
 
 	errorspkg "github.com/danieljustus/symaira-vault/internal/errors"
+	"github.com/danieljustus/symaira-vault/internal/fsutil"
 	vaultpkg "github.com/danieljustus/symaira-vault/internal/vault"
+)
+
+var (
+	maxRestoreFileSize  int64 = 1 << 30        // 1 GiB per restored file
+	maxRestoreTotalSize int64 = 16 * (1 << 30) // 16 GiB per archive
 )
 
 var BackupExcludeGit bool
@@ -62,7 +69,7 @@ func CreateBackup(vaultDir, archivePath string, excludeGit bool) error {
 		return fmt.Errorf("create backup directory: %w", err)
 	}
 
-	f, err := os.Create(archivePath) // #nosec // archivePath is user-provided output path
+	f, err := os.OpenFile(archivePath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600) // #nosec // archivePath is user-provided output path
 	if err != nil {
 		return fmt.Errorf("create archive: %w", err)
 	}
@@ -87,6 +94,9 @@ func CreateBackup(vaultDir, archivePath string, excludeGit bool) error {
 		relPath, err := filepath.Rel(vaultDir, path)
 		if err != nil {
 			return err
+		}
+		if relPath == "." {
+			return nil
 		}
 
 		if excludeGit && strings.HasPrefix(relPath, ".git") {
@@ -158,7 +168,7 @@ to ensure all expected files are present.`,
 }
 
 func RestoreBackup(archivePath, vaultDir string) error {
-	if err := os.MkdirAll(vaultDir, 0o700); err != nil {
+	if err := fsutil.SafeMkdirAll(vaultDir, 0o700); err != nil {
 		return fmt.Errorf("create vault directory: %w", err)
 	}
 
@@ -175,6 +185,7 @@ func RestoreBackup(archivePath, vaultDir string) error {
 	defer func() { _ = gr.Close() }()
 
 	tr := tar.NewReader(gr)
+	var totalSize int64
 
 	for {
 		header, err := tr.Next()
@@ -185,7 +196,12 @@ func RestoreBackup(archivePath, vaultDir string) error {
 			return fmt.Errorf("read archive: %w", err)
 		}
 
-		targetPath := filepath.Join(vaultDir, header.Name) // #nosec // path traversal checked below
+		relName, err := cleanBackupMemberName(header.Name)
+		if err != nil {
+			return err
+		}
+
+		targetPath := filepath.Join(vaultDir, relName) // #nosec // path traversal checked below
 		cleanTarget := filepath.Clean(targetPath)
 		cleanVaultDir := filepath.Clean(vaultDir)
 		if !strings.HasPrefix(cleanTarget, cleanVaultDir+string(filepath.Separator)) && cleanTarget != cleanVaultDir {
@@ -205,11 +221,22 @@ func RestoreBackup(archivePath, vaultDir string) error {
 				return fmt.Errorf("invalid negative mode in archive: %s", header.Name)
 			}
 			mode := os.FileMode(header.Mode) & 0o700 // #nosec G115 // header.Mode validated as non-negative above
-			if err := os.MkdirAll(targetPath, mode); err != nil {
+			if err := fsutil.SafeMkdirAll(targetPath, mode); err != nil {
 				return fmt.Errorf("create directory: %w", err)
 			}
 		case tar.TypeReg:
-			if err := os.MkdirAll(filepath.Dir(targetPath), 0o700); err != nil {
+			if header.Size < 0 {
+				return fmt.Errorf("invalid negative size in archive: %s", header.Name)
+			}
+			if header.Size > maxRestoreFileSize {
+				return fmt.Errorf("archive entry %s exceeds maximum file size of %d bytes", header.Name, maxRestoreFileSize)
+			}
+			if totalSize > maxRestoreTotalSize-header.Size {
+				return fmt.Errorf("archive exceeds maximum extraction size of %d bytes", maxRestoreTotalSize)
+			}
+			totalSize += header.Size
+
+			if err := fsutil.SafeMkdirAll(filepath.Dir(targetPath), 0o700); err != nil {
 				return fmt.Errorf("create parent directory: %w", err)
 			}
 			if header.Mode < 0 {
@@ -231,6 +258,25 @@ func RestoreBackup(archivePath, vaultDir string) error {
 	}
 
 	return VerifyBackup(vaultDir)
+}
+
+func cleanBackupMemberName(name string) (string, error) {
+	if name == "" || name == "." {
+		return "", fmt.Errorf("archive contains unsafe path: %s", name)
+	}
+	if strings.Contains(name, "\\") {
+		return "", fmt.Errorf("archive contains unsafe path: %s", name)
+	}
+	if strings.HasPrefix(name, "/") || filepath.IsAbs(name) || (len(name) >= 2 && name[1] == ':') {
+		return "", fmt.Errorf("archive contains absolute path: %s", name)
+	}
+
+	name = strings.TrimSuffix(name, "/")
+	clean := path.Clean(name)
+	if clean == "." || clean != name || clean == ".." || strings.HasPrefix(clean, "../") {
+		return "", fmt.Errorf("archive contains path traversal: %s", name)
+	}
+	return filepath.FromSlash(clean), nil
 }
 
 func VerifyBackup(vaultDir string) error {

--- a/cmd/admin/backup_test.go
+++ b/cmd/admin/backup_test.go
@@ -1,0 +1,53 @@
+package admin
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRestoreBackupRejectsOversizedFile(t *testing.T) {
+	oldFileLimit := maxRestoreFileSize
+	oldTotalLimit := maxRestoreTotalSize
+	maxRestoreFileSize = 4
+	maxRestoreTotalSize = 1024
+	t.Cleanup(func() {
+		maxRestoreFileSize = oldFileLimit
+		maxRestoreTotalSize = oldTotalLimit
+	})
+
+	archivePath := filepath.Join(t.TempDir(), "oversized.tar.gz")
+	f, err := os.Create(archivePath)
+	if err != nil {
+		t.Fatalf("create archive: %v", err)
+	}
+	gw := gzip.NewWriter(f)
+	tw := tar.NewWriter(gw)
+	content := []byte("too large")
+	if err := tw.WriteHeader(&tar.Header{Name: "identity.age", Mode: 0o600, Size: int64(len(content)), Typeflag: tar.TypeReg}); err != nil {
+		t.Fatalf("write header: %v", err)
+	}
+	if _, err := tw.Write(content); err != nil {
+		t.Fatalf("write content: %v", err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("close tar: %v", err)
+	}
+	if err := gw.Close(); err != nil {
+		t.Fatalf("close gzip: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("close archive: %v", err)
+	}
+
+	err = RestoreBackup(archivePath, t.TempDir())
+	if err == nil {
+		t.Fatal("expected error for oversized archive entry")
+	}
+	if !strings.Contains(err.Error(), "exceeds maximum file size") {
+		t.Fatalf("error = %v, want file size limit rejection", err)
+	}
+}

--- a/cmd/backup_test.go
+++ b/cmd/backup_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"archive/tar"
 	"compress/gzip"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -32,6 +33,31 @@ func TestCreateBackup(t *testing.T) {
 
 	if _, err := os.Stat(archivePath); err != nil {
 		t.Fatalf("archive not created: %v", err)
+	}
+}
+
+func TestCreateBackup_ArchiveMode0600(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows: file mode behavior differs")
+	}
+	vaultDir := t.TempDir()
+	passphrase := []byte("test-passphrase-123")
+	cfg := config.Default()
+	if _, err := vaultpkg.InitWithPassphrase(vaultDir, passphrase, cfg); err != nil {
+		t.Fatalf("init vault: %v", err)
+	}
+
+	archivePath := filepath.Join(t.TempDir(), "backup.tar.gz")
+	if err := admin.CreateBackup(vaultDir, archivePath, false); err != nil {
+		t.Fatalf("admin.CreateBackup() error = %v", err)
+	}
+
+	info, err := os.Stat(archivePath)
+	if err != nil {
+		t.Fatalf("stat archive: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("archive mode = %o, want 0600", info.Mode().Perm())
 	}
 }
 
@@ -137,6 +163,54 @@ func TestRestoreBackup_PathTraversal(t *testing.T) {
 	restoreDir := t.TempDir()
 	if err := admin.RestoreBackup(archivePath, restoreDir); err == nil {
 		t.Fatal("expected error for path traversal in archive")
+	}
+}
+
+func TestRestoreBackup_RejectsNonCleanMemberName(t *testing.T) {
+	archivePath := filepath.Join(t.TempDir(), "nonclean.tar.gz")
+	if err := writeTestTarGz(archivePath, []testTarEntry{
+		{name: "identity.age", mode: 0o600, content: "id", typ: tar.TypeReg},
+		{name: "config.yaml", mode: 0o600, content: "cfg", typ: tar.TypeReg},
+		{name: "entries", mode: 0o700, typ: tar.TypeDir},
+		{name: "entries/../evil.txt", mode: 0o600, content: "evil", typ: tar.TypeReg},
+	}); err != nil {
+		t.Fatalf("write archive: %v", err)
+	}
+
+	restoreDir := t.TempDir()
+	err := admin.RestoreBackup(archivePath, restoreDir)
+	if err == nil {
+		t.Fatal("expected error for non-clean archive member name")
+	}
+	if !strings.Contains(err.Error(), "path traversal") {
+		t.Fatalf("error = %v, want path traversal rejection", err)
+	}
+}
+
+func TestRestoreBackup_RejectsSymlinkParent(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows: symlink privileges vary")
+	}
+	archivePath := filepath.Join(t.TempDir(), "symlink-parent.tar.gz")
+	if err := writeTestTarGz(archivePath, []testTarEntry{
+		{name: "identity.age", mode: 0o600, content: "id", typ: tar.TypeReg},
+		{name: "config.yaml", mode: 0o600, content: "cfg", typ: tar.TypeReg},
+		{name: "entries/secret.txt", mode: 0o600, content: "secret", typ: tar.TypeReg},
+	}); err != nil {
+		t.Fatalf("write archive: %v", err)
+	}
+
+	restoreDir := t.TempDir()
+	targetDir := t.TempDir()
+	if err := os.Symlink(targetDir, filepath.Join(restoreDir, "entries")); err != nil {
+		t.Fatalf("create symlink: %v", err)
+	}
+
+	if err := admin.RestoreBackup(archivePath, restoreDir); err == nil {
+		t.Fatal("expected error when archive writes through symlink parent")
+	}
+	if _, err := os.Stat(filepath.Join(targetDir, "secret.txt")); !os.IsNotExist(err) {
+		t.Fatalf("symlink target was written through, stat error = %v", err)
 	}
 }
 
@@ -540,4 +614,46 @@ func TestCreateBackup_UnreadableFile(t *testing.T) {
 	if err := admin.CreateBackup(vaultDir, archivePath, false); err == nil {
 		t.Fatal("expected error for unreadable file")
 	}
+}
+
+type testTarEntry struct {
+	name    string
+	mode    int64
+	content string
+	typ     byte
+}
+
+func writeTestTarGz(path string, entries []testTarEntry) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("create archive: %w", err)
+	}
+	defer f.Close()
+
+	gw := gzip.NewWriter(f)
+	defer gw.Close()
+	tw := tar.NewWriter(gw)
+	defer tw.Close()
+
+	for _, entry := range entries {
+		size := int64(len(entry.content))
+		if entry.typ == tar.TypeDir {
+			size = 0
+		}
+		header := &tar.Header{
+			Name:     entry.name,
+			Mode:     entry.mode,
+			Size:     size,
+			Typeflag: entry.typ,
+		}
+		if err := tw.WriteHeader(header); err != nil {
+			return fmt.Errorf("write header %s: %w", entry.name, err)
+		}
+		if entry.typ == tar.TypeReg && entry.content != "" {
+			if _, err := tw.Write([]byte(entry.content)); err != nil {
+				return fmt.Errorf("write %s: %w", entry.name, err)
+			}
+		}
+	}
+	return nil
 }

--- a/cmd/crud/find.go
+++ b/cmd/crud/find.go
@@ -3,7 +3,6 @@ package crud
 import (
 	"fmt"
 	"os"
-	"runtime"
 	"strings"
 
 	cli "github.com/danieljustus/symaira-vault/internal/cli"
@@ -18,26 +17,14 @@ import (
 )
 
 // searchWorkers returns the number of concurrent decryption workers for find
-// operations. It uses the vault.searchWorkers config if set (> 0), otherwise
-// auto-scales based on vault entry count and CPU cores.
-func searchWorkers(vaultDir string, cfg *configpkg.Config) int {
+// operations. It uses the vault.searchWorkers config if set (> 0), otherwise it
+// lets the vault package apply its default bounded worker policy.
+func searchWorkers(cfg *configpkg.Config) int {
+	configured := 0
 	if cfg != nil && cfg.Vault != nil && cfg.Vault.SearchWorkers > 0 {
-		return cfg.Vault.SearchWorkers
+		configured = cfg.Vault.SearchWorkers
 	}
-
-	entries, _ := vaultpkg.List(vaultDir, "", nil)
-	entryCount := len(entries)
-	cpuCount := runtime.GOMAXPROCS(0)
-
-	// Scale workers with vault size: base 2, +1 per 1000 entries, capped at CPU count
-	workers := entryCount/1000 + 2
-	if workers > cpuCount {
-		workers = cpuCount
-	}
-	if workers < 2 {
-		workers = 2
-	}
-	return workers
+	return vaultpkg.SearchWorkerCount(configured)
 }
 
 var findCmd = &cobra.Command{
@@ -56,7 +43,7 @@ var findCmd = &cobra.Command{
 		return cli.WithVault(func(v *vaultpkg.Vault, vs *cli.VaultService) error {
 			cli.MaybeAutoPull(vs.VaultDir(), v.Config)
 			cfg := v.Config
-			workers := searchWorkers(vs.VaultDir(), cfg)
+			workers := searchWorkers(cfg)
 
 			matches, err := vs.FindEntries(args[0], vaultpkg.FindOptions{MaxWorkers: workers})
 			if err != nil {

--- a/cmd/crud/find_test.go
+++ b/cmd/crud/find_test.go
@@ -1,0 +1,27 @@
+package crud
+
+import (
+	"testing"
+
+	configpkg "github.com/danieljustus/symaira-vault/internal/config"
+	vaultpkg "github.com/danieljustus/symaira-vault/internal/vault"
+)
+
+func TestSearchWorkersUsesVaultDefault(t *testing.T) {
+	got := searchWorkers(nil)
+	want := vaultpkg.SearchWorkerCount(0)
+	if got != want {
+		t.Fatalf("searchWorkers(nil) = %d, want %d", got, want)
+	}
+}
+
+func TestSearchWorkersUsesConfiguredValue(t *testing.T) {
+	cfg := &configpkg.Config{
+		Vault: &configpkg.VaultConfig{SearchWorkers: 12},
+	}
+
+	got := searchWorkers(cfg)
+	if got != 12 {
+		t.Fatalf("searchWorkers(configured) = %d, want 12", got)
+	}
+}

--- a/docs/hermes-safe-adoption.md
+++ b/docs/hermes-safe-adoption.md
@@ -209,7 +209,7 @@ mcp_servers:
     url: http://127.0.0.1:8090/mcp
     headers:
       Authorization: env:OPENPASS_MCP_TOKEN
-      X-Symaira Vault-Agent: hermes-metadata
+      X-Symaira-Agent: hermes-metadata
     timeout: 60
     connect_timeout: 30
     sampling:

--- a/docs/mcp-api.md
+++ b/docs/mcp-api.md
@@ -75,14 +75,14 @@ Authorization: Bearer <token>
 #### Agent Identification Header
 
 ```
-X-Symaira Vault-Agent: <agent-profile-name>
+X-Symaira-Agent: <agent-profile-name>
 ```
 
 #### Example Request
 
 ```bash
 curl -H "Authorization: Bearer $(cat ~/.symvault/mcp-token)" \
-     -H "X-Symaira Vault-Agent: claude-code" \
+     -H "X-Symaira-Agent: claude-code" \
      -H "Content-Type: application/json" \
      -X POST \
      -d '{"tool": "list_entries", "arguments": {}}' \
@@ -272,7 +272,7 @@ With this configuration, `opencode mcp auth symvault` will:
       "url": "http://127.0.0.1:8080/mcp",
       "headers": {
         "Authorization": "Bearer YOUR_SYMVAULT_TOKEN",
-        "X-Symaira Vault-Agent": "opencode"
+        "X-Symaira-Agent": "opencode"
       },
       "oauth": false
     }
@@ -1561,21 +1561,21 @@ curl -s "$BASE_URL/health" | jq .
 # List entries
 curl -s -X POST "$BASE_URL/mcp" \
   -H "Authorization: Bearer $TOKEN" \
-  -H "X-Symaira Vault-Agent: $AGENT" \
+  -H "X-Symaira-Agent: $AGENT" \
   -H "Content-Type: application/json" \
   -d '{"tool": "list_entries", "arguments": {}}' | jq .
 
 # Get entry
 curl -s -X POST "$BASE_URL/mcp" \
   -H "Authorization: Bearer $TOKEN" \
-  -H "X-Symaira Vault-Agent: $AGENT" \
+  -H "X-Symaira-Agent: $AGENT" \
   -H "Content-Type: application/json" \
   -d '{"tool": "get_entry", "arguments": {"path": "github"}}' | jq .
 
 # Generate password
 curl -s -X POST "$BASE_URL/mcp" \
   -H "Authorization: Bearer $TOKEN" \
-  -H "X-Symaira Vault-Agent: $AGENT" \
+  -H "X-Symaira-Agent: $AGENT" \
   -H "Content-Type: application/json" \
   -d '{"tool": "generate_password", "arguments": {"length": 20}}' | jq .
 ```

--- a/docs/release-checklist-v4.md
+++ b/docs/release-checklist-v4.md
@@ -65,7 +65,7 @@ justification in the release PR.
       written, token issued, skill dropped, smoke test passes).
 - [ ] `symvault agent upgrade hermes --tier standard` shows the spec'd diff
       and the upgrade applies after confirmation.
-- [ ] Real Hermes session can call `mcp_openpass_openpass_whoami` and
+- [ ] Real Hermes session can call `mcp_openpass_whoami` and
       `mcp_openpass_get_entry` against the upgraded profile.
 - [ ] `OPENPASS_AGENT=hermes symvault list --output json` respects the
       profile's `allowedPaths`.

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -574,14 +574,14 @@ curl -s http://127.0.0.1:8080/health | jq .
 # 2. MCP tool health test
 curl -s -X POST http://127.0.0.1:8080/mcp \
   -H "Authorization: Bearer $(cat ~/.symvault/mcp-token)" \
-  -H "X-Symaira Vault-Agent: default" \
+  -H "X-Symaira-Agent: default" \
   -H "Content-Type: application/json" \
   -d '{"tool": "health", "arguments": {}}'
 
 # 3. End-to-end test (list entries)
 curl -s -X POST http://127.0.0.1:8080/mcp \
   -H "Authorization: Bearer $(cat ~/.symvault/mcp-token)" \
-  -H "X-Symaira Vault-Agent: default" \
+  -H "X-Symaira-Agent: default" \
   -H "Content-Type: application/json" \
   -d '{"tool": "list_entries", "arguments": {}}' | jq '.entries | length'
 # Expected: Number of vault entries (0 or more)
@@ -827,7 +827,7 @@ symvault mcp-config claude-code --http --include-token
 
 # 4. Verify health
 curl -H "Authorization: Bearer $NEW_TOKEN" \
-     -H "X-Symaira Vault-Agent: claude-code" \
+     -H "X-Symaira-Agent: claude-code" \
      http://127.0.0.1:8080/health
 
 # 5. Enable auto-start if previously disabled

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -149,7 +149,7 @@ If `identity.age` is lost, **there is no recovery**. The identity file is the pr
 
 5. **Verify agent name matches:**
    - The `--agent` flag must match a profile in `config.yaml`
-   - For HTTP mode, the `X-Symaira Vault-Agent` header must match a profile
+   - For HTTP mode, the `X-Symaira-Agent` header must match a profile
 
 **Common MCP issues and solutions:**
 
@@ -166,7 +166,7 @@ If `identity.age` is lost, **there is no recovery**. The identity file is the pr
 ```bash
 # Test HTTP endpoint
 curl -H "Authorization: Bearer $(cat ~/.symvault/mcp-token)" \
-     -H "X-Symaira Vault-Agent: default" \
+     -H "X-Symaira-Agent: default" \
      http://127.0.0.1:8080/mcp
 
 # Generate config for testing
@@ -394,7 +394,7 @@ symvault unlock                     # Verify passphrase
 # HTTP mode
 curl -s http://127.0.0.1:8080/health
 curl -H "Authorization: Bearer $(cat ~/.symvault/mcp-token)" \
-     -H "X-Symaira Vault-Agent: default" \
+     -H "X-Symaira-Agent: default" \
      http://127.0.0.1:8080/mcp
 
 # Config generation
@@ -529,7 +529,7 @@ symvault mcp-config claude-code --http --include-token
 
 # 8. Verify new configuration works
 curl -H "Authorization: Bearer $NEW_TOKEN" \
-     -H "X-Symaira Vault-Agent: claude-code" \
+     -H "X-Symaira-Agent: claude-code" \
      http://127.0.0.1:8080/mcp
 
 # 9. Remove backup token after verification

--- a/internal/mcp/auth/auth.go
+++ b/internal/mcp/auth/auth.go
@@ -303,6 +303,10 @@ func AgentHeaderMiddleware(next http.Handler) http.Handler {
 			http.Error(w, "forbidden: missing X-Symaira-Agent header", http.StatusForbidden)
 			return
 		}
+		if token, ok := TokenFromContext(r.Context()); ok && token != nil && token.AgentName != "" && token.AgentName != agent {
+			http.Error(w, "forbidden: token agent does not match X-Symaira-Agent header", http.StatusForbidden)
+			return
+		}
 		ctx := context.WithValue(r.Context(), agentContextKey, agent)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})

--- a/internal/mcp/auth/auth_test.go
+++ b/internal/mcp/auth/auth_test.go
@@ -117,6 +117,54 @@ func TestAgentHeaderSetsContext(t *testing.T) {
 	}
 }
 
+func TestAgentHeaderRejectsScopedTokenAgentMismatch(t *testing.T) {
+	handler := AgentHeaderMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("handler should not be reached for mismatched token agent")
+	}))
+
+	req := httptest.NewRequest("POST", "/mcp", nil)
+	req.Header.Set("X-Symaira-Agent", "opencode")
+	req = req.WithContext(WithToken(req.Context(), &ScopedToken{AgentName: "claude-code"}))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", rec.Code)
+	}
+}
+
+func TestAgentHeaderAcceptsScopedTokenAgentMatch(t *testing.T) {
+	handler := AgentHeaderMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("POST", "/mcp", nil)
+	req.Header.Set("X-Symaira-Agent", "claude-code")
+	req = req.WithContext(WithToken(req.Context(), &ScopedToken{AgentName: "claude-code"}))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+}
+
+func TestAgentHeaderAllowsLegacyUnscopedToken(t *testing.T) {
+	handler := BearerAuthMiddleware("legacy-secret", nil, nil, AgentHeaderMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})))
+
+	req := httptest.NewRequest("POST", "/mcp", nil)
+	req.Header.Set("Authorization", "Bearer legacy-secret")
+	req.Header.Set("X-Symaira-Agent", "opencode")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+}
+
 func TestRateLimiterStartCleanupPeriodic(t *testing.T) {
 	rl := NewRateLimiter(5, 50*time.Millisecond)
 	ctx, cancel := context.WithCancel(context.Background())

--- a/internal/vault/search_bench_test.go
+++ b/internal/vault/search_bench_test.go
@@ -211,6 +211,12 @@ func BenchmarkFind_10kEntries_FieldSearch_IndexHot(b *testing.B) {
 	benchmarkFindFieldSearchIndexHot(b, 10000)
 }
 
+// BenchmarkFind_10kEntries_FieldSearch_IndexCold measures first field search
+// latency when the encrypted index must be built from entry ciphertexts.
+func BenchmarkFind_10kEntries_FieldSearch_IndexCold(b *testing.B) {
+	benchmarkFindFieldSearchIndexCold(b, 10000)
+}
+
 // benchmarkIndexBuild builds the encrypted search index for the given number
 // of entries and reports the time taken.
 func benchmarkIndexBuild(b *testing.B, numEntries int) {
@@ -262,6 +268,28 @@ func benchmarkFindFieldSearchIndexHot(b *testing.B, numEntries int) {
 	b.ReportAllocs()
 
 	for i := 0; i < b.N; i++ {
+		matches, err := FindWithOptions(vaultDir, fieldQuery, FindOptions{MaxWorkers: 0}, identity)
+		if err != nil {
+			b.Fatalf("FindWithOptions failed: %v", err)
+		}
+		if len(matches) != 1 {
+			b.Fatalf("expected 1 match, got %d", len(matches))
+		}
+	}
+}
+
+func benchmarkFindFieldSearchIndexCold(b *testing.B, numEntries int) {
+	vaultDir := b.TempDir()
+	identity := generateTestIdentity(b)
+	createTestEntries(b, vaultDir, identity, numEntries)
+
+	fieldQuery := fmt.Sprintf("secret-password-%05d", min(50, numEntries-1))
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		globalIndex.Invalidate()
 		matches, err := FindWithOptions(vaultDir, fieldQuery, FindOptions{MaxWorkers: 0}, identity)
 		if err != nil {
 			b.Fatalf("FindWithOptions failed: %v", err)

--- a/internal/vault/search_index.go
+++ b/internal/vault/search_index.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"unicode"
@@ -114,23 +115,71 @@ func (idx *EncryptedIndex) Build(vaultDir string, identity *age.X25519Identity) 
 	}
 	doc.Salt = salt
 
-	for _, entryPath := range paths {
-		entry, readErr := ReadEntry(vaultDir, entryPath, identity)
-		if readErr != nil {
+	type indexJob struct {
+		i    int
+		path string
+	}
+	type indexResult struct {
+		i      int
+		path   string
+		values []string
+	}
+
+	jobs := make(chan indexJob, len(paths))
+	results := make(chan indexResult, len(paths))
+
+	maxWorkers := SearchWorkerCount(0)
+	if len(paths) < maxWorkers {
+		maxWorkers = len(paths)
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < maxWorkers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for job := range jobs {
+				entry, readErr := ReadEntry(vaultDir, job.path, identity)
+				if readErr != nil {
+					results <- indexResult{i: job.i, path: job.path}
+					continue
+				}
+
+				var values []string
+				collectStringValues(&values, entry.Data)
+				sort.Strings(values)
+				results <- indexResult{i: job.i, path: job.path, values: values}
+			}
+		}()
+	}
+
+	for i, entryPath := range paths {
+		jobs <- indexJob{i: i, path: entryPath}
+	}
+	close(jobs)
+
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
+
+	collected := make([]indexResult, len(paths))
+	for result := range results {
+		collected[result.i] = result
+	}
+
+	for _, result := range collected {
+		if len(result.values) == 0 {
 			continue
 		}
 
-		var values []string
-		collectStringValues(&values, entry.Data)
-		if len(values) > 0 {
-			doc.Values[entryPath] = values
-			for _, val := range values {
-				for _, token := range tokenize(val) {
-					if doc.TokenIndex[token] == nil {
-						doc.TokenIndex[token] = make(map[string]struct{})
-					}
-					doc.TokenIndex[token][entryPath] = struct{}{}
+		doc.Values[result.path] = result.values
+		for _, val := range result.values {
+			for _, token := range tokenize(val) {
+				if doc.TokenIndex[token] == nil {
+					doc.TokenIndex[token] = make(map[string]struct{})
 				}
+				doc.TokenIndex[token][result.path] = struct{}{}
 			}
 		}
 	}

--- a/internal/vault/search_index_test.go
+++ b/internal/vault/search_index_test.go
@@ -3,10 +3,14 @@ package vault
 import (
 	"bytes"
 	"crypto/sha256"
+	"encoding/json"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
+
+	"filippo.io/age"
 
 	vaultcrypto "github.com/danieljustus/symaira-vault/internal/crypto"
 	"github.com/danieljustus/symaira-vault/internal/testutil"
@@ -95,6 +99,68 @@ func TestEncryptedIndexBuildAndMatch(t *testing.T) {
 			t.Fatalf("MatchEntries(empty candidates) = %v, want nil", results)
 		}
 	})
+}
+
+func TestEncryptedIndexBuildDeterministicDoc(t *testing.T) {
+	vaultDir := t.TempDir()
+	identity := testutil.TempIdentity(t)
+
+	mustWriteEntry(t, vaultDir, identity, "z-last", map[string]interface{}{
+		"nested": map[string]interface{}{
+			"owner": "Carol",
+			"note":  "Alpha Beta",
+		},
+	})
+	mustWriteEntry(t, vaultDir, identity, "a-first", map[string]interface{}{
+		"username": "alice",
+		"password": "s3cr3t",
+	})
+
+	idx := &EncryptedIndex{}
+	if err := idx.Build(vaultDir, identity); err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	first := decryptIndexDocForTest(t, idx, identity)
+
+	idx.Invalidate()
+	if err := idx.Build(vaultDir, identity); err != nil {
+		t.Fatalf("Build() second error = %v", err)
+	}
+	second := decryptIndexDocForTest(t, idx, identity)
+
+	if !reflect.DeepEqual(first.Values, second.Values) {
+		t.Fatalf("Values changed after rebuild:\nfirst: %#v\nsecond: %#v", first.Values, second.Values)
+	}
+	if !reflect.DeepEqual(first.TokenIndex, second.TokenIndex) {
+		t.Fatalf("TokenIndex changed after rebuild:\nfirst: %#v\nsecond: %#v", first.TokenIndex, second.TokenIndex)
+	}
+	if first.EntryCount != second.EntryCount {
+		t.Fatalf("EntryCount changed after rebuild: %d != %d", first.EntryCount, second.EntryCount)
+	}
+}
+
+func decryptIndexDocForTest(t *testing.T, idx *EncryptedIndex, identity *age.X25519Identity) indexDoc {
+	t.Helper()
+
+	idx.mu.RLock()
+	ct := append([]byte(nil), idx.ciphertext...)
+	salt := append([]byte(nil), idx.salt...)
+	idx.mu.RUnlock()
+
+	key := deriveIndexKey(identity, salt)
+	defer vaultcrypto.Wipe(key)
+
+	plaintext, err := vaultcrypto.DecryptWithKey(ct, key)
+	if err != nil {
+		t.Fatalf("DecryptWithKey() error = %v", err)
+	}
+	defer vaultcrypto.Wipe(plaintext)
+
+	var doc indexDoc
+	if err := json.Unmarshal(plaintext, &doc); err != nil {
+		t.Fatalf("Unmarshal index doc error = %v", err)
+	}
+	return doc
 }
 
 func TestEncryptedIndexInvalidate(t *testing.T) {


### PR DESCRIPTION
Bundles fixes for multiple open issues. The list below grows as commits land; every linked issue will close automatically on merge.

<!-- closes-list-start -->
- Closes #415 Bind scoped MCP tokens to their agent profile
- Closes #416 Harden backup archive permissions and restore extraction
- Closes #417 Align MCP docs and support templates with Symaira Vault v0.x
- Closes #418 Improve cold search performance and worker defaults
<!-- closes-list-end -->