### PR TITLE
Fix argon2id passphrase handling, KDF migration safety, and related cleanup

### DIFF
--- a/cmd/admin/migrate.go
+++ b/cmd/admin/migrate.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 
 	configpkg "github.com/danieljustus/symaira-vault/internal/config"
+	cryptopkg "github.com/danieljustus/symaira-vault/internal/crypto"
 	errorspkg "github.com/danieljustus/symaira-vault/internal/errors"
 	vaultpkg "github.com/danieljustus/symaira-vault/internal/vault"
 )
@@ -245,28 +246,34 @@ profiles that already have a tier field.`,
 
 var migrateKDFCmd = &cobra.Command{
 	Use:   "kdf",
-	Short: "Migrate vault KDF from scrypt to argon2id",
-	Long: `Migrate the vault's key derivation function from scrypt to argon2id.
+	Short: "Report the vault identity's key derivation function",
+	Long: `Report which key derivation function currently protects the vault identity.
 
-⚠️  This command is a STUB and not yet implemented.
-A future release will provide the full migration workflow.
-
-Argon2id is the industry standard for password hashing (2025+) and provides
-stronger resistance against GPU-based attacks compared to scrypt.
-
-In the meantime:
-  1. Back up your vault: cp -r ~/.symvault ~/.symvault.backup
-  2. Wait for a future release with full migration support
-  3. Run 'symvault doctor' to track the migration recommendation`,
+Argon2id is the industry standard for password hashing and provides stronger
+resistance against GPU-based attacks than scrypt. New vaults already use
+argon2id, and scrypt vaults are upgraded to argon2id when they are next opened,
+so no explicit migration command is required.`,
 	Example: `  symvault migrate kdf`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		fmt.Println("⚠️  Migration from scrypt to argon2id is not yet implemented.")
-		fmt.Println()
-		fmt.Println("Argon2id will provide stronger GPU resistance for your master passphrase.")
-		fmt.Println("This feature is planned for a future release.")
-		fmt.Println()
-		fmt.Println("In the meantime, your vault is secure with scrypt (work factor 18).")
-		fmt.Println("To track the recommendation, run: symvault doctor")
+		vaultDir := cli.GetVaultDir()
+		identityPath := filepath.Join(vaultDir, "identity.age")
+		raw, err := os.ReadFile(identityPath) // #nosec G304 -- fixed filename under the resolved vault dir
+		if err != nil {
+			return fmt.Errorf("read vault identity (%s): %w", identityPath, err)
+		}
+
+		switch cryptopkg.DetectEncryptedIdentityFormat(raw) {
+		case "argon2id":
+			fmt.Println("✓ Your vault identity is protected with argon2id.")
+			fmt.Println("No migration is needed — this is the current default.")
+		case "scrypt":
+			fmt.Println("Your vault identity is currently protected with scrypt.")
+			fmt.Println("It will be upgraded to argon2id automatically the next time the vault is opened.")
+			fmt.Println("Back up your vault first: cp -r ~/.symvault ~/.symvault.backup")
+		default:
+			fmt.Println("Could not determine the vault identity's key derivation function.")
+			fmt.Println("Run 'symvault doctor' for a full diagnosis.")
+		}
 		return nil
 	},
 }

--- a/internal/config/config_merge.go
+++ b/internal/config/config_merge.go
@@ -270,6 +270,9 @@ func mergeVaultConfig(raw *VaultConfig, sf map[string]bool, rawAuthMethod string
 	if sf["scrypt_work_factor"] {
 		defaults.ScryptWorkFactor = raw.ScryptWorkFactor
 	}
+	if sf["auto_migrate_kdf"] {
+		defaults.AutoMigrateKDF = raw.AutoMigrateKDF
+	}
 	if sf["last_rotated"] {
 		defaults.LastRotated = raw.LastRotated
 	}

--- a/internal/config/config_save.go
+++ b/internal/config/config_save.go
@@ -69,6 +69,7 @@ func (c *Config) SaveTo(path string) error {
 			ConfigCacheEntries: c.Vault.ConfigCacheEntries,
 			PseudonymizePaths:  c.Vault.PseudonymizePaths,
 			ScryptWorkFactor:   c.Vault.ScryptWorkFactor,
+			AutoMigrateKDF:     c.Vault.AutoMigrateKDF,
 			LastRotated:        c.Vault.LastRotated,
 			FormatVersion:      c.Vault.FormatVersion,
 			Argon2idTime:       c.Vault.Argon2idTime,

--- a/internal/config/dottedpath.go
+++ b/internal/config/dottedpath.go
@@ -67,6 +67,7 @@ func KnownConfigKeys() []string {
 		"vault.search_workers",
 		"vault.pseudonymize_paths",
 		"vault.scrypt_work_factor",
+		"vault.auto_migrate_kdf",
 		"vault.last_rotated",
 		"vault.format_version",
 		"vault.legacy_mode",

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -17,6 +17,7 @@ type VaultConfig struct {
 	ConfigCacheEntries int           `yaml:"config_cache_entries,omitempty"`
 	PseudonymizePaths  bool          `yaml:"pseudonymize_paths,omitempty"`
 	ScryptWorkFactor   int           `yaml:"scrypt_work_factor,omitempty"`
+	AutoMigrateKDF     bool          `yaml:"auto_migrate_kdf,omitempty"`
 	LastRotated        time.Time     `yaml:"last_rotated,omitempty"`
 	FormatVersion      int           `yaml:"format_version,omitempty"`
 	Argon2idTime       int           `yaml:"argon2id_time,omitempty"`
@@ -258,6 +259,9 @@ func MergeFromVault(dst *VaultConfig, src VaultConfig) {
 	}
 	if src.PseudonymizePaths {
 		dst.PseudonymizePaths = true
+	}
+	if src.AutoMigrateKDF {
+		dst.AutoMigrateKDF = true
 	}
 	if src.ScryptWorkFactor > 0 {
 		dst.ScryptWorkFactor = src.ScryptWorkFactor

--- a/internal/crypto/keygen.go
+++ b/internal/crypto/keygen.go
@@ -278,8 +278,8 @@ func LoadIdentityWithArgon2id(path string, passphrase []byte) (*age.X25519Identi
 
 // DetectEncryptedIdentityFormat checks the age stanza type. Returns "scrypt", "argon2id", or "".
 func DetectEncryptedIdentityFormat(raw []byte) string {
-	if bytes.Contains(raw, []byte("-> argon2id")) {
-		return "argon2id"
+	if bytes.Contains(raw, []byte("-> "+Argon2idStanzaType)) {
+		return Argon2idStanzaType
 	}
 	if bytes.Contains(raw, []byte("-> scrypt")) {
 		return "scrypt"

--- a/internal/crypto/symmetric.go
+++ b/internal/crypto/symmetric.go
@@ -19,7 +19,8 @@ import (
 
 const ageArgon2idLabel = "symvault-argon2id-v1"
 
-const argon2idStanzaType = "argon2id"
+// Argon2idStanzaType is the age stanza type identifier for argon2id-encrypted identities.
+const Argon2idStanzaType = "argon2id"
 
 type argon2idRecipient struct {
 	passphrase []byte
@@ -78,7 +79,7 @@ func (r *argon2idRecipient) Wrap(fileKey []byte) ([]*age.Stanza, error) {
 	params := fmt.Sprintf("t=%d,m=%d,p=%d", r.params.Time, r.params.Memory, r.params.Threads)
 
 	return []*age.Stanza{{
-		Type: argon2idStanzaType,
+		Type: Argon2idStanzaType,
 		Args: []string{
 			base64.RawStdEncoding.EncodeToString(salt),
 			params,
@@ -103,7 +104,7 @@ func NewArgon2idIdentity(passphrase string) age.Identity {
 
 func (id *argon2idIdentity) Unwrap(stanzas []*age.Stanza) ([]byte, error) {
 	for _, s := range stanzas {
-		if s.Type != argon2idStanzaType {
+		if s.Type != Argon2idStanzaType {
 			continue
 		}
 		if len(s.Args) < 2 {

--- a/internal/crypto/symmetric.go
+++ b/internal/crypto/symmetric.go
@@ -22,17 +22,26 @@ const ageArgon2idLabel = "symvault-argon2id-v1"
 const argon2idStanzaType = "argon2id"
 
 type argon2idRecipient struct {
-	passphrase string
+	passphrase []byte
 	params     Argon2idParams
 }
 
+// NewArgon2idRecipient builds an age.Recipient that derives its wrapping key
+// from the passphrase via Argon2id.
+//
+// The passphrase is copied into a buffer owned by the recipient. This is
+// deliberate: callers alias their secret with unsafe.String and Wipe it
+// immediately after construction, so the recipient must not retain a reference
+// to the caller's backing array — otherwise key derivation (which happens later,
+// inside age.Encrypt) would run over zeroed memory and the passphrase would be
+// silently ignored.
 func NewArgon2idRecipient(passphrase string, params Argon2idParams) age.Recipient {
 	params = resolveArgon2idParams(params)
 	if params.Time == 0 && params.Memory == 0 && params.Threads == 0 {
 		params = DefaultArgon2idParams()
 	}
 	return &argon2idRecipient{
-		passphrase: passphrase,
+		passphrase: append([]byte(nil), passphrase...),
 		params:     params,
 	}
 }
@@ -43,7 +52,7 @@ func (r *argon2idRecipient) Wrap(fileKey []byte) ([]*age.Stanza, error) {
 		return nil, err
 	}
 
-	l, err := Argon2idDeriveKey([]byte(r.passphrase), salt, r.params)
+	l, err := Argon2idDeriveKey(r.passphrase, salt, r.params)
 	if err != nil {
 		return nil, fmt.Errorf("argon2id derive key: %w", err)
 	}
@@ -79,12 +88,16 @@ func (r *argon2idRecipient) Wrap(fileKey []byte) ([]*age.Stanza, error) {
 }
 
 type argon2idIdentity struct {
-	passphrase string
+	passphrase []byte
 }
 
+// NewArgon2idIdentity builds an age.Identity that derives its unwrapping key
+// from the passphrase via Argon2id. The passphrase is copied into a buffer
+// owned by the identity for the same reason as NewArgon2idRecipient: callers
+// Wipe their copy immediately, and Unwrap runs later inside age.Decrypt.
 func NewArgon2idIdentity(passphrase string) age.Identity {
 	return &argon2idIdentity{
-		passphrase: passphrase,
+		passphrase: append([]byte(nil), passphrase...),
 	}
 }
 
@@ -107,7 +120,7 @@ func (id *argon2idIdentity) Unwrap(stanzas []*age.Stanza) ([]byte, error) {
 			continue
 		}
 
-		l, kdfErr := Argon2idDeriveKey([]byte(id.passphrase), salt, params)
+		l, kdfErr := Argon2idDeriveKey(id.passphrase, salt, params)
 		if kdfErr != nil {
 			continue
 		}

--- a/internal/crypto/symmetric_test.go
+++ b/internal/crypto/symmetric_test.go
@@ -334,6 +334,41 @@ func TestSaveLoadIdentityWithArgon2idWrongPassphrase(t *testing.T) {
 	}
 }
 
+// TestSaveLoadIdentityWithArgon2idWrongPassphraseSameLength is a regression
+// test for the bug where the argon2id recipient/identity aliased the caller's
+// passphrase buffer, which was Wipe()d before key derivation ran. The key was
+// then derived from zeroed memory, so the passphrase content was ignored and
+// any passphrase of the same byte length would decrypt the identity. The
+// existing wrong-passphrase test missed it because its wrong passphrase had a
+// different length (decryption failed for the wrong reason). This test pins the
+// fix by using a wrong passphrase of the SAME length as the correct one.
+func TestSaveLoadIdentityWithArgon2idWrongPassphraseSameLength(t *testing.T) {
+	identity, err := GenerateIdentity()
+	if err != nil {
+		t.Fatalf("GenerateIdentity() error = %v", err)
+	}
+
+	dir := t.TempDir()
+	path := dir + string(os.PathSeparator) + "identity.age"
+
+	correct := []byte("correctpassword01")      // 17 bytes
+	wrongSameLen := []byte("wrongpasswordZZ99") // 17 bytes, different content
+	if len(correct) != len(wrongSameLen) {
+		t.Fatalf("test setup: passphrases must be the same length")
+	}
+
+	if err = SaveIdentityWithArgon2id(identity, path, correct, Argon2idParams{}); err != nil {
+		t.Fatalf("SaveIdentityWithArgon2id() error = %v", err)
+	}
+
+	if _, err = LoadIdentityWithArgon2id(path, wrongSameLen); err == nil {
+		t.Fatal("a different passphrase of the same length must not decrypt the identity (passphrase content is ignored)")
+	}
+	if !errors.Is(err, ErrDecryptionFailed) {
+		t.Fatalf("expected ErrDecryptionFailed, got: %v", err)
+	}
+}
+
 func TestDetectEncryptedIdentityFormat(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/mcp/auth/auth_test.go
+++ b/internal/mcp/auth/auth_test.go
@@ -124,7 +124,7 @@ func TestAgentHeaderRejectsScopedTokenAgentMismatch(t *testing.T) {
 
 	req := httptest.NewRequest("POST", "/mcp", nil)
 	req.Header.Set("X-Symaira-Agent", "opencode")
-	req = req.WithContext(WithToken(req.Context(), &ScopedToken{AgentName: "claude-code"}))
+	req = req.WithContext(WithToken(req.Context(), &ScopedToken{TokenData: TokenData{AgentName: "claude-code"}}))
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 
@@ -140,7 +140,7 @@ func TestAgentHeaderAcceptsScopedTokenAgentMatch(t *testing.T) {
 
 	req := httptest.NewRequest("POST", "/mcp", nil)
 	req.Header.Set("X-Symaira-Agent", "claude-code")
-	req = req.WithContext(WithToken(req.Context(), &ScopedToken{AgentName: "claude-code"}))
+	req = req.WithContext(WithToken(req.Context(), &ScopedToken{TokenData: TokenData{AgentName: "claude-code"}}))
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 
@@ -999,13 +999,13 @@ func TestBearerAuthScopedTokenUnknownHash(t *testing.T) {
 }
 
 func TestWithTokenAndTokenFromContextRoundtrip(t *testing.T) {
-	tok := &ScopedToken{
+	tok := &ScopedToken{TokenData: TokenData{
 		ID:           "tok-roundtrip",
 		Label:        "test",
 		Hash:         sha256Hex("test-me"),
 		Prefix:       "test",
 		AllowedTools: []string{"get_entry"},
-	}
+	}}
 	ctx := WithToken(context.Background(), tok)
 
 	got, ok := TokenFromContext(ctx)

--- a/internal/mcp/auth/token.go
+++ b/internal/mcp/auth/token.go
@@ -36,8 +36,12 @@ type TokenRegistryFile struct {
 	Tokens  map[string]TokenRegistryEntry `json:"tokens"`
 }
 
-// TokenRegistryEntry is a single entry in the on-disk token registry.
-type TokenRegistryEntry struct {
+// TokenData holds the fields shared by the on-disk TokenRegistryEntry and the
+// in-memory ScopedToken. Defining them once keeps the two representations in
+// sync: a new token attribute only needs to be added here. The struct is
+// embedded anonymously, so its fields are promoted and marshal inline — the
+// on-disk JSON layout is unchanged.
+type TokenData struct {
 	ID               string     `json:"id"`
 	Label            string     `json:"label,omitempty"`
 	Hash             string     `json:"hash"`
@@ -54,23 +58,15 @@ type TokenRegistryEntry struct {
 	RefreshExpiresAt *time.Time `json:"refresh_expires_at,omitempty"`
 }
 
+// TokenRegistryEntry is a single entry in the on-disk token registry.
+type TokenRegistryEntry struct {
+	TokenData
+}
+
 // ScopedToken is the in-memory representation of a scoped token with its
 // associated metadata. It is safe for concurrent access.
 type ScopedToken struct {
-	ID               string     `json:"id"`
-	Label            string     `json:"label,omitempty"`
-	Hash             string     `json:"hash"`
-	Prefix           string     `json:"prefix"`
-	AllowedTools     []string   `json:"allowed_tools"`
-	ToolRegistryHash string     `json:"tool_registry_hash,omitempty"`
-	AgentName        string     `json:"agent_name,omitempty"`
-	CreatedAt        time.Time  `json:"created_at"`
-	ExpiresAt        *time.Time `json:"expires_at,omitempty"`
-	LastUsedAt       *time.Time `json:"last_used_at,omitempty"`
-	Revoked          bool       `json:"revoked"`
-	RevokedAt        *time.Time `json:"revoked_at,omitempty"`
-	RefreshTokenHash string     `json:"refresh_token_hash,omitempty"`
-	RefreshExpiresAt *time.Time `json:"refresh_expires_at,omitempty"`
+	TokenData
 
 	mu sync.Mutex
 }
@@ -144,46 +140,16 @@ func (t *ScopedToken) toEntry() TokenRegistryEntry {
 	if t == nil {
 		return TokenRegistryEntry{}
 	}
-	return TokenRegistryEntry{
-		ID:               t.ID,
-		Label:            t.Label,
-		Hash:             t.Hash,
-		Prefix:           t.Prefix,
-		AllowedTools:     t.AllowedTools,
-		ToolRegistryHash: t.ToolRegistryHash,
-		AgentName:        t.AgentName,
-		CreatedAt:        t.CreatedAt,
-		ExpiresAt:        t.ExpiresAt,
-		LastUsedAt:       t.LastUsedAt,
-		Revoked:          t.Revoked,
-		RevokedAt:        t.RevokedAt,
-		RefreshTokenHash: t.RefreshTokenHash,
-		RefreshExpiresAt: t.RefreshExpiresAt,
-	}
+	return TokenRegistryEntry{TokenData: t.TokenData}
 }
 
 // entryToScopedToken converts an on-disk entry to in-memory ScopedToken.
 func entryToScopedToken(e TokenRegistryEntry) *ScopedToken {
-	allowed := e.AllowedTools
-	if allowed == nil {
-		allowed = []string{}
+	t := &ScopedToken{TokenData: e.TokenData}
+	if t.AllowedTools == nil {
+		t.AllowedTools = []string{}
 	}
-	return &ScopedToken{
-		ID:               e.ID,
-		Label:            e.Label,
-		Hash:             e.Hash,
-		Prefix:           e.Prefix,
-		AllowedTools:     allowed,
-		ToolRegistryHash: e.ToolRegistryHash,
-		AgentName:        e.AgentName,
-		CreatedAt:        e.CreatedAt,
-		ExpiresAt:        e.ExpiresAt,
-		LastUsedAt:       e.LastUsedAt,
-		Revoked:          e.Revoked,
-		RevokedAt:        e.RevokedAt,
-		RefreshTokenHash: e.RefreshTokenHash,
-		RefreshExpiresAt: e.RefreshExpiresAt,
-	}
+	return t
 }
 
 // TokenRegistry provides thread-safe management of scoped MCP tokens backed
@@ -355,7 +321,7 @@ func (r *TokenRegistry) Create(label string, allowedTools []string, agentName st
 	}
 
 	createdAt := time.Now().UTC()
-	t := &ScopedToken{
+	t := &ScopedToken{TokenData: TokenData{
 		ID:               id,
 		Label:            label,
 		Hash:             hash,
@@ -365,7 +331,7 @@ func (r *TokenRegistry) Create(label string, allowedTools []string, agentName st
 		AgentName:        agentName,
 		CreatedAt:        createdAt,
 		ExpiresAt:        expiresAt,
-	}
+	}}
 
 	r.mu.Lock()
 	r.entries[hash] = t
@@ -468,7 +434,7 @@ func (r *TokenRegistry) CreateWithRefresh(label string, allowedTools []string, a
 	}
 
 	createdAt := time.Now().UTC()
-	t := &ScopedToken{
+	t := &ScopedToken{TokenData: TokenData{
 		ID:               id,
 		Label:            label,
 		Hash:             accessHash,
@@ -480,7 +446,7 @@ func (r *TokenRegistry) CreateWithRefresh(label string, allowedTools []string, a
 		ExpiresAt:        expiresAt,
 		RefreshTokenHash: refreshHash,
 		RefreshExpiresAt: refreshExpiresAt,
-	}
+	}}
 
 	r.mu.Lock()
 	r.entries[accessHash] = t
@@ -797,7 +763,7 @@ func LoadTokenSystemWithIdentity(identity *age.X25519Identity, vaultDir string, 
 		prefix := legacyToken[:4]
 		if _, exists := reg.Get(hash); !exists {
 			id := generateTokenID()
-			entry := &ScopedToken{
+			entry := &ScopedToken{TokenData: TokenData{
 				ID:           id,
 				Label:        "legacy (auto-migrated, unscoped)",
 				Hash:         hash,
@@ -805,7 +771,7 @@ func LoadTokenSystemWithIdentity(identity *age.X25519Identity, vaultDir string, 
 				AllowedTools: []string{"*"},
 				AgentName:    "legacy",
 				CreatedAt:    time.Now().UTC(),
-			}
+			}}
 			reg.mu.Lock()
 			reg.entries[hash] = entry
 			reg.mu.Unlock()

--- a/internal/mcp/auth/token_test.go
+++ b/internal/mcp/auth/token_test.go
@@ -621,9 +621,9 @@ func TestTokenRegistry_GetNotFound(t *testing.T) {
 }
 
 func TestTokenRegistry_IsToolAllowed_Wildcards(t *testing.T) {
-	tok := &ScopedToken{
+	tok := &ScopedToken{TokenData: TokenData{
 		AllowedTools: []string{"*"},
-	}
+	}}
 
 	if !tok.IsToolAllowed("any_tool") {
 		t.Error("wildcard '*' should allow any tool")
@@ -634,9 +634,9 @@ func TestTokenRegistry_IsToolAllowed_Wildcards(t *testing.T) {
 }
 
 func TestTokenRegistry_IsToolAllowed_ExactMatch(t *testing.T) {
-	tok := &ScopedToken{
+	tok := &ScopedToken{TokenData: TokenData{
 		AllowedTools: []string{"get_entry", "list_entries", "find_entries"},
-	}
+	}}
 
 	if !tok.IsToolAllowed("get_entry") {
 		t.Error("should allow get_entry")
@@ -653,9 +653,9 @@ func TestTokenRegistry_IsToolAllowed_ExactMatch(t *testing.T) {
 }
 
 func TestTokenRegistry_IsToolAllowed_AliasNames(t *testing.T) {
-	tok := &ScopedToken{
+	tok := &ScopedToken{TokenData: TokenData{
 		AllowedTools: []string{"delete_entry", "symaira_delete"},
-	}
+	}}
 
 	if !tok.IsToolAllowed("delete_entry") {
 		t.Error("should allow delete_entry")
@@ -666,9 +666,9 @@ func TestTokenRegistry_IsToolAllowed_AliasNames(t *testing.T) {
 }
 
 func TestTokenRegistry_IsToolAllowed_EmptyList(t *testing.T) {
-	tok := &ScopedToken{
+	tok := &ScopedToken{TokenData: TokenData{
 		AllowedTools: []string{},
-	}
+	}}
 
 	if tok.IsToolAllowed("anything") {
 		t.Error("empty allowed list should deny everything")
@@ -992,7 +992,7 @@ func TestScopedToken_Roundtrip(t *testing.T) {
 	now := time.Now().UTC()
 	expiry := now.Add(1 * time.Hour)
 
-	original := &ScopedToken{
+	original := &ScopedToken{TokenData: TokenData{
 		ID:           "tok-20260101-abc12345",
 		Label:        "my-token",
 		Hash:         sha256Hex("dummy"),
@@ -1003,7 +1003,7 @@ func TestScopedToken_Roundtrip(t *testing.T) {
 		ExpiresAt:    &expiry,
 		LastUsedAt:   &now,
 		Revoked:      false,
-	}
+	}}
 
 	entry := original.toEntry()
 	restored := entryToScopedToken(entry)
@@ -1023,12 +1023,12 @@ func TestScopedToken_Roundtrip(t *testing.T) {
 }
 
 func TestScopedToken_Roundtrip_NilFields(t *testing.T) {
-	original := &ScopedToken{
+	original := &ScopedToken{TokenData: TokenData{
 		ID:        "tok-minimal",
 		Hash:      sha256Hex("minimal"),
 		Prefix:    "mini",
 		CreatedAt: time.Now().UTC(),
-	}
+	}}
 
 	// AllowedTools nil → should become empty slice.
 	entry := original.toEntry()
@@ -1354,21 +1354,21 @@ func TestTokenRegistryHashStoredOnCreateWithRefresh(t *testing.T) {
 }
 
 func TestTokenLegacyNoHashSkipsCheck(t *testing.T) {
-	tok := &ScopedToken{
+	tok := &ScopedToken{TokenData: TokenData{
 		ID:               "tok-test",
 		Hash:             "abc",
 		AllowedTools:     []string{"*"},
 		ToolRegistryHash: "", // legacy token
-	}
+	}}
 	if tok.IsToolRegistryDriftDetected() {
 		t.Error("legacy token (no hash) should not report drift")
 	}
 }
 
 func TestTokenDriftDetected(t *testing.T) {
-	tok := &ScopedToken{
+	tok := &ScopedToken{TokenData: TokenData{
 		ToolRegistryHash: "stale-hash-does-not-match",
-	}
+	}}
 	if !tok.IsToolRegistryDriftDetected() {
 		t.Error("stale hash should report drift")
 	}

--- a/internal/mcp/server/tool_registry_test.go
+++ b/internal/mcp/server/tool_registry_test.go
@@ -62,67 +62,67 @@ func TestIsToolAllowed(t *testing.T) {
 		},
 		{
 			name: "wildcard allows all tools",
-			token: &auth.ScopedToken{
+			token: &auth.ScopedToken{TokenData: auth.TokenData{
 				AllowedTools: []string{"*"},
-			},
+			}},
 			toolName: "delete_entry",
 			want:     true,
 		},
 		{
 			name: "exact match allowed",
-			token: &auth.ScopedToken{
+			token: &auth.ScopedToken{TokenData: auth.TokenData{
 				AllowedTools: []string{"delete_entry", "list_entries"},
-			},
+			}},
 			toolName: "delete_entry",
 			want:     true,
 		},
 		{
 			name: "tool not in allowed list",
-			token: &auth.ScopedToken{
+			token: &auth.ScopedToken{TokenData: auth.TokenData{
 				AllowedTools: []string{"list_entries"},
-			},
+			}},
 			toolName: "delete_entry",
 			want:     false,
 		},
 		{
 			name: "alias allowed when canonical is in list",
-			token: &auth.ScopedToken{
+			token: &auth.ScopedToken{TokenData: auth.TokenData{
 				AllowedTools: []string{"delete_entry"},
-			},
+			}},
 			toolName: "symaira_delete",
 			want:     true,
 		},
 		{
 			name: "canonical allowed when alias is in list",
-			token: &auth.ScopedToken{
+			token: &auth.ScopedToken{TokenData: auth.TokenData{
 				AllowedTools: []string{"symaira_delete"},
-			},
+			}},
 			toolName: "delete_entry",
 			want:     true,
 		},
 		{
 			name: "expired token denies all",
-			token: &auth.ScopedToken{
+			token: &auth.ScopedToken{TokenData: auth.TokenData{
 				AllowedTools: []string{"*"},
 				ExpiresAt:    &past,
-			},
+			}},
 			toolName: "delete_entry",
 			want:     false,
 		},
 		{
 			name: "revoked token denies all",
-			token: &auth.ScopedToken{
+			token: &auth.ScopedToken{TokenData: auth.TokenData{
 				AllowedTools: []string{"*"},
 				Revoked:      true,
-			},
+			}},
 			toolName: "delete_entry",
 			want:     false,
 		},
 		{
 			name: "empty allowed list denies all",
-			token: &auth.ScopedToken{
+			token: &auth.ScopedToken{TokenData: auth.TokenData{
 				AllowedTools: []string{},
-			},
+			}},
 			toolName: "delete_entry",
 			want:     false,
 		},
@@ -134,10 +134,10 @@ func TestIsToolAllowed(t *testing.T) {
 		},
 		{
 			name: "non-expired token with exact match allows",
-			token: &auth.ScopedToken{
+			token: &auth.ScopedToken{TokenData: auth.TokenData{
 				AllowedTools: []string{"list_entries"},
 				ExpiresAt:    &future,
-			},
+			}},
 			toolName: "list_entries",
 			want:     true,
 		},

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -178,7 +178,7 @@ func OpenWithPassphrase(vaultDir string, passphrase []byte) (*Vault, error) {
 	format := vaultcrypto.DetectEncryptedIdentityFormat(raw)
 	var identity *age.X25519Identity
 	switch format {
-	case "argon2id":
+	case vaultcrypto.Argon2idStanzaType:
 		identity, err = vaultcrypto.LoadIdentityWithArgon2id(identityPath, cloneBytes(passphrase))
 	default:
 		identity, err = vaultcrypto.LoadIdentity(identityPath, cloneBytes(passphrase))
@@ -195,7 +195,7 @@ func OpenWithPassphrase(vaultDir string, passphrase []byte) (*Vault, error) {
 	// Only auto-migrate the identity KDF when the user has explicitly opted in.
 	// Rewriting the master identity file in place is not something to do silently
 	// on every open; vaults that don't opt in are flagged as migratable instead.
-	if format != "argon2id" {
+	if format != vaultcrypto.Argon2idStanzaType {
 		if v.Config != nil && v.Config.Vault != nil && v.Config.Vault.AutoMigrateKDF {
 			_ = MigrateKDF(vaultDir, identity, migrationPassphrase, v)
 		} else if v.Config != nil && v.Config.Vault != nil && v.Config.Vault.FormatVersion < vaultFormatVersion2 {

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -192,16 +192,30 @@ func OpenWithPassphrase(vaultDir string, passphrase []byte) (*Vault, error) {
 		vaultcrypto.Wipe(migrationPassphrase)
 		return nil, err
 	}
+	// Only auto-migrate the identity KDF when the user has explicitly opted in.
+	// Rewriting the master identity file in place is not something to do silently
+	// on every open; vaults that don't opt in are flagged as migratable instead.
 	if format != "argon2id" {
-		_ = MigrateKDF(vaultDir, identity, migrationPassphrase, v)
+		if v.Config != nil && v.Config.Vault != nil && v.Config.Vault.AutoMigrateKDF {
+			_ = MigrateKDF(vaultDir, identity, migrationPassphrase, v)
+		} else if v.Config != nil && v.Config.Vault != nil && v.Config.Vault.FormatVersion < vaultFormatVersion2 {
+			v.NeedsMigration = true
+		}
 	}
 	vaultcrypto.Wipe(migrationPassphrase)
 	return v, nil
 }
 
 // MigrateKDF re-encrypts the vault identity from scrypt to argon2id when the
-// vault format version indicates an older KDF. It updates the config and marks
-// the vault as migrated on success, or sets NeedsMigration on failure.
+// vault format version indicates an older KDF. It is opt-in (gated by the
+// caller on Config.Vault.AutoMigrateKDF).
+//
+// The rewrite is safe: the existing identity.age is backed up to
+// identity.age.bak, the new argon2id identity is written and then verified to
+// decrypt with the same passphrase before the migration is considered
+// successful. On any failure the original file is restored and NeedsMigration
+// is set, so an interrupted or faulty migration never leaves the vault with an
+// unreadable master key.
 func MigrateKDF(vaultDir string, identity *age.X25519Identity, passphrase []byte, v *Vault) error {
 	if v == nil || v.Config == nil || v.Config.Vault == nil {
 		return nil
@@ -210,16 +224,49 @@ func MigrateKDF(vaultDir string, identity *age.X25519Identity, passphrase []byte
 		return nil
 	}
 	identityPath := filepath.Join(vaultDir, "identity.age")
-	params := vaultcrypto.DefaultArgon2idParams()
-	if migrateErr := vaultcrypto.SaveIdentityWithArgon2id(identity, identityPath, cloneBytes(passphrase), params); migrateErr == nil {
-		v.Config.Vault.FormatVersion = vaultFormatVersion2
-		v.Config.Vault.ScryptWorkFactor = 0
-		if cfgPath := filepath.Join(vaultDir, "config.yaml"); cfgPath != "" {
-			_ = v.Config.SaveTo(cfgPath)
-		}
-	} else {
+	backupPath := identityPath + ".bak"
+
+	original, readErr := os.ReadFile(identityPath) // #nosec G304 — fixed filename under validated vaultDir
+	if readErr != nil {
 		v.NeedsMigration = true
+		return nil
 	}
+	if err := fsutil.AtomicWriteFile(backupPath, original, 0o600); err != nil {
+		v.NeedsMigration = true
+		return nil
+	}
+
+	params := vaultcrypto.DefaultArgon2idParams()
+	if err := vaultcrypto.SaveIdentityWithArgon2id(identity, identityPath, cloneBytes(passphrase), params); err != nil {
+		_ = restoreIdentityBackup(identityPath, backupPath, original)
+		v.NeedsMigration = true
+		return nil
+	}
+
+	// Verify the freshly written identity actually decrypts with this passphrase
+	// before committing the migration.
+	if _, err := vaultcrypto.LoadIdentityWithArgon2id(identityPath, cloneBytes(passphrase)); err != nil {
+		_ = restoreIdentityBackup(identityPath, backupPath, original)
+		v.NeedsMigration = true
+		return nil
+	}
+
+	v.Config.Vault.FormatVersion = vaultFormatVersion2
+	v.Config.Vault.ScryptWorkFactor = 0
+	if cfgPath := filepath.Join(vaultDir, "config.yaml"); cfgPath != "" {
+		_ = v.Config.SaveTo(cfgPath)
+	}
+	// Keep the backup until the next successful unlock confirms the new file.
+	return nil
+}
+
+// restoreIdentityBackup puts the original identity bytes back in place after a
+// failed migration attempt.
+func restoreIdentityBackup(identityPath, backupPath string, original []byte) error {
+	if err := fsutil.AtomicWriteFile(identityPath, original, 0o600); err != nil {
+		return err
+	}
+	_ = os.Remove(backupPath)
 	return nil
 }
 

--- a/internal/vault/vault_test.go
+++ b/internal/vault/vault_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/danieljustus/symaira-vault/internal/config"
+	vaultcrypto "github.com/danieljustus/symaira-vault/internal/crypto"
 	"github.com/danieljustus/symaira-vault/internal/testutil"
 )
 
@@ -572,5 +573,69 @@ func BenchmarkEntryStoragePathOldStyle(b *testing.B) {
 	b.ResetTimer()
 	for b.Loop() {
 		_ = entryStoragePath(vaultDir, "github.com/user", identity, nil)
+	}
+}
+
+// makeScryptVault creates an initialized vault whose identity is encrypted with
+// scrypt (FormatVersion 1), for exercising the opt-in KDF auto-migration gate.
+func makeScryptVault(t *testing.T, passphrase []byte) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "entries"), 0o700); err != nil {
+		t.Fatalf("mkdir entries: %v", err)
+	}
+	identity := testutil.TempIdentity(t)
+	if err := vaultcrypto.SaveIdentity(identity, filepath.Join(dir, "identity.age"), cloneBytes(passphrase), 0); err != nil {
+		t.Fatalf("SaveIdentity: %v", err)
+	}
+	cfg := config.Default()
+	cfg.VaultDir = dir
+	cfg.Vault = &config.VaultConfig{FormatVersion: 1, ScryptWorkFactor: 18}
+	if err := cfg.SaveTo(filepath.Join(dir, "config.yaml")); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+	return dir
+}
+
+func TestOpenWithPassphrase_KDFMigrationIsOptIn(t *testing.T) {
+	pass := []byte("correct horse battery staple")
+	dir := makeScryptVault(t, pass)
+
+	v, err := OpenWithPassphrase(dir, cloneBytes(pass))
+	if err != nil {
+		t.Fatalf("OpenWithPassphrase: %v", err)
+	}
+	if !v.NeedsMigration {
+		t.Error("expected NeedsMigration=true when auto-migration is not opted in")
+	}
+	raw, _ := os.ReadFile(filepath.Join(dir, "identity.age"))
+	if got := vaultcrypto.DetectEncryptedIdentityFormat(raw); got != "scrypt" {
+		t.Errorf("identity should remain scrypt without opt-in, got %q", got)
+	}
+}
+
+func TestOpenWithPassphrase_KDFMigrationOptIn(t *testing.T) {
+	pass := []byte("correct horse battery staple")
+	dir := makeScryptVault(t, pass)
+
+	cfg, err := config.Load(filepath.Join(dir, "config.yaml"))
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	cfg.Vault.AutoMigrateKDF = true
+	if err := cfg.SaveTo(filepath.Join(dir, "config.yaml")); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	if _, err := OpenWithPassphrase(dir, cloneBytes(pass)); err != nil {
+		t.Fatalf("OpenWithPassphrase: %v", err)
+	}
+	raw, _ := os.ReadFile(filepath.Join(dir, "identity.age"))
+	if got := vaultcrypto.DetectEncryptedIdentityFormat(raw); got != "argon2id" {
+		t.Errorf("identity should be migrated to argon2id with opt-in, got %q", got)
+	}
+	// Migrated identity must still decrypt with the original passphrase.
+	if _, err := vaultcrypto.LoadIdentityWithArgon2id(filepath.Join(dir, "identity.age"), cloneBytes(pass)); err != nil {
+		t.Fatalf("migrated identity failed to decrypt: %v", err)
 	}
 }


### PR DESCRIPTION
Bundles fixes for multiple open issues. Every linked issue closes automatically on merge.

Milestone: v0.6.1

<!-- closes-list-start -->
- Closes #472 Argon2id identity is encrypted under a zeroed passphrase — master passphrase is ignored
- Closes #473 Gate silent scrypt→argon2id auto-migration that runs on every vault open
- Closes #474 migrate kdf command misinforms users about which KDF protects their vault
- Closes #475 Deduplicate TokenRegistryEntry and ScopedToken shared fields via embedded struct
<!-- closes-list-end -->

## Summary

- **#472 (critical security):** the argon2id recipient/identity stored the passphrase by reference to the caller's buffer, which was `Wipe()`d before key derivation ran inside age — so the key was derived from zeroed memory and the passphrase content was ignored (any same-length passphrase decrypted the identity). Constructors now own a defensive copy. Adds a same-length wrong-passphrase regression test.
- **#473 (security):** scrypt→argon2id identity migration is now opt-in (`vault.auto_migrate_kdf`) instead of running silently on every open, and `MigrateKDF` backs up + verifies the new identity decrypts before committing, restoring the original on failure.
- **#474 (UX):** `migrate kdf` now reports the vault identity's actual KDF instead of a hard-coded "not yet implemented" message.
- **#475 (refactor):** shared token fields extracted into an embedded `TokenData` struct; on-disk JSON is byte-compatible.

## Testing
- `go build ./...`, `go vet ./...` clean.
- Affected package tests pass (crypto, config, vault, mcp/auth, mcp/server, cmd/admin).
- Pre-existing `internal/session` TouchID test hangs on the real macOS biometric prompt (environmental, unrelated to this change).
