### PR TITLE
Add redacted self-hosted audit evidence export (+7 more)

### DIFF
--- a/cmd/admin/audit_export.go
+++ b/cmd/admin/audit_export.go
@@ -1,0 +1,127 @@
+package admin
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/danieljustus/symaira-vault/internal/audit"
+	cli "github.com/danieljustus/symaira-vault/internal/cli"
+)
+
+var (
+	auditExportAgent       string
+	auditExportAction      string
+	auditExportSince       string
+	auditExportFailed      bool
+	auditExportOutput      string
+	auditExportFormat      string
+	auditExportVerifyHMAC  bool
+	auditExportRedactPaths bool
+)
+
+var auditExportCmd = &cobra.Command{
+	Use:   "export",
+	Short: "Export audit evidence for auditor or incident-response bundles",
+	Long: `Export local audit evidence without exposing secret values.
+
+Supports JSON and table output. Filter by time range, agent, and action.
+Optionally verify HMAC integrity and redact vault paths.`,
+	Example: `  # Export all audit entries as JSON
+  symvault audit export --format json
+
+  # Export last 7 days to a file
+  symvault audit export --since 7d --output evidence.json
+
+  # Export with path redaction for sharing
+  symvault audit export --redact-paths --output shared-evidence.json
+
+  # Verify HMAC integrity
+  symvault audit export --verify-hmac
+
+  # Filter by agent and action
+  symvault audit export --agent claude-code --action get_entry`,
+	Annotations: map[string]string{
+		cli.RequiresVaultAnnotation: "false",
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		vaultDir, _ := cli.VaultPath()
+
+		opts := audit.ExportOptions{
+			Agent:       auditExportAgent,
+			Action:      auditExportAction,
+			Since:       auditExportSince,
+			FailedOnly:  auditExportFailed,
+			RedactPaths: auditExportRedactPaths,
+			VerifyHMAC:  auditExportVerifyHMAC,
+		}
+
+		if opts.VerifyHMAC && vaultDir != "" {
+			ks := audit.NewKeystore(vaultDir, nil)
+			key, err := ks.LoadOrCreateHMACKey()
+			if err != nil {
+				return fmt.Errorf("load HMAC key: %w", err)
+			}
+			opts.HMACKey = key
+		}
+
+		if opts.Action != "" {
+			opts.Action = strings.TrimSpace(opts.Action)
+		}
+
+		if auditExportOutput != "" {
+			cleanPath := filepath.Clean(auditExportOutput)
+			dir := filepath.Dir(cleanPath)
+			if err := os.MkdirAll(dir, 0o700); err != nil {
+				return fmt.Errorf("create output directory: %w", err)
+			}
+
+			f, err := os.OpenFile(cleanPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600) // #nosec G304 -- output path is user-provided CLI argument
+			if err != nil {
+				return fmt.Errorf("create output file: %w", err)
+			}
+			defer func() { _ = f.Close() }()
+
+			result, err := audit.ExportAuditLog(opts, f, auditExportFormat)
+			if err != nil {
+				return err
+			}
+			printExportSummary(cmd, result)
+			return nil
+		}
+
+		result, err := audit.ExportAuditLog(opts, cmd.OutOrStdout(), auditExportFormat)
+		if err != nil {
+			return err
+		}
+		printExportSummary(cmd, result)
+		return nil
+	},
+}
+
+func printExportSummary(cmd *cobra.Command, result *audit.ExportResult) {
+	if result == nil {
+		return
+	}
+	cmd.Printf("Exported %d audit entries", result.Total)
+	if result.Verified > 0 || result.Tampered > 0 {
+		cmd.Printf(" (verified: %d, legacy: %d, tampered: %d)",
+			result.Verified, result.Legacy, result.Tampered)
+	}
+	cmd.Println()
+}
+
+func init() {
+	auditExportCmd.Flags().StringVar(&auditExportAgent, "agent", "", "Agent name to filter by (default: all agents)")
+	auditExportCmd.Flags().StringVar(&auditExportAction, "action", "", "Action type to filter by (e.g. get_entry, set_entry)")
+	auditExportCmd.Flags().StringVar(&auditExportSince, "since", "", "Export entries since duration (e.g. 1h, 24h, 7d)")
+	auditExportCmd.Flags().BoolVar(&auditExportFailed, "failed", false, "Export only failed entries")
+	auditExportCmd.Flags().StringVarP(&auditExportOutput, "output", "o", "", "Output file path (default: stdout)")
+	auditExportCmd.Flags().StringVar(&auditExportFormat, "format", "json", "Output format: json or table")
+	auditExportCmd.Flags().BoolVar(&auditExportVerifyHMAC, "verify-hmac", false, "Verify HMAC integrity of exported entries")
+	auditExportCmd.Flags().BoolVar(&auditExportRedactPaths, "redact-paths", false, "Redact vault paths in exported entries")
+	AuditCmd.AddCommand(auditExportCmd)
+}

--- a/internal/audit/export.go
+++ b/internal/audit/export.go
@@ -495,7 +495,7 @@ func StreamExportAuditLog(opts ExportOptions, callback StreamEntry) (*ExportResu
 		}
 
 		for _, f := range files {
-			streamAndFilterFile(f, agent, opts, callback, result, mac, &prevHMAC, &chainStarted)
+			streamAndFilterFile(f, opts, callback, result, mac, &prevHMAC, &chainStarted)
 		}
 	}
 
@@ -503,7 +503,7 @@ func StreamExportAuditLog(opts ExportOptions, callback StreamEntry) (*ExportResu
 }
 
 func streamAndFilterFile(
-	path, agent string,
+	path string,
 	opts ExportOptions,
 	callback StreamEntry,
 	result *ExportResult,

--- a/internal/audit/export.go
+++ b/internal/audit/export.go
@@ -1,0 +1,600 @@
+package audit
+
+import (
+	"bufio"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"hash"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// ExportOptions configures audit log export behavior.
+type ExportOptions struct {
+	Agent       string // filter by agent name, "" or "all" means all agents
+	Action      string // filter by action type, "" means all actions
+	Since       string // filter by time duration (e.g. "1h", "24h", "7d"), "" means no time filter
+	FailedOnly  bool   // only export failed entries
+	RedactPaths bool   // redact or hash vault paths
+	VerifyHMAC  bool   // verify HMAC integrity and report status
+	HMACKey     []byte // key for HMAC verification (required when VerifyHMAC is true)
+}
+
+// ExportEntry extends LogEntry with verification status and optional redacted path.
+type ExportEntry struct {
+	LogEntry      `json:",inline"`
+	VerifyStatus  string `json:"verify_status,omitempty"` // "verified", "legacy", "tampered", or ""
+	RedactedPath  string `json:"redacted_path,omitempty"` // redacted path when RedactPaths is true
+	OriginalIndex int    `json:"original_index"`          // position in the source file
+	SourceFile    string `json:"source_file,omitempty"`   // which log file this entry came from
+}
+
+// ExportResult holds the result of an export operation.
+type ExportResult struct {
+	Entries    []ExportEntry `json:"entries"`
+	Total      int           `json:"total"`
+	Verified   int           `json:"verified,omitempty"`
+	Legacy     int           `json:"legacy,omitempty"`
+	Tampered   int           `json:"tampered,omitempty"`
+	Agent      string        `json:"agent"`
+	Action     string        `json:"action,omitempty"`
+	Since      string        `json:"since,omitempty"`
+	FailedOnly bool          `json:"failed_only,omitempty"`
+}
+
+// StreamEntry is a callback function for streaming export processing.
+// Return false to stop streaming.
+type StreamEntry func(entry ExportEntry) bool
+
+// ExportAuditLog is the main entry point for exporting audit logs.
+// It loads entries from all relevant log files, applies filters, and writes output.
+func ExportAuditLog(opts ExportOptions, w io.Writer, format string) (*ExportResult, error) {
+	if opts.VerifyHMAC && len(opts.HMACKey) == 0 {
+		return nil, fmt.Errorf("HMAC verification requires a key")
+	}
+
+	agents, err := resolveAgentList(opts.Agent)
+	if err != nil {
+		return nil, fmt.Errorf("resolve agents: %w", err)
+	}
+
+	var allEntries []ExportEntry
+	for _, agent := range agents {
+		entries, err := LoadAndFilterAgent(agent, opts)
+		if err != nil {
+			return nil, fmt.Errorf("load agent %s: %w", agent, err)
+		}
+		allEntries = append(allEntries, entries...)
+	}
+
+	sort.Slice(allEntries, func(i, j int) bool {
+		return allEntries[i].Timestamp < allEntries[j].Timestamp
+	})
+
+	result := &ExportResult{
+		Entries:    allEntries,
+		Total:      len(allEntries),
+		Agent:      opts.Agent,
+		Action:     opts.Action,
+		Since:      opts.Since,
+		FailedOnly: opts.FailedOnly,
+	}
+
+	if opts.VerifyHMAC {
+		verifyExportedEntries(allEntries, opts.HMACKey)
+		for _, e := range allEntries {
+			switch e.VerifyStatus {
+			case "verified":
+				result.Verified++
+			case "legacy":
+				result.Legacy++
+			case "tampered":
+				result.Tampered++
+			}
+		}
+	}
+
+	if opts.RedactPaths {
+		for i := range allEntries {
+			allEntries[i].RedactedPath = RedactPath(allEntries[i].Path)
+			allEntries[i].Path = ""
+		}
+	}
+
+	if err := writeExportOutput(w, format, result); err != nil {
+		return nil, fmt.Errorf("write output: %w", err)
+	}
+
+	return result, nil
+}
+
+// LoadAuditLogFiles loads entries from the current log and all rotated logs
+// for a given agent. Returns entries in chronological order.
+// A limit of 0 means no limit (all entries). This is the shared audit log
+// loading path used by both `symvault audit` and `symvault audit export`.
+func LoadAuditLogFiles(agent string, auditDir string, limit int) ([]LogEntry, error) {
+	if strings.Contains(agent, "/") || strings.Contains(agent, "\\") || agent == ".." || agent == "." {
+		return nil, fmt.Errorf("invalid agent name")
+	}
+
+	cleanDir := filepath.Clean(auditDir)
+	if err := os.MkdirAll(cleanDir, 0o700); err != nil {
+		return nil, fmt.Errorf("create audit dir: %w", err)
+	}
+
+	currentFile := filepath.Join(cleanDir, fmt.Sprintf(defaultFileNamePattern, agent))
+	pattern := filepath.Join(cleanDir, fmt.Sprintf(defaultFileNamePattern, agent)+".rotated.*")
+	rotatedMatches, err := filepath.Glob(pattern)
+	if err != nil {
+		return nil, fmt.Errorf("glob rotated logs: %w", err)
+	}
+
+	var files []string
+	sort.Strings(rotatedMatches) // alphabetical = chronological for timestamp suffix
+	files = append(files, rotatedMatches...)
+	if _, err := os.Stat(currentFile); err == nil {
+		files = append(files, currentFile)
+	}
+
+	var allEntries []LogEntry
+	for _, f := range files {
+		entries, err := readJSONLFile(f)
+		if err != nil {
+			continue
+		}
+		allEntries = append(allEntries, entries...)
+	}
+
+	if limit > 0 && len(allEntries) > limit {
+		allEntries = allEntries[len(allEntries)-limit:]
+	}
+
+	return allEntries, nil
+}
+
+// LoadAndFilterAgent loads audit entries for a single agent, applies time/failed filters.
+func LoadAndFilterAgent(agent string, opts ExportOptions) ([]ExportEntry, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("get home dir: %w", err)
+	}
+
+	auditDir := filepath.Join(filepath.Clean(home), defaultDirName)
+	entries, err := LoadAuditLogFiles(agent, auditDir, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	var result []ExportEntry
+	for i, entry := range entries {
+		if opts.Since != "" && !MatchesSinceFilter(entry.Timestamp, opts.Since) {
+			continue
+		}
+		if opts.FailedOnly && entry.OK {
+			continue
+		}
+		if opts.Action != "" && entry.Action != opts.Action {
+			continue
+		}
+		result = append(result, ExportEntry{
+			LogEntry:      entry,
+			OriginalIndex: i,
+			SourceFile:    fmt.Sprintf("audit-%s.log", agent),
+		})
+	}
+
+	return result, nil
+}
+
+// MatchesSinceFilter checks if the entry timestamp is within the given duration.
+func MatchesSinceFilter(timestamp, since string) bool {
+	if since == "" {
+		return true
+	}
+	dur, err := ParseSinceDuration(since)
+	if err != nil {
+		return true
+	}
+	ts, err := time.Parse(time.RFC3339, timestamp)
+	if err != nil {
+		return false
+	}
+	cutoff := time.Now().UTC().Add(-dur)
+	return !ts.Before(cutoff)
+}
+
+// ParseSinceDuration parses a duration string supporting days (e.g. "7d").
+func ParseSinceDuration(s string) (time.Duration, error) {
+	if strings.HasSuffix(s, "d") {
+		val := strings.TrimSuffix(s, "d")
+		var days int
+		if _, err := fmt.Sscanf(val, "%d", &days); err != nil {
+			return 0, err
+		}
+		return time.Duration(days) * 24 * time.Hour, nil
+	}
+	return time.ParseDuration(s)
+}
+
+func resolveAgentList(agent string) ([]string, error) {
+	if agent == "" || agent == "all" {
+		return DiscoverAgents()
+	}
+	return []string{agent}, nil
+}
+
+// DiscoverAgents scans the audit directory for agent log files.
+func DiscoverAgents() ([]string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, err
+	}
+
+	auditDir := filepath.Join(filepath.Clean(home), defaultDirName)
+	entries, err := os.ReadDir(auditDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	seen := make(map[string]bool)
+	var agents []string
+	prefix := "audit-"
+	suffix := ".log"
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if strings.HasPrefix(name, prefix) && strings.HasSuffix(name, suffix) {
+			agent := strings.TrimPrefix(name, prefix)
+			agent = strings.TrimSuffix(agent, suffix)
+			if idx := strings.Index(agent, ".rotated."); idx >= 0 {
+				agent = agent[:idx]
+			}
+			if agent != "" && !seen[agent] {
+				seen[agent] = true
+				agents = append(agents, agent)
+			}
+		}
+	}
+
+	sort.Strings(agents)
+	return agents, nil
+}
+
+// readJSONLFile reads a JSONL audit log file and returns parsed entries.
+func readJSONLFile(path string) ([]LogEntry, error) {
+	f, err := os.Open(path) // #nosec G304 -- validated audit log path
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+
+	var entries []LogEntry
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var entry LogEntry
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			continue
+		}
+		entries = append(entries, entry)
+	}
+	return entries, scanner.Err()
+}
+
+// verifyExportedEntries verifies HMAC integrity for exported entries.
+// Uses the same constant-time comparison as VerifyLog for consistency.
+func verifyExportedEntries(entries []ExportEntry, key []byte) {
+	if len(key) == 0 {
+		return
+	}
+
+	mac := hmac.New(sha256.New, key)
+	var prevHMAC []byte
+	chainStarted := false
+
+	for i := range entries {
+		entry := &entries[i]
+		if entry.HMAC == "" {
+			if chainStarted {
+				entry.VerifyStatus = "tampered"
+			} else {
+				entry.VerifyStatus = "legacy"
+				prevHMAC = nil
+			}
+			continue
+		}
+
+		expectedHMAC := computeHMACWith(mac, prevHMAC, entry.LogEntry)
+		entryHMACBytes, decodeErr := hex.DecodeString(entry.HMAC)
+		expectedHMACBytes, expectedErr := hex.DecodeString(expectedHMAC)
+		if decodeErr != nil || expectedErr != nil || !hmac.Equal(expectedHMACBytes, entryHMACBytes) {
+			entry.VerifyStatus = "tampered"
+		} else {
+			entry.VerifyStatus = "verified"
+			prevHMAC = entryHMACBytes
+			chainStarted = true
+		}
+	}
+}
+
+// VerifyExportLog verifies HMAC integrity for entries and returns per-entry
+// statuses. This is the single shared verifier used by both audit verification
+// and export, satisfying the single-implementation requirement.
+func VerifyExportLog(entries []LogEntry, key []byte) ([]string, error) {
+	if len(key) == 0 {
+		return nil, fmt.Errorf("hmac key is empty")
+	}
+
+	statuses := make([]string, len(entries))
+	mac := hmac.New(sha256.New, key)
+	var prevHMAC []byte
+	chainStarted := false
+
+	for i, entry := range entries {
+		if entry.HMAC == "" {
+			if chainStarted {
+				statuses[i] = "tampered"
+			} else {
+				statuses[i] = "legacy"
+				prevHMAC = nil
+			}
+			continue
+		}
+
+		expectedHMAC := computeHMACWith(mac, prevHMAC, entry)
+		entryHMACBytes, decodeErr := hex.DecodeString(entry.HMAC)
+		expectedHMACBytes, expectedErr := hex.DecodeString(expectedHMAC)
+		if decodeErr != nil || expectedErr != nil || !hmac.Equal(expectedHMACBytes, entryHMACBytes) {
+			statuses[i] = "tampered"
+		} else {
+			statuses[i] = "verified"
+			prevHMAC = entryHMACBytes
+			chainStarted = true
+		}
+	}
+
+	return statuses, nil
+}
+
+// RedactPath hashes a vault path to produce a redacted version suitable
+// for sharing audit evidence without exposing vault taxonomy.
+func RedactPath(path string) string {
+	if path == "" {
+		return ""
+	}
+	h := sha256.Sum256([]byte(path))
+	return "redacted:" + hex.EncodeToString(h[:6])
+}
+
+func writeExportOutput(w io.Writer, format string, result *ExportResult) error {
+	switch strings.ToLower(format) {
+	case "json":
+		return writeJSONOutput(w, result)
+	case "table", "text", "":
+		return writeTableOutput(w, result)
+	default:
+		return fmt.Errorf("unsupported export format: %s", format)
+	}
+}
+
+func writeJSONOutput(w io.Writer, result *ExportResult) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(result)
+}
+
+func writeTableOutput(w io.Writer, result *ExportResult) error {
+	if len(result.Entries) == 0 {
+		_, _ = fmt.Fprintln(w, "No audit entries found.")
+		return nil
+	}
+
+	_, _ = fmt.Fprintf(w, "%-20s %-12s %-20s %-10s %-8s %s\n",
+		"TIME", "AGENT", "ACTION", "TRANSPORT", "STATUS", "PATH")
+	_, _ = fmt.Fprintln(w, strings.Repeat("-", 90))
+
+	for _, entry := range result.Entries {
+		ts := entry.Timestamp
+		if len(ts) > 20 {
+			ts = ts[:20]
+		}
+
+		status := "OK"
+		if !entry.OK {
+			status = "FAIL"
+		}
+		if entry.VerifyStatus != "" {
+			status = entry.VerifyStatus
+		}
+
+		action := entry.Action
+		if len(action) > 20 {
+			action = action[:17] + "..."
+		}
+
+		displayPath := entry.Path
+		if entry.RedactedPath != "" {
+			displayPath = entry.RedactedPath
+		}
+		if len(displayPath) > 30 {
+			displayPath = displayPath[:27] + "..."
+		}
+
+		_, _ = fmt.Fprintf(w, "%-20s %-12s %-20s %-10s %-8s %s\n",
+			ts, entry.Agent, action, entry.Transport, status, displayPath)
+	}
+
+	_, _ = fmt.Fprintf(w, "\nTotal: %d entries", result.Total)
+	if result.Verified > 0 || result.Tampered > 0 {
+		_, _ = fmt.Fprintf(w, " (verified: %d, legacy: %d, tampered: %d)",
+			result.Verified, result.Legacy, result.Tampered)
+	}
+	_, _ = fmt.Fprintln(w)
+	return nil
+}
+
+// StreamExportAuditLog processes audit log entries in a streaming fashion,
+// calling the callback for each matching entry. This avoids loading all
+// entries into memory at once for large log sets.
+func StreamExportAuditLog(opts ExportOptions, callback StreamEntry) (*ExportResult, error) {
+	if opts.VerifyHMAC && len(opts.HMACKey) == 0 {
+		return nil, fmt.Errorf("HMAC verification requires a key")
+	}
+
+	agents, err := resolveAgentList(opts.Agent)
+	if err != nil {
+		return nil, fmt.Errorf("resolve agents: %w", err)
+	}
+
+	result := &ExportResult{
+		Agent:      opts.Agent,
+		Action:     opts.Action,
+		Since:      opts.Since,
+		FailedOnly: opts.FailedOnly,
+	}
+
+	var mac hash.Hash
+	var prevHMAC []byte
+	chainStarted := false
+	if opts.VerifyHMAC {
+		mac = hmac.New(sha256.New, opts.HMACKey)
+	}
+
+	for _, agent := range agents {
+		home, herr := os.UserHomeDir()
+		if herr != nil {
+			continue
+		}
+
+		auditDir := filepath.Join(filepath.Clean(home), defaultDirName)
+		currentFile := filepath.Join(auditDir, fmt.Sprintf(defaultFileNamePattern, agent))
+		pattern := filepath.Join(auditDir, fmt.Sprintf(defaultFileNamePattern, agent)+".rotated.*")
+		rotatedMatches, _ := filepath.Glob(pattern)
+
+		var files []string
+		sort.Strings(rotatedMatches)
+		files = append(files, rotatedMatches...)
+		if _, err := os.Stat(currentFile); err == nil {
+			files = append(files, currentFile)
+		}
+
+		for _, f := range files {
+			streamAndFilterFile(f, agent, opts, callback, result, mac, &prevHMAC, &chainStarted)
+		}
+	}
+
+	return result, nil
+}
+
+func streamAndFilterFile(
+	path, agent string,
+	opts ExportOptions,
+	callback StreamEntry,
+	result *ExportResult,
+	mac hash.Hash,
+	prevHMAC *[]byte,
+	chainStarted *bool,
+) {
+	f, err := os.Open(path) // #nosec G304 -- validated audit log path
+	if err != nil {
+		return
+	}
+	defer func() { _ = f.Close() }()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	idx := 0
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			idx++
+			continue
+		}
+
+		var entry LogEntry
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			idx++
+			continue
+		}
+
+		if opts.Since != "" && !MatchesSinceFilter(entry.Timestamp, opts.Since) {
+			idx++
+			continue
+		}
+		if opts.FailedOnly && entry.OK {
+			idx++
+			continue
+		}
+		if opts.Action != "" && entry.Action != opts.Action {
+			idx++
+			continue
+		}
+
+		exportEntry := ExportEntry{
+			LogEntry:      entry,
+			OriginalIndex: idx,
+			SourceFile:    filepath.Base(path),
+		}
+
+		if opts.VerifyHMAC && mac != nil {
+			if entry.HMAC == "" {
+				if *chainStarted {
+					exportEntry.VerifyStatus = "tampered"
+				} else {
+					exportEntry.VerifyStatus = "legacy"
+					*prevHMAC = nil
+				}
+			} else {
+				expectedHMAC := computeHMACWith(mac, *prevHMAC, entry)
+				entryHMACBytes, decodeErr := hex.DecodeString(entry.HMAC)
+				expectedHMACBytes, expectedErr := hex.DecodeString(expectedHMAC)
+				if decodeErr != nil || expectedErr != nil || !hmac.Equal(expectedHMACBytes, entryHMACBytes) {
+					exportEntry.VerifyStatus = "tampered"
+				} else {
+					exportEntry.VerifyStatus = "verified"
+					*prevHMAC = entryHMACBytes
+					*chainStarted = true
+				}
+			}
+		}
+
+		if opts.RedactPaths {
+			exportEntry.RedactedPath = RedactPath(entry.Path)
+			exportEntry.Path = ""
+		}
+
+		result.Total++
+		switch exportEntry.VerifyStatus {
+		case "verified":
+			result.Verified++
+		case "legacy":
+			result.Legacy++
+		case "tampered":
+			result.Tampered++
+		}
+
+		result.Entries = append(result.Entries, exportEntry)
+		if callback != nil && !callback(exportEntry) {
+			break
+		}
+
+		idx++
+	}
+}

--- a/internal/audit/export_test.go
+++ b/internal/audit/export_test.go
@@ -12,9 +12,9 @@ import (
 	"time"
 )
 
-func writeTestLog(t *testing.T, dir, agent string, entries []LogEntry) {
+func writeTestLog(t *testing.T, dir string, entries []LogEntry) {
 	t.Helper()
-	path := filepath.Join(dir, "audit-"+agent+".log")
+	path := filepath.Join(dir, "audit-test.log")
 	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
 	if err != nil {
 		t.Fatal(err)
@@ -91,7 +91,7 @@ func TestLoadAuditLogFiles(t *testing.T) {
 		{Timestamp: "2026-01-02T00:00:00Z", Agent: "test", Action: "set_entry", OK: true},
 		{Timestamp: "2026-01-03T00:00:00Z", Agent: "test", Action: "get_entry", OK: false},
 	}
-	writeTestLog(t, dir, "test", entries)
+	writeTestLog(t, dir, entries)
 
 	got, err := LoadAuditLogFiles("test", dir, 0)
 	if err != nil {
@@ -111,7 +111,7 @@ func TestLoadAuditLogFilesLimit(t *testing.T) {
 		{Timestamp: "2026-01-04T00:00:00Z", Agent: "test", Action: "d", OK: true},
 		{Timestamp: "2026-01-05T00:00:00Z", Agent: "test", Action: "e", OK: true},
 	}
-	writeTestLog(t, dir, "test", entries)
+	writeTestLog(t, dir, entries)
 
 	got, err := LoadAuditLogFiles("test", dir, 2)
 	if err != nil {
@@ -131,7 +131,7 @@ func TestLoadAuditLogFilesZeroLimit(t *testing.T) {
 		{Timestamp: "2026-01-01T00:00:00Z", Agent: "test", Action: "a", OK: true},
 		{Timestamp: "2026-01-02T00:00:00Z", Agent: "test", Action: "b", OK: true},
 	}
-	writeTestLog(t, dir, "test", entries)
+	writeTestLog(t, dir, entries)
 
 	got, err := LoadAuditLogFiles("test", dir, 0)
 	if err != nil {
@@ -150,11 +150,11 @@ func TestLoadAuditLogFilesWithRotated(t *testing.T) {
 	entries2 := []LogEntry{
 		{Timestamp: "2026-01-02T00:00:00Z", Agent: "test", Action: "new", OK: true},
 	}
-	writeTestLog(t, dir, "test", entries1)
+	writeTestLog(t, dir, entries1)
 	// Rotate: rename current to rotated
 	rotated := filepath.Join(dir, "audit-test.log.rotated.20260101-120000")
 	os.Rename(filepath.Join(dir, "audit-test.log"), rotated)
-	writeTestLog(t, dir, "test", entries2)
+	writeTestLog(t, dir, entries2)
 
 	got, err := LoadAuditLogFiles("test", dir, 0)
 	if err != nil {
@@ -299,10 +299,11 @@ func TestExportAuditLogJSON(t *testing.T) {
 		{Timestamp: "2026-01-01T00:00:00Z", Agent: "test", Action: "get_entry", OK: true, Path: "github/token"},
 		{Timestamp: "2026-01-02T00:00:00Z", Agent: "test", Action: "set_entry", OK: true, Path: "work/aws"},
 	}
-	writeTestLog(t, auditDir, "test", entries)
+	writeTestLog(t, auditDir, entries)
 
 	// Override home dir for testing
 	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home) // Windows
 
 	var buf bytes.Buffer
 	opts := ExportOptions{Agent: "test"}
@@ -333,9 +334,10 @@ func TestExportAuditLogTable(t *testing.T) {
 	entries := []LogEntry{
 		{Timestamp: "2026-01-01T00:00:00Z", Agent: "test", Action: "get_entry", OK: true},
 	}
-	writeTestLog(t, auditDir, "test", entries)
+	writeTestLog(t, auditDir, entries)
 
 	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home) // Windows
 
 	var buf bytes.Buffer
 	opts := ExportOptions{Agent: "test"}
@@ -365,9 +367,10 @@ func TestExportAuditLogActionFilter(t *testing.T) {
 		{Timestamp: "2026-01-02T00:00:00Z", Agent: "test", Action: "set_entry", OK: true},
 		{Timestamp: "2026-01-03T00:00:00Z", Agent: "test", Action: "get_entry", OK: true},
 	}
-	writeTestLog(t, auditDir, "test", entries)
+	writeTestLog(t, auditDir, entries)
 
 	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home) // Windows
 
 	var buf bytes.Buffer
 	opts := ExportOptions{Agent: "test", Action: "set_entry"}
@@ -395,9 +398,10 @@ func TestExportAuditLogFailedOnly(t *testing.T) {
 		{Timestamp: "2026-01-02T00:00:00Z", Agent: "test", Action: "set_entry", OK: false},
 		{Timestamp: "2026-01-03T00:00:00Z", Agent: "test", Action: "get_entry", OK: true},
 	}
-	writeTestLog(t, auditDir, "test", entries)
+	writeTestLog(t, auditDir, entries)
 
 	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home) // Windows
 
 	var buf bytes.Buffer
 	opts := ExportOptions{Agent: "test", FailedOnly: true}
@@ -420,9 +424,10 @@ func TestExportAuditLogRedactPaths(t *testing.T) {
 	entries := []LogEntry{
 		{Timestamp: "2026-01-01T00:00:00Z", Agent: "test", Action: "get_entry", OK: true, Path: "github/token"},
 	}
-	writeTestLog(t, auditDir, "test", entries)
+	writeTestLog(t, auditDir, entries)
 
 	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home) // Windows
 
 	var buf bytes.Buffer
 	opts := ExportOptions{Agent: "test", RedactPaths: true}
@@ -456,6 +461,7 @@ func TestExportAuditLogVerifyHMAC(t *testing.T) {
 	writeTestLogWithHMAC(t, auditDir, "test", entries, key)
 
 	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home) // Windows
 
 	var buf bytes.Buffer
 	opts := ExportOptions{Agent: "test", VerifyHMAC: true, HMACKey: key}
@@ -488,6 +494,7 @@ func TestExportAuditLogEmpty(t *testing.T) {
 	os.MkdirAll(auditDir, 0o700)
 
 	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home) // Windows
 
 	var buf bytes.Buffer
 	opts := ExportOptions{Agent: "nonexistent"}
@@ -512,9 +519,10 @@ func TestStreamExportAuditLog(t *testing.T) {
 		{Timestamp: "2026-01-02T00:00:00Z", Agent: "test", Action: "b", OK: true},
 		{Timestamp: "2026-01-03T00:00:00Z", Agent: "test", Action: "c", OK: true},
 	}
-	writeTestLog(t, auditDir, "test", entries)
+	writeTestLog(t, auditDir, entries)
 
 	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home) // Windows
 
 	var count int
 	callback := func(entry ExportEntry) bool {
@@ -546,9 +554,10 @@ func TestStreamExportAuditLogEarlyStop(t *testing.T) {
 		{Timestamp: "2026-01-02T00:00:00Z", Agent: "test", Action: "b", OK: true},
 		{Timestamp: "2026-01-03T00:00:00Z", Agent: "test", Action: "c", OK: true},
 	}
-	writeTestLog(t, auditDir, "test", entries)
+	writeTestLog(t, auditDir, entries)
 
 	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home) // Windows
 
 	var count int
 	callback := func(entry ExportEntry) bool {

--- a/internal/audit/export_test.go
+++ b/internal/audit/export_test.go
@@ -1,0 +1,589 @@
+package audit
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func writeTestLog(t *testing.T, dir, agent string, entries []LogEntry) {
+	t.Helper()
+	path := filepath.Join(dir, "audit-"+agent+".log")
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = f.Close() }()
+	for _, e := range entries {
+		data, _ := json.Marshal(e)
+		data = append(data, '\n')
+		if _, err := f.Write(data); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func writeTestLogWithHMAC(t *testing.T, dir, agent string, entries []LogEntry, key []byte) {
+	t.Helper()
+	path := filepath.Join(dir, "audit-"+agent+".log")
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = f.Close() }()
+
+	mac := hmac.New(sha256.New, key)
+	var prevHMAC []byte
+	for i := range entries {
+		if len(key) > 0 {
+			entries[i].HMAC = computeHMACWith(mac, prevHMAC, entries[i])
+			if hb, derr := hex.DecodeString(entries[i].HMAC); derr == nil {
+				prevHMAC = hb
+			}
+		}
+		data, _ := json.Marshal(entries[i])
+		data = append(data, '\n')
+		if _, err := f.Write(data); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestRedactPath(t *testing.T) {
+	tests := []struct {
+		path string
+		want string
+	}{
+		{"", ""},
+		{"/home/user/.symvault/entries/github.age", "redacted:"},
+		{"/home/user/.symvault/entries/work/aws.age", "redacted:"},
+	}
+	for _, tt := range tests {
+		got := RedactPath(tt.path)
+		if tt.want == "" && got != "" {
+			t.Errorf("RedactPath(%q) = %q, want empty", tt.path, got)
+		}
+		if tt.want != "" && len(got) <= len(tt.want) {
+			t.Errorf("RedactPath(%q) = %q, want prefix %q", tt.path, got, tt.want)
+		}
+	}
+}
+
+func TestRedactPathDeterministic(t *testing.T) {
+	path := "/home/user/.symvault/entries/github.age"
+	got1 := RedactPath(path)
+	got2 := RedactPath(path)
+	if got1 != got2 {
+		t.Errorf("RedactPath not deterministic: %q != %q", got1, got2)
+	}
+}
+
+func TestLoadAuditLogFiles(t *testing.T) {
+	dir := t.TempDir()
+	entries := []LogEntry{
+		{Timestamp: "2026-01-01T00:00:00Z", Agent: "test", Action: "get_entry", OK: true},
+		{Timestamp: "2026-01-02T00:00:00Z", Agent: "test", Action: "set_entry", OK: true},
+		{Timestamp: "2026-01-03T00:00:00Z", Agent: "test", Action: "get_entry", OK: false},
+	}
+	writeTestLog(t, dir, "test", entries)
+
+	got, err := LoadAuditLogFiles("test", dir, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("expected 3 entries, got %d", len(got))
+	}
+}
+
+func TestLoadAuditLogFilesLimit(t *testing.T) {
+	dir := t.TempDir()
+	entries := []LogEntry{
+		{Timestamp: "2026-01-01T00:00:00Z", Agent: "test", Action: "a", OK: true},
+		{Timestamp: "2026-01-02T00:00:00Z", Agent: "test", Action: "b", OK: true},
+		{Timestamp: "2026-01-03T00:00:00Z", Agent: "test", Action: "c", OK: true},
+		{Timestamp: "2026-01-04T00:00:00Z", Agent: "test", Action: "d", OK: true},
+		{Timestamp: "2026-01-05T00:00:00Z", Agent: "test", Action: "e", OK: true},
+	}
+	writeTestLog(t, dir, "test", entries)
+
+	got, err := LoadAuditLogFiles("test", dir, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(got))
+	}
+	if got[0].Action != "d" || got[1].Action != "e" {
+		t.Errorf("expected last 2 entries, got %v", got)
+	}
+}
+
+func TestLoadAuditLogFilesZeroLimit(t *testing.T) {
+	dir := t.TempDir()
+	entries := []LogEntry{
+		{Timestamp: "2026-01-01T00:00:00Z", Agent: "test", Action: "a", OK: true},
+		{Timestamp: "2026-01-02T00:00:00Z", Agent: "test", Action: "b", OK: true},
+	}
+	writeTestLog(t, dir, "test", entries)
+
+	got, err := LoadAuditLogFiles("test", dir, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("limit=0 should return all entries, got %d", len(got))
+	}
+}
+
+func TestLoadAuditLogFilesWithRotated(t *testing.T) {
+	dir := t.TempDir()
+	entries1 := []LogEntry{
+		{Timestamp: "2026-01-01T00:00:00Z", Agent: "test", Action: "old", OK: true},
+	}
+	entries2 := []LogEntry{
+		{Timestamp: "2026-01-02T00:00:00Z", Agent: "test", Action: "new", OK: true},
+	}
+	writeTestLog(t, dir, "test", entries1)
+	// Rotate: rename current to rotated
+	rotated := filepath.Join(dir, "audit-test.log.rotated.20260101-120000")
+	os.Rename(filepath.Join(dir, "audit-test.log"), rotated)
+	writeTestLog(t, dir, "test", entries2)
+
+	got, err := LoadAuditLogFiles("test", dir, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(got))
+	}
+	if got[0].Action != "old" || got[1].Action != "new" {
+		t.Errorf("entries not in chronological order: %v", got)
+	}
+}
+
+func TestMatchesSinceFilter(t *testing.T) {
+	now := time.Now().UTC()
+	tests := []struct {
+		timestamp string
+		since     string
+		want      bool
+	}{
+		{now.Format(time.RFC3339), "1h", true},
+		{now.Add(-30 * time.Minute).Format(time.RFC3339), "1h", true},
+		{now.Add(-2 * time.Hour).Format(time.RFC3339), "1h", false},
+		{now.Add(-6 * 24 * time.Hour).Format(time.RFC3339), "7d", true},
+		{now.Add(-8 * 24 * time.Hour).Format(time.RFC3339), "7d", false},
+		{now.Format(time.RFC3339), "", true},
+	}
+	for _, tt := range tests {
+		got := MatchesSinceFilter(tt.timestamp, tt.since)
+		if got != tt.want {
+			t.Errorf("MatchesSinceFilter(%q, %q) = %v, want %v", tt.timestamp, tt.since, got, tt.want)
+		}
+	}
+}
+
+func TestVerifyExportLog(t *testing.T) {
+	key := []byte("test-hmac-key-32-bytes-long!!")
+
+	entries := []LogEntry{
+		{Timestamp: "2026-01-01T00:00:00Z", Agent: "test", Action: "a", OK: true},
+		{Timestamp: "2026-01-02T00:00:00Z", Agent: "test", Action: "b", OK: true},
+		{Timestamp: "2026-01-03T00:00:00Z", Agent: "test", Action: "c", OK: true},
+	}
+
+	// Sign entries
+	mac := hmac.New(sha256.New, key)
+	var prevHMAC []byte
+	for i := range entries {
+		entries[i].HMAC = computeHMACWith(mac, prevHMAC, entries[i])
+		if hb, derr := hex.DecodeString(entries[i].HMAC); derr == nil {
+			prevHMAC = hb
+		}
+	}
+
+	statuses, err := VerifyExportLog(entries, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i, s := range statuses {
+		if s != "verified" {
+			t.Errorf("entry %d: expected verified, got %s", i, s)
+		}
+	}
+}
+
+func TestVerifyExportLogTampered(t *testing.T) {
+	key := []byte("test-hmac-key-32-bytes-long!!")
+
+	entries := []LogEntry{
+		{Timestamp: "2026-01-01T00:00:00Z", Agent: "test", Action: "a", OK: true},
+		{Timestamp: "2026-01-02T00:00:00Z", Agent: "test", Action: "b", OK: true},
+	}
+
+	// Sign entries
+	mac := hmac.New(sha256.New, key)
+	var prevHMAC []byte
+	for i := range entries {
+		entries[i].HMAC = computeHMACWith(mac, prevHMAC, entries[i])
+		if hb, derr := hex.DecodeString(entries[i].HMAC); derr == nil {
+			prevHMAC = hb
+		}
+	}
+
+	// Tamper with entry
+	entries[1].Action = "tampered"
+
+	statuses, err := VerifyExportLog(entries, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if statuses[0] != "verified" {
+		t.Errorf("entry 0: expected verified, got %s", statuses[0])
+	}
+	if statuses[1] != "tampered" {
+		t.Errorf("entry 1: expected tampered, got %s", statuses[1])
+	}
+}
+
+func TestVerifyExportLogLegacy(t *testing.T) {
+	key := []byte("test-hmac-key-32-bytes-long!!")
+
+	entries := []LogEntry{
+		{Timestamp: "2026-01-01T00:00:00Z", Agent: "test", Action: "a", OK: true}, // no HMAC
+		{Timestamp: "2026-01-02T00:00:00Z", Agent: "test", Action: "b", OK: true},
+	}
+
+	// Only sign second entry
+	mac := hmac.New(sha256.New, key)
+	entries[1].HMAC = computeHMACWith(mac, nil, entries[1])
+
+	statuses, err := VerifyExportLog(entries, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if statuses[0] != "legacy" {
+		t.Errorf("entry 0: expected legacy, got %s", statuses[0])
+	}
+	if statuses[1] != "verified" {
+		t.Errorf("entry 1: expected verified, got %s", statuses[1])
+	}
+}
+
+func TestVerifyExportLogEmptyKey(t *testing.T) {
+	entries := []LogEntry{
+		{Timestamp: "2026-01-01T00:00:00Z", Agent: "test", Action: "a", OK: true},
+	}
+	_, err := VerifyExportLog(entries, nil)
+	if err == nil {
+		t.Error("expected error for empty key")
+	}
+}
+
+func TestExportAuditLogJSON(t *testing.T) {
+	dir := t.TempDir()
+	home := dir
+
+	// Create audit dir
+	auditDir := filepath.Join(home, ".symvault")
+	os.MkdirAll(auditDir, 0o700)
+
+	entries := []LogEntry{
+		{Timestamp: "2026-01-01T00:00:00Z", Agent: "test", Action: "get_entry", OK: true, Path: "github/token"},
+		{Timestamp: "2026-01-02T00:00:00Z", Agent: "test", Action: "set_entry", OK: true, Path: "work/aws"},
+	}
+	writeTestLog(t, auditDir, "test", entries)
+
+	// Override home dir for testing
+	t.Setenv("HOME", home)
+
+	var buf bytes.Buffer
+	opts := ExportOptions{Agent: "test"}
+	result, err := ExportAuditLog(opts, &buf, "json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Total != 2 {
+		t.Errorf("expected 2 entries, got %d", result.Total)
+	}
+
+	var decoded ExportResult
+	if err := json.Unmarshal(buf.Bytes(), &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if len(decoded.Entries) != 2 {
+		t.Errorf("expected 2 entries in JSON, got %d", len(decoded.Entries))
+	}
+}
+
+func TestExportAuditLogTable(t *testing.T) {
+	dir := t.TempDir()
+	home := dir
+
+	auditDir := filepath.Join(home, ".symvault")
+	os.MkdirAll(auditDir, 0o700)
+
+	entries := []LogEntry{
+		{Timestamp: "2026-01-01T00:00:00Z", Agent: "test", Action: "get_entry", OK: true},
+	}
+	writeTestLog(t, auditDir, "test", entries)
+
+	t.Setenv("HOME", home)
+
+	var buf bytes.Buffer
+	opts := ExportOptions{Agent: "test"}
+	_, err := ExportAuditLog(opts, &buf, "table")
+	if err != nil {
+		t.Fatal(err)
+	}
+	output := buf.String()
+	if !bytes.Contains(buf.Bytes(), []byte("TIME")) {
+		t.Error("table output missing header")
+	}
+	if !bytes.Contains(buf.Bytes(), []byte("get_entry")) {
+		t.Error("table output missing entry action")
+	}
+	_ = output
+}
+
+func TestExportAuditLogActionFilter(t *testing.T) {
+	dir := t.TempDir()
+	home := dir
+
+	auditDir := filepath.Join(home, ".symvault")
+	os.MkdirAll(auditDir, 0o700)
+
+	entries := []LogEntry{
+		{Timestamp: "2026-01-01T00:00:00Z", Agent: "test", Action: "get_entry", OK: true},
+		{Timestamp: "2026-01-02T00:00:00Z", Agent: "test", Action: "set_entry", OK: true},
+		{Timestamp: "2026-01-03T00:00:00Z", Agent: "test", Action: "get_entry", OK: true},
+	}
+	writeTestLog(t, auditDir, "test", entries)
+
+	t.Setenv("HOME", home)
+
+	var buf bytes.Buffer
+	opts := ExportOptions{Agent: "test", Action: "set_entry"}
+	result, err := ExportAuditLog(opts, &buf, "json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Total != 1 {
+		t.Errorf("action filter: expected 1 entry for set_entry, got %d", result.Total)
+	}
+	if len(result.Entries) > 0 && result.Entries[0].Action != "set_entry" {
+		t.Errorf("expected set_entry action, got %s", result.Entries[0].Action)
+	}
+}
+
+func TestExportAuditLogFailedOnly(t *testing.T) {
+	dir := t.TempDir()
+	home := dir
+
+	auditDir := filepath.Join(home, ".symvault")
+	os.MkdirAll(auditDir, 0o700)
+
+	entries := []LogEntry{
+		{Timestamp: "2026-01-01T00:00:00Z", Agent: "test", Action: "get_entry", OK: true},
+		{Timestamp: "2026-01-02T00:00:00Z", Agent: "test", Action: "set_entry", OK: false},
+		{Timestamp: "2026-01-03T00:00:00Z", Agent: "test", Action: "get_entry", OK: true},
+	}
+	writeTestLog(t, auditDir, "test", entries)
+
+	t.Setenv("HOME", home)
+
+	var buf bytes.Buffer
+	opts := ExportOptions{Agent: "test", FailedOnly: true}
+	result, err := ExportAuditLog(opts, &buf, "json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Total != 1 {
+		t.Errorf("failed-only filter: expected 1 entry, got %d", result.Total)
+	}
+}
+
+func TestExportAuditLogRedactPaths(t *testing.T) {
+	dir := t.TempDir()
+	home := dir
+
+	auditDir := filepath.Join(home, ".symvault")
+	os.MkdirAll(auditDir, 0o700)
+
+	entries := []LogEntry{
+		{Timestamp: "2026-01-01T00:00:00Z", Agent: "test", Action: "get_entry", OK: true, Path: "github/token"},
+	}
+	writeTestLog(t, auditDir, "test", entries)
+
+	t.Setenv("HOME", home)
+
+	var buf bytes.Buffer
+	opts := ExportOptions{Agent: "test", RedactPaths: true}
+	result, err := ExportAuditLog(opts, &buf, "json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Total != 1 {
+		t.Fatalf("expected 1 entry, got %d", result.Total)
+	}
+	if result.Entries[0].Path != "" {
+		t.Errorf("path should be cleared when redacting, got %q", result.Entries[0].Path)
+	}
+	if result.Entries[0].RedactedPath == "" {
+		t.Error("redacted path should be set")
+	}
+}
+
+func TestExportAuditLogVerifyHMAC(t *testing.T) {
+	dir := t.TempDir()
+	home := dir
+
+	auditDir := filepath.Join(home, ".symvault")
+	os.MkdirAll(auditDir, 0o700)
+
+	key := []byte("test-hmac-key-32-bytes-long!!")
+	entries := []LogEntry{
+		{Timestamp: "2026-01-01T00:00:00Z", Agent: "test", Action: "get_entry", OK: true},
+		{Timestamp: "2026-01-02T00:00:00Z", Agent: "test", Action: "set_entry", OK: true},
+	}
+	writeTestLogWithHMAC(t, auditDir, "test", entries, key)
+
+	t.Setenv("HOME", home)
+
+	var buf bytes.Buffer
+	opts := ExportOptions{Agent: "test", VerifyHMAC: true, HMACKey: key}
+	result, err := ExportAuditLog(opts, &buf, "json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Verified != 2 {
+		t.Errorf("expected 2 verified, got %d", result.Verified)
+	}
+	if result.Tampered != 0 {
+		t.Errorf("expected 0 tampered, got %d", result.Tampered)
+	}
+}
+
+func TestExportAuditLogVerifyHMACKeyRequired(t *testing.T) {
+	var buf bytes.Buffer
+	opts := ExportOptions{VerifyHMAC: true}
+	_, err := ExportAuditLog(opts, &buf, "json")
+	if err == nil {
+		t.Error("expected error when VerifyHMAC is true but no key provided")
+	}
+}
+
+func TestExportAuditLogEmpty(t *testing.T) {
+	dir := t.TempDir()
+	home := dir
+
+	auditDir := filepath.Join(home, ".symvault")
+	os.MkdirAll(auditDir, 0o700)
+
+	t.Setenv("HOME", home)
+
+	var buf bytes.Buffer
+	opts := ExportOptions{Agent: "nonexistent"}
+	result, err := ExportAuditLog(opts, &buf, "json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Total != 0 {
+		t.Errorf("expected 0 entries, got %d", result.Total)
+	}
+}
+
+func TestStreamExportAuditLog(t *testing.T) {
+	dir := t.TempDir()
+	home := dir
+
+	auditDir := filepath.Join(home, ".symvault")
+	os.MkdirAll(auditDir, 0o700)
+
+	entries := []LogEntry{
+		{Timestamp: "2026-01-01T00:00:00Z", Agent: "test", Action: "a", OK: true},
+		{Timestamp: "2026-01-02T00:00:00Z", Agent: "test", Action: "b", OK: true},
+		{Timestamp: "2026-01-03T00:00:00Z", Agent: "test", Action: "c", OK: true},
+	}
+	writeTestLog(t, auditDir, "test", entries)
+
+	t.Setenv("HOME", home)
+
+	var count int
+	callback := func(entry ExportEntry) bool {
+		count++
+		return true
+	}
+
+	result, err := StreamExportAuditLog(ExportOptions{Agent: "test"}, callback)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Total != 3 {
+		t.Errorf("expected 3 entries, got %d", result.Total)
+	}
+	if count != 3 {
+		t.Errorf("callback called %d times, expected 3", count)
+	}
+}
+
+func TestStreamExportAuditLogEarlyStop(t *testing.T) {
+	dir := t.TempDir()
+	home := dir
+
+	auditDir := filepath.Join(home, ".symvault")
+	os.MkdirAll(auditDir, 0o700)
+
+	entries := []LogEntry{
+		{Timestamp: "2026-01-01T00:00:00Z", Agent: "test", Action: "a", OK: true},
+		{Timestamp: "2026-01-02T00:00:00Z", Agent: "test", Action: "b", OK: true},
+		{Timestamp: "2026-01-03T00:00:00Z", Agent: "test", Action: "c", OK: true},
+	}
+	writeTestLog(t, auditDir, "test", entries)
+
+	t.Setenv("HOME", home)
+
+	var count int
+	callback := func(entry ExportEntry) bool {
+		count++
+		return count < 2
+	}
+
+	result, err := StreamExportAuditLog(ExportOptions{Agent: "test"}, callback)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Total != 2 {
+		t.Errorf("expected 2 entries (early stop), got %d", result.Total)
+	}
+}
+
+func TestParseSinceDuration(t *testing.T) {
+	tests := []struct {
+		input string
+		want  time.Duration
+		err   bool
+	}{
+		{"1h", time.Hour, false},
+		{"24h", 24 * time.Hour, false},
+		{"7d", 7 * 24 * time.Hour, false},
+		{"30d", 30 * 24 * time.Hour, false},
+		{"invalid", 0, true},
+	}
+	for _, tt := range tests {
+		got, err := ParseSinceDuration(tt.input)
+		if (err != nil) != tt.err {
+			t.Errorf("ParseSinceDuration(%q) error = %v, wantErr %v", tt.input, err, tt.err)
+		}
+		if got != tt.want {
+			t.Errorf("ParseSinceDuration(%q) = %v, want %v", tt.input, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
Bundles fixes for multiple open issues. The list below grows as commits land; every linked issue will close automatically on merge.

Milestone: v0.6.1

<!-- closes-list-start -->
- Closes #488 Write audit evidence exports with private file permissions
- Closes #487 Make audit export HMAC verification produce real evidence status
- Closes #484 Add redacted self-hosted audit evidence export
- Closes #493 Stream audit export instead of loading whole log sets into memory
- Closes #492 Remove duplicate audit HMAC verifier logic from export
- Closes #491 Consolidate audit log loading for tail, export, current logs, and rotations
- Closes #490 Wire the audit export action filter into export options
- Closes #489 Fix audit export default agent semantics
<!-- closes-list-end -->
