### PR TITLE
fix: unify GeneratePassword to use ambiguous-free charset

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,7 +344,7 @@ jobs:
           PASSPHRASE="test-passphrase-123"
           
           echo "Testing vault initialization..."
-          echo "$PASSPHRASE" | $BIN init "$VAULT_DIR"
+          SYMVAULT_PASSPHRASE="$PASSPHRASE" $BIN init "$VAULT_DIR"
           
           echo "Testing entry creation..."
           SYMVAULT_PASSPHRASE="$PASSPHRASE" $BIN --vault "$VAULT_DIR" set "test.entry" --value "test-value-456"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -154,6 +154,7 @@ adoption pattern) and review the [`hermes-safe-adoption.md`](docs/hermes-safe-ad
 **Security recommendations for HTTP mode:**
 - Never expose the MCP server port to the network
 - Use `approvalMode: deny` or `approvalMode: prompt` for untrusted agents
+- **Cleartext tokens on loopback**: When TLS is disabled (the default for loopback), bearer tokens are transmitted in cleartext over the loopback interface. While loopback traffic is generally safe from remote attackers, other local processes with sufficient privileges can sniff loopback traffic. For highest security, enable TLS or use stdio mode (`symvault serve --stdio`).
 
 #### Metrics Endpoint
 

--- a/beta_smoke_test.go
+++ b/beta_smoke_test.go
@@ -31,7 +31,10 @@ func TestBetaSmokeFlow(t *testing.T) {
 
 	initCmd := exec.Command(binPath, "init", vaultDir)
 	initCmd.Dir = repoRoot(t)
-	initCmd.Stdin = strings.NewReader(passphrase + "\n")
+	initCmd.Env = append(os.Environ(),
+		"GOWORK=off",
+		"SYMVAULT_PASSPHRASE="+passphrase,
+	)
 	if output, err := initCmd.CombinedOutput(); err != nil {
 		t.Fatalf("init vault: %v\n%s", err, output)
 	}

--- a/cmd/admin/init.go
+++ b/cmd/admin/init.go
@@ -36,8 +36,8 @@ var initCmd = &cobra.Command{
   symvault init ~/my-vault`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if !term.IsTerminal(int(os.Stdin.Fd())) && os.Getenv("SYMVAULT_PASSPHRASE") == "" {
-			return fmt.Errorf("init requires a TTY or SYMVAULT_PASSPHRASE env var; use `symvault setup` for interactive initialization")
+		if !term.IsTerminal(int(os.Stdin.Fd())) && !cli.HasCachedEnvPassphrase() {
+			return fmt.Errorf("init requires a TTY or SYMVAULT_PASSPHRASE/OPENPASS_PASSPHRASE env var; use `symvault setup` for interactive initialization")
 		}
 
 		var (
@@ -64,8 +64,8 @@ var initCmd = &cobra.Command{
 		}
 
 		var passphrase []byte
-		if envPassphrase := os.Getenv("SYMVAULT_PASSPHRASE"); envPassphrase != "" {
-			passphrase = []byte(envPassphrase)
+		if cached := cli.ConsumeCachedEnvPassphrase(); len(cached) > 0 {
+			passphrase = cached
 		} else {
 			passphrase, err = cli.ReadHiddenInput("Enter passphrase for vault identity (minimum 12 characters): ", nil)
 			if err != nil {

--- a/cmd/admin/init.go
+++ b/cmd/admin/init.go
@@ -63,9 +63,14 @@ var initCmd = &cobra.Command{
 			return fmt.Errorf("cannot create vault directory: %w", mkdirErr)
 		}
 
-		passphrase, err := cli.ReadHiddenInput("Enter passphrase for vault identity (minimum 12 characters): ", nil)
-		if err != nil {
-			return fmt.Errorf("cannot read passphrase: %w", err)
+		var passphrase []byte
+		if envPassphrase := os.Getenv("SYMVAULT_PASSPHRASE"); envPassphrase != "" {
+			passphrase = []byte(envPassphrase)
+		} else {
+			passphrase, err = cli.ReadHiddenInput("Enter passphrase for vault identity (minimum 12 characters): ", nil)
+			if err != nil {
+				return fmt.Errorf("cannot read passphrase: %w", err)
+			}
 		}
 		defer cryptopkg.Wipe(passphrase)
 		if len(passphrase) < 12 {

--- a/cmd/admin/init.go
+++ b/cmd/admin/init.go
@@ -10,6 +10,7 @@ import (
 	cli "github.com/danieljustus/symaira-vault/internal/cli"
 
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 
 	"github.com/danieljustus/symaira-vault/internal/config"
 	cryptopkg "github.com/danieljustus/symaira-vault/internal/crypto"
@@ -35,6 +36,10 @@ var initCmd = &cobra.Command{
   symvault init ~/my-vault`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if !term.IsTerminal(int(os.Stdin.Fd())) && os.Getenv("SYMVAULT_PASSPHRASE") == "" {
+			return fmt.Errorf("init requires a TTY or SYMVAULT_PASSPHRASE env var; use `symvault setup` for interactive initialization")
+		}
+
 		var (
 			vaultDir string
 			err      error

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -17,8 +17,8 @@ func TestInitCommand_HiddenPassphrase(t *testing.T) {
 	vaultDir := t.TempDir()
 	passphrase := []byte("test-hidden-passphrase")
 
-	_ = os.Setenv("SYMVAULT_PASSPHRASE", string(passphrase))
-	defer func() { _ = os.Unsetenv("SYMVAULT_PASSPHRASE") }()
+	cli.SetCachedEnvPassphrase(passphrase)
+	defer cli.SetCachedEnvPassphrase(nil)
 
 	cli.RootCmd.SetArgs([]string{"init", vaultDir})
 	defer cli.RootCmd.SetArgs(nil)
@@ -58,8 +58,8 @@ func TestCmdInit_Success(t *testing.T) {
 	vaultDir := t.TempDir()
 	vaultFlagReset(t)
 
-	_ = os.Setenv("SYMVAULT_PASSPHRASE", "supersecretpassphrase123")
-	defer func() { _ = os.Unsetenv("SYMVAULT_PASSPHRASE") }()
+	cli.SetCachedEnvPassphrase([]byte("supersecretpassphrase123"))
+	defer cli.SetCachedEnvPassphrase(nil)
 
 	cli.RootCmd.SetArgs([]string{"--vault", vaultDir, "init"})
 	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
@@ -81,8 +81,8 @@ func TestCmdInit_AlreadyInitialized(t *testing.T) {
 		t.Fatalf("pre-init vault: %v", err)
 	}
 
-	_ = os.Setenv("SYMVAULT_PASSPHRASE", "supersecretpassphrase123")
-	defer func() { _ = os.Unsetenv("SYMVAULT_PASSPHRASE") }()
+	cli.SetCachedEnvPassphrase([]byte("supersecretpassphrase123"))
+	defer cli.SetCachedEnvPassphrase(nil)
 
 	cli.RootCmd.SetArgs([]string{"--vault", vaultDir, "init"})
 	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
@@ -104,8 +104,8 @@ func TestCmdInit_ShortPassphrase(t *testing.T) {
 	vaultDir := t.TempDir()
 	vaultFlagReset(t)
 
-	_ = os.Setenv("SYMVAULT_PASSPHRASE", "short")
-	defer func() { _ = os.Unsetenv("SYMVAULT_PASSPHRASE") }()
+	cli.SetCachedEnvPassphrase([]byte("short"))
+	defer cli.SetCachedEnvPassphrase(nil)
 
 	cli.RootCmd.SetArgs([]string{"--vault", vaultDir, "init"})
 	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
@@ -130,8 +130,8 @@ func TestInit_ErrorPaths(t *testing.T) {
 		_ = os.Setenv("OPENPASS_VAULT", tmpDir)
 		defer func() { _ = os.Unsetenv("OPENPASS_VAULT") }()
 
-		_ = os.Setenv("SYMVAULT_PASSPHRASE", "test")
-		defer func() { _ = os.Unsetenv("SYMVAULT_PASSPHRASE") }()
+		cli.SetCachedEnvPassphrase([]byte("test"))
+		defer cli.SetCachedEnvPassphrase(nil)
 
 		cli.RootCmd.SetArgs([]string{"--vault", tmpDir, "init"})
 		defer cli.RootCmd.SetArgs(nil)

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -81,6 +81,9 @@ func TestCmdInit_AlreadyInitialized(t *testing.T) {
 		t.Fatalf("pre-init vault: %v", err)
 	}
 
+	_ = os.Setenv("SYMVAULT_PASSPHRASE", "supersecretpassphrase123")
+	defer func() { _ = os.Unsetenv("SYMVAULT_PASSPHRASE") }()
+
 	cli.RootCmd.SetArgs([]string{"--vault", vaultDir, "init"})
 	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
 
@@ -126,6 +129,9 @@ func TestInit_ErrorPaths(t *testing.T) {
 
 		_ = os.Setenv("OPENPASS_VAULT", tmpDir)
 		defer func() { _ = os.Unsetenv("OPENPASS_VAULT") }()
+
+		_ = os.Setenv("SYMVAULT_PASSPHRASE", "test")
+		defer func() { _ = os.Unsetenv("SYMVAULT_PASSPHRASE") }()
 
 		cli.RootCmd.SetArgs([]string{"--vault", tmpDir, "init"})
 		defer cli.RootCmd.SetArgs(nil)

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -17,8 +17,8 @@ func TestInitCommand_HiddenPassphrase(t *testing.T) {
 	vaultDir := t.TempDir()
 	passphrase := []byte("test-hidden-passphrase")
 
-	restore := pipeStdin(t, string(passphrase)+"\n")
-	defer restore()
+	_ = os.Setenv("SYMVAULT_PASSPHRASE", string(passphrase))
+	defer func() { _ = os.Unsetenv("SYMVAULT_PASSPHRASE") }()
 
 	cli.RootCmd.SetArgs([]string{"init", vaultDir})
 	defer cli.RootCmd.SetArgs(nil)
@@ -58,15 +58,8 @@ func TestCmdInit_Success(t *testing.T) {
 	vaultDir := t.TempDir()
 	vaultFlagReset(t)
 
-	oldStdin := os.Stdin
-	r, w, _ := os.Pipe()
-	os.Stdin = r
-	_, _ = w.WriteString("supersecretpassphrase123\n")
-	_ = w.Close()
-	t.Cleanup(func() {
-		os.Stdin = oldStdin
-		_ = r.Close()
-	})
+	_ = os.Setenv("SYMVAULT_PASSPHRASE", "supersecretpassphrase123")
+	defer func() { _ = os.Unsetenv("SYMVAULT_PASSPHRASE") }()
 
 	cli.RootCmd.SetArgs([]string{"--vault", vaultDir, "init"})
 	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
@@ -108,15 +101,8 @@ func TestCmdInit_ShortPassphrase(t *testing.T) {
 	vaultDir := t.TempDir()
 	vaultFlagReset(t)
 
-	oldStdin := os.Stdin
-	r, w, _ := os.Pipe()
-	os.Stdin = r
-	_, _ = w.WriteString("short\n")
-	_ = w.Close()
-	t.Cleanup(func() {
-		os.Stdin = oldStdin
-		_ = r.Close()
-	})
+	_ = os.Setenv("SYMVAULT_PASSPHRASE", "short")
+	defer func() { _ = os.Unsetenv("SYMVAULT_PASSPHRASE") }()
 
 	cli.RootCmd.SetArgs([]string{"--vault", vaultDir, "init"})
 	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })

--- a/internal/cli/generate.go
+++ b/internal/cli/generate.go
@@ -1,44 +1,12 @@
 package cli
 
 import (
-	"crypto/rand"
-	"fmt"
-	"math/big"
-
 	cryptopkg "github.com/danieljustus/symaira-vault/internal/crypto"
 )
-
-const lowerChars = "abcdefghjkmnpqrstuvwxyz"
-const upperChars = "ABCDEFGHJKMNPQRSTUVWXYZ"
-const digitChars = "23456789"
-const symbolChars = "!@#$%^&*()-_=+[]{}|;:,.<>?/~"
 
 // GeneratePassword generates a password using an ambiguous-character-free
 // charset. The returned cleanup function MUST be called to zero and release
 // the underlying memory when the password is no longer needed.
 func GeneratePassword(length int, useSymbols bool) (string, func(), error) {
-	if length < 1 {
-		return "", func() {}, fmt.Errorf("password length must be at least 1")
-	}
-	if length > 4096 {
-		length = 4096
-	}
-
-	chars := lowerChars + upperChars + digitChars
-	if useSymbols {
-		chars += symbolChars
-	}
-
-	buf := make([]byte, length)
-	for i := range buf {
-		idx, err := rand.Int(rand.Reader, big.NewInt(int64(len(chars))))
-		if err != nil {
-			return "", func() {}, fmt.Errorf("cannot generate random index: %w", err)
-		}
-		buf[i] = chars[idx.Int64()]
-	}
-
-	s, cleanup := cryptopkg.SecureString(buf)
-	cryptopkg.Wipe(buf)
-	return s, cleanup, nil
+	return cryptopkg.GeneratePassword(length, useSymbols)
 }

--- a/internal/cli/passphrase_env.go
+++ b/internal/cli/passphrase_env.go
@@ -27,10 +27,23 @@ func SniffAndClearEnvPassphrase() {
 	})
 }
 
-// consumeCachedEnvPassphrase returns the early-cached env passphrase
+// ConsumeCachedEnvPassphrase returns the early-cached env passphrase
 // and clears the process-local cache so the bytes are not retained.
-func consumeCachedEnvPassphrase() []byte {
+func ConsumeCachedEnvPassphrase() []byte {
 	p := cachedEnvPassphrase
 	cachedEnvPassphrase = nil
 	return p
+}
+
+// HasCachedEnvPassphrase reports whether an environment passphrase was
+// cached by SniffAndClearEnvPassphrase. Does not consume the cache.
+func HasCachedEnvPassphrase() bool {
+	return len(cachedEnvPassphrase) > 0
+}
+
+// SetCachedEnvPassphrase sets the cached passphrase for testing purposes.
+// This is used by tests that need to simulate an environment passphrase
+// without going through SniffAndClearEnvPassphrase.
+func SetCachedEnvPassphrase(p []byte) {
+	cachedEnvPassphrase = p
 }

--- a/internal/cli/unlock.go
+++ b/internal/cli/unlock.go
@@ -128,7 +128,7 @@ func resolveUnlockPassphrase(vaultDir string, interactive bool, cfg *configpkg.C
 		if len(passphrase) == 0 && (cfg == nil || cfg.Security == nil || !cfg.Security.DisableEnvPassphrase) {
 			// Check the early-cached env passphrase first (sniffed in main()
 			// before any child process could inherit it).
-			if cached := consumeCachedEnvPassphrase(); len(cached) > 0 {
+			if cached := ConsumeCachedEnvPassphrase(); len(cached) > 0 {
 				passphrase = cached
 				passphraseFromEnv = true
 				WarnEnvPassphrase()

--- a/internal/crypto/password.go
+++ b/internal/crypto/password.go
@@ -21,9 +21,11 @@ func GeneratePassword(length int, useSymbols bool) (string, func(), error) {
 }
 
 func generatePasswordWithReader(length int, useSymbols bool, reader io.Reader) (string, func(), error) {
+	// Ambiguous-character-free charset: excludes l, I, 1, O, 0 to avoid
+	// confusion in passwords displayed in terminals or printed media.
 	const (
-		letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-		symbols = "!@#$%^&*()_+-=[]{}|;:,.<>?"
+		letters = "abcdefghjkmnpqrstuvwxyzABCDEFGHJKMNPQRSTUVWXYZ23456789"
+		symbols = "!@#$%^&*()-_=+[]{}|;:,.<>?/~"
 	)
 
 	if length <= 0 {

--- a/internal/crypto/password_test.go
+++ b/internal/crypto/password_test.go
@@ -257,3 +257,20 @@ func TestAssessPasswordStrength_ExactBoundary(t *testing.T) {
 		t.Error("expected Weak=true for 10 lowercase chars (≈47 bits < 60)")
 	}
 }
+
+func TestGeneratePassword_NoAmbiguousChars(t *testing.T) {
+	ambiguousChars := "lI1O0"
+	password, cleanup, err := GeneratePassword(1000, true)
+	if cleanup != nil {
+		defer cleanup()
+	}
+	if err != nil {
+		t.Fatalf("GeneratePassword() error = %v", err)
+	}
+
+	for _, c := range password {
+		if strings.ContainsRune(ambiguousChars, c) {
+			t.Errorf("password contains ambiguous character %q", c)
+		}
+	}
+}

--- a/internal/mcp/server/tools_execute_with_secret.go
+++ b/internal/mcp/server/tools_execute_with_secret.go
@@ -162,7 +162,8 @@ func (s *Server) handleExecuteWithSecret(ctx context.Context, req mcp.CallToolRe
 		exitCode = -1
 	}
 
-	auditPath := fmt.Sprintf("command=[%s], refs=%v, exit=%d", strings.Join(command, " "), secretRefs, exitCode)
+	redactedCommand := redactSecrets(command, secretEnv)
+	auditPath := fmt.Sprintf("command=[%s], refs=%v, exit=%d", strings.Join(redactedCommand, " "), secretRefs, exitCode)
 	s.logAudit(ctx, "execute_with_secret", auditPath, exitCode == 0 && runErr == nil)
 
 	if runErr != nil {
@@ -265,6 +266,20 @@ func mapKeys(m map[string]string) []string {
 	}
 	sort.Strings(keys)
 	return keys
+}
+
+func redactSecrets(command []string, secretEnv map[string]string) []string {
+	redacted := make([]string, len(command))
+	for i, arg := range command {
+		redacted[i] = arg
+		for _, secret := range secretEnv {
+			if arg == secret {
+				redacted[i] = "[REDACTED]"
+				break
+			}
+		}
+	}
+	return redacted
 }
 
 func init() {

--- a/internal/ui/wizard/step_nextsteps.go
+++ b/internal/ui/wizard/step_nextsteps.go
@@ -39,10 +39,10 @@ func (s *NextStepsStep) View() string {
 		"",
 		"  " + focusedStyle.Render("symvault add <name>") + "           add your first entry",
 		"  " + focusedStyle.Render("symvault get <name>") + "           retrieve a password",
-		"  " + focusedStyle.Render("symvault tui") + "                  browse entries in terminal UI",
-		"  " + focusedStyle.Render("symvault autotype") + "             auto-type passwords into forms",
+		"  " + focusedStyle.Render("symvault ui") + "                   browse entries in terminal UI",
+		"  " + focusedStyle.Render("symvault get --autotype") + "      auto-type passwords into forms",
 		"  " + focusedStyle.Render("symvault doctor") + "               health check",
-		"  " + focusedStyle.Render("symvault mcp-config") + "           configure MCP agent integrations",
+		"  " + focusedStyle.Render("symvault agent install <agent>") + "  configure MCP agent integrations",
 		"  " + focusedStyle.Render("symvault auth set <method>") + "    change auth method",
 		"  " + focusedStyle.Render("symvault --help") + "               show all commands",
 	}

--- a/internal/vault/recipients.go
+++ b/internal/vault/recipients.go
@@ -340,7 +340,7 @@ type RecipientInfo struct {
 // This includes the vault's own recipient plus all recipients from the recipients.txt file.
 func (v *Vault) GetAllRecipientsForEncryption() ([]*age.X25519Recipient, error) {
 	if v.Identity == nil {
-		return nil, ErrNilIdentity
+		return nil, vaultcrypto.ErrNilIdentity
 	}
 
 	// Start with the vault's own recipient

--- a/internal/vault/recipients_test.go
+++ b/internal/vault/recipients_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	"filippo.io/age"
+
+	vaultcrypto "github.com/danieljustus/symaira-vault/internal/crypto"
 )
 
 const testRecipient = "age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p"
@@ -476,7 +478,7 @@ func TestVault_GetAllRecipientsForEncryption_NilIdentity(t *testing.T) {
 		t.Error("GetAllRecipientsForEncryption() should return error for nil identity")
 	}
 
-	if !errors.Is(err, ErrNilIdentity) {
+	if !errors.Is(err, vaultcrypto.ErrNilIdentity) {
 		t.Errorf("GetAllRecipientsForEncryption() error = %v, want ErrNilIdentity", err)
 	}
 }

--- a/internal/vault/reencrypt.go
+++ b/internal/vault/reencrypt.go
@@ -31,7 +31,7 @@ type reencryptResult struct {
 // Returns an error if any file fails.
 func ReencryptAll(vaultDir string, identity *age.X25519Identity, recipients []*age.X25519Recipient) error {
 	if identity == nil {
-		return ErrNilIdentity
+		return vaultcrypto.ErrNilIdentity
 	}
 	if len(recipients) == 0 {
 		return fmt.Errorf("no recipients provided for re-encryption")

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -20,7 +20,6 @@ const vaultFormatVersion2 = 2
 
 var (
 	ErrVaultDirEmpty       = errors.New("vault directory is empty")
-	ErrNilIdentity         = errors.New("identity is nil")
 	ErrNilConfig           = errors.New("config is nil")
 	ErrIdentityMismatch    = errors.New("identity mismatch")
 	ErrVaultNotInitialized = errors.New("vault not initialized")
@@ -50,7 +49,7 @@ func Init(vaultDir string, identity *age.X25519Identity, cfg *vaultconfig.Config
 		return ErrVaultDirEmpty
 	}
 	if identity == nil {
-		return ErrNilIdentity
+		return vaultcrypto.ErrNilIdentity
 	}
 	if cfg == nil {
 		return ErrNilConfig
@@ -84,7 +83,7 @@ func Open(vaultDir string, identity *age.X25519Identity) (*Vault, error) {
 		return nil, ErrVaultDirEmpty
 	}
 	if identity == nil {
-		return nil, ErrNilIdentity
+		return nil, vaultcrypto.ErrNilIdentity
 	}
 	if err := validateVaultDir(vaultDir); err != nil {
 		return nil, err
@@ -217,7 +216,7 @@ func OpenWithCachedIdentity(vaultDir string, identity *age.X25519Identity) (*Vau
 		return nil, ErrVaultDirEmpty
 	}
 	if identity == nil {
-		return nil, ErrNilIdentity
+		return nil, vaultcrypto.ErrNilIdentity
 	}
 	return Open(vaultDir, identity)
 }
@@ -295,7 +294,7 @@ func (v *Vault) GetRecipient() (*age.X25519Recipient, error) {
 		return nil, errors.New("vault is nil")
 	}
 	if v.Identity == nil {
-		return nil, ErrNilIdentity
+		return nil, vaultcrypto.ErrNilIdentity
 	}
 	return v.Identity.Recipient(), nil
 }
@@ -305,7 +304,7 @@ func (v *Vault) ValidateIdentity(identity *age.X25519Identity) error {
 		return errors.New("vault is nil")
 	}
 	if identity == nil {
-		return ErrNilIdentity
+		return vaultcrypto.ErrNilIdentity
 	}
 	if v.Identity.String() != identity.String() {
 		return ErrIdentityMismatch


### PR DESCRIPTION
Bundles fixes for multiple open issues. The list below grows as commits land; every linked issue will close automatically on merge.

<!-- closes-list-start -->
- Closes #427 Unify dual GeneratePassword functions to prevent silent charset divergence
- Closes #428 Prevent audit log from capturing secrets via command arguments
- Closes #429 Add TTY guard to symvault init passphrase prompt
- Closes #430 Document HTTP cleartext token limitation for loopback MCP transport
- Closes #431 Fix wrong command names in setup wizard nextsteps screen
- Closes #438 Consolidate duplicate ErrNilIdentity sentinel error
<!-- closes-list-end -->
