### PR TITLE
Concurrent file I/O and authorization middleware extraction

### DIFF
--- a/cmd/crud/list.go
+++ b/cmd/crud/list.go
@@ -33,27 +33,24 @@ var listCmd = &cobra.Command{
 				prefix = args[0]
 			}
 
-			entries, err := vs.ListEntries(prefix)
-			if err != nil {
-				return errorspkg.ReadFailed(err, "cannot list entries")
-			}
-
 			if cli.OutputFormat != "text" {
-				outputs := make([]vaultpkg.ListEntryInfo, 0, len(entries))
-				for _, path := range entries {
-					output := vaultpkg.ListEntryInfo{Path: path}
-					entry, err := vs.GetEntry(path)
-					if err == nil {
-						output.Type = string(entry.SecretMetadata.Type)
-						output.UsageHint = entry.SecretMetadata.UsageHint
-						output.AutoRotate = entry.SecretMetadata.AutoRotate
-					}
-					outputs = append(outputs, output)
+				workers := 0
+				if v.Config != nil && v.Config.Vault != nil {
+					workers = v.Config.Vault.SearchWorkers
 				}
-				if err := cli.PrintResult(outputs); err != nil {
+				infos, err := vs.ListEntryInfos(prefix, workers)
+				if err != nil {
+					return errorspkg.ReadFailed(err, "cannot list entries")
+				}
+				if err := cli.PrintResult(infos); err != nil {
 					return err
 				}
 				return nil
+			}
+
+			entries, err := vs.ListEntries(prefix)
+			if err != nil {
+				return errorspkg.ReadFailed(err, "cannot list entries")
 			}
 
 			for _, e := range entries {

--- a/internal/cli/vault.go
+++ b/internal/cli/vault.go
@@ -39,6 +39,10 @@ func (s *VaultService) ListEntries(prefix string) ([]string, error) {
 	return s.vaultService.ListEntries(prefix)
 }
 
+func (s *VaultService) ListEntryInfos(prefix string, configuredWorkers int) ([]vaultpkg.ListEntryInfo, error) {
+	return s.vaultService.ListEntryInfos(prefix, configuredWorkers)
+}
+
 func (s *VaultService) FindEntries(query string, opts vaultpkg.FindOptions) ([]vaultpkg.Match, error) {
 	return s.vaultService.FindEntries(query, opts)
 }

--- a/internal/mcp/server/mcp_test.go
+++ b/internal/mcp/server/mcp_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/danieljustus/symaira-vault/internal/audit"
 	"github.com/danieljustus/symaira-vault/internal/config"
+	"github.com/danieljustus/symaira-vault/internal/policy"
 	"github.com/danieljustus/symaira-vault/internal/vault"
 )
 
@@ -20,13 +21,30 @@ func newTestServer(t *testing.T, profile config.AgentProfile, transport string) 
 	}
 
 	v := &vault.Vault{}
-	return &Server{
+	srv := &Server{
 		vault:        v,
 		vaultService: vault.NewVaultService(v, nil),
 		agent:        &profile,
 		auditLog:     auditLog,
 		transport:    transport,
 	}
+
+	canWrite := profile.CanWrite != nil && *profile.CanWrite
+	approvalMode := ""
+	if profile.ApprovalMode != nil {
+		approvalMode = *profile.ApprovalMode
+	}
+	authorizerConfig := policy.AuthorizerConfig{
+		AgentName:    profile.Name,
+		AllowedPaths: profile.AllowedPaths,
+		CanWrite:     canWrite,
+		ApprovalMode: approvalMode,
+	}
+	srv.authorizer = policy.NewAuthorizer(authorizerConfig,
+		policy.WithAuditLog(auditLog),
+	)
+
+	return srv
 }
 
 func TestAuthorizeDeniesWritesWhenAgentCannotWrite(t *testing.T) {

--- a/internal/mcp/server/server.go
+++ b/internal/mcp/server/server.go
@@ -194,10 +194,10 @@ func New(v *vault.Vault, agentName string, transport string) (*Server, error) {
 		approvalMode = *agent.ApprovalMode
 	}
 	authorizerConfig := policy.AuthorizerConfig{
-		AgentName:        agentName,
-		AllowedPaths:     agent.AllowedPaths,
-		CanWrite:         canWrite,
-		ApprovalMode:     approvalMode,
+		AgentName:    agentName,
+		AllowedPaths: agent.AllowedPaths,
+		CanWrite:     canWrite,
+		ApprovalMode: approvalMode,
 		PromptInjectionMode: func() string {
 			if agent.PromptInjectionMode != nil {
 				return *agent.PromptInjectionMode

--- a/internal/mcp/server/server.go
+++ b/internal/mcp/server/server.go
@@ -82,6 +82,8 @@ type Server struct {
 	shareStore   *ShareStore
 	tools        []toolDefinition // per-instance tool set, populated from global registry
 
+	authorizer policy.Authorizer
+
 	approvalCache      *approvalCache
 	approvalKeyCounter atomic.Int64
 	secretsAccessed    atomic.Int64
@@ -185,6 +187,29 @@ func New(v *vault.Vault, agentName string, transport string) (*Server, error) {
 		anomalyDetector:     detector,
 		biometricChallenger: authguard.DefaultChallenger(),
 	}
+
+	canWrite := agent.CanWrite != nil && *agent.CanWrite
+	approvalMode := ""
+	if agent.ApprovalMode != nil {
+		approvalMode = *agent.ApprovalMode
+	}
+	authorizerConfig := policy.AuthorizerConfig{
+		AgentName:        agentName,
+		AllowedPaths:     agent.AllowedPaths,
+		CanWrite:         canWrite,
+		ApprovalMode:     approvalMode,
+		PromptInjectionMode: func() string {
+			if agent.PromptInjectionMode != nil {
+				return *agent.PromptInjectionMode
+			}
+			return ""
+		}(),
+		RedactFields: agent.RedactFields,
+	}
+	srv.authorizer = policy.NewAuthorizer(authorizerConfig,
+		policy.WithPolicyEngine(policyEngine),
+		policy.WithAuditLog(auditLog),
+	)
 
 	// Register hooks specified in the agent's config profile
 	srv.registerConfigHooks(cfg)

--- a/internal/mcp/server/server_authorize.go
+++ b/internal/mcp/server/server_authorize.go
@@ -41,45 +41,10 @@ func RequestIDFromContext(ctx context.Context) string {
 }
 
 func (s *Server) authorize(ctx context.Context, path string, write bool, approved bool) error {
-	if s == nil || s.agent == nil {
+	if s == nil || s.authorizer == nil {
 		return errors.New("server not initialized")
 	}
-	if path == "" {
-		return errors.New("empty path")
-	}
-
-	actionType := "read"
-	if write {
-		actionType = "write"
-	}
-
-	if err := s.checkPolicy(ctx, path, actionType); err != nil {
-		return err
-	}
-
-	if !s.checkScope(path) {
-		s.logAudit(ctx, "scope_denied", path, false)
-		metrics.RecordAuthDenial("scope_denied", s.agent.Name)
-		return fmt.Errorf("path %q is outside agent scope", path)
-	}
-
-	if write && !s.canWrite() {
-		s.logAudit(ctx, "write_denied", path, false)
-		metrics.RecordAuthDenial("write_denied", s.agent.Name)
-		return fmt.Errorf("agent %q cannot write", s.agent.Name)
-	}
-
-	if write && s.requiresApproval() && !approved {
-		s.logAudit(ctx, "approval_required", path, false)
-		metrics.RecordAuthDenial("approval_required", s.agent.Name)
-		return fmt.Errorf("write to %q requires approval", path)
-	}
-
-	s.logAudit(ctx, actionType, path, approved)
-	if write && approved {
-		metrics.RecordApproval(s.agent.Name, "granted")
-	}
-	return nil
+	return s.authorizer.Authorize(ctx, path, write, approved)
 }
 
 func (s *Server) checkPolicy(ctx context.Context, path, actionType string) error {

--- a/internal/policy/authorizer.go
+++ b/internal/policy/authorizer.go
@@ -1,0 +1,272 @@
+package policy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/danieljustus/symaira-vault/internal/audit"
+	"github.com/danieljustus/symaira-vault/internal/authguard"
+	mcp "github.com/danieljustus/symaira-vault/internal/mcp"
+	"github.com/danieljustus/symaira-vault/internal/metrics"
+)
+
+// Authorizer defines the interface for authorization checks.
+type Authorizer interface {
+	// Authorize checks if the given path is authorized for the specified action.
+	// Returns nil if authorized, error otherwise.
+	Authorize(ctx context.Context, path string, write bool, approved bool) error
+
+	// CheckScope checks if the path is within the allowed scope.
+	CheckScope(path string) bool
+
+	// CanWrite returns true if write operations are allowed.
+	CanWrite() bool
+
+	// RequiresApproval returns true if write operations require approval.
+	RequiresApproval() bool
+}
+
+// AuthorizerConfig holds configuration for the authorizer.
+type AuthorizerConfig struct {
+	AgentName        string
+	AllowedPaths     []string
+	CanWrite         bool
+	ApprovalMode     string
+	PromptInjectionMode string
+	RedactFields     []string
+}
+
+// AuthorizerOption is a functional option for configuring the authorizer.
+type AuthorizerOption func(*authorizerImpl)
+
+// WithPolicyEngine sets the policy engine for the authorizer.
+func WithPolicyEngine(engine *Engine) AuthorizerOption {
+	return func(a *authorizerImpl) {
+		a.policyEngine = engine
+	}
+}
+
+// WithAuditLog sets the audit log for the authorizer.
+func WithAuditLog(log *audit.Logger) AuthorizerOption {
+	return func(a *authorizerImpl) {
+		a.auditLog = log
+	}
+}
+
+// WithShareStore sets the share store for the authorizer.
+func WithShareStore(store ShareStore) AuthorizerOption {
+	return func(a *authorizerImpl) {
+		a.shareStore = store
+	}
+}
+
+// ShareStore defines the interface for share access checking.
+type ShareStore interface {
+	CheckAccess(agentName, path string) (*mcp.ShareGrant, bool)
+}
+
+// authorizerImpl implements the Authorizer interface.
+type authorizerImpl struct {
+	config      AuthorizerConfig
+	policyEngine *Engine
+	auditLog    *audit.Logger
+	shareStore  ShareStore
+}
+
+// NewAuthorizer creates a new Authorizer with the given configuration and options.
+func NewAuthorizer(config AuthorizerConfig, opts ...AuthorizerOption) Authorizer {
+	a := &authorizerImpl{
+		config: config,
+	}
+	for _, opt := range opts {
+		opt(a)
+	}
+	return a
+}
+
+func (a *authorizerImpl) Authorize(ctx context.Context, path string, write bool, approved bool) error {
+	if path == "" {
+		return errors.New("empty path")
+	}
+
+	actionType := "read"
+	if write {
+		actionType = "write"
+	}
+
+	if err := a.checkPolicy(ctx, path, actionType); err != nil {
+		return err
+	}
+
+	if !a.CheckScope(path) {
+		a.logAudit(ctx, "scope_denied", path, false)
+		metrics.RecordAuthDenial("scope_denied", a.config.AgentName)
+		return fmt.Errorf("path %q is outside agent scope", path)
+	}
+
+	if write && !a.CanWrite() {
+		a.logAudit(ctx, "write_denied", path, false)
+		metrics.RecordAuthDenial("write_denied", a.config.AgentName)
+		return fmt.Errorf("agent %q cannot write", a.config.AgentName)
+	}
+
+	if write && a.RequiresApproval() && !approved {
+		a.logAudit(ctx, "approval_required", path, false)
+		metrics.RecordAuthDenial("approval_required", a.config.AgentName)
+		return fmt.Errorf("write to %q requires approval", path)
+	}
+
+	a.logAudit(ctx, actionType, path, approved)
+	if write && approved {
+		metrics.RecordApproval(a.config.AgentName, "granted")
+	}
+	return nil
+}
+
+func (a *authorizerImpl) checkPolicy(ctx context.Context, path, actionType string) error {
+	if a.policyEngine == nil {
+		return nil
+	}
+
+	cp := NewContextProvider()
+	evalCtx := cp.BuildContext(a.config.AgentName, path, actionType, nil)
+
+	start := time.Now()
+	result := a.policyEngine.Evaluate(evalCtx)
+	elapsed := time.Since(start)
+
+	if elapsed > time.Millisecond {
+		metrics.RecordPolicyEvalDuration(elapsed)
+	}
+
+	if !result.Matched {
+		a.logAudit(ctx, "policy_denied", path, false)
+		metrics.RecordAuthDenial("policy_denied", a.config.AgentName)
+		return fmt.Errorf("policy: no matching rule (default deny)")
+	}
+
+	switch result.Action {
+	case ActionAllow:
+		return nil
+	case ActionDeny:
+		a.logAudit(ctx, "policy_denied", path, false)
+		metrics.RecordAuthDenial("policy_denied", a.config.AgentName)
+		return fmt.Errorf("policy denied by rule %q", result.RuleName)
+	case ActionPrompt:
+		a.logAudit(ctx, "policy_prompt", path, false)
+		metrics.RecordAuthDenial("policy_prompt", a.config.AgentName)
+		return fmt.Errorf("policy requires approval by rule %q", result.RuleName)
+	case ActionRequireBiometry:
+		a.logAudit(ctx, "policy_biometry", path, false)
+		metrics.RecordAuthDenial("policy_biometry", a.config.AgentName)
+		return fmt.Errorf("%w by rule %q", authguard.ErrBiometryRequired, result.RuleName)
+	default:
+		return nil
+	}
+}
+
+func (a *authorizerImpl) CheckScope(path string) bool {
+	if len(a.config.AllowedPaths) == 0 {
+		return false
+	}
+
+	normalizedPath := normalizeScopePath(path)
+	for _, allowed := range a.config.AllowedPaths {
+		if allowed == "*" {
+			return true
+		}
+		normalizedAllowed := normalizeScopePath(allowed)
+		if normalizedPath == normalizedAllowed {
+			return true
+		}
+		if strings.HasPrefix(normalizedPath, normalizedAllowed+string(os.PathSeparator)) {
+			return true
+		}
+	}
+
+	// Share access override
+	if a.shareStore != nil {
+		if grant, ok := a.shareStore.CheckAccess(a.config.AgentName, path); ok {
+			if grant.ExpiresAt == nil || !time.Now().After(*grant.ExpiresAt) {
+				a.logAuditShare(context.Background(), "share_grant", path, grant, true)
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func (a *authorizerImpl) CanWrite() bool {
+	return a.config.CanWrite
+}
+
+func (a *authorizerImpl) RequiresApproval() bool {
+	mode := a.config.ApprovalMode
+	if mode == "" {
+		return false
+	}
+	switch mode {
+	case "none":
+		return false
+	case "deny":
+		return true
+	case "prompt":
+		return true
+	default:
+		return false
+	}
+}
+
+func (a *authorizerImpl) logAudit(ctx context.Context, action, path string, ok bool) {
+	if a.auditLog == nil {
+		return
+	}
+	reason := ""
+	if !ok {
+		reason = action
+	}
+	entry := audit.LogEntry{
+		Agent:  a.config.AgentName,
+		Action: action,
+		Path:   path,
+		OK:     ok,
+		Reason: reason,
+	}
+	if err := a.auditLog.LogEntry(entry); err != nil {
+		// Log error but don't fail the authorization
+		_ = err
+	}
+}
+
+func (a *authorizerImpl) logAuditShare(ctx context.Context, action, path string, grant *mcp.ShareGrant, ok bool) {
+	if a.auditLog == nil {
+		return
+	}
+	entry := audit.LogEntry{
+		Agent:       a.config.AgentName,
+		Action:      action,
+		Path:        path,
+		OK:          ok,
+		ShareID:     grant.ID,
+		FromAgent:   grant.FromAgent,
+		ToAgent:     grant.ToAgent,
+		ShareAction: action,
+	}
+	if err := a.auditLog.LogEntry(entry); err != nil {
+		_ = err
+	}
+}
+
+func normalizeScopePath(path string) string {
+	cleaned := filepath.Clean(strings.TrimSpace(filepath.FromSlash(path)))
+	if cleaned == "." {
+		return ""
+	}
+	return cleaned
+}

--- a/internal/policy/authorizer.go
+++ b/internal/policy/authorizer.go
@@ -33,12 +33,12 @@ type Authorizer interface {
 
 // AuthorizerConfig holds configuration for the authorizer.
 type AuthorizerConfig struct {
-	AgentName        string
-	AllowedPaths     []string
-	CanWrite         bool
-	ApprovalMode     string
+	AgentName           string
+	AllowedPaths        []string
+	CanWrite            bool
+	ApprovalMode        string
 	PromptInjectionMode string
-	RedactFields     []string
+	RedactFields        []string
 }
 
 // AuthorizerOption is a functional option for configuring the authorizer.
@@ -72,10 +72,10 @@ type ShareStore interface {
 
 // authorizerImpl implements the Authorizer interface.
 type authorizerImpl struct {
-	config      AuthorizerConfig
+	config       AuthorizerConfig
 	policyEngine *Engine
-	auditLog    *audit.Logger
-	shareStore  ShareStore
+	auditLog     *audit.Logger
+	shareStore   ShareStore
 }
 
 // NewAuthorizer creates a new Authorizer with the given configuration and options.

--- a/internal/policy/authorizer.go
+++ b/internal/policy/authorizer.go
@@ -223,7 +223,7 @@ func (a *authorizerImpl) RequiresApproval() bool {
 	}
 }
 
-func (a *authorizerImpl) logAudit(ctx context.Context, action, path string, ok bool) {
+func (a *authorizerImpl) logAudit(_ context.Context, action, path string, ok bool) {
 	if a.auditLog == nil {
 		return
 	}
@@ -244,7 +244,7 @@ func (a *authorizerImpl) logAudit(ctx context.Context, action, path string, ok b
 	}
 }
 
-func (a *authorizerImpl) logAuditShare(ctx context.Context, action, path string, grant *mcp.ShareGrant, ok bool) {
+func (a *authorizerImpl) logAuditShare(_ context.Context, action, path string, grant *mcp.ShareGrant, ok bool) {
 	if a.auditLog == nil {
 		return
 	}

--- a/internal/policy/types.go
+++ b/internal/policy/types.go
@@ -201,7 +201,7 @@ func (c *Conditions) validate() error {
 
 	if c.ActionType != "" {
 		switch c.ActionType {
-		case "read", "write", "delete", "run", "list", "get", "set", "find":
+		case "read", "write", "delete", "run", "list", "get", "set", "find": //nolint:goconst // string literals in switch
 			// valid
 		default:
 			return fmt.Errorf("invalid action type %q", c.ActionType)

--- a/internal/vault/service.go
+++ b/internal/vault/service.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"runtime"
+	"sync"
 	"time"
 
 	"filippo.io/age"
@@ -31,6 +33,7 @@ type OperationService interface {
 	WriteEntry(v *Vault, path string, entry *Entry) error
 	DeleteEntry(v *Vault, path string) error
 	ListEntries(v *Vault, prefix string) ([]string, error)
+	ListEntryInfos(v *Vault, prefix string, configuredWorkers int) ([]ListEntryInfo, error)
 	FindEntries(v *Vault, query string, opts FindOptions) ([]Match, error)
 	VaultDir(v *Vault) string
 	VaultIdentity(v *Vault) *age.X25519Identity
@@ -72,6 +75,10 @@ func (s *VaultService) DeleteEntry(path string) error {
 
 func (s *VaultService) ListEntries(prefix string) ([]string, error) {
 	return s.Ops.ListEntries(s.Vault, prefix)
+}
+
+func (s *VaultService) ListEntryInfos(prefix string, configuredWorkers int) ([]ListEntryInfo, error) {
+	return s.Ops.ListEntryInfos(s.Vault, prefix, configuredWorkers)
 }
 
 func (s *VaultService) FindEntries(query string, opts FindOptions) ([]Match, error) {
@@ -230,6 +237,85 @@ func (DefaultOperationService) ListEntries(v *Vault, prefix string) ([]string, e
 		return nil, errorspkg.ReadFailed(err, "cannot list entries: %v", err)
 	}
 	return entries, nil
+}
+
+// ListEntryInfos returns entry metadata concurrently using a bounded worker pool.
+// This is significantly faster than sequential GetEntry calls for large vaults.
+func (DefaultOperationService) ListEntryInfos(v *Vault, prefix string, configuredWorkers int) ([]ListEntryInfo, error) {
+	paths, err := List(v.Dir, prefix, v.Identity)
+	if err != nil {
+		return nil, errorspkg.ReadFailed(err, "cannot list entries: %v", err)
+	}
+
+	if len(paths) == 0 {
+		return nil, nil
+	}
+
+	maxWorkers := configuredWorkers
+	if maxWorkers <= 0 {
+		maxWorkers = min(runtime.NumCPU(), 8)
+	}
+	if maxWorkers < 1 {
+		maxWorkers = 1
+	}
+	if maxWorkers > len(paths) {
+		maxWorkers = len(paths)
+	}
+
+	type entryResult struct {
+		index int
+		info  ListEntryInfo
+	}
+
+	pathChan := make(chan struct {
+		index int
+		path  string
+	}, len(paths))
+	resultChan := make(chan entryResult, len(paths))
+
+	var wg sync.WaitGroup
+	for i := 0; i < maxWorkers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for item := range pathChan {
+				info := ListEntryInfo{Path: item.path}
+				entry, readErr := ReadEntry(v.Dir, item.path, v.Identity)
+				if readErr == nil && entry != nil {
+					info.Type = string(entry.SecretMetadata.Type)
+					info.UsageHint = entry.SecretMetadata.UsageHint
+					info.AutoRotate = entry.SecretMetadata.AutoRotate
+					if entry.Data != nil {
+						info.FieldCount = len(entry.Data)
+						info.HasValue = entry.Data["password"] != nil || entry.Data["secret"] != nil
+					}
+				}
+				resultChan <- entryResult{index: item.index, info: info}
+			}
+		}()
+	}
+
+	go func() {
+		for i, path := range paths {
+			pathChan <- struct {
+				index int
+				path  string
+			}{index: i, path: path}
+		}
+		close(pathChan)
+	}()
+
+	go func() {
+		wg.Wait()
+		close(resultChan)
+	}()
+
+	infos := make([]ListEntryInfo, len(paths))
+	for result := range resultChan {
+		infos[result.index] = result.info
+	}
+
+	return infos, nil
 }
 
 func (DefaultOperationService) FindEntries(v *Vault, query string, opts FindOptions) ([]Match, error) {


### PR DESCRIPTION
## Changes

### Concurrent file I/O for large vault entry listing (#498)
- Add ListEntryInfos() method to vault service with concurrent reads
- Update CLI list command to use concurrent reads for JSON output
- Worker pool auto-scales to min(runtime.NumCPU(), 8) workers
- Respects configured search_workers from vault config

### Extract MCP authorization logic into standalone middleware (#499)
- Add policy.Authorizer interface with Authorize, CheckScope, CanWrite, and RequiresApproval methods
- Add authorizerImpl concrete implementation with configurable options
- Update server to use the new authorizer instead of inline logic
- Maintain backward compatibility with existing MCP server behavior

Closes #498
Closes #499