### PR TITLE
fix(security): v0.6.1 security hardening — 6 vulnerabilities

### DIFF
--- a/cmd/device.go
+++ b/cmd/device.go
@@ -453,8 +453,8 @@ request so the first device can accept it.`,
 			token = raw
 		}
 
-		if err := pairing.ValidatePairingToken(token); err != nil {
-			return fmt.Errorf("invalid pairing token: %w", err)
+		if valErr := pairing.ValidatePairingToken(token); valErr != nil {
+			return fmt.Errorf("invalid pairing token: %w", valErr)
 		}
 
 		if !strings.HasPrefix(existingPubkey, "age1") || len(existingPubkey) < 50 {

--- a/cmd/device.go
+++ b/cmd/device.go
@@ -115,6 +115,10 @@ to re-encrypt all entries for this new device.`,
 		remoteURL := args[0]
 		token := strings.TrimSpace(args[1])
 
+		if err := pairing.ValidatePairingToken(token); err != nil {
+			return fmt.Errorf("invalid pairing token: %w", err)
+		}
+
 		vaultDir, err := cli.VaultPath()
 		if err != nil {
 			return err
@@ -135,7 +139,7 @@ to re-encrypt all entries for this new device.`,
 		pairingPath := filepath.Join(vaultDir, configpkg.DefaultVaultSubdir, "pairing", token+".json")
 		var pf pairingFile
 		// #nosec G304 -- pairingPath is constructed within the vault directory
-		pfData, err := os.ReadFile(pairingPath)
+		pfData, err := vaultpkg.SafeReadFile(pairingPath)
 		if err != nil {
 			return fmt.Errorf("invalid or expired pairing token: could not read pairing file. Ensure the token is correct and the pairing device has pushed the token file: %w", err)
 		}
@@ -244,6 +248,10 @@ can decrypt them.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		token := strings.TrimSpace(args[0])
 
+		if err := pairing.ValidatePairingToken(token); err != nil {
+			return fmt.Errorf("invalid pairing token: %w", err)
+		}
+
 		vaultDir, err := cli.VaultPath()
 		if err != nil {
 			return err
@@ -257,7 +265,7 @@ can decrypt them.`,
 		joinedPath := filepath.Join(vaultDir, configpkg.DefaultVaultSubdir, "pairing", token+"-joined.json")
 		var jf joinedFile
 		// #nosec G304 -- joinedPath is constructed within the vault directory
-		jfData, err := os.ReadFile(joinedPath)
+		jfData, err := vaultpkg.SafeReadFile(joinedPath)
 		if err != nil {
 			return fmt.Errorf("no join request found for token %s. Ensure the joining device has completed 'symvault device join' and pushed: %w", token, err)
 		}
@@ -443,6 +451,10 @@ request so the first device can accept it.`,
 			existingPubkey = raw[idx+1:]
 		} else {
 			token = raw
+		}
+
+		if err := pairing.ValidatePairingToken(token); err != nil {
+			return fmt.Errorf("invalid pairing token: %w", err)
 		}
 
 		if !strings.HasPrefix(existingPubkey, "age1") || len(existingPubkey) < 50 {

--- a/docs/commercial-boundary.md
+++ b/docs/commercial-boundary.md
@@ -27,3 +27,9 @@ The current Symaira Vault release line is `v0.x`. Historical OpenPass releases
 such as `v4.0.0` remain part of the old release history and must not be treated
 as the current Symaira Vault release target. The next planned core milestone is
 `v0.4.1`.
+
+## Related
+
+- [`research-handoff-eu-commercialization.md`](research-handoff-eu-commercialization.md)
+  preserves the public-core findings from the EU compliance and commercialization
+  research folders.

--- a/docs/research-handoff-eu-commercialization.md
+++ b/docs/research-handoff-eu-commercialization.md
@@ -1,0 +1,68 @@
+# Research Handoff: EU Compliance and Commercialization
+
+This document preserves the actionable findings from the local research folders:
+
+- `sonstiges/Research/Kimi_Research_symvault-EU-Compliance`
+- `sonstiges/Research/Kimi_Research_symvault-exopenpass-kommerzialisierung`
+
+The original folders can be deleted once the linked GitHub issues are visible.
+This file keeps only the parts that belong in the public MIT self-hosted core.
+Hosted service, billing, tenant operations, SSO/SCIM, hosted RBAC, SIEM export,
+and compliance operations belong to `symaira-vault-pro`.
+
+## Current Public-Core Status
+
+| Research item | Current status | Evidence |
+|---|---|---|
+| Local-first/self-hosted positioning | Implemented | README, `docs/commercial-boundary.md`, `SECURITY.md` |
+| age X25519 + ChaCha20-Poly1305 encryption | Implemented | `internal/crypto/age.go`, README, `SECURITY.md` |
+| Multi-recipient shared vaults | Implemented | `internal/vault/recipients.go`, `SECURITY.md` |
+| TOTP storage and code generation | Implemented | `cmd`, `internal/mcp/server/tools_totp.go`, `docs/mcp-api.md` |
+| MCP stdio and HTTP integrations | Implemented | `internal/mcp/server/`, `docs/mcp-api.md` |
+| Scoped agent tokens and path/tool controls | Implemented | `internal/mcp/auth/`, `internal/agentctx/`, `SECURITY.md` |
+| Out-of-band approval and policy gates | Implemented | `internal/policy/`, `SECURITY.md`, `docs/threat-model.md` |
+| Output sanitization and taint controls | Implemented | `internal/mcp/render.go`, `internal/vault/taint/`, `SECURITY.md` |
+| Local audit logging with integrity | Implemented | `internal/audit/`, `docs/audit-schema.md`, `docs/audit-retention.md` |
+| Configurable local audit retention | Implemented | `docs/audit-retention.md`, `config.yaml.example` |
+| Release hardening, checksums, signing, SBOM direction | Mostly implemented | `.goreleaser.yml`, `SECURITY.md`, `docs/distribution.md`, `docs/reproducible-builds.md` |
+| Redacted audit evidence export for self-hosted users | Open | `docs/error-tracking-strategy.md` marks audit export as future work |
+| Post-quantum transition planning | Open | No public PQC or ML-KEM migration plan is documented |
+| Enterprise SSO, SCIM, hosted RBAC, SIEM, compliance UI | Out of scope here | Tracked in `symaira-vault-pro` |
+
+## Core Decisions
+
+- Keep Symaira Vault self-hosted free and MIT licensed.
+- Do not add Cloud Pro, billing, customer-support, tenant-management, or hosted
+  compliance code to this repo.
+- General core/runtime capabilities that Pro needs must be implemented here
+  first, released, and then consumed by Pro through versioned runtime artifacts.
+- Public compliance work should help self-hosted users prove what the local
+  tool does: encryption, no telemetry, local audit integrity, scoped MCP access,
+  release verification, and operational runbooks.
+
+## Preserved Research Takeaways
+
+1. The strongest public differentiators are AI-agent credential safety,
+   local-first operation, zero telemetry, file-level age encryption, Git-backed
+   history, scoped MCP access, and local audit integrity.
+2. Public self-hosted users still need a safer way to prepare auditor evidence
+   without leaking secret values or raw vault paths.
+3. X25519 and ChaCha20-Poly1305 remain the current cryptographic baseline, but
+   German/EU regulated buyers will ask for a documented post-quantum transition
+   plan before long-term procurement decisions.
+4. Hardware-backed unlock and FIDO2/WebAuthn are enterprise-relevant, but hosted
+   MFA enforcement belongs to Pro. Public core may later evaluate local
+   hardware-key unlock without creating paid gates.
+5. The old OpenPass commercialization advice is now partially obsolete: the repo
+   has been renamed and substantially hardened, and Pro has its own private
+   service layer. The still-useful part is the positioning around AI-agent
+   credentials and local-first trust.
+
+## GitHub Tracking
+
+The following issues preserve the remaining public-core work:
+
+- [#484](https://github.com/danieljustus/symaira-vault/issues/484):
+  add a redacted self-hosted audit evidence export.
+- [#485](https://github.com/danieljustus/symaira-vault/issues/485):
+  document the post-quantum transition plan for the public crypto envelope.

--- a/editors/cursor/jest.config.js
+++ b/editors/cursor/jest.config.js
@@ -1,0 +1,20 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: "ts-jest",
+  testEnvironment: "node",
+  roots: ["<rootDir>/tests"],
+  testMatch: ["**/*.test.ts"],
+  moduleNameMapper: {
+    "^vscode$": "<rootDir>/tests/__mocks__/vscode.ts",
+    "^@symaira/mcp-client$": "<rootDir>/tests/__mocks__/mcp-client.ts",
+  },
+  moduleFileExtensions: ["ts", "js", "json"],
+  transform: {
+    "^.+\\.ts$": [
+      "ts-jest",
+      {
+        diagnostics: false,
+      },
+    ],
+  },
+};

--- a/editors/cursor/src/cursorContext.ts
+++ b/editors/cursor/src/cursorContext.ts
@@ -6,6 +6,64 @@ import { SymairaTools, maskValue } from "@symaira/mcp-client";
 const CONTEXT_MARKER_START = "<!-- SYMAIRA VAULT CONTEXT -->";
 const CONTEXT_MARKER_END = "<!-- END SYMAIRA VAULT CONTEXT -->";
 
+/**
+ * Sanitize an entry path to prevent prompt injection when writing to
+ * .cursorrules or similar context files.
+ *
+ * - Replaces newlines (LF, CR, CRLF) with escaped sequences
+ * - Escapes backticks to prevent code injection
+ * - Escapes pipe characters to prevent markdown table injection
+ */
+export function sanitizeEntryPath(entryPath: string): string {
+  // CRLF must be replaced before LF/CR to avoid partial escapes
+  let sanitized = entryPath.replace(/\r\n/g, "\\r\\n");
+  sanitized = sanitized.replace(/\n/g, "\\n");
+  sanitized = sanitized.replace(/\r/g, "\\r");
+  sanitized = sanitized.replace(/`/g, "\\`");
+  sanitized = sanitized.replace(/\|/g, "\\|");
+  return sanitized;
+}
+
+/**
+ * Validate a context file path to prevent path traversal attacks.
+ *
+ * - Rejects absolute paths (starting with / or drive letter on Windows)
+ * - Rejects paths containing `..` traversal
+ * - Verifies the resolved path stays inside the workspace folder
+ *
+ * @param contextFile - The context file path from configuration
+ * @param workspaceFolder - The workspace folder absolute path
+ * @returns The validated absolute path
+ * @throws Error if the path is invalid or escapes the workspace
+ */
+export function validateContextFilePath(
+  contextFile: string,
+  workspaceFolder: string
+): string {
+  if (path.isAbsolute(contextFile)) {
+    throw new Error(
+      `Context file path must be relative, got absolute path: ${contextFile}`
+    );
+  }
+
+  if (contextFile.includes("..")) {
+    throw new Error(
+      `Context file path must not contain ".." traversal: ${contextFile}`
+    );
+  }
+
+  const resolved = path.resolve(workspaceFolder, contextFile);
+  const resolvedWorkspace = path.resolve(workspaceFolder);
+
+  if (!resolved.startsWith(resolvedWorkspace + path.sep) && resolved !== resolvedWorkspace) {
+    throw new Error(
+      `Context file path escapes workspace folder: ${contextFile} resolves to ${resolved}`
+    );
+  }
+
+  return resolved;
+}
+
 export async function injectCursorContext(tools: SymairaTools): Promise<void> {
   const workspaceFolders = vscode.workspace.workspaceFolders;
   if (!workspaceFolders || workspaceFolders.length === 0) {
@@ -16,7 +74,10 @@ export async function injectCursorContext(tools: SymairaTools): Promise<void> {
   const contextFile = config.get<string>("contextFile", ".cursorrules");
 
   for (const folder of workspaceFolders) {
-    const cursorrulesPath = path.join(folder.uri.fsPath, contextFile);
+    const cursorrulesPath = validateContextFilePath(
+      contextFile,
+      folder.uri.fsPath
+    );
     await updateCursorrulesFile(cursorrulesPath, tools);
   }
 }
@@ -59,7 +120,7 @@ function parseEntries(result: { content: Array<{ type: string; text: string }> }
   return entries;
 }
 
-function buildContextBlock(entries: string[]): string {
+export function buildContextBlock(entries: string[]): string {
   if (entries.length === 0) {
     return `${CONTEXT_MARKER_START}\nNo Symaira Vault secrets available.\n${CONTEXT_MARKER_END}`;
   }
@@ -72,7 +133,8 @@ function buildContextBlock(entries: string[]): string {
   ];
 
   for (const entry of entries) {
-    lines.push(`- ${entry} (value: ${maskValue(entry)})`);
+    const sanitized = sanitizeEntryPath(entry);
+    lines.push(`- ${sanitized} (value: ${maskValue(entry)})`);
   }
 
   lines.push("");

--- a/editors/cursor/tests/__mocks__/mcp-client.ts
+++ b/editors/cursor/tests/__mocks__/mcp-client.ts
@@ -1,0 +1,10 @@
+export function maskValue(value: string): string {
+  if (!value || value.length === 0) {
+    return "";
+  }
+  return "*".repeat(3);
+}
+
+export class SymairaTools {
+  constructor() {}
+}

--- a/editors/cursor/tests/__mocks__/vscode.ts
+++ b/editors/cursor/tests/__mocks__/vscode.ts
@@ -1,0 +1,8 @@
+const workspace = {
+  workspaceFolders: undefined,
+  getConfiguration: jest.fn().mockReturnValue({
+    get: jest.fn().mockReturnValue(".cursorrules"),
+  }),
+};
+
+module.exports = { workspace };

--- a/editors/cursor/tests/cursorContext.test.ts
+++ b/editors/cursor/tests/cursorContext.test.ts
@@ -1,0 +1,120 @@
+import {
+  sanitizeEntryPath,
+  validateContextFilePath,
+  buildContextBlock,
+} from "../src/cursorContext";
+
+describe("sanitizeEntryPath", () => {
+  it("returns normal paths unchanged", () => {
+    expect(sanitizeEntryPath("github/password")).toBe("github/password");
+    expect(sanitizeEntryPath("work/aws.access-key")).toBe("work/aws.access-key");
+  });
+
+  it("escapes LF (\\n) characters", () => {
+    expect(sanitizeEntryPath("github\npassword")).toBe("github\\npassword");
+  });
+
+  it("escapes CR (\\r) characters", () => {
+    expect(sanitizeEntryPath("github\rpassword")).toBe("github\\rpassword");
+  });
+
+  it("escapes CRLF (\\r\\n) as a single unit", () => {
+    expect(sanitizeEntryPath("github\r\npassword")).toBe("github\\r\\npassword");
+  });
+
+  it("escapes backtick characters", () => {
+    expect(sanitizeEntryPath("github`injection")).toBe("github\\`injection");
+  });
+
+  it("escapes pipe characters", () => {
+    expect(sanitizeEntryPath("github|injection")).toBe("github\\|injection");
+  });
+
+  it("handles multiple injection vectors in one path", () => {
+    const malicious = "github\n`malicious`|table";
+    expect(sanitizeEntryPath(malicious)).toBe(
+      "github\\n\\`malicious\\`\\|table"
+    );
+  });
+
+  it("handles empty string", () => {
+    expect(sanitizeEntryPath("")).toBe("");
+  });
+});
+
+describe("validateContextFilePath", () => {
+  const workspace = "/home/user/project";
+
+  it("accepts valid relative paths", () => {
+    expect(validateContextFilePath(".cursorrules", workspace)).toBe(
+      "/home/user/project/.cursorrules"
+    );
+    expect(validateContextFilePath("subdir/.cursorrules", workspace)).toBe(
+      "/home/user/project/subdir/.cursorrules"
+    );
+  });
+
+  it("rejects absolute paths starting with /", () => {
+    expect(() =>
+      validateContextFilePath("/etc/passwd", workspace)
+    ).toThrow("must be relative");
+  });
+
+  it("rejects absolute Windows paths (C:\\) on Windows", () => {
+    if (process.platform !== "win32") {
+      return;
+    }
+    expect(() =>
+      validateContextFilePath("C:\\Windows\\System32", workspace)
+    ).toThrow("must be relative");
+  });
+
+  it("rejects paths containing .. traversal", () => {
+    expect(() =>
+      validateContextFilePath("../../etc/passwd", workspace)
+    ).toThrow('".."');
+  });
+
+  it("rejects paths that resolve outside workspace", () => {
+    expect(() =>
+      validateContextFilePath("subdir/../../escape", workspace)
+    ).toThrow('".."');
+  });
+
+  it("accepts paths that stay within workspace", () => {
+    const result = validateContextFilePath("deep/nested/.cursorrules", workspace);
+    expect(result).toBe("/home/user/project/deep/nested/.cursorrules");
+  });
+});
+
+describe("buildContextBlock", () => {
+  it("returns empty message when no entries", () => {
+    const block = buildContextBlock([]);
+    expect(block).toContain("No Symaira Vault secrets available.");
+  });
+
+  it("sanitizes entry paths with newline injection", () => {
+    const entries = ["github\n# This is a injected rule"];
+    const block = buildContextBlock(entries);
+    expect(block).toContain("github\\n# This is a injected rule");
+    expect(block).not.toContain("# This is a injected rule\n");
+  });
+
+  it("sanitizes entry paths with backtick injection", () => {
+    const entries = ["github`system prompt override`"];
+    const block = buildContextBlock(entries);
+    expect(block).toContain("github\\`system prompt override\\`");
+  });
+
+  it("sanitizes entry paths with pipe injection", () => {
+    const entries = ["github| malicious | column"];
+    const block = buildContextBlock(entries);
+    expect(block).toContain("github\\| malicious \\| column");
+  });
+
+  it("preserves context markers", () => {
+    const block = buildContextBlock(["safe/entry"]);
+    expect(block).toContain("<!-- SYMAIRA VAULT CONTEXT -->");
+    expect(block).toContain("<!-- END SYMAIRA VAULT CONTEXT -->");
+  });
+});

--- a/editors/mcp-client/jest.config.js
+++ b/editors/mcp-client/jest.config.js
@@ -1,0 +1,8 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: "ts-jest",
+  testEnvironment: "node",
+  roots: ["<rootDir>/tests"],
+  testMatch: ["**/*.test.ts"],
+  moduleFileExtensions: ["ts", "js", "json"],
+};

--- a/editors/mcp-client/src/client.ts
+++ b/editors/mcp-client/src/client.ts
@@ -13,13 +13,47 @@ import {
 } from "./protocol";
 import { buildAuthHeaders, AuthHeaders } from "./auth";
 import { MCPMessage, ToolResult } from "./types";
-import { SymairaConnectionError, SymairaToolError } from "./errors";
+import { SymairaConnectionError, SymairaToolError, SymairaURLError } from "./errors";
 
 export interface ClientOptions {
   baseUrl?: string;
   agentName?: string;
   vaultPath?: string;
   timeoutMs?: number;
+}
+
+/**
+ * Validate that a URL points to a loopback address.
+ * Only allows http/https protocols and loopback hostnames:
+ * 127.0.0.1, localhost, ::1, [::1], 0.0.0.0
+ */
+export function validateBaseUrl(urlString: string): void {
+  let url: URL;
+  try {
+    url = new URL(urlString);
+  } catch {
+    throw new SymairaURLError(`Invalid URL: "${urlString}"`);
+  }
+
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new SymairaURLError(
+      `Only http and https protocols are allowed, got "${url.protocol}"`
+    );
+  }
+
+  const LOOPBACK_HOSTNAMES = new Set([
+    "127.0.0.1",
+    "localhost",
+    "::1",
+    "[::1]",
+    "0.0.0.0",
+  ]);
+
+  if (!LOOPBACK_HOSTNAMES.has(url.hostname)) {
+    throw new SymairaURLError(
+      `URL must point to a loopback address (127.0.0.1, localhost, ::1, 0.0.0.0), got "${url.hostname}"`
+    );
+  }
 }
 
 export class SymairaMCPClient {
@@ -30,6 +64,7 @@ export class SymairaMCPClient {
 
   constructor(options: ClientOptions = {}) {
     this.baseUrl = options.baseUrl || "http://127.0.0.1:8080";
+    validateBaseUrl(this.baseUrl);
     const agentName = options.agentName || "vscode";
     this.headers = buildAuthHeaders(agentName, options.vaultPath);
     this.timeoutMs = options.timeoutMs || 30000;

--- a/editors/mcp-client/src/errors.ts
+++ b/editors/mcp-client/src/errors.ts
@@ -34,3 +34,10 @@ export class SymairaToolError extends SymairaError {
     this.toolError = toolError;
   }
 }
+
+export class SymairaURLError extends SymairaError {
+  constructor(message: string) {
+    super(message);
+    this.name = "SymairaURLError";
+  }
+}

--- a/editors/mcp-client/src/index.ts
+++ b/editors/mcp-client/src/index.ts
@@ -2,7 +2,7 @@
  * Public API exports for @symaira/mcp-client
  */
 
-export { SymairaMCPClient, ClientOptions } from "./client";
+export { SymairaMCPClient, ClientOptions, validateBaseUrl } from "./client";
 export { SymairaTools } from "./tools";
 export {
   buildAuthHeaders,
@@ -22,6 +22,7 @@ export {
   SymairaAuthError,
   SymairaConnectionError,
   SymairaToolError,
+  SymairaURLError,
 } from "./errors";
 export {
   buildRequest,

--- a/editors/mcp-client/tests/url-validation.test.ts
+++ b/editors/mcp-client/tests/url-validation.test.ts
@@ -1,0 +1,92 @@
+import { validateBaseUrl, SymairaMCPClient, SymairaURLError } from "../src";
+
+describe("validateBaseUrl", () => {
+  describe("valid loopback URLs", () => {
+    const validUrls = [
+      { url: "http://127.0.0.1:8080", label: "127.0.0.1 with port" },
+      { url: "http://127.0.0.1:3000", label: "127.0.0.1 with alternate port" },
+      { url: "http://localhost:8080", label: "localhost with port" },
+      { url: "http://localhost:3000", label: "localhost with alternate port" },
+      { url: "http://[::1]:8080", label: "IPv6 loopback [::1]" },
+      { url: "http://0.0.0.0:8080", label: "0.0.0.0 with port" },
+      { url: "https://127.0.0.1:8080", label: "https 127.0.0.1" },
+      { url: "https://localhost:8080", label: "https localhost" },
+      { url: "https://[::1]:8080", label: "https IPv6 loopback" },
+      { url: "https://0.0.0.0:8080", label: "https 0.0.0.0" },
+      { url: "http://127.0.0.1", label: "127.0.0.1 no port" },
+      { url: "http://localhost", label: "localhost no port" },
+    ];
+
+    test.each(validUrls)("$label — $url should be accepted", ({ url }) => {
+      expect(() => validateBaseUrl(url)).not.toThrow();
+    });
+  });
+
+  describe("invalid non-loopback URLs", () => {
+    const invalidUrls = [
+      { url: "http://example.com:8080", label: "external domain" },
+      { url: "https://evil.com", label: "evil domain" },
+      { url: "http://192.168.1.1:8080", label: "private LAN IP" },
+      { url: "http://10.0.0.1:8080", label: "private class A IP" },
+      { url: "http://172.16.0.1:8080", label: "private class B IP" },
+      { url: "http://attacker.example.com/token", label: "attacker domain with path" },
+    ];
+
+    test.each(invalidUrls)("$label — $url should be rejected", ({ url }) => {
+      expect(() => validateBaseUrl(url)).toThrow(SymairaURLError);
+      expect(() => validateBaseUrl(url)).toThrow(/loopback/i);
+    });
+  });
+
+  describe("invalid protocols", () => {
+    const protocolUrls = [
+      { url: "ftp://127.0.0.1:8080", label: "ftp" },
+      { url: "file:///etc/passwd", label: "file protocol" },
+      { url: "javascript:alert(1)", label: "javascript protocol" },
+      { url: "data:text/html,<h1>xss</h1>", label: "data protocol" },
+    ];
+
+    test.each(protocolUrls)("$label — $url should be rejected", ({ url }) => {
+      expect(() => validateBaseUrl(url)).toThrow(SymairaURLError);
+    });
+  });
+
+  describe("malformed / edge cases", () => {
+    test("empty string throws SymairaURLError", () => {
+      expect(() => validateBaseUrl("")).toThrow(SymairaURLError);
+      expect(() => validateBaseUrl("")).toThrow(/Invalid URL/);
+    });
+
+    test("missing protocol throws SymairaURLError", () => {
+      expect(() => validateBaseUrl("127.0.0.1:8080")).toThrow(SymairaURLError);
+    });
+
+    test("random garbage throws SymairaURLError", () => {
+      expect(() => validateBaseUrl("not-a-url")).toThrow(SymairaURLError);
+    });
+  });
+});
+
+describe("SymairaMCPClient constructor validation", () => {
+  test("accepts default baseUrl (http://127.0.0.1:8080)", () => {
+    expect(() => new SymairaMCPClient()).not.toThrow();
+  });
+
+  test("accepts explicit loopback URL", () => {
+    expect(
+      () => new SymairaMCPClient({ baseUrl: "http://localhost:3000" })
+    ).not.toThrow();
+  });
+
+  test("rejects non-loopback URL", () => {
+    expect(
+      () => new SymairaMCPClient({ baseUrl: "http://evil.com:8080" })
+    ).toThrow(SymairaURLError);
+  });
+
+  test("rejects private IP", () => {
+    expect(
+      () => new SymairaMCPClient({ baseUrl: "http://192.168.1.1:8080" })
+    ).toThrow(SymairaURLError);
+  });
+});

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -840,10 +840,21 @@ func VerifyLog(logFilePath string, key []byte) (*VerifyResult, error) {
 
 	mac := hmac.New(sha256.New, key)
 	var prevHMAC []byte
+	chainStarted := false
 	for i, entry := range entries {
 		if entry.HMAC == "" {
-			result.Legacy++
-			prevHMAC = nil
+			if chainStarted {
+				// Legacy record after HMAC chain started — tampered (chain reset attack).
+				result.Tampered++
+				result.Valid = false
+				if result.FirstBadIdx < 0 {
+					result.FirstBadIdx = i
+				}
+			} else {
+				// Legacy record before any HMAC entry — backward-compatible legacy prefix.
+				result.Legacy++
+				prevHMAC = nil
+			}
 			continue
 		}
 
@@ -859,6 +870,7 @@ func VerifyLog(logFilePath string, key []byte) (*VerifyResult, error) {
 		} else {
 			result.Verified++
 			prevHMAC = entryHMACBytes
+			chainStarted = true
 		}
 	}
 

--- a/internal/audit/audit_hmac_test.go
+++ b/internal/audit/audit_hmac_test.go
@@ -396,6 +396,139 @@ func TestHMACReopenRetainsChain(t *testing.T) {
 	}
 }
 
+func TestHMACInsertedLegacyRecord(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	logger, err := New("hmac-insert-legacy-test", "", nil)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	for i := 0; i < 3; i++ {
+		_ = logger.LogEntry(LogEntry{
+			Agent:  "test-agent",
+			Action: fmt.Sprintf("get-%d", i),
+			Path:   "test/path",
+			OK:     true,
+		})
+	}
+	_ = logger.Close()
+
+	logFile := filepath.Join(home, configpkg.DefaultVaultSubdir, "audit-hmac-insert-legacy-test.log")
+	content, err := os.ReadFile(logFile)
+	if err != nil {
+		t.Fatalf("ReadFile error = %v", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(string(content)), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 lines, got %d", len(lines))
+	}
+
+	legacyEntry := `{"ts":"2024-01-01T00:00:00Z","agent":"attacker","action":"injected","path":"x","ok":true}`
+	var tamperedLines []string
+	tamperedLines = append(tamperedLines, lines[0], lines[1], legacyEntry, lines[2])
+
+	if err := os.WriteFile(logFile, []byte(strings.Join(tamperedLines, "\n")+"\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile error = %v", err)
+	}
+
+	auditDir := filepath.Join(home, configpkg.DefaultVaultSubdir)
+	ks := NewKeystore(auditDir, nil)
+	key, err := ks.LoadHMACKey()
+	if err != nil {
+		t.Fatalf("LoadHMACKey() error = %v", err)
+	}
+
+	result, err := VerifyLog(logFile, key)
+	if err != nil {
+		t.Fatalf("VerifyLog() error = %v", err)
+	}
+	if result.Valid {
+		t.Fatal("expected inserted legacy record to be detected as tampered, got Valid=true")
+	}
+	if result.Tampered != 1 {
+		t.Fatalf("Tampered = %d, want 1", result.Tampered)
+	}
+	if result.Verified != 3 {
+		t.Fatalf("Verified = %d, want 3", result.Verified)
+	}
+	if result.Legacy != 0 {
+		t.Fatalf("Legacy = %d, want 0", result.Legacy)
+	}
+	if result.FirstBadIdx != 2 {
+		t.Fatalf("FirstBadIdx = %d, want 2", result.FirstBadIdx)
+	}
+}
+
+func TestHMACTrailingLegacyRecord(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	logger, err := New("hmac-trail-legacy-test", "", nil)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	for i := 0; i < 3; i++ {
+		_ = logger.LogEntry(LogEntry{
+			Agent:  "test-agent",
+			Action: fmt.Sprintf("get-%d", i),
+			Path:   "test/path",
+			OK:     true,
+		})
+	}
+	_ = logger.Close()
+
+	logFile := filepath.Join(home, configpkg.DefaultVaultSubdir, "audit-hmac-trail-legacy-test.log")
+	content, err := os.ReadFile(logFile)
+	if err != nil {
+		t.Fatalf("ReadFile error = %v", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(string(content)), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 lines, got %d", len(lines))
+	}
+
+	legacyEntry := `{"ts":"2024-01-01T00:00:00Z","agent":"attacker","action":"trailing","path":"x","ok":true}`
+	var tamperedLines []string
+	tamperedLines = append(tamperedLines, lines...)
+	tamperedLines = append(tamperedLines, legacyEntry)
+
+	if err := os.WriteFile(logFile, []byte(strings.Join(tamperedLines, "\n")+"\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile error = %v", err)
+	}
+
+	auditDir := filepath.Join(home, configpkg.DefaultVaultSubdir)
+	ks := NewKeystore(auditDir, nil)
+	key, err := ks.LoadHMACKey()
+	if err != nil {
+		t.Fatalf("LoadHMACKey() error = %v", err)
+	}
+
+	result, err := VerifyLog(logFile, key)
+	if err != nil {
+		t.Fatalf("VerifyLog() error = %v", err)
+	}
+	if result.Valid {
+		t.Fatal("expected trailing legacy record to be detected as tampered, got Valid=true")
+	}
+	if result.Tampered != 1 {
+		t.Fatalf("Tampered = %d, want 1", result.Tampered)
+	}
+	if result.Verified != 3 {
+		t.Fatalf("Verified = %d, want 3", result.Verified)
+	}
+	if result.Legacy != 0 {
+		t.Fatalf("Legacy = %d, want 0", result.Legacy)
+	}
+	if result.FirstBadIdx != 3 {
+		t.Fatalf("FirstBadIdx = %d, want 3", result.FirstBadIdx)
+	}
+}
+
 func TestHMACMixedLegacyAndNew(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/internal/audit/audit_hmac_test.go
+++ b/internal/audit/audit_hmac_test.go
@@ -427,7 +427,7 @@ func TestHMACInsertedLegacyRecord(t *testing.T) {
 	}
 
 	legacyEntry := `{"ts":"2024-01-01T00:00:00Z","agent":"attacker","action":"injected","path":"x","ok":true}`
-	var tamperedLines []string
+	tamperedLines := make([]string, 0, 4)
 	tamperedLines = append(tamperedLines, lines[0], lines[1], legacyEntry, lines[2])
 
 	if err := os.WriteFile(logFile, []byte(strings.Join(tamperedLines, "\n")+"\n"), 0o600); err != nil {
@@ -493,7 +493,7 @@ func TestHMACTrailingLegacyRecord(t *testing.T) {
 	}
 
 	legacyEntry := `{"ts":"2024-01-01T00:00:00Z","agent":"attacker","action":"trailing","path":"x","ok":true}`
-	var tamperedLines []string
+	tamperedLines := make([]string, 0, len(lines)+1)
 	tamperedLines = append(tamperedLines, lines...)
 	tamperedLines = append(tamperedLines, legacyEntry)
 

--- a/internal/mcp/server/tools_search_openai.go
+++ b/internal/mcp/server/tools_search_openai.go
@@ -8,9 +8,11 @@ import (
 	"strings"
 	"time"
 
-	mcp "github.com/danieljustus/symaira-vault/internal/mcp"
 	"github.com/danieljustus/symaira-vault/internal/metrics"
 	vaultpkg "github.com/danieljustus/symaira-vault/internal/vault"
+	"github.com/danieljustus/symaira-vault/internal/vault/taint"
+
+	mcp "github.com/danieljustus/symaira-vault/internal/mcp"
 )
 
 type openAISearchResult struct {
@@ -122,7 +124,71 @@ func (s *Server) handleFetchOpenAI(ctx context.Context, req mcp.CallToolRequest)
 		},
 	}
 
-	if s.canReadValues() && len(entry.Data) > 0 {
+	// Block value access for quarantined entries. Normalize path first to prevent
+	// traversal bypasses (e.g., "quarantine/../secrets/foo" normalizes to
+	// "secrets/foo", correctly bypassing the check — that path is not quarantined).
+	{
+		cleanedPath := path.Clean(id)
+		if cleanedPath == "quarantine" || strings.HasPrefix(cleanedPath, "quarantine/") {
+			s.logAudit(ctx, "quarantine_block", id, false)
+			return mcp.NewToolResultError("entry is in quarantine — run 'symvault import review promote' to make it accessible"), nil
+		}
+	}
+
+	// Gate value exposure on ExposeValueTools: when false, fetch returns metadata-only.
+	// ExposeValueTools controls whether the get_entry_value tool is registered at all;
+	// fetch must respect the same gate to avoid a side-channel bypass.
+	exposeValues := s.agent != nil && s.agent.ExposeValueTools != nil && *s.agent.ExposeValueTools
+
+	if exposeValues && s.canReadValues() && len(entry.Data) > 0 {
+		// Apply the same security controls as handleGetValue for value exposure.
+
+		if s.agent != nil {
+			if patterns := s.agent.EffectiveRedactFields("fetch_openai"); len(patterns) > 0 {
+				entry = redactEntry(entry, patterns)
+			}
+		}
+
+		shouldSeal := entry.Classification >= taint.Secret && (s.agent == nil || s.agent.AutoUnseal == nil || !*s.agent.AutoUnseal)
+		if shouldSeal {
+			return s.sealEntryResponse(ctx, entry, id), nil
+		}
+
+		maxSecrets := 0
+		if s.agent.MaxSecretsInSession != nil {
+			maxSecrets = *s.agent.MaxSecretsInSession
+		}
+		if maxSecrets > 0 {
+			accessed := s.secretsAccessed.Load()
+			fieldCount := int64(len(entry.Data))
+			if accessed+fieldCount > int64(maxSecrets) {
+				return mcp.NewToolResultError(
+					fmt.Sprintf("max secrets per session exceeded (%d/%d)", accessed+fieldCount, maxSecrets)), nil
+			}
+		}
+
+		for range entry.Data {
+			s.secretsAccessed.Add(1)
+		}
+
+		entry.Data = wrapDataFields(entry.Data)
+
+		piMode := ""
+		if s.agent != nil && s.agent.PromptInjectionMode != nil {
+			piMode = *s.agent.PromptInjectionMode
+		}
+		if piMode != "" && piMode != "off" {
+			for k, v := range entry.Data {
+				if str, ok := v.(string); ok {
+					checked, checkErr := s.applySemanticInjectionCheck(str)
+					if checkErr != nil {
+						return mcp.NewToolResultError(checkErr.Error()), nil
+					}
+					entry.Data[k] = checked
+				}
+			}
+		}
+
 		response.Values = entry.Data
 	}
 

--- a/internal/mcp/server/tools_search_openai_test.go
+++ b/internal/mcp/server/tools_search_openai_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/danieljustus/symaira-vault/internal/config"
 	mcp "github.com/danieljustus/symaira-vault/internal/mcp"
+	"github.com/danieljustus/symaira-vault/internal/vault"
 )
 
 func TestHandleSearchOpenAI_Success(t *testing.T) {
@@ -173,11 +174,12 @@ func TestHandleSearchOpenAI_NoResults(t *testing.T) {
 func TestHandleFetchOpenAI_Success(t *testing.T) {
 	vaultDir, identity := mockVault(t)
 	srv := newTestServerWithVault(t, config.AgentProfile{
-		Name:          "test",
-		AllowedPaths:  []string{"*"},
-		CanWrite:      config.BoolPtr(false),
-		CanReadValues: config.BoolPtr(true),
-		ApprovalMode:  config.StrPtr("none"),
+		Name:             "test",
+		AllowedPaths:     []string{"*"},
+		CanWrite:         config.BoolPtr(false),
+		CanReadValues:    config.BoolPtr(true),
+		ExposeValueTools: config.BoolPtr(true),
+		ApprovalMode:     config.StrPtr("none"),
 	}, "stdio", vaultDir)
 	srv.vault.Identity = identity
 
@@ -532,11 +534,12 @@ func TestExecuteTool_SearchOpenAI(t *testing.T) {
 func TestExecuteTool_FetchOpenAI(t *testing.T) {
 	vaultDir, identity := mockVault(t)
 	srv := newTestServerWithVault(t, config.AgentProfile{
-		Name:          "test",
-		AllowedPaths:  []string{"*"},
-		CanWrite:      config.BoolPtr(false),
-		CanReadValues: config.BoolPtr(true),
-		ApprovalMode:  config.StrPtr("none"),
+		Name:             "test",
+		AllowedPaths:     []string{"*"},
+		CanWrite:         config.BoolPtr(false),
+		CanReadValues:    config.BoolPtr(true),
+		ExposeValueTools: config.BoolPtr(true),
+		ApprovalMode:     config.StrPtr("none"),
 	}, "stdio", vaultDir)
 	srv.vault.Identity = identity
 
@@ -557,5 +560,77 @@ func TestExecuteTool_FetchOpenAI(t *testing.T) {
 
 	if _, ok := result["structuredContent"]; !ok {
 		t.Error("expected structuredContent in result")
+	}
+}
+
+func TestFetchOpenAI_QuarantineBlocked(t *testing.T) {
+	vaultDir, identity := mockVault(t)
+
+	entry := &vault.Entry{
+		Data: map[string]any{"password": "testpass123"},
+	}
+	if err := vault.WriteEntry(vaultDir, "quarantine/bad", entry, identity); err != nil {
+		t.Fatalf("write quarantine entry: %v", err)
+	}
+
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:             "test",
+		AllowedPaths:     []string{"*"},
+		CanWrite:         config.BoolPtr(false),
+		CanReadValues:    config.BoolPtr(true),
+		ExposeValueTools: config.BoolPtr(true),
+		ApprovalMode:     config.StrPtr("none"),
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+
+	req := mcp.CallToolRequest{
+		Arguments: map[string]any{"id": "quarantine/bad"},
+	}
+
+	result, err := srv.handleFetchOpenAI(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleFetchOpenAI() error = %v", err)
+	}
+	if result == nil || !result.IsError {
+		t.Fatal("handleFetchOpenAI() expected error for quarantined entry")
+	}
+	if !strings.Contains(result.Text, "quarantine") {
+		t.Errorf("error = %q, want quarantine message", result.Text)
+	}
+}
+
+func TestFetchOpenAI_ValuesBlockedWhenExposeValueToolsFalse(t *testing.T) {
+	vaultDir, identity := mockVault(t)
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:             "test",
+		AllowedPaths:     []string{"*"},
+		CanWrite:         config.BoolPtr(false),
+		CanReadValues:    config.BoolPtr(true),
+		ExposeValueTools: config.BoolPtr(false),
+		ApprovalMode:     config.StrPtr("none"),
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+
+	req := mcp.CallToolRequest{
+		Arguments: map[string]any{"id": "github"},
+	}
+
+	result, err := srv.handleFetchOpenAI(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleFetchOpenAI() error = %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handleFetchOpenAI() returned error: %s", result.Text)
+	}
+
+	structured, ok := result.StructuredContent.(openAIFetchResponse)
+	if !ok {
+		t.Fatalf("StructuredContent type = %T, want openAIFetchResponse", result.StructuredContent)
+	}
+	if structured.Values != nil {
+		t.Error("Values must be nil when ExposeValueTools=false, even if canReadValues=true")
+	}
+	if structured.Metadata == nil {
+		t.Error("Metadata should still be present")
 	}
 }

--- a/internal/pairing/token.go
+++ b/internal/pairing/token.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode"
 )
 
 // TokenTTL is the time-to-live for pairing tokens. Exported for testing.
@@ -71,6 +72,35 @@ func GenerateToken() (Token, error) {
 	// base32 hex encoding is URL-safe, case-insensitive, and readable.
 	token := base32.HexEncoding.WithPadding(base32.NoPadding).EncodeToString(b)
 	return Token(token), nil
+}
+
+var errInvalidTokenFormat = fmt.Errorf("invalid pairing token format")
+
+// ValidatePairingToken checks that a token string is safe to use in
+// file-path construction. It rejects tokens containing path separators,
+// null bytes, control characters, or characters outside the base32-hex
+// alphabet that GenerateToken produces.
+func ValidatePairingToken(token string) error {
+	if token == "" {
+		return errInvalidTokenFormat
+	}
+	if len(token) > 64 {
+		return errInvalidTokenFormat
+	}
+	for _, ch := range token {
+		switch {
+		case ch == '/' || ch == '\\':
+			return errInvalidTokenFormat
+		case ch == 0:
+			return errInvalidTokenFormat
+		case unicode.IsControl(ch):
+			return errInvalidTokenFormat
+		case (ch >= '0' && ch <= '9') || (ch >= 'A' && ch <= 'V') || (ch >= 'a' && ch <= 'v'):
+		default:
+			return errInvalidTokenFormat
+		}
+	}
+	return nil
 }
 
 // Store saves a token with its associated public key and sets expiry.

--- a/internal/pairing/token_test.go
+++ b/internal/pairing/token_test.go
@@ -308,3 +308,72 @@ func TestGenerateToken_DisplayFormat(t *testing.T) {
 		t.Errorf("Display reconstruction mismatch: %q vs %q", reconstructed, string(token))
 	}
 }
+
+func TestValidatePairingToken_Valid(t *testing.T) {
+	token, err := GenerateToken()
+	if err != nil {
+		t.Fatalf("GenerateToken error: %v", err)
+	}
+	if err := ValidatePairingToken(string(token)); err != nil {
+		t.Errorf("ValidatePairingToken(%q) = %v, want nil", string(token), err)
+	}
+}
+
+func TestValidatePairingToken_Empty(t *testing.T) {
+	if err := ValidatePairingToken(""); err == nil {
+		t.Error("expected error for empty token")
+	}
+}
+
+func TestValidatePairingToken_PathSeparator(t *testing.T) {
+	for _, tok := range []string{"../../../etc/passwd", "abc/def", `abc\def`} {
+		if err := ValidatePairingToken(tok); err == nil {
+			t.Errorf("expected error for token %q", tok)
+		}
+	}
+}
+
+func TestValidatePairingToken_NullByte(t *testing.T) {
+	if err := ValidatePairingToken("abc\x00def"); err == nil {
+		t.Error("expected error for null byte in token")
+	}
+}
+
+func TestValidatePairingToken_ControlChars(t *testing.T) {
+	if err := ValidatePairingToken("abc\x01def"); err == nil {
+		t.Error("expected error for control character in token")
+	}
+}
+
+func TestValidatePairingToken_InvalidChars(t *testing.T) {
+	for _, tok := range []string{"abc def", "abc:def", "abc=def", "abc+def"} {
+		if err := ValidatePairingToken(tok); err == nil {
+			t.Errorf("expected error for token %q", tok)
+		}
+	}
+}
+
+func TestValidatePairingToken_LowercaseValid(t *testing.T) {
+	if err := ValidatePairingToken("abcdef012345"); err != nil {
+		t.Errorf("lowercase base32 hex should be valid, got %v", err)
+	}
+}
+
+func TestValidatePairingToken_TooLong(t *testing.T) {
+	long := strings.Repeat("A", 65)
+	if err := ValidatePairingToken(long); err == nil {
+		t.Error("expected error for token > 64 chars")
+	}
+}
+
+func TestValidatePairingToken_GenerateTokenAlwaysValid(t *testing.T) {
+	for i := 0; i < 50; i++ {
+		token, err := GenerateToken()
+		if err != nil {
+			t.Fatalf("iteration %d: GenerateToken error: %v", i, err)
+		}
+		if err := ValidatePairingToken(string(token)); err != nil {
+			t.Errorf("iteration %d: generated token %q rejected: %v", i, string(token), err)
+		}
+	}
+}

--- a/internal/vault/devices.go
+++ b/internal/vault/devices.go
@@ -45,7 +45,7 @@ func (dm *DeviceManager) LoadDevices() ([]Device, error) {
 	}
 
 	// #nosec G304 -- path is the devices.json file within the vault directory
-	data, err := os.ReadFile(path)
+	data, err := SafeReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("read devices file: %w", err)
 	}
@@ -69,7 +69,7 @@ func (dm *DeviceManager) SaveDevices(devices []Device) error {
 		return fmt.Errorf("marshal devices: %w", err)
 	}
 
-	if err := os.WriteFile(dm.devicesPath(), data, 0o600); err != nil {
+	if err := SafeWriteFile(dm.devicesPath(), data, 0o600); err != nil {
 		return fmt.Errorf("write devices file: %w", err)
 	}
 

--- a/internal/vault/entry_readwrite.go
+++ b/internal/vault/entry_readwrite.go
@@ -82,14 +82,13 @@ func ReadEntry(vaultDir, path string, identity *age.X25519Identity) (*Entry, err
 		return nil, err
 	}
 	filePath := entryStoragePath(vaultDir, path, identity, cfg)
-	// #nosec G304
-	raw, err := os.ReadFile(filePath)
+	raw, err := SafeReadFile(filePath)
 	if os.IsNotExist(err) && canUseLegacyEntryPath(path) {
 		if legacyErr := validateLegacyEntryPath(vaultDir, path); legacyErr != nil {
 			span.SetStatus(codes.Error, legacyErr.Error())
 			return nil, legacyErr
 		}
-		raw, err = os.ReadFile(legacyEntryFilePath(vaultDir, path))
+		raw, err = SafeReadFile(legacyEntryFilePath(vaultDir, path))
 	}
 	if err != nil {
 		span.SetStatus(codes.Error, err.Error())
@@ -143,14 +142,13 @@ func readEntryInner(vaultDir, path string, identity *age.X25519Identity, pseudoK
 	} else {
 		filePath = entryStoragePath(vaultDir, path, identity, cfg)
 	}
-	// #nosec G304 -- filePath is constructed by entryStoragePath from validated vaultDir and path
-	raw, err := os.ReadFile(filePath)
+	raw, err := SafeReadFile(filePath)
 	if os.IsNotExist(err) && canUseLegacyEntryPath(path) {
 		if legacyErr := validateLegacyEntryPath(vaultDir, path); legacyErr != nil {
 			span.SetStatus(codes.Error, legacyErr.Error())
 			return nil, legacyErr
 		}
-		raw, err = os.ReadFile(legacyEntryFilePath(vaultDir, path))
+		raw, err = SafeReadFile(legacyEntryFilePath(vaultDir, path))
 	}
 	if err != nil {
 		span.SetStatus(codes.Error, err.Error())
@@ -446,12 +444,12 @@ func GetEntryMetadata(vaultDir, path string, identity *age.X25519Identity) (*Ent
 	if err != nil {
 		return nil, err
 	}
-	raw, err := os.ReadFile(entryStoragePath(vaultDir, path, identity, cfg))
+	raw, err := SafeReadFile(entryStoragePath(vaultDir, path, identity, cfg))
 	if os.IsNotExist(err) && canUseLegacyEntryPath(path) {
 		if legacyErr := validateLegacyEntryPath(vaultDir, path); legacyErr != nil {
 			return nil, legacyErr
 		}
-		raw, err = os.ReadFile(legacyEntryFilePath(vaultDir, path))
+		raw, err = SafeReadFile(legacyEntryFilePath(vaultDir, path))
 	}
 	if err != nil {
 		return nil, err

--- a/internal/vault/recipients.go
+++ b/internal/vault/recipients.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"time"
 
 	"filippo.io/age"
@@ -120,7 +121,7 @@ func (rm *RecipientsManager) LoadRecipientStrings() ([]string, error) {
 		return []string{}, nil
 	}
 
-	data, err := os.ReadFile(path) //#nosec G304 -- path is constructed from validated vaultDir via RecipientsFilePath()
+	data, err := SafeReadFile(path) //#nosec G304 -- path is constructed from validated vaultDir via RecipientsFilePath()
 	if err != nil {
 		return nil, fmt.Errorf("read recipients file: %w", err)
 	}
@@ -170,6 +171,12 @@ func (rm *RecipientsManager) AddRecipient(recipientStr string) error {
 	}
 
 	// Create file if it doesn't exist, or append to existing
+	// Verify file is not a symlink before opening for append.
+	if info, err := os.Lstat(path); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return &os.PathError{Op: "open", Path: path, Err: syscall.ELOOP}
+		}
+	}
 	flags := os.O_APPEND | os.O_WRONLY | os.O_CREATE
 	file, err := os.OpenFile(path, flags, 0o600) //#nosec G304 -- path is constructed from validated vaultDir via RecipientsFilePath()
 	if err != nil {
@@ -225,7 +232,7 @@ func (rm *RecipientsManager) RemoveRecipient(recipientStr string) error {
 	}
 
 	// Read all lines
-	data, err := os.ReadFile(path) //#nosec G304 -- path is constructed from validated vaultDir via RecipientsFilePath()
+	data, err := SafeReadFile(path) //#nosec G304 -- path is constructed from validated vaultDir via RecipientsFilePath()
 	if err != nil {
 		return fmt.Errorf("read recipients file: %w", err)
 	}
@@ -285,7 +292,7 @@ func (rm *RecipientsManager) ListRecipients() ([]RecipientInfo, error) {
 		return []RecipientInfo{}, nil
 	}
 
-	data, err := os.ReadFile(path) //#nosec G304 -- path is constructed from validated vaultDir via RecipientsFilePath()
+	data, err := SafeReadFile(path) //#nosec G304 -- path is constructed from validated vaultDir via RecipientsFilePath()
 	if err != nil {
 		return nil, fmt.Errorf("read recipients file: %w", err)
 	}

--- a/internal/vault/recipients.go
+++ b/internal/vault/recipients.go
@@ -172,7 +172,7 @@ func (rm *RecipientsManager) AddRecipient(recipientStr string) error {
 
 	// Create file if it doesn't exist, or append to existing
 	// Verify file is not a symlink before opening for append.
-	if info, err := os.Lstat(path); err == nil {
+	if info, lstatErr := os.Lstat(path); lstatErr == nil {
 		if info.Mode()&os.ModeSymlink != 0 {
 			return &os.PathError{Op: "open", Path: path, Err: syscall.ELOOP}
 		}

--- a/internal/vault/symlink_harden.go
+++ b/internal/vault/symlink_harden.go
@@ -29,6 +29,24 @@ func SafeWriteFile(path string, data []byte, perm os.FileMode) error {
 	return fsutil.AtomicWriteFile(path, data, perm)
 }
 
+// SafeReadFile reads the file at path after verifying it is not a symlink
+// or other non-regular file. This prevents an attacker who controls a
+// symlink at path from having the vault read an arbitrary file.
+func SafeReadFile(path string) ([]byte, error) {
+	if info, err := os.Lstat(path); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return nil, &os.PathError{Op: "open", Path: path, Err: syscall.ELOOP}
+		}
+		if !info.Mode().IsRegular() {
+			return nil, &os.PathError{Op: "open", Path: path, Err: syscall.ENOTDIR}
+		}
+	} else if !os.IsNotExist(err) {
+		return nil, &os.PathError{Op: "lstat", Path: path, Err: err}
+	}
+
+	return os.ReadFile(path) // #nosec G304 -- symlink check performed above
+}
+
 // SafeRemove delegates to the safepath package's symlink-hardened remove.
 func SafeRemove(path string) error {
 	return safepath.DefaultManager.Remove(path)

--- a/internal/vault/symlink_harden_test.go
+++ b/internal/vault/symlink_harden_test.go
@@ -196,3 +196,62 @@ func TestSafeRemove_FstatFails(t *testing.T) {
 		t.Fatal("expected error")
 	}
 }
+
+func TestSafeReadFile_SymlinkAttack(t *testing.T) {
+	vaultDir := t.TempDir()
+
+	targetPath := filepath.Join(t.TempDir(), "secret.txt")
+	os.WriteFile(targetPath, []byte("sensitive"), 0o600)
+
+	symlinkPath := filepath.Join(vaultDir, "tricked")
+	os.Symlink(targetPath, symlinkPath)
+
+	_, err := SafeReadFile(symlinkPath)
+	if err == nil {
+		t.Fatal("SafeReadFile should reject symlink")
+	}
+	pathErr, ok := err.(*os.PathError)
+	if !ok {
+		t.Fatalf("expected PathError, got %T", err)
+	}
+	if pathErr.Err != syscall.ELOOP && pathErr.Err != syscall.ENOTDIR {
+		t.Errorf("expected ELOOP or ENOTDIR, got %v", pathErr.Err)
+	}
+}
+
+func TestSafeReadFile_RegularFile(t *testing.T) {
+	vaultDir := t.TempDir()
+	filePath := filepath.Join(vaultDir, "test.age")
+
+	data := []byte("hello world")
+	if err := os.WriteFile(filePath, data, 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	got, err := SafeReadFile(filePath)
+	if err != nil {
+		t.Fatalf("SafeReadFile() error = %v", err)
+	}
+	if string(got) != string(data) {
+		t.Errorf("content = %q, want %q", string(got), string(data))
+	}
+}
+
+func TestSafeReadFile_NotExist(t *testing.T) {
+	vaultDir := t.TempDir()
+	_, err := SafeReadFile(filepath.Join(vaultDir, "nonexistent"))
+	if err == nil {
+		t.Fatal("expected error for non-existent file")
+	}
+}
+
+func TestSafeReadFile_DirectoryTarget(t *testing.T) {
+	vaultDir := t.TempDir()
+	dirPath := filepath.Join(vaultDir, "mydir")
+	os.MkdirAll(dirPath, 0o700)
+
+	_, err := SafeReadFile(dirPath)
+	if err == nil {
+		t.Fatal("SafeReadFile should reject directory target")
+	}
+}

--- a/internal/vault/symlink_harden_windows.go
+++ b/internal/vault/symlink_harden_windows.go
@@ -39,6 +39,24 @@ func SafeMkdirAll(path string, perm os.FileMode) error {
 	return safepath.DefaultManager.MkdirAll(path, perm)
 }
 
+// SafeReadFile reads the file at path after verifying it is not a symlink
+// or other non-regular file. This prevents an attacker who controls a
+// symlink at path from having the vault read an arbitrary file.
+func SafeReadFile(path string) ([]byte, error) {
+	if err := rejectSymlink(path); err != nil {
+		return nil, err
+	}
+	if info, err := os.Lstat(path); err == nil {
+		if !info.Mode().IsRegular() {
+			return nil, &os.PathError{Op: "open", Path: path, Err: errUnsafePath}
+		}
+	} else if !errors.Is(err, fs.ErrNotExist) {
+		return nil, err
+	}
+
+	return os.ReadFile(path) // #nosec G304 -- symlink check performed above
+}
+
 func rejectSymlink(path string) error {
 	info, err := os.Lstat(path)
 	if err == nil {

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -15,17 +15,24 @@
 .PARAMETER DryRun
     Download and verify but do not install.
 
+.PARAMETER SkipCosignVerification
+    Skip cosign signature verification of the checksums file.
+    By default, the installer requires cosign and fails if it is not installed.
+    Use this flag only if you cannot install cosign and understand the risk
+    of an unauthenticated checksums file.
+
 .EXAMPLE
     irm https://raw.githubusercontent.com/danieljustus/symaira-vault/main/scripts/install.ps1 | iex
     install.ps1 -Version 1.2.3
     install.ps1 -InstallDir C:\Tools
 #>
 
-[CmdletBinding()]
+    [CmdletBinding()]
 param(
     [string]$Version,
     [string]$InstallDir,
-    [switch]$DryRun
+    [switch]$DryRun,
+    [switch]$SkipCosignVerification
 )
 
 Set-StrictMode -Version Latest
@@ -106,23 +113,39 @@ function Test-ChecksumsSignature {
     param(
         [string]$ChecksumsPath,
         [string]$ChecksumsSigUrl,
-        [string]$ChecksumsPemUrl
+        [string]$ChecksumsPemUrl,
+        [switch]$SkipCosignVerification
     )
 
     if (-not (Test-CosignAvailable)) {
-        Write-Warn 'cosign not found — skipping checksums.txt signature verification.'
-        Write-Host ''
-        Write-Host '  The checksums file has NOT been signature-verified. A tampered release' -ForegroundColor Yellow
-        Write-Host '  asset could ship with matching tampered checksums.' -ForegroundColor Yellow
-        Write-Host ''
-        Write-Host '  To verify manually:' -ForegroundColor Yellow
-        Write-Host "    cosign verify-blob --certificate <checksums.pem> --signature <checksums.sig> ``" -ForegroundColor Yellow
-        Write-Host "      --certificate-identity-regexp '$CosignIdentityRegexp' ``" -ForegroundColor Yellow
-        Write-Host "      --certificate-oidc-issuer '$CosignOIDCIssuer' ``" -ForegroundColor Yellow
-        Write-Host "      checksums.txt" -ForegroundColor Yellow
-        Write-Host ''
-        Write-Host '  Install cosign: https://docs.sigstore.dev/cosign/installation/' -ForegroundColor Yellow
-        return
+        if ($SkipCosignVerification) {
+            Write-Warn 'cosign not found — skipping checksums.txt signature verification.'
+            Write-Host ''
+            Write-Host '  WARNING: You are installing with -SkipCosignVerification.' -ForegroundColor Yellow
+            Write-Host '  The checksums file has NOT been signature-verified. A tampered release' -ForegroundColor Yellow
+            Write-Host '  asset could ship with matching tampered checksums.' -ForegroundColor Yellow
+            Write-Host ''
+            Write-Host '  To verify manually:' -ForegroundColor Yellow
+            Write-Host "    cosign verify-blob --certificate <checksums.pem> --signature <checksums.sig> ``" -ForegroundColor Yellow
+            Write-Host "      --certificate-identity-regexp '$CosignIdentityRegexp' ``" -ForegroundColor Yellow
+            Write-Host "      --certificate-oidc-issuer '$CosignOIDCIssuer' ``" -ForegroundColor Yellow
+            Write-Host "      checksums.txt" -ForegroundColor Yellow
+            Write-Host ''
+            Write-Host '  Install cosign: https://docs.sigstore.dev/cosign/installation/' -ForegroundColor Yellow
+            return
+        }
+
+        throw @"
+cosign is required but was not found in PATH.
+
+  The installer cannot verify the checksums file signature without cosign.
+  This means a tampered release could ship with matching tampered checksums.
+
+  Install cosign: https://docs.sigstore.dev/cosign/installation/
+
+  If you understand the risk and want to bypass this check, re-run with:
+    -SkipCosignVerification
+"@
     }
 
     $sigPath = "${ChecksumsPath}.sig"
@@ -191,7 +214,7 @@ function Install-SymairaVault {
         # Verify checksums signature with cosign.
         $checksumsSigUrl = "$GitHubDl/$resolvedVersion/${checksumsFile}.sig"
         $checksumsPemUrl = "$GitHubDl/$resolvedVersion/${checksumsFile}.pem"
-        Test-ChecksumsSignature -ChecksumsPath $checksumsPath -ChecksumsSigUrl $checksumsSigUrl -ChecksumsPemUrl $checksumsPemUrl
+        Test-ChecksumsSignature -ChecksumsPath $checksumsPath -ChecksumsSigUrl $checksumsSigUrl -ChecksumsPemUrl $checksumsPemUrl -SkipCosignVerification:$SkipCosignVerification
 
         # Download archive.
         Write-Info "Downloading $archiveFile..."

--- a/scripts/install.tests.ps1
+++ b/scripts/install.tests.ps1
@@ -1,0 +1,109 @@
+#Requires -Module Pester
+
+BeforeAll {
+    # Dot-source the installer to load function definitions.
+    # We suppress the entry point execution by temporarily overriding Install-SymairaVault.
+    $scriptPath = Join-Path $PSScriptRoot 'install.ps1'
+
+    # Read the script content and extract only function definitions (skip entry point).
+    $content = Get-Content $scriptPath -Raw
+
+    # Remove the entry point block at the bottom that calls Install-SymairaVault.
+    $content = $content -replace '(?s)# ── Entry point ─.*$', ''
+
+    # Remove the call to Install-SymairaVault if it exists standalone.
+    $content = $content -replace '(?m)^Install-SymairaVault\s*$', ''
+
+    # Execute the modified content to define functions.
+    Invoke-Expression $content
+}
+
+Describe 'Test-ChecksumsSignature' {
+
+    Context 'when cosign is NOT available' {
+
+        BeforeEach {
+            # Mock cosign as unavailable.
+            Mock Test-CosignAvailable { return $false }
+        }
+
+        It 'should throw an error when SkipCosignVerification is false' {
+            { Test-ChecksumsSignature -ChecksumsPath 'dummy checksums.txt' -ChecksumsSigUrl 'https://example.com/sig' -ChecksumsPemUrl 'https://example.com/pem' } |
+                Should -Throw -ExpectedMessage '*cosign is required but was not found*'
+        }
+
+        It 'should throw an error when SkipCosignVerification is not specified (default)' {
+            { Test-ChecksumsSignature -ChecksumsPath 'dummy checksums.txt' -ChecksumsSigUrl 'https://example.com/sig' -ChecksumsPemUrl 'https://example.com/pem' } |
+                Should -Throw -ExpectedMessage '*cosign is required but was not found*'
+        }
+
+        It 'should succeed with a warning when SkipCosignVerification is true' {
+            Mock Write-Host { }
+
+            { Test-ChecksumsSignature -ChecksumsPath 'dummy checksums.txt' -ChecksumsSigUrl 'https://example.com/sig' -ChecksumsPemUrl 'https://example.com/pem' -SkipCosignVerification } |
+                Should -Not -Throw
+        }
+
+        It 'should warn about unauthenticated checksums when SkipCosignVerification is true' {
+            $warnings = @()
+            Mock Write-Host { param($Object, $ForegroundColor) if ($ForegroundColor -eq [ConsoleColor]::Yellow) { $warnings += $Object } }
+
+            Test-ChecksumsSignature -ChecksumsPath 'dummy checksums.txt' -ChecksumsSigUrl 'https://example.com/sig' -ChecksumsPemUrl 'https://example.com/pem' -SkipCosignVerification
+
+            $warnings | Should -Contain '  WARNING: You are installing with -SkipCosignVerification.'
+        }
+    }
+
+    Context 'when cosign IS available' {
+
+        BeforeEach {
+            Mock Test-CosignAvailable { return $true }
+            Mock Invoke-WebRequest { }
+            Mock Start-Process { return [PSCustomObject]@{ ExitCode = 0 } }
+        }
+
+        It 'should proceed with verification without throwing' {
+            { Test-ChecksumsSignature -ChecksumsPath 'dummy checksums.txt' -ChecksumsSigUrl 'https://example.com/sig' -ChecksumsPemUrl 'https://example.com/pem' } |
+                Should -Not -Throw
+        }
+
+        It 'should download the signature file' {
+            Test-ChecksumsSignature -ChecksumsPath 'dummy checksums.txt' -ChecksumsSigUrl 'https://example.com/sig' -ChecksumsPemUrl 'https://example.com/pem'
+
+            Should -Invoke Invoke-WebRequest -Times 1 -ParameterFilter {
+                $Uri -eq 'https://example.com/sig'
+            }
+        }
+
+        It 'should download the certificate file' {
+            Test-ChecksumsSignature -ChecksumsPath 'dummy checksums.txt' -ChecksumsSigUrl 'https://example.com/sig' -ChecksumsPemUrl 'https://example.com/pem'
+
+            Should -Invoke Invoke-WebRequest -Times 1 -ParameterFilter {
+                $Uri -eq 'https://example.com/pem'
+            }
+        }
+
+        It 'should invoke cosign verify-blob' {
+            Test-ChecksumsSignature -ChecksumsPath 'dummy checksums.txt' -ChecksumsSigUrl 'https://example.com/sig' -ChecksumsPemUrl 'https://example.com/pem'
+
+            Should -Invoke Start-Process -Times 1 -ParameterFilter {
+                $FilePath -eq 'cosign' -and
+                ($ArgumentList -join ' ') -match 'verify-blob'
+            }
+        }
+    }
+
+    Context 'when cosign verification fails' {
+
+        BeforeEach {
+            Mock Test-CosignAvailable { return $true }
+            Mock Invoke-WebRequest { }
+            Mock Start-Process { return [PSCustomObject]@{ ExitCode = 1 } }
+        }
+
+        It 'should throw when cosign exits with non-zero code' {
+            { Test-ChecksumsSignature -ChecksumsPath 'dummy checksums.txt' -ChecksumsSigUrl 'https://example.com/sig' -ChecksumsPemUrl 'https://example.com/pem' } |
+                Should -Throw -ExpectedMessage '*Cosign signature verification failed*'
+        }
+    }
+}


### PR DESCRIPTION
## Security Fixes for v0.6.1

Closes #477, Closes #478, Closes #479, Closes #480, Closes #481, Closes #482

### Changes

| Issue | Severity | Fix |
|-------|----------|-----|
| #477 | high | Harden MCP fetch against value-control bypass |
| #478 | medium | Restrict editor MCP base URLs before sending bearer tokens |
| #479 | medium | Harden Cursor context generation against prompt injection |
| #480 | medium | Fail closed when PowerShell installer cannot verify signed checksums |
| #481 | low | Harden local vault and pairing file paths against traversal and symlinks |
| #482 | low | Prevent legacy audit records from resetting HMAC chains mid-log |

### Testing
- All existing tests pass
- New tests added for each fix (75+ new test cases)
- LSP diagnostics clean on all changed files