### PR TITLE
fix: improve MCP tool availability and approval fallback

### DIFF
--- a/internal/mcp/server/approval_helper.go
+++ b/internal/mcp/server/approval_helper.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/danieljustus/symaira-vault/internal/secrets"
+	"github.com/danieljustus/symaira-vault/internal/secureui"
 	"github.com/danieljustus/symaira-vault/internal/vault/taint"
 )
 
@@ -52,9 +53,9 @@ func (s *Server) requireApproval(ctx context.Context, intent Intent) error {
 		s.logAudit(ctx, "approval."+intent.Action+".denied", intent.EntryPath, false)
 		return fmt.Errorf("%s denied: approval mode is 'deny'", intent.Action)
 	case "prompt":
-		if !IsTTYPresent() {
+		if !IsTTYPresent() && secureui.Detect() == secureui.CapNone {
 			s.logAudit(ctx, "approval."+intent.Action+".denied", intent.EntryPath, false)
-			return fmt.Errorf("%s requires approval but no TTY available", intent.Action)
+			return fmt.Errorf("%s requires approval but no TTY or GUI dialog available", intent.Action)
 		}
 
 		riskLevel := toolRiskLevel(intent.Action)
@@ -75,6 +76,30 @@ func (s *Server) requireApproval(ctx context.Context, intent Intent) error {
 		}
 		if timeout <= 0 {
 			timeout = defaultTimeout
+		}
+
+		if !IsTTYPresent() && secureui.Detect() == secureui.CapGUI {
+			result, err := secureui.PromptApproval(secureui.ApprovalRequest{
+				Operation:   intent.Action,
+				Details:     intent.Summary,
+				Timeout:     timeout,
+				CanRemember: riskLevel.CanRemember(),
+			})
+			if err != nil {
+				return fmt.Errorf("%s approval failed: %w", intent.Action, err)
+			}
+			if !result.Approved {
+				s.logAudit(ctx, "approval."+intent.Action+".denied", intent.EntryPath, false)
+				return fmt.Errorf("%s denied: user did not approve", intent.Action)
+			}
+			if result.Remembered && riskLevel.CanRemember() && s.approvalCache != nil {
+				cacheKey := approvalCacheKey(s.agent.Name, intent.Action, intent.EntryPath)
+				s.approvalCache.setRemembered(cacheKey)
+				s.logAudit(ctx, "approval."+intent.Action+".remembered", intent.EntryPath, true)
+			}
+			s.approvalKeyCounter.Add(1)
+			s.logAudit(ctx, "approval."+intent.Action+".granted", intent.EntryPath, true)
+			return nil
 		}
 
 		workingDir := getWorkingDir()

--- a/internal/mcp/server/leanmode.go
+++ b/internal/mcp/server/leanmode.go
@@ -16,6 +16,7 @@ var LeanToolSet = []string{
 	"find_entries",
 	"get_entry_metadata",
 	"request_credential",
+	"set_entry_field",
 	"symaira_audit_self",
 }
 

--- a/internal/mcp/server/tools_execute_with_secret_test.go
+++ b/internal/mcp/server/tools_execute_with_secret_test.go
@@ -999,6 +999,8 @@ func TestHandleExecuteWithSecret_ApprovalPromptNoTTY(t *testing.T) {
 		return nil, errors.New("no tty available")
 	}
 
+	t.Setenv("SYMVAULT_SECUREUI", "none")
+
 	srv := newTestServer(t, config.AgentProfile{
 		Name:           "test",
 		AllowedPaths:   []string{"*"},
@@ -1017,8 +1019,8 @@ func TestHandleExecuteWithSecret_ApprovalPromptNoTTY(t *testing.T) {
 	if err == nil {
 		t.Fatal("handleExecuteWithSecret() expected error for no TTY, got nil")
 	}
-	if !strings.Contains(err.Error(), "no TTY available") {
-		t.Fatalf("error = %v, want 'no TTY available'", err)
+	if !strings.Contains(err.Error(), "no TTY or GUI dialog available") {
+		t.Fatalf("error = %v, want 'no TTY or GUI dialog available'", err)
 	}
 }
 

--- a/internal/secureui/backend_tty.go
+++ b/internal/secureui/backend_tty.go
@@ -149,13 +149,13 @@ func buildTTYPrompt(req PromptRequest) string {
 	sb.WriteString("║           SECURE INPUT REQUIRED — AGENT CANNOT SEE          ║\n")
 	sb.WriteString("╠══════════════════════════════════════════════════════════════╣\n")
 	if req.Path != "" {
-		fmt.Fprintf(&sb, "║ Entry:    %-50s ║\n", truncate(req.Path, 50))
+		fmt.Fprintf(&sb, "║ Entry:    %-50s ║\n", truncate(req.Path))
 	}
 	if req.Field != "" {
-		fmt.Fprintf(&sb, "║ Field:    %-50s ║\n", truncate(req.Field, 50))
+		fmt.Fprintf(&sb, "║ Field:    %-50s ║\n", truncate(req.Field))
 	}
 	if req.Description != "" {
-		fmt.Fprintf(&sb, "║ Details:  %-50s ║\n", truncate(req.Description, 50))
+		fmt.Fprintf(&sb, "║ Details:  %-50s ║\n", truncate(req.Description))
 	}
 	sb.WriteString("╚══════════════════════════════════════════════════════════════╝\n")
 	sb.WriteString("Enter value (input hidden): ")
@@ -181,12 +181,10 @@ func buildPlainTTYPrompt(req PromptRequest) string {
 	return sb.String()
 }
 
-func truncate(s string, max int) string {
+func truncate(s string) string {
+	const max = 50
 	if len(s) <= max {
 		return s
-	}
-	if max <= 3 {
-		return s[:max]
 	}
 	return s[:max-3] + "..."
 }

--- a/internal/secureui/secureui.go
+++ b/internal/secureui/secureui.go
@@ -198,10 +198,10 @@ func buildApprovalPrompt(req ApprovalRequest) string {
 	sb.WriteString("║                 MCP OPERATION APPROVAL REQUIRED              ║\n")
 	sb.WriteString("╠══════════════════════════════════════════════════════════════╣\n")
 	if req.Operation != "" {
-		fmt.Fprintf(&sb, "║ Operation: %-50s ║\n", truncate(req.Operation, 50))
+		fmt.Fprintf(&sb, "║ Operation: %-50s ║\n", truncate(req.Operation))
 	}
 	if req.Details != "" {
-		fmt.Fprintf(&sb, "║ Details:   %-50s ║\n", truncate(req.Details, 50))
+		fmt.Fprintf(&sb, "║ Details:   %-50s ║\n", truncate(req.Details))
 	}
 	sb.WriteString("╚══════════════════════════════════════════════════════════════╝\n")
 	if req.CanRemember {

--- a/internal/secureui/secureui.go
+++ b/internal/secureui/secureui.go
@@ -8,6 +8,7 @@ package secureui
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -78,6 +79,167 @@ func Prompt(req PromptRequest) (string, error) {
 		return "", ErrCanceled
 	}
 	return value, nil
+}
+
+// ApprovalRequest describes a request for user approval of a sensitive operation.
+type ApprovalRequest struct {
+	// Operation is the name of the operation being approved (e.g., "set_entry_field").
+	Operation string
+	// Details is a human-readable description of what the operation does.
+	Details string
+	// Timeout is the maximum time to wait for user input.
+	Timeout time.Duration
+	// CanRemember indicates whether the "remember for session" option is offered.
+	CanRemember bool
+}
+
+// ApprovalResult represents the outcome of an approval request.
+type ApprovalResult struct {
+	Approved   bool
+	Remembered bool
+}
+
+// PromptApproval asks the user to approve or deny a sensitive operation using
+// the best available backend (TTY or GUI). Returns the approval result or
+// ErrUnavailable if no backend is available.
+func PromptApproval(req ApprovalRequest) (ApprovalResult, error) {
+	if req.Timeout <= 0 {
+		req.Timeout = defaultTimeout
+	}
+	b := chooseBackend()
+	switch b.capability() {
+	case CapTTY:
+		return promptApprovalTTY(req)
+	case CapGUI:
+		return promptApprovalGUI(req)
+	default:
+		return ApprovalResult{}, ErrUnavailable
+	}
+}
+
+// promptApprovalTTY shows the approval prompt via TTY and reads the user's response.
+func promptApprovalTTY(req ApprovalRequest) (ApprovalResult, error) {
+	dev, err := openTTYDevice()
+	if err != nil {
+		return ApprovalResult{}, fmt.Errorf("failed to open TTY: %w", err)
+	}
+	defer func() { _ = dev.Close() }()
+
+	if out := dev.Output(); out != nil {
+		prompt := buildApprovalPrompt(req)
+		if _, werr := out.WriteString(prompt); werr != nil {
+			return ApprovalResult{}, fmt.Errorf("failed to write to TTY: %w", werr)
+		}
+	}
+
+	response, rerr := readTTY(dev, req.Timeout)
+	if rerr != nil {
+		if errors.Is(rerr, ErrCanceled) {
+			return ApprovalResult{}, ErrCanceled
+		}
+		if isTimeout(rerr) {
+			return ApprovalResult{}, ErrTimeout
+		}
+		return ApprovalResult{}, fmt.Errorf("failed to read from TTY: %w", rerr)
+	}
+
+	approved := parseApprovalResponse(response)
+	remembered := req.CanRemember && parseRememberResponse(response)
+
+	if out := dev.Output(); out != nil {
+		if approved || remembered {
+			_, _ = fmt.Fprintln(out, "yes")
+		} else {
+			_, _ = fmt.Fprintln(out, "no")
+		}
+	}
+
+	return ApprovalResult{
+		Approved:   approved || remembered,
+		Remembered: remembered,
+	}, nil
+}
+
+// promptApprovalGUI shows the approval dialog via GUI backend (osascript, zenity, etc.).
+func promptApprovalGUI(req ApprovalRequest) (ApprovalResult, error) {
+	b := chooseBackend()
+	if b.capability() != CapGUI {
+		return ApprovalResult{}, ErrUnavailable
+	}
+
+	// For GUI, we use the existing prompt function with a special request
+	// that asks for "y" or "n" input instead of a secret value.
+	guiReq := PromptRequest{
+		Title:       "Symaira Vault: Approval Required",
+		Description: buildApprovalDescription(req),
+		Hidden:      false,
+		Timeout:     req.Timeout,
+	}
+
+	value, err := b.prompt(guiReq)
+	if err != nil {
+		return ApprovalResult{}, err
+	}
+
+	approved := parseApprovalResponse(value)
+	remembered := req.CanRemember && parseRememberResponse(value)
+
+	return ApprovalResult{
+		Approved:   approved || remembered,
+		Remembered: remembered,
+	}, nil
+}
+
+// buildApprovalPrompt creates the approval prompt string for TTY display.
+func buildApprovalPrompt(req ApprovalRequest) string {
+	var sb strings.Builder
+	sb.WriteString("\n")
+	sb.WriteString("╔══════════════════════════════════════════════════════════════╗\n")
+	sb.WriteString("║                 MCP OPERATION APPROVAL REQUIRED              ║\n")
+	sb.WriteString("╠══════════════════════════════════════════════════════════════╣\n")
+	if req.Operation != "" {
+		fmt.Fprintf(&sb, "║ Operation: %-50s ║\n", truncate(req.Operation, 50))
+	}
+	if req.Details != "" {
+		fmt.Fprintf(&sb, "║ Details:   %-50s ║\n", truncate(req.Details, 50))
+	}
+	sb.WriteString("╚══════════════════════════════════════════════════════════════╝\n")
+	if req.CanRemember {
+		sb.WriteString("\nApprove this operation? (y/n/r, r=remember for session): ")
+	} else {
+		sb.WriteString("\nApprove this operation? (y/n): ")
+	}
+	return sb.String()
+}
+
+// buildApprovalDescription creates the approval description for GUI display.
+func buildApprovalDescription(req ApprovalRequest) string {
+	var sb strings.Builder
+	sb.WriteString("MCP Operation Approval Required\n\n")
+	if req.Operation != "" {
+		fmt.Fprintf(&sb, "Operation: %s\n", req.Operation)
+	}
+	if req.Details != "" {
+		fmt.Fprintf(&sb, "Details: %s\n", req.Details)
+	}
+	if req.CanRemember {
+		sb.WriteString("\nType 'y' to approve, 'n' to deny, or 'r' to remember for session.")
+	} else {
+		sb.WriteString("\nType 'y' to approve or 'n' to deny.")
+	}
+	return sb.String()
+}
+
+// parseApprovalResponse determines if the user approved the operation.
+func parseApprovalResponse(response string) bool {
+	lower := strings.ToLower(strings.TrimSpace(response))
+	return lower == "y" || lower == "yes" || lower == "r" || lower == "remember"
+}
+
+// parseRememberResponse determines if the user opted to remember the approval.
+func parseRememberResponse(response string) bool {
+	lower := strings.ToLower(strings.TrimSpace(response))
+	return lower == "r" || lower == "remember"
 }
 
 // FormatPrompt renders the request body for backends that take a single text


### PR DESCRIPTION
- Add set_entry_field to LeanToolSet so agents can store credentials
  programmatically when request_credential fails (closes #423)

- Modify requireApproval to accept GUI backend when TTY is unavailable,
  allowing request_credential to work in stdio mode on macOS (closes #422)

- Add PromptApproval function to secureui for GUI-based approval prompts

- Update error message to indicate both TTY and GUI availability check

- Update test to match new error message
