### PR TITLE
ci: pin docker/* actions and fix invalid github-script pin

### DIFF
--- a/.github/workflows/deferred-deps-check.yml
+++ b/.github/workflows/deferred-deps-check.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Create issue if CVEs found in deferred crypto dependency
         if: steps.cve.outputs.has_cves == 'true'
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799c7f6 # v9
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             const fs = require('fs');
@@ -111,7 +111,7 @@ jobs:
 
       - name: Create issue if ProtonMail/go-crypto updated
         if: steps.check.outputs.proton_version != '' && !contains(steps.check.outputs.proton_version, 'v1.1.')
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799c7f6 # v9
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             const version = '${{ steps.check.outputs.proton_version }}';
@@ -138,7 +138,7 @@ jobs:
 
       - name: Create issue if golang/protobuf still present
         if: steps.check.outputs.has_golang_protobuf != ''
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799c7f6 # v9
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             const version = '${{ steps.check.outputs.has_golang_protobuf }}';

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,13 +114,13 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -128,7 +128,7 @@ jobs:
 
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6
         with:
           images: ghcr.io/danieljustus/symvault
           tags: |
@@ -139,7 +139,7 @@ jobs:
 
       - name: Build and push
         id: build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: .
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
Hardens the GitHub Actions supply chain in the release and deferred-dependency workflows.

## Changes
- **Pin `docker/*` actions to commit SHAs** (`release.yml`): the five docker actions used floating major tags while every other action in the workflows is pinned to a full commit SHA. They are now SHA-pinned with `# vX` comments; Dependabot's `github-actions` ecosystem keeps them current.
- **Fix invalid `actions/github-script` pin** (`deferred-deps-check.yml`): the action was pinned to commit `60a0d83…` (commented `v9`), a SHA that does not exist upstream — the GitHub API returns `422 No commit found`. This broke the scheduled deferred-dependency workflow at the `github-script` step and caused the Dependabot `github_actions` update job to fail with `error: no such commit 60a0d83…`. Re-pinned to the current `v8` release SHA (`ed59741…`).

## Verification
- Both workflow files parse as valid YAML.
- All five docker SHAs resolved from the actions' current major tags; the github-script SHA resolves to `actions/github-script@v8`.

<!-- closes-list-start -->
- Closes #506 — Pin docker/* GitHub Actions to commit SHAs
- Closes #504 — Investigate intermittent Dependabot Updates workflow failures (github_actions half: invalid github-script pin)
<!-- closes-list-end -->

Milestone: v0.7.1
