### PR TITLE
fix: strengthen session cache, add MCP rate-limiting, improve error messages

### DIFF
--- a/cmd/mcp/serve_deps.go
+++ b/cmd/mcp/serve_deps.go
@@ -128,7 +128,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 				cliout.Warnf("Vault is locked; starting MCP server in read-only mode. Run 'symvault unlock' to enable vault tools.")
 				vault = nil
 			} else {
-				return err
+				return wrapVaultError(err, vaultDir)
 			}
 		}
 	}
@@ -223,5 +223,28 @@ func runServe(cmd *cobra.Command, args []string) error {
 			_ = cli.ClearRuntimePort(vDir)
 		}
 		return nil
+	}
+}
+
+func wrapVaultError(err error, vaultDir string) error {
+	if err == nil {
+		return nil
+	}
+
+	errMsg := err.Error()
+
+	switch {
+	case strings.Contains(errMsg, "load config"):
+		return fmt.Errorf("vault configuration is missing or corrupted — run 'symvault init' to reinitialize, or restore config.yaml from backup: %w", err)
+	case strings.Contains(errMsg, "permission denied") || strings.Contains(errMsg, "EACCES"):
+		return fmt.Errorf("permission denied accessing vault at %s — check file permissions (ls -la %s): %w", vaultDir, vaultDir, err)
+	case strings.Contains(errMsg, "no such file") || strings.Contains(errMsg, "ENOENT"):
+		return fmt.Errorf("vault directory not found at %s — run 'symvault init' to create a new vault: %w", vaultDir, err)
+	case strings.Contains(errMsg, "identity") && strings.Contains(errMsg, "decrypt"):
+		return fmt.Errorf("cannot decrypt vault identity — wrong passphrase? Run 'symvault unlock' and try again: %w", err)
+	case isVaultLockedError(err):
+		return err
+	default:
+		return err
 	}
 }

--- a/internal/mcp/auth/auth.go
+++ b/internal/mcp/auth/auth.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/subtle"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"net"
 	"net/http"
@@ -285,7 +286,21 @@ func clientIP(r *http.Request, trustedProxies []string) string {
 }
 
 func BearerAuthMiddleware(legacyToken string, registry *TokenRegistry, auditLog *audit.Logger, next http.Handler) http.Handler {
+	return BearerAuthMiddlewareWithRateLimit(legacyToken, registry, auditLog, nil, next)
+}
+
+func BearerAuthMiddlewareWithRateLimit(legacyToken string, registry *TokenRegistry, auditLog *audit.Logger, rateLimiter *TokenRateLimiter, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		agentID := r.Header.Get("X-Symaira-Agent")
+
+		if rateLimiter != nil && agentID != "" && rateLimiter.IsLocked(agentID) {
+			remaining := rateLimiter.RemainingLockout(agentID)
+			logAuthFailure(auditLog, r, "rate_limited", "agent locked out due to too many failed attempts")
+			w.Header().Set("Retry-After", formatDuration(remaining))
+			http.Error(w, "rate limited: too many failed token attempts", http.StatusTooManyRequests)
+			return
+		}
+
 		auth := r.Header.Get("Authorization")
 		if !strings.HasPrefix(auth, "Bearer ") {
 			logAuthFailure(auditLog, r, "missing_bearer", "authorization header missing or malformed")
@@ -295,6 +310,9 @@ func BearerAuthMiddleware(legacyToken string, registry *TokenRegistry, auditLog 
 		provided := strings.TrimPrefix(auth, "Bearer ")
 
 		if legacyToken != "" && subtle.ConstantTimeCompare([]byte(provided), []byte(legacyToken)) == 1 {
+			if rateLimiter != nil && agentID != "" {
+				rateLimiter.RecordSuccess(agentID)
+			}
 			next.ServeHTTP(w, r)
 			return
 		}
@@ -303,6 +321,9 @@ func BearerAuthMiddleware(legacyToken string, registry *TokenRegistry, auditLog 
 			hash := sha256Hex(provided)
 			tok, ok := registry.Get(hash)
 			if ok {
+				if rateLimiter != nil && agentID != "" {
+					rateLimiter.RecordSuccess(agentID)
+				}
 				ctx := WithToken(r.Context(), tok)
 				next.ServeHTTP(w, r.WithContext(ctx))
 				return
@@ -318,6 +339,10 @@ func BearerAuthMiddleware(legacyToken string, registry *TokenRegistry, auditLog 
 					logAuthFailure(auditLog, r, "token_expired", "token has expired")
 				}
 			}
+		}
+
+		if rateLimiter != nil && agentID != "" {
+			rateLimiter.RecordFailure(agentID)
 		}
 
 		if legacyToken == "" && registry == nil {
@@ -390,4 +415,15 @@ func AgentFromContext(ctx context.Context) string {
 		return v
 	}
 	return ""
+}
+
+func formatDuration(d time.Duration) string {
+	if d <= 0 {
+		return "0"
+	}
+	secs := int(d.Seconds())
+	if secs < 1 {
+		return "1"
+	}
+	return fmt.Sprintf("%d", secs)
 }

--- a/internal/mcp/auth/token_ratelimit.go
+++ b/internal/mcp/auth/token_ratelimit.go
@@ -6,9 +6,9 @@ import (
 )
 
 type tokenBucket struct {
-	failures  int
-	lockedAt  time.Time
-	lastFail  time.Time
+	failures int
+	lockedAt time.Time
+	lastFail time.Time
 }
 
 type TokenRateLimiter struct {

--- a/internal/mcp/auth/token_ratelimit.go
+++ b/internal/mcp/auth/token_ratelimit.go
@@ -37,13 +37,14 @@ func (rl *TokenRateLimiter) RecordFailure(agentID string) {
 	defer rl.mu.Unlock()
 
 	b, ok := rl.buckets[agentID]
-	if !ok {
+	switch {
+	case !ok:
 		b = &tokenBucket{failures: 1, lastFail: time.Now()}
 		rl.buckets[agentID] = b
-	} else if !b.lockedAt.IsZero() && time.Since(b.lockedAt) > rl.lockout {
+	case !b.lockedAt.IsZero() && time.Since(b.lockedAt) > rl.lockout:
 		b.failures = 1
 		b.lockedAt = time.Time{}
-	} else if b.lockedAt.IsZero() {
+	case b.lockedAt.IsZero():
 		b.failures++
 	}
 	b.lastFail = time.Now()

--- a/internal/mcp/auth/token_ratelimit.go
+++ b/internal/mcp/auth/token_ratelimit.go
@@ -1,0 +1,102 @@
+package auth
+
+import (
+	"sync"
+	"time"
+)
+
+type tokenBucket struct {
+	failures  int
+	lockedAt  time.Time
+	lastFail  time.Time
+}
+
+type TokenRateLimiter struct {
+	buckets     map[string]*tokenBucket
+	mu          sync.RWMutex
+	maxAttempts int
+	lockout     time.Duration
+}
+
+func NewTokenRateLimiter(maxAttempts int, lockout time.Duration) *TokenRateLimiter {
+	if maxAttempts <= 0 {
+		maxAttempts = 5
+	}
+	if lockout <= 0 {
+		lockout = 30 * time.Second
+	}
+	return &TokenRateLimiter{
+		buckets:     make(map[string]*tokenBucket),
+		maxAttempts: maxAttempts,
+		lockout:     lockout,
+	}
+}
+
+func (rl *TokenRateLimiter) RecordFailure(agentID string) {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+
+	b, ok := rl.buckets[agentID]
+	if !ok {
+		b = &tokenBucket{failures: 1, lastFail: time.Now()}
+		rl.buckets[agentID] = b
+	} else if !b.lockedAt.IsZero() && time.Since(b.lockedAt) > rl.lockout {
+		b.failures = 1
+		b.lockedAt = time.Time{}
+	} else if b.lockedAt.IsZero() {
+		b.failures++
+	}
+	b.lastFail = time.Now()
+
+	if b.failures >= rl.maxAttempts && b.lockedAt.IsZero() {
+		b.lockedAt = time.Now()
+	}
+}
+
+func (rl *TokenRateLimiter) RecordSuccess(agentID string) {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+	delete(rl.buckets, agentID)
+}
+
+func (rl *TokenRateLimiter) IsLocked(agentID string) bool {
+	rl.mu.RLock()
+	defer rl.mu.RUnlock()
+
+	b, ok := rl.buckets[agentID]
+	if !ok {
+		return false
+	}
+
+	if !b.lockedAt.IsZero() && time.Since(b.lockedAt) <= rl.lockout {
+		return true
+	}
+
+	if !b.lockedAt.IsZero() && time.Since(b.lockedAt) > rl.lockout {
+		return false
+	}
+
+	return b.failures >= rl.maxAttempts
+}
+
+func (rl *TokenRateLimiter) RemainingLockout(agentID string) time.Duration {
+	rl.mu.RLock()
+	defer rl.mu.RUnlock()
+
+	b, ok := rl.buckets[agentID]
+	if !ok || b.lockedAt.IsZero() {
+		return 0
+	}
+
+	elapsed := time.Since(b.lockedAt)
+	if elapsed >= rl.lockout {
+		return 0
+	}
+	return rl.lockout - elapsed
+}
+
+func (rl *TokenRateLimiter) Cleanup() {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+	rl.buckets = make(map[string]*tokenBucket)
+}

--- a/internal/mcp/auth/token_ratelimit_test.go
+++ b/internal/mcp/auth/token_ratelimit_test.go
@@ -111,7 +111,7 @@ func TestTokenRateLimiter_ConcurrentAccess(t *testing.T) {
 
 	done := make(chan struct{})
 	for i := 0; i < 10; i++ {
-		go func(id int) {
+		go func(_ int) {
 			defer func() { done <- struct{}{} }()
 			agentID := "concurrent-agent"
 			for j := 0; j < 50; j++ {

--- a/internal/mcp/auth/token_ratelimit_test.go
+++ b/internal/mcp/auth/token_ratelimit_test.go
@@ -1,0 +1,128 @@
+package auth
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTokenRateLimiter_LockoutAfterMaxAttempts(t *testing.T) {
+	rl := NewTokenRateLimiter(3, 5*time.Second)
+
+	agentID := "test-agent"
+
+	for i := 0; i < 3; i++ {
+		if rl.IsLocked(agentID) {
+			t.Fatalf("IsLocked() = true after %d failures, want false", i+1)
+		}
+		rl.RecordFailure(agentID)
+	}
+
+	if !rl.IsLocked(agentID) {
+		t.Fatal("IsLocked() = false after max attempts, want true")
+	}
+}
+
+func TestTokenRateLimiter_LockoutExpires(t *testing.T) {
+	rl := NewTokenRateLimiter(2, 50*time.Millisecond)
+
+	agentID := "test-agent"
+	rl.RecordFailure(agentID)
+	rl.RecordFailure(agentID)
+
+	if !rl.IsLocked(agentID) {
+		t.Fatal("IsLocked() = false after 2 failures, want true")
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	if rl.IsLocked(agentID) {
+		t.Fatal("IsLocked() = true after lockout expired, want false")
+	}
+}
+
+func TestTokenRateLimiter_SuccessResetsCount(t *testing.T) {
+	rl := NewTokenRateLimiter(3, 5*time.Second)
+
+	agentID := "test-agent"
+	rl.RecordFailure(agentID)
+	rl.RecordFailure(agentID)
+	rl.RecordSuccess(agentID)
+
+	if rl.IsLocked(agentID) {
+		t.Fatal("IsLocked() = true after success reset, want false")
+	}
+
+	rl.RecordFailure(agentID)
+	rl.RecordFailure(agentID)
+	rl.RecordFailure(agentID)
+
+	if !rl.IsLocked(agentID) {
+		t.Fatal("IsLocked() = false after re-locking, want true")
+	}
+}
+
+func TestTokenRateLimiter_RemainingLockout(t *testing.T) {
+	rl := NewTokenRateLimiter(1, 100*time.Millisecond)
+
+	agentID := "test-agent"
+	rl.RecordFailure(agentID)
+
+	remaining := rl.RemainingLockout(agentID)
+	if remaining <= 0 || remaining > 100*time.Millisecond {
+		t.Fatalf("RemainingLockout() = %v, want (0, 100ms]", remaining)
+	}
+
+	time.Sleep(150 * time.Millisecond)
+
+	remaining = rl.RemainingLockout(agentID)
+	if remaining != 0 {
+		t.Fatalf("RemainingLockout() = %v after expiry, want 0", remaining)
+	}
+}
+
+func TestTokenRateLimiter_Cleanup(t *testing.T) {
+	rl := NewTokenRateLimiter(1, 5*time.Second)
+	rl.RecordFailure("agent-a")
+	rl.RecordFailure("agent-b")
+
+	rl.Cleanup()
+
+	if rl.IsLocked("agent-a") {
+		t.Fatal("IsLocked() = true after cleanup, want false")
+	}
+	if rl.IsLocked("agent-b") {
+		t.Fatal("IsLocked() = true after cleanup, want false")
+	}
+}
+
+func TestTokenRateLimiter_DefaultValues(t *testing.T) {
+	rl := NewTokenRateLimiter(0, 0)
+
+	if rl.maxAttempts != 5 {
+		t.Fatalf("maxAttempts = %d, want 5", rl.maxAttempts)
+	}
+	if rl.lockout != 30*time.Second {
+		t.Fatalf("lockout = %v, want 30s", rl.lockout)
+	}
+}
+
+func TestTokenRateLimiter_ConcurrentAccess(t *testing.T) {
+	rl := NewTokenRateLimiter(100, 5*time.Second)
+
+	done := make(chan struct{})
+	for i := 0; i < 10; i++ {
+		go func(id int) {
+			defer func() { done <- struct{}{} }()
+			agentID := "concurrent-agent"
+			for j := 0; j < 50; j++ {
+				rl.RecordFailure(agentID)
+				_ = rl.IsLocked(agentID)
+				rl.RecordSuccess(agentID)
+			}
+		}(i)
+	}
+
+	for i := 0; i < 10; i++ {
+		<-done
+	}
+}

--- a/internal/session/memory_keyring.go
+++ b/internal/session/memory_keyring.go
@@ -10,9 +10,12 @@ import (
 )
 
 // memoryKeyring stores session and identity entries in process memory only.
+// All stored values are wrapped in SecureBytes for explicit memory zeroing
+// on eviction, preventing sensitive data from lingering in process memory
+// after lock/timeout.
 type memoryKeyring struct {
 	mu    sync.RWMutex
-	store map[string][]byte
+	store map[string]*SecureBytes
 }
 
 func vaultDirFromService(service string) string {
@@ -30,15 +33,15 @@ func (m *memoryKeyring) Set(service, account, value string) error {
 	defer m.mu.Unlock()
 
 	if m.store == nil {
-		m.store = make(map[string][]byte)
+		m.store = make(map[string]*SecureBytes)
 	}
 
 	if account == wrapKeyAccount || account == identityAccount || account == sessionAccount {
 		key := service + "|" + account
 		if old, ok := m.store[key]; ok {
-			zeroBytes(old)
+			old.Destroy()
 		}
-		m.store[key] = []byte(value)
+		m.store[key] = NewSecureBytes([]byte(value))
 		return nil
 	}
 
@@ -68,9 +71,9 @@ func (m *memoryKeyring) Set(service, account, value string) error {
 
 	key := service + "|" + account
 	if old, ok := m.store[key]; ok {
-		zeroBytes(old)
+		old.Destroy()
 	}
-	m.store[key] = append([]byte(nil), payload...)
+	m.store[key] = NewSecureBytes(append([]byte(nil), payload...))
 
 	return nil
 }
@@ -80,7 +83,7 @@ func (m *memoryKeyring) Set(service, account, value string) error {
 func (m *memoryKeyring) encryptionKeyForStore(service string) ([]byte, error) {
 	wrapKeyKey := service + "|" + wrapKeyAccount
 	if w, ok := m.store[wrapKeyKey]; ok {
-		if k, err := base64.StdEncoding.DecodeString(string(w)); err == nil && len(k) == wrapKeyLen {
+		if k, err := base64.StdEncoding.DecodeString(string(w.Data())); err == nil && len(k) == wrapKeyLen {
 			return k, nil
 		}
 	}
@@ -96,23 +99,25 @@ func (m *memoryKeyring) Get(service, account string) (string, error) {
 	}
 
 	key := service + "|" + account
-	payload, ok := m.store[key]
+	sb, ok := m.store[key]
 	if !ok {
 		return "", fmt.Errorf("not found")
 	}
 
+	payload := sb.Data()
 	if account == wrapKeyAccount || account == identityAccount {
 		return string(payload), nil
 	}
 
 	var sess storedSession
 	if err := json.Unmarshal(payload, &sess); err != nil {
+		sb.Destroy()
 		delete(m.store, key)
 		return "", fmt.Errorf("not found")
 	}
 
 	if sess.TTL <= 0 {
-		zeroBytes(payload)
+		sb.Destroy()
 		delete(m.store, key)
 		return "", fmt.Errorf("not found")
 	}
@@ -122,7 +127,7 @@ func (m *memoryKeyring) Get(service, account string) (string, error) {
 		lastActivity = sess.SavedAt
 	}
 	if time.Since(lastActivity) > time.Duration(sess.TTL) {
-		zeroBytes(payload)
+		sb.Destroy()
 		delete(m.store, key)
 		return "", fmt.Errorf("not found")
 	}
@@ -133,8 +138,8 @@ func (m *memoryKeyring) Get(service, account string) (string, error) {
 		return "", fmt.Errorf("not found")
 	}
 
-	zeroBytes(payload)
-	m.store[key] = append([]byte(nil), newPayload...)
+	sb.Destroy()
+	m.store[key] = NewSecureBytes(append([]byte(nil), newPayload...))
 
 	return string(newPayload), nil
 }
@@ -148,12 +153,25 @@ func (m *memoryKeyring) Delete(service, account string) error {
 	}
 
 	key := service + "|" + account
-	if payload, ok := m.store[key]; ok {
-		zeroBytes(payload)
+	if sb, ok := m.store[key]; ok {
+		sb.Destroy()
 		delete(m.store, key)
 	}
 
 	return nil
+}
+
+// DestroyAll zeroes every entry in the keyring at once. This is used
+// by ClearSession/Lock to ensure all sensitive data is wiped even if
+// individual Delete calls are skipped.
+func (m *memoryKeyring) DestroyAll() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for key, sb := range m.store {
+		sb.Destroy()
+		delete(m.store, key)
+	}
 }
 
 // memoryKeyringBackend adapts memoryKeyring to the KeyringBackend

--- a/internal/session/memory_keyring_test.go
+++ b/internal/session/memory_keyring_test.go
@@ -84,7 +84,7 @@ func TestMemoryKeyring_Set_StoresOpaque(t *testing.T) {
 
 func TestMemoryKeyring_Set_InvalidJSON(t *testing.T) {
 	mk := &memoryKeyring{}
-	mk.store = map[string][]byte{}
+	mk.store = map[string]*SecureBytes{}
 	if err := mk.Set("symvault:/tmp/vault", wrapKeyAccount, ""); err != nil {
 		t.Fatalf("Set wrap key error = %v", err)
 	}
@@ -151,8 +151,8 @@ func TestMemoryKeyring_Get_ZeroTTL(t *testing.T) {
 
 func TestMemoryKeyring_Get_MalformedJSON(t *testing.T) {
 	mk := &memoryKeyring{}
-	mk.store = map[string][]byte{
-		"symvault:/tmp/vault|" + sessionAccount: []byte("not-valid-json"),
+	mk.store = map[string]*SecureBytes{
+		"symvault:/tmp/vault|" + sessionAccount: NewSecureBytes([]byte("not-valid-json")),
 	}
 
 	_, err := mk.Get("symvault:/tmp/vault", sessionAccount)
@@ -194,13 +194,13 @@ func TestMemoryKeyring_Get_UpdatesLastAccess(t *testing.T) {
 	// Verify LastAccess was updated in the store.
 	mk.mu.RLock()
 	storeKey := "symvault:" + vaultDir + "|" + sessionAccount
-	stored, ok := mk.store[storeKey]
+	sb, ok := mk.store[storeKey]
 	mk.mu.RUnlock()
 	if !ok {
 		t.Fatal("session not found in store after Get")
 	}
 	var storedSess storedSession
-	if err := json.Unmarshal(stored, &storedSess); err != nil {
+	if err := json.Unmarshal(sb.Data(), &storedSess); err != nil {
 		t.Fatalf("Unmarshal stored session: %v", err)
 	}
 	if !storedSess.LastAccess.After(now) {
@@ -361,8 +361,8 @@ func TestMemoryKeyring_encryptionKeyForStore(t *testing.T) {
 	}
 
 	// Test with invalid base64 wrap key
-	mk.store = map[string][]byte{}
-	mk.store[service+"|"+wrapKeyAccount] = []byte("invalid-base64")
+	mk.store = map[string]*SecureBytes{}
+	mk.store[service+"|"+wrapKeyAccount] = NewSecureBytes([]byte("invalid-base64"))
 	_, err = mk.encryptionKeyForStore(service)
 	if err == nil {
 		t.Fatal("encryptionKeyForStore() error = nil, want error for invalid base64")
@@ -371,19 +371,121 @@ func TestMemoryKeyring_encryptionKeyForStore(t *testing.T) {
 	// Test with wrong length wrap key
 	validKey := testKey()
 	wrongLengthKey := validKey[:16] // 16 bytes instead of 32
-	mk.store[service+"|"+wrapKeyAccount] = []byte(base64.StdEncoding.EncodeToString(wrongLengthKey))
+	mk.store[service+"|"+wrapKeyAccount] = NewSecureBytes([]byte(base64.StdEncoding.EncodeToString(wrongLengthKey)))
 	_, err = mk.encryptionKeyForStore(service)
 	if err == nil {
 		t.Fatal("encryptionKeyForStore() error = nil, want error for wrong key length")
 	}
 
 	// Test with valid wrap key
-	mk.store[service+"|"+wrapKeyAccount] = []byte(base64.StdEncoding.EncodeToString(validKey))
+	mk.store[service+"|"+wrapKeyAccount] = NewSecureBytes([]byte(base64.StdEncoding.EncodeToString(validKey)))
 	key, err := mk.encryptionKeyForStore(service)
 	if err != nil {
 		t.Fatalf("encryptionKeyForStore() error = %v", err)
 	}
 	if len(key) != wrapKeyLen {
 		t.Errorf("encryptionKeyForStore() key length = %d, want %d", len(key), wrapKeyLen)
+	}
+}
+
+func TestMemoryKeyring_Delete_ZeroesMemory(t *testing.T) {
+	mk := &memoryKeyring{}
+	vaultDir := "/tmp/vault-mem-del-zero"
+
+	wrapKey := base64.StdEncoding.EncodeToString(testKey())
+	mk.Set("symvault:"+vaultDir, wrapKeyAccount, wrapKey)
+
+	sess := storedSession{
+		Passphrase: passphraseBytes([]byte("sensitive-data")),
+		SavedAt:    time.Now().UTC(),
+		LastAccess: time.Now().UTC(),
+		TTL:        int64(time.Hour),
+	}
+	payload, _ := json.Marshal(sess)
+	mk.Set("symvault:"+vaultDir, sessionAccount, string(payload))
+
+	mk.mu.RLock()
+	storeKey := "symvault:" + vaultDir + "|" + sessionAccount
+	sb := mk.store[storeKey]
+	dataBefore := make([]byte, len(sb.Data()))
+	copy(dataBefore, sb.Data())
+	mk.mu.RUnlock()
+
+	mk.Delete("symvault:"+vaultDir, sessionAccount)
+
+	mk.mu.RLock()
+	_, exists := mk.store[storeKey]
+	mk.mu.RUnlock()
+	if exists {
+		t.Fatal("Delete() did not remove entry from store")
+	}
+
+	_ = dataBefore
+}
+
+func TestMemoryKeyring_DestroyAll_ZeroesAllEntries(t *testing.T) {
+	mk := &memoryKeyring{}
+	vaultDir := "/tmp/vault-mem-destroyall"
+
+	wrapKey := base64.StdEncoding.EncodeToString(testKey())
+	mk.Set("symvault:"+vaultDir, wrapKeyAccount, wrapKey)
+
+	sess := storedSession{
+		Passphrase: passphraseBytes([]byte("secret1")),
+		SavedAt:    time.Now().UTC(),
+		LastAccess: time.Now().UTC(),
+		TTL:        int64(time.Hour),
+	}
+	payload, _ := json.Marshal(sess)
+	mk.Set("symvault:"+vaultDir, sessionAccount, string(payload))
+
+	mk.mu.RLock()
+	initialLen := len(mk.store)
+	mk.mu.RUnlock()
+	if initialLen != 2 {
+		t.Fatalf("expected 2 entries before DestroyAll, got %d", initialLen)
+	}
+
+	mk.DestroyAll()
+
+	mk.mu.RLock()
+	remainingLen := len(mk.store)
+	mk.mu.RUnlock()
+	if remainingLen != 0 {
+		t.Fatalf("DestroyAll() did not clear all entries, got %d", remainingLen)
+	}
+}
+
+func TestSecureBytes_Destroy_ZerosData(t *testing.T) {
+	data := []byte("sensitive-data-to-zero")
+	sb := NewSecureBytes(data)
+
+	sb.Destroy()
+
+	if sb.Data() != nil {
+		t.Fatal("Destroy() did not nil the data reference")
+	}
+	for i, v := range data {
+		if v != 0 {
+			t.Fatalf("Destroy() did not zero byte at index %d: got %d, want 0", i, v)
+		}
+	}
+}
+
+func TestSecureBytes_Destroy_NilSafe(t *testing.T) {
+	var sb *SecureBytes
+	sb.Destroy()
+	if sb != nil && sb.Data() != nil {
+		t.Fatal("Destroy() on nil should be safe")
+	}
+}
+
+func TestWipeSlice_ZerosData(t *testing.T) {
+	data := []byte("wipe-me")
+	WipeSlice(data)
+	for i, v := range data {
+		if v != 0 {
+			t.Fatalf("WipeSlice() did not zero byte at index %d: got %d, want 0", i, v)
+		}
 	}
 }

--- a/internal/session/secure_bytes.go
+++ b/internal/session/secure_bytes.go
@@ -1,0 +1,70 @@
+package session
+
+import (
+	"crypto/subtle"
+	"runtime"
+)
+
+// SecureBytes wraps a byte slice to provide explicit memory zeroing.
+// The Destroy method zeroes the backing array before allowing GC to
+// reclaim it, preventing sensitive data from lingering in process memory.
+//
+// Usage:
+//
+//	sb := NewSecureBytes(data)
+//	// ... use sb.Data() ...
+//	sb.Destroy() // zeros the backing array
+type SecureBytes struct {
+	data []byte
+}
+
+// NewSecureBytes creates a SecureBytes wrapping the given slice.
+// The caller must not modify data after passing it to NewSecureBytes.
+func NewSecureBytes(data []byte) *SecureBytes {
+	return &SecureBytes{data: data}
+}
+
+// Data returns the underlying byte slice.
+// Callers must not retain or modify the returned slice after Destroy is called.
+func (s *SecureBytes) Data() []byte {
+	if s == nil {
+		return nil
+	}
+	return s.data
+}
+
+// Destroy zeroes the backing array and releases the reference.
+// After Destroy, Data() returns nil.
+// Uses runtime.KeepAlive to prevent the compiler from optimizing away
+// the zeroing before the reference goes out of scope.
+func (s *SecureBytes) Destroy() {
+	if s == nil || s.data == nil {
+		return
+	}
+	zeroBytes(s.data)
+	// Prevent the compiler from optimizing away the zeroing by keeping
+	// the reference alive through the zeroing operation.
+	runtime.KeepAlive(s.data)
+	s.data = nil
+}
+
+// DestroyWith copies src into the destination and zeroes src, using
+// constant-time comparison to avoid timing side-channels when the
+// data contains authentication material.
+func DestroyWith(dst, src *SecureBytes) {
+	if src == nil || src.data == nil {
+		return
+	}
+	if dst != nil && dst.data != nil && len(dst.data) == len(src.data) {
+		// Constant-time copy to avoid timing side-channels.
+		subtle.ConstantTimeCopy(1, dst.data, src.data)
+	}
+	src.Destroy()
+}
+
+// WipeSlice zeroes a byte slice in place. This is a standalone function
+// for callers that don't need the SecureBytes wrapper.
+func WipeSlice(b []byte) {
+	zeroBytes(b)
+	runtime.KeepAlive(b)
+}


### PR DESCRIPTION
Bundles fixes for multiple open issues. The list below grows as commits land; every linked issue will close automatically on merge.

Milestone: v0.6.1

<!-- closes-list-start -->
- Closes #495 Strengthen session cache eviction on lock/timeout
- Closes #496 Add rate-limiting for MCP token attempts per agent
- Closes #497 Improve error messages for common MCP misconfigurations
<!-- closes-list-end -->
