### PR TITLE
session/20260616 224519

### DIFF
--- a/internal/crypto/password.go
+++ b/internal/crypto/password.go
@@ -55,9 +55,10 @@ func generatePasswordWithReader(length int, useSymbols bool, reader io.Reader) (
 
 // PasswordStrength represents the result of a password strength assessment.
 type PasswordStrength struct {
-	Weak    bool    `json:"weak"`
-	Message string  `json:"message,omitempty"`
-	Entropy float64 `json:"entropy"`
+	Weak    bool     `json:"weak"`
+	Message string   `json:"message,omitempty"`
+	Entropy float64  `json:"entropy"`
+	Missing []string `json:"missing,omitempty"`
 }
 
 // AssessPasswordStrength evaluates password strength without blocking.
@@ -89,6 +90,19 @@ func AssessPasswordStrength(password string) PasswordStrength {
 		case unicode.IsPunct(r), unicode.IsSymbol(r):
 			hasSymbol = true
 		}
+	}
+
+	if !hasLower {
+		s.Missing = append(s.Missing, "lowercase")
+	}
+	if !hasUpper {
+		s.Missing = append(s.Missing, "uppercase")
+	}
+	if !hasDigit {
+		s.Missing = append(s.Missing, "digits")
+	}
+	if !hasSymbol {
+		s.Missing = append(s.Missing, "symbols")
 	}
 
 	if hasLower {

--- a/internal/mcp/auth/auth.go
+++ b/internal/mcp/auth/auth.go
@@ -63,7 +63,7 @@ type rateLimitEntry struct {
 }
 
 // defaultRateLimiterContext is the background context for the auto-started
-// cleanup goroutine. It is never cancelled — cleanup runs for the lifetime
+// cleanup goroutine. It is never canceled — cleanup runs for the lifetime
 // of the process and is stopped only via Close().
 var defaultRateLimiterContext = context.Background()
 

--- a/internal/mcp/auth/auth.go
+++ b/internal/mcp/auth/auth.go
@@ -39,6 +39,11 @@ func TokenFromContext(ctx context.Context) (*ScopedToken, bool) {
 // When the cap is reached, the oldest tracked entries are evicted.
 const MaxRateLimiterEntries = 10000
 
+// defaultCleanupInterval is how often the background sweeper runs to
+// remove entries that somehow survived past their resetAt (e.g. timer
+// coalescing, GC pauses).
+const defaultCleanupInterval = 5 * time.Minute
+
 type RateLimiter struct {
 	attempts       map[string]*rateLimitEntry
 	mu             sync.Mutex
@@ -49,6 +54,7 @@ type RateLimiter struct {
 	evictionCount  int64
 	log            *slog.Logger
 	trustedProxies []string
+	stopCh         chan struct{} // closed by Close() to stop background cleanup
 }
 
 type rateLimitEntry struct {
@@ -56,14 +62,22 @@ type rateLimitEntry struct {
 	count   int
 }
 
+// defaultRateLimiterContext is the background context for the auto-started
+// cleanup goroutine. It is never cancelled — cleanup runs for the lifetime
+// of the process and is stopped only via Close().
+var defaultRateLimiterContext = context.Background()
+
 func NewRateLimiter(limit int, dur time.Duration, trustedProxies ...string) *RateLimiter {
-	return &RateLimiter{
+	rl := &RateLimiter{
 		attempts:       make(map[string]*rateLimitEntry),
 		limit:          limit,
 		window:         dur,
 		maxEntries:     MaxRateLimiterEntries,
 		trustedProxies: trustedProxies,
+		stopCh:         make(chan struct{}),
 	}
+	rl.startCleanup(defaultRateLimiterContext, defaultCleanupInterval)
+	return rl
 }
 
 // SetMaxEntriesForTests overrides the eviction cap; intended only for tests.
@@ -149,6 +163,25 @@ func (rl *RateLimiter) Cleanup() {
 	}
 }
 
+// startCleanup starts a background goroutine that periodically calls cleanupOnce.
+// It runs until the RateLimiter's stopCh is closed.
+func (rl *RateLimiter) startCleanup(ctx context.Context, interval time.Duration) {
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				rl.cleanupOnce()
+			case <-rl.stopCh:
+				return
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+}
+
 // StartCleanup starts a background goroutine that periodically calls Cleanup.
 // It cleans up expired rate limit entries every interval duration until the context is canceled.
 // Returns a cancellable stop function.
@@ -198,6 +231,7 @@ func (rl *RateLimiter) CleanupCount() int64 {
 }
 
 func (rl *RateLimiter) Close() error {
+	close(rl.stopCh)
 	return nil
 }
 

--- a/internal/mcp/auth/token.go
+++ b/internal/mcp/auth/token.go
@@ -14,6 +14,8 @@ import (
 	"time"
 	"unsafe"
 
+	"filippo.io/age"
+
 	"github.com/danieljustus/symaira-vault/internal/crypto"
 	"github.com/danieljustus/symaira-vault/internal/envutil"
 	"github.com/danieljustus/symaira-vault/internal/fsutil"
@@ -185,9 +187,11 @@ func entryToScopedToken(e TokenRegistryEntry) *ScopedToken {
 }
 
 // TokenRegistry provides thread-safe management of scoped MCP tokens backed
-// by an on-disk JSON file.
+// by an encrypted age file (registry.age). Falls back to plaintext JSON for
+// migration from older versions.
 type TokenRegistry struct {
 	path             string
+	identity         *age.X25519Identity // when non-nil, registry is encrypted at rest
 	mu               sync.RWMutex
 	entries          map[string]*ScopedToken                                        // keyed by token hash
 	stopFn           func()                                                         // stops the background cleanup goroutine
@@ -213,6 +217,15 @@ func (r *TokenRegistry) SetCleanupLogger(fn func(action, tokenID, label, reason 
 	r.cleanupLogger = fn
 }
 
+// SetIdentity enables encrypted-at-rest persistence for the token registry.
+// When set, the registry is encrypted using the vault's age identity on save
+// and decrypted on load.
+func (r *TokenRegistry) SetIdentity(identity *age.X25519Identity) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.identity = identity
+}
+
 // DefaultRevokedTokenRetention is the default retention period for revoked
 // tokens before they are purged from the registry.
 const DefaultRevokedTokenRetention = 30 * 24 * time.Hour
@@ -227,11 +240,25 @@ func NewTokenRegistry(path string) *TokenRegistry {
 	}
 }
 
-// Load reads the JSON registry file from disk and populates the in-memory
-// entries. If the file does not exist it is a no-op (empty registry).
+// Load reads the registry from disk and populates the in-memory entries.
+// When an identity is set it first attempts to load from the encrypted
+// registry.age file. If that does not exist it falls back to the plaintext
+// JSON file (migration path from pre-encryption versions).
 func (r *TokenRegistry) Load() error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+
+	if r.identity != nil {
+		encryptedPath := TokenRegistryEncryptedFilePath(filepath.Dir(r.path))
+		if data, err := os.ReadFile(encryptedPath); err == nil { // #nosec G304
+			plaintext, err := crypto.Decrypt(data, r.identity)
+			if err != nil {
+				return fmt.Errorf("decrypt token registry: %w", err)
+			}
+			defer crypto.Wipe(plaintext)
+			return r.unmarshalEntries(plaintext)
+		}
+	}
 
 	data, err := os.ReadFile(r.path) //#nosec G304 -- path comes from NewTokenRegistry which is controlled
 	if err != nil {
@@ -241,6 +268,10 @@ func (r *TokenRegistry) Load() error {
 		return fmt.Errorf("read token registry: %w", err)
 	}
 
+	return r.unmarshalEntries(data)
+}
+
+func (r *TokenRegistry) unmarshalEntries(data []byte) error {
 	var file TokenRegistryFile
 	if err := json.Unmarshal(data, &file); err != nil {
 		return fmt.Errorf("parse token registry: %w", err)
@@ -256,11 +287,12 @@ func (r *TokenRegistry) Load() error {
 	return nil
 }
 
-// Save persists the current in-memory entries to the JSON registry file with
-// 0o600 permissions. The lock is held for the entire marshal+write operation
-// to prevent a concurrent Create() or Revoke() from mutating entries after
-// the snapshot is taken but before it is persisted — a crash in that window
-// would silently lose the mutation.
+// Save persists the current in-memory entries to disk. When an identity is
+// set the data is encrypted to registry.age; otherwise it is written as
+// plaintext JSON for migration compatibility. The lock is held for the
+// entire marshal+write operation to prevent a concurrent Create() or
+// Revoke() from mutating entries after the snapshot is taken but before
+// it is persisted — a crash in that window would silently lose the mutation.
 func (r *TokenRegistry) Save() error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -276,6 +308,19 @@ func (r *TokenRegistry) Save() error {
 	data, err := json.MarshalIndent(file, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshal token registry: %w", err)
+	}
+	defer crypto.Wipe(data)
+
+	if r.identity != nil {
+		ciphertext, err := crypto.Encrypt(data, r.identity.Recipient())
+		if err != nil {
+			return fmt.Errorf("encrypt token registry: %w", err)
+		}
+		encryptedPath := TokenRegistryEncryptedFilePath(filepath.Dir(r.path))
+		if err := fsutil.AtomicWriteFile(encryptedPath, ciphertext, 0o600); err != nil {
+			return fmt.Errorf("write encrypted token registry: %w", err)
+		}
+		return nil
 	}
 
 	if err := fsutil.AtomicWriteFile(r.path, append(data, '\n'), 0o600); err != nil {
@@ -698,15 +743,32 @@ func TokenRegistryFilePath(vaultDir string) string {
 	return filepath.Join(vaultDir, "mcp-tokens.json")
 }
 
-// LoadTokenSystem tries to load the scoped token registry from
-// <vaultDir>/mcp-tokens.json. If that file does not exist it falls back to the
-// legacy single-token file and transparently seeds a new registry with one
-// wildcard-allowing entry. An optional customLegacyPath can be provided to
-// override the default <vaultDir>/mcp-token location. The returned string is
-// the raw legacy token (empty when the new registry is used).
+// TokenRegistryEncryptedFilePath returns the path to the encrypted token
+// registry file. The encrypted format supersedes the plaintext JSON for
+// tokens created after encryption is enabled.
+func TokenRegistryEncryptedFilePath(vaultDir string) string {
+	return filepath.Join(vaultDir, "registry.age")
+}
+
+// LoadTokenSystem tries to load the scoped token registry from the encrypted
+// registry.age (if identity is provided) or from mcp-tokens.json. If that
+// file does not exist it falls back to the legacy single-token file and
+// transparently seeds a new registry with one wildcard-allowing entry. The
+// returned string is the raw legacy token (empty when the new registry is
+// used).
 func LoadTokenSystem(vaultDir string, customLegacyPath ...string) (*TokenRegistry, string, error) {
+	return LoadTokenSystemWithIdentity(nil, vaultDir, customLegacyPath...)
+}
+
+// LoadTokenSystemWithIdentity is like LoadTokenSystem but accepts an optional
+// age identity for encrypted-at-rest token registry storage. When identity is
+// non-nil the registry is loaded from and saved to registry.age.
+func LoadTokenSystemWithIdentity(identity *age.X25519Identity, vaultDir string, customLegacyPath ...string) (*TokenRegistry, string, error) {
 	regPath := TokenRegistryFilePath(vaultDir)
 	reg := NewTokenRegistry(regPath)
+	if identity != nil {
+		reg.SetIdentity(identity)
+	}
 
 	if err := reg.Load(); err != nil {
 		return nil, "", err

--- a/internal/mcp/auth/token.go
+++ b/internal/mcp/auth/token.go
@@ -257,9 +257,14 @@ func (r *TokenRegistry) Load() error {
 }
 
 // Save persists the current in-memory entries to the JSON registry file with
-// 0o600 permissions.
+// 0o600 permissions. The lock is held for the entire marshal+write operation
+// to prevent a concurrent Create() or Revoke() from mutating entries after
+// the snapshot is taken but before it is persisted — a crash in that window
+// would silently lose the mutation.
 func (r *TokenRegistry) Save() error {
 	r.mu.Lock()
+	defer r.mu.Unlock()
+
 	file := TokenRegistryFile{
 		Version: 2,
 		Tokens:  make(map[string]TokenRegistryEntry, len(r.entries)),
@@ -267,7 +272,6 @@ func (r *TokenRegistry) Save() error {
 	for _, t := range r.entries {
 		file.Tokens[t.ID] = t.toEntry()
 	}
-	r.mu.Unlock()
 
 	data, err := json.MarshalIndent(file, "", "  ")
 	if err != nil {

--- a/internal/mcp/auth/token_test.go
+++ b/internal/mcp/auth/token_test.go
@@ -1623,3 +1623,35 @@ func TestTokenRegistry_CleanupReportsBothTypes(t *testing.T) {
 		t.Fatalf("len(RemovedIDs) = %d, want 2", len(result.RemovedIDs))
 	}
 }
+
+func TestTokenRegistry_SaveConcurrentCreateNoLoss(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mcp-tokens.json")
+	reg := NewTokenRegistry(path)
+
+	const N = 50
+	var wg sync.WaitGroup
+	wg.Add(N)
+	for i := range N {
+		go func(i int) {
+			defer wg.Done()
+			label := fmt.Sprintf("token-%d", i)
+			if _, _, err := reg.Create(label, []string{"*"}, "", 1*time.Hour); err != nil {
+				t.Errorf("Create(%q) error = %v", label, err)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	if err := reg.Save(); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	reg2 := NewTokenRegistry(path)
+	if err := reg2.Load(); err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if tokens := reg2.List(); len(tokens) != N {
+		t.Fatalf("loaded %d tokens, want %d", len(tokens), N)
+	}
+}

--- a/internal/mcp/auth/token_test.go
+++ b/internal/mcp/auth/token_test.go
@@ -14,6 +14,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"filippo.io/age"
 )
 
 func TestLoadOrCreateTokenCreatesFile(t *testing.T) {
@@ -1653,5 +1655,53 @@ func TestTokenRegistry_SaveConcurrentCreateNoLoss(t *testing.T) {
 	}
 	if tokens := reg2.List(); len(tokens) != N {
 		t.Fatalf("loaded %d tokens, want %d", len(tokens), N)
+	}
+}
+
+func TestTokenRegistry_EncryptedAtRest(t *testing.T) {
+	identity, err := age.GenerateX25519Identity()
+	if err != nil {
+		t.Fatalf("GenerateX25519Identity() error = %v", err)
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mcp-tokens.json")
+	reg := NewTokenRegistry(path)
+	reg.SetIdentity(identity)
+
+	if _, _, err := reg.Create("secret-agent", []string{"find_entries"}, "test", 1*time.Hour); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	if err := reg.Save(); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	// Plaintext JSON should NOT exist when encrypted mode is active.
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatal("plaintext mcp-tokens.json should not exist when encrypted mode is active")
+	}
+
+	// Encrypted file should exist.
+	encryptedPath := TokenRegistryEncryptedFilePath(dir)
+	if _, err := os.Stat(encryptedPath); err != nil {
+		t.Fatalf("registry.age should exist, got: %v", err)
+	}
+
+	// Reload with same identity.
+	reg2 := NewTokenRegistry(path)
+	reg2.SetIdentity(identity)
+	if err := reg2.Load(); err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if tokens := reg2.List(); len(tokens) != 1 {
+		t.Fatalf("loaded %d tokens, want 1", len(tokens))
+	}
+
+	// Reload with wrong identity should fail or return empty.
+	wrongIdentity, _ := age.GenerateX25519Identity()
+	reg3 := NewTokenRegistry(path)
+	reg3.SetIdentity(wrongIdentity)
+	if err := reg3.Load(); err == nil {
+		t.Fatal("Load() with wrong identity should fail")
 	}
 }

--- a/internal/mcp/server/leanmode.go
+++ b/internal/mcp/server/leanmode.go
@@ -15,6 +15,7 @@ var LeanToolSet = []string{
 	"symaira_search",
 	"health",
 	"find_entries",
+	"get_entry",
 	"get_entry_metadata",
 	"request_credential",
 	"set_entry_field",

--- a/internal/mcp/server/server.go
+++ b/internal/mcp/server/server.go
@@ -80,6 +80,7 @@ type Server struct {
 	transport    string
 	policyEngine *policy.Engine
 	shareStore   *ShareStore
+	tools        []toolDefinition // per-instance tool set, populated from global registry
 
 	approvalCache      *approvalCache
 	approvalKeyCounter atomic.Int64
@@ -100,6 +101,17 @@ func (s *Server) SessionID() string {
 		return ""
 	}
 	return s.sessionID
+}
+
+// ToolDefinitions returns a snapshot of the server's tool definitions.
+// This enables per-instance tool sets without global state mutation.
+func (s *Server) ToolDefinitions() []toolDefinition {
+	if s == nil {
+		return nil
+	}
+	result := make([]toolDefinition, len(s.tools))
+	copy(result, s.tools)
+	return result
 }
 
 // New creates a new MCP server instance with the specified vault and agent configuration.
@@ -177,6 +189,7 @@ func New(v *vault.Vault, agentName string, transport string) (*Server, error) {
 		auditLog:            auditLog,
 		transport:           transport,
 		policyEngine:        policyEngine,
+		tools:               toolDefinitions(),
 		approvalCache:       newApprovalCache(),
 		hookRegistry:        NewHookRegistry(),
 		sessionID:           sessionID,

--- a/internal/mcp/server/server.go
+++ b/internal/mcp/server/server.go
@@ -103,17 +103,6 @@ func (s *Server) SessionID() string {
 	return s.sessionID
 }
 
-// ToolDefinitions returns a snapshot of the server's tool definitions.
-// This enables per-instance tool sets without global state mutation.
-func (s *Server) ToolDefinitions() []toolDefinition {
-	if s == nil {
-		return nil
-	}
-	result := make([]toolDefinition, len(s.tools))
-	copy(result, s.tools)
-	return result
-}
-
 // New creates a new MCP server instance with the specified vault and agent configuration.
 func New(v *vault.Vault, agentName string, transport string) (*Server, error) {
 	if v == nil {

--- a/internal/mcp/server/server_dispatch.go
+++ b/internal/mcp/server/server_dispatch.go
@@ -180,33 +180,30 @@ func (s *Server) validateToolAccess(ctx context.Context, def toolDefinition, nam
 		return callToolResultPayload(toolError(msg))
 	}
 
-	if agentErr := isToolBlockedByAgent(s.agent, name); agentErr != nil {
-		span.SetStatus(codes.Error, "agent_tool_denied")
-		metrics.RecordMCPRequest(name, agentName, "agent_tool_denied", time.Since(start))
-		s.logAudit(ctx, "agent_tool_denied", name, false)
-		return callToolResultPayload(toolError(agentErr.Error()))
+	token, _ := auth.TokenFromContext(ctx)
+	if authErr := authorizeTool(s.agent, token, name); authErr != nil {
+		span.SetStatus(codes.Error, "tool_denied")
+		if token != nil {
+			metrics.RecordAuthDenial("tool_scope_denied", agentName)
+		} else {
+			metrics.RecordMCPRequest(name, agentName, "agent_tool_denied", time.Since(start))
+		}
+		s.logAudit(ctx, "tool_denied", name, false)
+		return callToolResultPayload(toolError(authErr.Error()))
 	}
 
-	if token, ok := auth.TokenFromContext(ctx); ok {
-		if !isToolAllowed(token, name) {
-			span.SetStatus(codes.Error, "tool scope denied")
-			metrics.RecordAuthDenial("tool_scope_denied", agentName)
-			s.logAudit(ctx, "tool_scope_denied", name, false)
-			return nil
-		}
+	if token != nil {
 		token.UpdateLastUsed()
 	}
 
-	if token, ok := auth.TokenFromContext(ctx); ok && token != nil {
-		if token.IsToolRegistryDriftDetected() {
-			span.SetStatus(codes.Error, "tool registry drift")
-			metrics.RecordMCPRequest(name, agentName, "error", time.Since(start))
-			s.logAudit(ctx, "tool_registry_drift", name, false)
-			return callToolResultPayload(toolError(
-				"tool registry has changed since this token was issued — " +
-					"re-issue the token with 'symvault mcp token create'",
-			))
-		}
+	if token != nil && token.IsToolRegistryDriftDetected() {
+		span.SetStatus(codes.Error, "tool registry drift")
+		metrics.RecordMCPRequest(name, agentName, "error", time.Since(start))
+		s.logAudit(ctx, "tool_registry_drift", name, false)
+		return callToolResultPayload(toolError(
+			"tool registry has changed since this token was issued — " +
+				"re-issue the token with 'symvault mcp token create'",
+		))
 	}
 
 	if entryPath != "" {

--- a/internal/mcp/server/tool_registry.go
+++ b/internal/mcp/server/tool_registry.go
@@ -603,6 +603,19 @@ func isToolBlockedByAgent(agent *config.AgentProfile, toolName string) *errors.M
 	return nil
 }
 
+// authorizeTool performs a single-pass authorization check that evaluates
+// agent tier, token scope, and special flags. Returns nil when the tool is
+// allowed, or an *errors.MCPError describing the denial reason.
+func authorizeTool(agent *config.AgentProfile, token *auth.ScopedToken, toolName string) *errors.MCPError {
+	if err := isToolBlockedByAgent(agent, toolName); err != nil {
+		return err
+	}
+	if !isToolAllowed(token, toolName) {
+		return errors.ToolNotAllowed(toolName, "token_scope", "")
+	}
+	return nil
+}
+
 // checkToolBlockedByTier applies tier-based tool blocking rules.
 // Returns an *errors.MCPError describing the block, or nil if allowed.
 func checkToolBlockedByTier(agent *config.AgentProfile, toolName string) *errors.MCPError {

--- a/internal/mcp/server/tools_set.go
+++ b/internal/mcp/server/tools_set.go
@@ -82,7 +82,10 @@ func (s *Server) handleSet(ctx context.Context, req mcp.CallToolRequest) (*mcp.C
 			if len(strength.Missing) > 0 {
 				detail["missing"] = strength.Missing
 			}
-			detailJSON, _ := json.Marshal(detail)
+			detailJSON, err := json.Marshal(detail)
+			if err != nil {
+				return mcp.NewToolResultError("password too weak"), nil
+			}
 			return mcp.NewToolResultError(string(detailJSON)), nil
 		}
 	}

--- a/internal/mcp/server/tools_set.go
+++ b/internal/mcp/server/tools_set.go
@@ -72,8 +72,18 @@ func (s *Server) handleSet(ctx context.Context, req mcp.CallToolRequest) (*mcp.C
 	}
 
 	if field == "password" && !req.GetBool("force", false) {
-		if err := crypto.ValidatePasswordStrength(value); err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("%s — re-call with force:true if you want to store this password (the entry will be tagged as weak)", err.Error())), nil
+		strength := crypto.AssessPasswordStrength(value)
+		if strength.Weak {
+			detail := map[string]any{
+				"weak":    true,
+				"entropy": strength.Entropy,
+				"message": fmt.Sprintf("%s — re-call with force:true to store this password (the entry will be tagged as weak)", strength.Message),
+			}
+			if len(strength.Missing) > 0 {
+				detail["missing"] = strength.Missing
+			}
+			detailJSON, _ := json.Marshal(detail)
+			return mcp.NewToolResultError(string(detailJSON)), nil
 		}
 	}
 

--- a/internal/vault/search_index.go
+++ b/internal/vault/search_index.go
@@ -523,7 +523,7 @@ func (idx *EncryptedIndex) loadFromDisk(vaultDir string, identity *age.X25519Ide
 		_ = os.Remove(indexPath)
 		return listErr
 	}
-	if doc.EntryCount > 0 && doc.EntryCount != len(paths) {
+	if doc.EntryCount != len(paths) {
 		_ = os.Remove(indexPath)
 		return errors.New("stale index")
 	}

--- a/internal/vault/search_index.go
+++ b/internal/vault/search_index.go
@@ -227,6 +227,134 @@ func (idx *EncryptedIndex) Build(vaultDir string, identity *age.X25519Identity) 
 	return nil
 }
 
+// BuildMemoryOnly builds the in-memory index without persisting to disk.
+// This is used by WarmSearchIndex to eliminate cold-start latency without
+// risking stale on-disk state from background goroutine races.
+func (idx *EncryptedIndex) BuildMemoryOnly(vaultDir string, identity *age.X25519Identity) error {
+	listCacheFor(vaultDir).Invalidate()
+
+	paths, err := List(vaultDir, "", identity)
+	if err != nil {
+		return err
+	}
+
+	doc := indexDoc{
+		Values:     make(map[string][]string, len(paths)),
+		TokenIndex: make(map[string]map[string]struct{}),
+		EntryCount: len(paths),
+	}
+
+	salt := make([]byte, indexSaltLen)
+	if _, randErr := rand.Read(salt); randErr != nil {
+		return randErr
+	}
+	doc.Salt = salt
+
+	type indexJob struct {
+		i    int
+		path string
+	}
+	type indexResult struct {
+		i      int
+		path   string
+		values []string
+	}
+
+	jobs := make(chan indexJob, len(paths))
+	results := make(chan indexResult, len(paths))
+
+	maxWorkers := SearchWorkerCount(0)
+	if len(paths) < maxWorkers {
+		maxWorkers = len(paths)
+	}
+
+	var pseudoKey []byte
+	cfg, cfgErr := loadVaultConfig(vaultDir)
+	if cfgErr == nil && identity != nil && isPseudonymizeEnabled(cfg) {
+		pseudoKey = derivePseudonymizationKey(identity)
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < maxWorkers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for job := range jobs {
+				entry, readErr := readEntryInner(vaultDir, job.path, identity, pseudoKey)
+				if readErr != nil {
+					results <- indexResult{i: job.i, path: job.path}
+					continue
+				}
+
+				var values []string
+				collectStringValues(&values, entry.Data)
+				sort.Strings(values)
+				results <- indexResult{i: job.i, path: job.path, values: values}
+			}
+		}()
+	}
+
+	for i, entryPath := range paths {
+		jobs <- indexJob{i: i, path: entryPath}
+	}
+	close(jobs)
+
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
+
+	collected := make([]indexResult, len(paths))
+	for result := range results {
+		collected[result.i] = result
+	}
+
+	for _, result := range collected {
+		if len(result.values) == 0 {
+			continue
+		}
+
+		doc.Values[result.path] = result.values
+		for _, val := range result.values {
+			for _, token := range tokenize(val) {
+				if doc.TokenIndex[token] == nil {
+					doc.TokenIndex[token] = make(map[string]struct{})
+				}
+				doc.TokenIndex[token][result.path] = struct{}{}
+			}
+		}
+	}
+
+	if len(paths) > 0 && len(doc.Values) == 0 {
+		return ErrIndexBuildEmpty
+	}
+
+	plaintext, err := json.Marshal(doc)
+	if err != nil {
+		return err
+	}
+	defer vaultcrypto.Wipe(plaintext)
+
+	key := deriveIndexKey(identity, salt)
+	defer vaultcrypto.Wipe(key)
+
+	ciphertext, err := vaultcrypto.EncryptWithKey(plaintext, key)
+	if err != nil {
+		return err
+	}
+
+	idHash := sha256.Sum256([]byte(identity.String()))
+
+	idx.mu.Lock()
+	idx.ciphertext = ciphertext
+	idx.salt = salt
+	idx.vaultDir = vaultDir
+	idx.idHash = idHash
+	idx.mu.Unlock()
+
+	return nil
+}
+
 // MatchEntries decrypts the index and checks which of the given entry paths
 // contain the needle as a substring in any of their stored values. Returns
 // the subset of paths that match.

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -44,6 +44,17 @@ type Vault struct {
 	searchIdentity atomic.Pointer[age.X25519Identity]
 }
 
+// WarmSearchIndex triggers a background build of the encrypted search index.
+// This eliminates cold-start latency on the first FindWithOptions call.
+func (v *Vault) WarmSearchIndex() {
+	if v == nil || v.Identity == nil {
+		return
+	}
+	go func() {
+		_ = globalIndex.Build(v.Dir, v.Identity)
+	}()
+}
+
 func Init(vaultDir string, identity *age.X25519Identity, cfg *vaultconfig.Config) error {
 	if vaultDir == "" {
 		return ErrVaultDirEmpty
@@ -133,6 +144,7 @@ func Open(vaultDir string, identity *age.X25519Identity) (*Vault, error) {
 	v := &Vault{Dir: vaultDir, Identity: identity, Config: cfg, Cache: cache}
 	v.searchIdentity.Store(identity)
 	registerVaultCache(vaultDir, cache)
+	v.WarmSearchIndex()
 	return v, nil
 }
 

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -51,7 +51,7 @@ func (v *Vault) WarmSearchIndex() {
 		return
 	}
 	go func() {
-		_ = globalIndex.Build(v.Dir, v.Identity)
+		_ = globalIndex.BuildMemoryOnly(v.Dir, v.Identity)
 	}()
 }
 
@@ -116,16 +116,15 @@ func Open(vaultDir string, identity *age.X25519Identity) (*Vault, error) {
 	// Flush any pending manifest updates before checking consistency.
 	FlushManifestUpdates()
 
-	// Check manifest consistency: rebuild in background if missing, or if the
-	// manifest is stale (config generation counter > manifest generation counter,
-	// indicating unflushed writes from a prior crash). The rebuild is
-	// non-blocking — reads are served from the directory walk while it runs.
+	// Check manifest consistency: rebuild if missing, or if the manifest is stale
+	// (config generation counter > manifest generation counter, indicating unflushed
+	// writes from a prior crash).
 	if _, err := os.Stat(filepath.Join(vaultDir, manifestFileName)); os.IsNotExist(err) {
-		go func() { _ = RebuildManifest(vaultDir, identity) }()
+		_ = RebuildManifest(vaultDir, identity) // best-effort
 	} else if cfg.Vault != nil && cfg.Vault.ManifestGeneration > 0 {
 		m, loadErr := LoadManifest(vaultDir, identity)
 		if loadErr == nil && m.Generation < cfg.Vault.ManifestGeneration {
-			go func() { _ = RebuildManifest(vaultDir, identity) }()
+			_ = RebuildManifest(vaultDir, identity) // best-effort
 		}
 	}
 	if _, err := os.Stat(filepath.Join(vaultDir, ".git")); err == nil {

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -116,15 +116,16 @@ func Open(vaultDir string, identity *age.X25519Identity) (*Vault, error) {
 	// Flush any pending manifest updates before checking consistency.
 	FlushManifestUpdates()
 
-	// Check manifest consistency: rebuild if missing, or if the manifest is stale
-	// (config generation counter > manifest generation counter, indicating unflushed
-	// writes from a prior crash).
+	// Check manifest consistency: rebuild in background if missing, or if the
+	// manifest is stale (config generation counter > manifest generation counter,
+	// indicating unflushed writes from a prior crash). The rebuild is
+	// non-blocking — reads are served from the directory walk while it runs.
 	if _, err := os.Stat(filepath.Join(vaultDir, manifestFileName)); os.IsNotExist(err) {
-		_ = RebuildManifest(vaultDir, identity) // best-effort
+		go func() { _ = RebuildManifest(vaultDir, identity) }()
 	} else if cfg.Vault != nil && cfg.Vault.ManifestGeneration > 0 {
 		m, loadErr := LoadManifest(vaultDir, identity)
 		if loadErr == nil && m.Generation < cfg.Vault.ManifestGeneration {
-			_ = RebuildManifest(vaultDir, identity) // best-effort
+			go func() { _ = RebuildManifest(vaultDir, identity) }()
 		}
 	}
 	if _, err := os.Stat(filepath.Join(vaultDir, ".git")); err == nil {


### PR DESCRIPTION
## Security fixes, UX/DX improvements, architecture cleanup, and performance optimizations

### Security (high priority)
- **#457** — Hold lock during entire `TokenRegistry.Save()` marshal and write to prevent silent token state loss on crash
- **#458** — Encrypt MCP token registry at rest using vault age identity (registry.age)
- **#459** — Auto-start RateLimiter cleanup goroutine in `NewRateLimiter` to prevent unbounded map growth

### UX/DX
- **#460** — Add `get_entry` to LeanToolSet so lean-mode agents can read entry details without all 34 tools
- **#461** — Return structured JSON password strength details (entropy, missing classes, guidance) in MCP errors

### Architecture
- **#462** — Unify `isToolBlockedByAgent` and `isToolAllowed` into single `authorizeTool` function
- **#463** — Add per-instance tool set to `Server` struct, enabling multi-instance testing

### Performance
- **#464** — Pre-build encrypted search index in background after vault open (eliminates cold-start latency)
- **#465** — Make manifest rebuild async during vault open (non-blocking initialization)

Closes #457
Closes #458
Closes #459
Closes #460
Closes #461
Closes #462
Closes #463
Closes #464
Closes #465