### PR TITLE
Add tests to improve coverage gate and package thresholds

### DIFF
--- a/internal/session/memory_keyring_test.go
+++ b/internal/session/memory_keyring_test.go
@@ -348,3 +348,42 @@ func TestMemoryKeyring_Set_ZeroesOldData(t *testing.T) {
 		t.Errorf("Passphrase = %q, want second-secret (memory keyring is opaque storage)", retrieved.Passphrase)
 	}
 }
+
+func TestMemoryKeyring_encryptionKeyForStore(t *testing.T) {
+	mk := &memoryKeyring{}
+	vaultDir := "/tmp/vault-encryption-key"
+	service := "symvault:" + vaultDir
+
+	// Test with no wrap key
+	_, err := mk.encryptionKeyForStore(service)
+	if err == nil {
+		t.Fatal("encryptionKeyForStore() error = nil, want error when no wrap key")
+	}
+
+	// Test with invalid base64 wrap key
+	mk.store = map[string][]byte{}
+	mk.store[service+"|"+wrapKeyAccount] = []byte("invalid-base64")
+	_, err = mk.encryptionKeyForStore(service)
+	if err == nil {
+		t.Fatal("encryptionKeyForStore() error = nil, want error for invalid base64")
+	}
+
+	// Test with wrong length wrap key
+	validKey := testKey()
+	wrongLengthKey := validKey[:16] // 16 bytes instead of 32
+	mk.store[service+"|"+wrapKeyAccount] = []byte(base64.StdEncoding.EncodeToString(wrongLengthKey))
+	_, err = mk.encryptionKeyForStore(service)
+	if err == nil {
+		t.Fatal("encryptionKeyForStore() error = nil, want error for wrong key length")
+	}
+
+	// Test with valid wrap key
+	mk.store[service+"|"+wrapKeyAccount] = []byte(base64.StdEncoding.EncodeToString(validKey))
+	key, err := mk.encryptionKeyForStore(service)
+	if err != nil {
+		t.Fatalf("encryptionKeyForStore() error = %v", err)
+	}
+	if len(key) != wrapKeyLen {
+		t.Errorf("encryptionKeyForStore() key length = %d, want %d", len(key), wrapKeyLen)
+	}
+}

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -1286,3 +1286,86 @@ func TestDecryptPassphrase_FailsWithWrongKey(t *testing.T) {
 		t.Fatal("decryptPassphrase with wrong key should fail")
 	}
 }
+
+func TestSetDefaultManager_And_DefaultManager(t *testing.T) {
+	original := DefaultManager()
+	defer SetDefaultManager(original)
+
+	fake := newFakeKeyring()
+	mgr := NewManager(fake, nil)
+
+	SetDefaultManager(mgr)
+	if got := DefaultManager(); got != mgr {
+		t.Errorf("DefaultManager() = %v, want %v", got, mgr)
+	}
+}
+
+func TestPackageLevelFunctions(t *testing.T) {
+	fake := newFakeKeyring()
+	mgr := NewManager(fake, nil)
+	SetDefaultManager(mgr)
+
+	vaultDir := "/tmp/vault-package-level"
+	setupTestWrapKey(t, fake, vaultDir)
+
+	err := SavePassphrase(vaultDir, []byte("secret"), time.Hour)
+	if err != nil {
+		t.Fatalf("SavePassphrase failed: %v", err)
+	}
+
+	pass, err := LoadPassphrase(vaultDir)
+	if err != nil {
+		t.Fatalf("LoadPassphrase failed: %v", err)
+	}
+	if string(pass) != "secret" {
+		t.Errorf("LoadPassphrase = %q, want %q", string(pass), "secret")
+	}
+
+	if IsSessionExpired(vaultDir) {
+		t.Error("IsSessionExpired = true, want false")
+	}
+
+	err = ClearSession(vaultDir)
+	if err != nil {
+		t.Fatalf("ClearSession failed: %v", err)
+	}
+
+	identity := "AGE-SECRET-KEY-1FAKE0000000000000000000000000000000000000000000000000000000"
+	err = SaveIdentity(vaultDir, identity, time.Hour)
+	if err != nil {
+		t.Fatalf("SaveIdentity failed: %v", err)
+	}
+
+	loaded, err := LoadIdentity(vaultDir)
+	if err != nil {
+		t.Fatalf("LoadIdentity failed: %v", err)
+	}
+	if loaded != identity {
+		t.Errorf("LoadIdentity = %q, want %q", loaded, identity)
+	}
+
+	err = ClearIdentity(vaultDir)
+	if err != nil {
+		t.Fatalf("ClearIdentity failed: %v", err)
+	}
+}
+
+func TestFallbackKeyring_ActivateFallback(t *testing.T) {
+	primary := newFakeKeyring()
+	fb := NewFallbackKeyring(primary)
+
+	fbImpl, ok := fb.(*fallbackKeyring)
+	if !ok {
+		t.Fatal("NewFallbackKeyring did not return *fallbackKeyring")
+	}
+
+	if fbImpl.IsFallbackActive() {
+		t.Error("IsFallbackActive() = true, want false")
+	}
+
+	fbImpl.ActivateFallback()
+
+	if !fbImpl.IsFallbackActive() {
+		t.Error("IsFallbackActive() = false, want true")
+	}
+}

--- a/internal/vault/coverage_expansion_test.go
+++ b/internal/vault/coverage_expansion_test.go
@@ -323,3 +323,45 @@ func TestVaultCache_PseudonymCacheTTL(t *testing.T) {
 		t.Errorf("expected 10m, got %v", ttl)
 	}
 }
+
+func TestDefaultVaultCache(t *testing.T) {
+	cache := DefaultVaultCache()
+	if cache == nil {
+		t.Fatal("DefaultVaultCache() returned nil")
+	}
+	if cache != DefaultVaultCache() {
+		t.Error("DefaultVaultCache() should return the same instance")
+	}
+}
+
+func TestRegisterVaultCache(t *testing.T) {
+	vaultCachesMu.Lock()
+	original := vaultCaches
+	vaultCaches = make(map[string]*VaultCache)
+	vaultCachesMu.Unlock()
+
+	defer func() {
+		vaultCachesMu.Lock()
+		vaultCaches = original
+		vaultCachesMu.Unlock()
+	}()
+
+	cache := NewVaultCache(VaultCacheConfig{})
+	registerVaultCache("/test/vault", cache)
+
+	if got := lookupVaultCache("/test/vault"); got != cache {
+		t.Error("registerVaultCache did not register the cache")
+	}
+
+	// Test nil cache
+	registerVaultCache("/test/nil", nil)
+	if got := lookupVaultCache("/test/nil"); got != nil {
+		t.Error("registerVaultCache with nil should not register")
+	}
+
+	// Test empty vaultDir
+	registerVaultCache("", cache)
+	if got := lookupVaultCache(""); got != nil {
+		t.Error("registerVaultCache with empty vaultDir should not register")
+	}
+}

--- a/internal/vault/coverage_expansion_test.go
+++ b/internal/vault/coverage_expansion_test.go
@@ -1,7 +1,11 @@
 package vault
 
 import (
+	"fmt"
 	"testing"
+	"time"
+
+	vaultconfig "github.com/danieljustus/symaira-vault/internal/config"
 )
 
 func TestEntry_RemoveTag(t *testing.T) {
@@ -138,5 +142,184 @@ func TestHasField_Basic(t *testing.T) {
 	}
 	if hasField([]string{"name", "path"}, "") {
 		t.Error("hasField should not find empty string")
+	}
+}
+
+func TestVaultCache_InvalidatePath(t *testing.T) {
+	cache := NewVaultCache(VaultCacheConfig{})
+
+	// Test nil cache
+	var nilCache *VaultCache
+	nilCache.InvalidatePath("test/path") // should not panic
+
+	// Test empty path (invalidates all)
+	cache.InvalidatePath("")
+
+	// Test path with pseudonym entries
+	cache.pseudonymMu.Lock()
+	cache.pseudonymItems["vault1"] = pseudonymizedCacheEntry{
+		entries: map[string]map[string]any{
+			"test/path": {"key": "value"},
+		},
+	}
+	cache.pseudonymItems["vault2"] = pseudonymizedCacheEntry{
+		entries: map[string]map[string]any{
+			"other/path": {"key": "value"},
+		},
+	}
+	cache.pseudonymMu.Unlock()
+
+	cache.InvalidatePath("test/path")
+
+	cache.pseudonymMu.RLock()
+	if _, ok := cache.pseudonymItems["vault1"]; ok {
+		t.Error("vault1 should have been invalidated")
+	}
+	if _, ok := cache.pseudonymItems["vault2"]; !ok {
+		t.Error("vault2 should still exist")
+	}
+	cache.pseudonymMu.RUnlock()
+}
+
+func TestVaultCache_InvalidateSearchIndex(t *testing.T) {
+	cache := NewVaultCache(VaultCacheConfig{})
+	cache.InvalidateSearchIndex() // should not panic
+}
+
+func TestVaultCache_GetOrLoad(t *testing.T) {
+	cache := NewVaultCache(VaultCacheConfig{})
+
+	// Test nil cache
+	var nilCache *VaultCache
+	loaded := false
+	v, err := nilCache.GetOrLoad("/test", func() (any, error) {
+		loaded = true
+		return &vaultconfig.Config{}, nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !loaded {
+		t.Error("loader should have been called")
+	}
+	if v == nil {
+		t.Error("expected non-nil config")
+	}
+
+	// Test cache miss with Config type
+	loaded = false
+	v, err = cache.GetOrLoad("/test", func() (any, error) {
+		loaded = true
+		return &vaultconfig.Config{}, nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !loaded {
+		t.Error("loader should have been called on cache miss")
+	}
+	if v == nil {
+		t.Error("expected non-nil config")
+	}
+
+	// Test cache hit
+	loaded = false
+	v, err = cache.GetOrLoad("/test", func() (any, error) {
+		loaded = true
+		return &vaultconfig.Config{}, nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if loaded {
+		t.Error("loader should not have been called on cache hit")
+	}
+	if v == nil {
+		t.Error("expected non-nil config from cache")
+	}
+
+	// Test non-Config type (not cached)
+	loaded = false
+	v, err = cache.GetOrLoad("/string", func() (any, error) {
+		loaded = true
+		return "string value", nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !loaded {
+		t.Error("loader should have been called for non-Config type")
+	}
+	if v != "string value" {
+		t.Errorf("expected 'string value', got %v", v)
+	}
+
+	// Test loader error
+	_, err = cache.GetOrLoad("/error", func() (any, error) {
+		return nil, fmt.Errorf("load error")
+	})
+	if err == nil {
+		t.Error("expected error from loader")
+	}
+}
+
+func TestVaultCache_SetConfigCacheSize(t *testing.T) {
+	cache := NewVaultCache(VaultCacheConfig{})
+
+	// Test nil cache
+	var nilCache *VaultCache
+	nilCache.SetConfigCacheSize(10) // should not panic
+
+	// Test valid size
+	cache.SetConfigCacheSize(50)
+	if cache.configMaxSize != 50 {
+		t.Errorf("expected configMaxSize 50, got %d", cache.configMaxSize)
+	}
+
+	// Test zero (resets to default)
+	cache.SetConfigCacheSize(0)
+	if cache.configMaxSize != defaultConfigCacheSize {
+		t.Errorf("expected configMaxSize %d, got %d", defaultConfigCacheSize, cache.configMaxSize)
+	}
+
+	// Test negative (resets to default)
+	cache.SetConfigCacheSize(-1)
+	if cache.configMaxSize != defaultConfigCacheSize {
+		t.Errorf("expected configMaxSize %d, got %d", defaultConfigCacheSize, cache.configMaxSize)
+	}
+}
+
+func TestVaultCache_SetPseudonymCacheTTL(t *testing.T) {
+	cache := NewVaultCache(VaultCacheConfig{})
+
+	// Test nil cache
+	var nilCache *VaultCache
+	nilCache.SetPseudonymCacheTTL(time.Minute) // should not panic
+
+	// Test valid TTL
+	cache.SetPseudonymCacheTTL(5 * time.Minute)
+	if cache.pseudonymTTL != 5*time.Minute {
+		t.Errorf("expected pseudonymTTL 5m, got %v", cache.pseudonymTTL)
+	}
+}
+
+func TestVaultCache_PseudonymCacheTTL(t *testing.T) {
+	cache := NewVaultCache(VaultCacheConfig{})
+
+	// Test nil cache
+	var nilCache *VaultCache
+	if ttl := nilCache.PseudonymCacheTTL(); ttl != 0 {
+		t.Errorf("expected 0, got %v", ttl)
+	}
+
+	// Test default TTL
+	if ttl := cache.PseudonymCacheTTL(); ttl != defaultPseudonymCacheTTL {
+		t.Errorf("expected %v, got %v", defaultPseudonymCacheTTL, ttl)
+	}
+
+	// Test custom TTL
+	cache.SetPseudonymCacheTTL(10 * time.Minute)
+	if ttl := cache.PseudonymCacheTTL(); ttl != 10*time.Minute {
+		t.Errorf("expected 10m, got %v", ttl)
 	}
 }


### PR DESCRIPTION
## Goal
Add tests to improve coverage gate and package thresholds.

## Changes
- Add cache tests for vault package (InvalidatePath, InvalidateSearchIndex, GetOrLoad, SetConfigCacheSize, SetPseudonymCacheTTL, PseudonymCacheTTL, DefaultVaultCache, registerVaultCache)
- Add session tests (encryptionKeyForStore, SetDefaultManager, DefaultManager, package-level functions, FallbackKeyring ActivateFallback)

## Coverage Results
- Total coverage: 63.7% (above 63.5% threshold)
- Vault package: 73.3% (improved from 71.0%)
- Session package: 72.1% (improved from 68.6%)

## Issues Closed
- Closes #450
- Closes #451
- Closes #452