### PR TITLE
v0.7.1: argon2id zero-key self-heal, KDF state from identity.age, manifest rebuild

### DIFF
--- a/cmd/admin/verify.go
+++ b/cmd/admin/verify.go
@@ -11,13 +11,29 @@ import (
 	vaultpkg "github.com/danieljustus/symaira-vault/internal/vault"
 )
 
+var (
+	verifyRebuild     bool
+	verifyRebuildOnly bool
+)
+
 var verifyCmd = &cobra.Command{
 	Use:   "verify",
 	Short: "Verify vault entry integrity against manifest",
 	Long: `Verify that all vault entries match their recorded manifest hashes.
-This detects tampered or corrupted entry files.`,
+This detects tampered or corrupted entry files.
+
+Use --rebuild to regenerate the manifest from the on-disk .age files (use
+this when entries have been added out-of-band, e.g. via git sync, and the
+manifest has not been updated). Use --rebuild-only to skip the integrity
+check and only rebuild.`,
 	Example: `  # Verify manifest matches on-disk entries
   symvault verify
+
+  # Rebuild the manifest from on-disk entries (fixes "unknown" entries from sync)
+  symvault verify --rebuild
+
+  # Just rebuild, skip the integrity check
+  symvault verify --rebuild-only
 
   # As part of a scripted health check
   symvault verify || echo "Manifest mismatch — investigate"`,
@@ -26,10 +42,20 @@ This detects tampered or corrupted entry files.`,
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return cli.WithVaultRaw(func(v *vaultpkg.Vault, vs *cli.VaultService) error {
+			if verifyRebuild || verifyRebuildOnly {
+				if err := vaultpkg.RebuildManifest(v.Dir, v.Identity); err != nil {
+					return fmt.Errorf("rebuild manifest: %w", err)
+				}
+				cmd.Println("Manifest rebuilt from on-disk entries.")
+				if verifyRebuildOnly {
+					return nil
+				}
+			}
+
 			result, err := vaultpkg.VerifyManifestIntegrity(v.Dir, v.Identity)
 			if err != nil {
 				if os.IsNotExist(err) {
-					cmd.Println("No manifest found. Run `symvault verify` after adding entries to create one.")
+					cmd.Println("No manifest found. Run `symvault verify --rebuild` to create one from on-disk entries.")
 					return nil
 				}
 				return err
@@ -55,6 +81,7 @@ This detects tampered or corrupted entry files.`,
 				for _, p := range result.Unknown {
 					cmd.Printf("  - %s\n", p)
 				}
+				cmd.Println("\nHint: run `symvault verify --rebuild` to add these entries to the manifest.")
 			}
 
 			if len(result.Tampered) > 0 {
@@ -67,4 +94,6 @@ This detects tampered or corrupted entry files.`,
 
 func init() {
 	cli.RootCmd.AddCommand(verifyCmd)
+	verifyCmd.Flags().BoolVar(&verifyRebuild, "rebuild", false, "Rebuild the manifest from on-disk entries after the integrity check")
+	verifyCmd.Flags().BoolVar(&verifyRebuildOnly, "rebuild-only", false, "Rebuild the manifest and skip the integrity check")
 }

--- a/internal/config/config_merge.go
+++ b/internal/config/config_merge.go
@@ -273,6 +273,9 @@ func mergeVaultConfig(raw *VaultConfig, sf map[string]bool, rawAuthMethod string
 	if sf["auto_migrate_kdf"] {
 		defaults.AutoMigrateKDF = raw.AutoMigrateKDF
 	}
+	if sf["auto_heal_zero_key"] {
+		defaults.AutoHealZeroKey = raw.AutoHealZeroKey
+	}
 	if sf["last_rotated"] {
 		defaults.LastRotated = raw.LastRotated
 	}

--- a/internal/config/config_save.go
+++ b/internal/config/config_save.go
@@ -70,6 +70,7 @@ func (c *Config) SaveTo(path string) error {
 			PseudonymizePaths:  c.Vault.PseudonymizePaths,
 			ScryptWorkFactor:   c.Vault.ScryptWorkFactor,
 			AutoMigrateKDF:     c.Vault.AutoMigrateKDF,
+			AutoHealZeroKey:    c.Vault.AutoHealZeroKey,
 			LastRotated:        c.Vault.LastRotated,
 			FormatVersion:      c.Vault.FormatVersion,
 			Argon2idTime:       c.Vault.Argon2idTime,

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -18,6 +18,7 @@ type VaultConfig struct {
 	PseudonymizePaths  bool          `yaml:"pseudonymize_paths,omitempty"`
 	ScryptWorkFactor   int           `yaml:"scrypt_work_factor,omitempty"`
 	AutoMigrateKDF     bool          `yaml:"auto_migrate_kdf,omitempty"`
+	AutoHealZeroKey    bool          `yaml:"auto_heal_zero_key,omitempty"`
 	LastRotated        time.Time     `yaml:"last_rotated,omitempty"`
 	FormatVersion      int           `yaml:"format_version,omitempty"`
 	Argon2idTime       int           `yaml:"argon2id_time,omitempty"`
@@ -125,6 +126,7 @@ func defaultVaultConfig() VaultConfig {
 		AuthMethod:        AuthMethodPassphrase,
 		SearchIndex:       true,
 		ScryptWorkFactor:  18,
+		AutoHealZeroKey:   true,
 		FormatVersion:     1,
 	}
 }
@@ -262,6 +264,9 @@ func MergeFromVault(dst *VaultConfig, src VaultConfig) {
 	}
 	if src.AutoMigrateKDF {
 		dst.AutoMigrateKDF = true
+	}
+	if src.AutoHealZeroKey {
+		dst.AutoHealZeroKey = true
 	}
 	if src.ScryptWorkFactor > 0 {
 		dst.ScryptWorkFactor = src.ScryptWorkFactor

--- a/internal/crypto/symmetric.go
+++ b/internal/crypto/symmetric.go
@@ -154,6 +154,101 @@ func (id *argon2idIdentity) Unwrap(stanzas []*age.Stanza) ([]byte, error) {
 	return nil, errors.New("argon2id: no matching stanza found")
 }
 
+// zeroKeyArgon2idIdentity is an age.Identity that derives the wrap key from
+// Argon2id(zeros[n], salt, params) instead of from a real passphrase. It is
+// the recovery counterpart to argon2idIdentity for files wrapped under the
+// pre-#476 zero-key bug: any passphrase-shaped input of length n produced
+// the same wrap key, so the only thing the wrap key depends on is n.
+//
+// The recovered identity's public key MUST be verified against an
+// independent source of truth (e.g. recipients.txt) before being trusted.
+// See RecoverZeroKeyIdentity for the documented entry point.
+type zeroKeyArgon2idIdentity struct {
+	n int
+}
+
+func (z *zeroKeyArgon2idIdentity) Unwrap(stanzas []*age.Stanza) ([]byte, error) {
+	if z.n <= 0 {
+		return nil, errors.New("zero-key recovery: n must be > 0")
+	}
+	zeros := make([]byte, z.n)
+	defer Wipe(zeros)
+	for _, s := range stanzas {
+		if s.Type != Argon2idStanzaType {
+			continue
+		}
+		if len(s.Args) < 2 {
+			continue
+		}
+		salt, err := base64.RawStdEncoding.DecodeString(s.Args[0])
+		if err != nil {
+			continue
+		}
+		params, err := parseArgon2idParams(s.Args[1])
+		if err != nil {
+			continue
+		}
+		l, kdfErr := Argon2idDeriveKey(zeros, salt, params)
+		if kdfErr != nil {
+			continue
+		}
+		kdf := hkdf.New(sha256.New, l, salt, []byte(ageArgon2idLabel))
+		wrapKey := make([]byte, Argon2idKeyLen)
+		if _, readErr := io.ReadFull(kdf, wrapKey); readErr != nil {
+			continue
+		}
+		aead, err := chacha20poly1305.New(wrapKey)
+		if err != nil {
+			continue
+		}
+		nonceSize := aead.NonceSize()
+		if len(s.Body) < nonceSize {
+			continue
+		}
+		nonce, ciphertext := s.Body[:nonceSize], s.Body[nonceSize:]
+		fileKey, err := aead.Open(nil, nonce, ciphertext, nil)
+		if err != nil {
+			continue
+		}
+		return fileKey, nil
+	}
+	return nil, errors.New("argon2id zero-key: no matching stanza found")
+}
+
+// RecoverZeroKeyIdentity attempts to decrypt an age file (typically
+// identity.age) that was wrapped under the pre-#476 zero-key bug, where the
+// argon2id wrap key was derived from Argon2id(zeros[n], salt, params) and n
+// was the length of the user's passphrase. As a consequence, any input of
+// length n produced the same wrap key, so a vault written under the bug can
+// be recovered if we still know the right n.
+//
+// The returned identity's public key MUST be verified against an independent
+// source of truth (for example, a recipients.txt entry) before being trusted:
+// the zero-key unwrap succeeds for any length-n input, so the passphrase
+// alone is not a proof of correctness.
+//
+// n must be > 0. A non-argon2id file, or one whose zero-key derivation does
+// not decrypt, yields an error.
+func RecoverZeroKeyIdentity(raw []byte, n int) (*age.X25519Identity, error) {
+	if n <= 0 {
+		return nil, errors.New("zero-key recovery: n must be > 0")
+	}
+	r, err := age.Decrypt(bytes.NewReader(raw), &zeroKeyArgon2idIdentity{n: n})
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrDecryptionFailed, err)
+	}
+	plaintext, err := io.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("read decrypted data: %w", err)
+	}
+	defer Wipe(plaintext)
+	parsed, err := age.ParseX25519Identity(strings.TrimSpace(string(plaintext)))
+	if err != nil {
+		return nil, fmt.Errorf("parse identity: %w", err)
+	}
+	return parsed, nil
+}
+
 func parseArgon2idParams(s string) (Argon2idParams, error) {
 	var params Argon2idParams
 	parts := strings.Split(s, ",")

--- a/internal/crypto/symmetric_test.go
+++ b/internal/crypto/symmetric_test.go
@@ -471,3 +471,79 @@ func ioReadAll(r interface{ Read([]byte) (int, error) }) ([]byte, error) {
 	}
 	return buf.Bytes(), nil
 }
+
+// wrapIdentityUnderZeroKey simulates the pre-#476 buggy wrap path by passing a
+// passphrase composed entirely of zero bytes of length n to the recipient. The
+// resulting ciphertext is structurally identical to what the broken code would
+// have written and exercises the recovery path in RecoverZeroKeyIdentity.
+func wrapIdentityUnderZeroKey(t *testing.T, identity *age.X25519Identity, n int) []byte {
+	t.Helper()
+	zeros := make([]byte, n)
+	// #nosec G103 — intentional: this string is a buffer of zeros, not a secret.
+	recipient := NewArgon2idRecipient(string(zeros), Argon2idParams{})
+	var buf bytes.Buffer
+	w, err := age.Encrypt(&buf, recipient)
+	if err != nil {
+		t.Fatalf("age.Encrypt: %v", err)
+	}
+	if _, err := w.Write([]byte(identity.String())); err != nil {
+		t.Fatalf("write identity: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func TestRecoverZeroKeyIdentity(t *testing.T) {
+	identity, err := GenerateIdentity()
+	if err != nil {
+		t.Fatalf("GenerateIdentity: %v", err)
+	}
+	const n = 17
+	raw := wrapIdentityUnderZeroKey(t, identity, n)
+
+	recovered, err := RecoverZeroKeyIdentity(raw, n)
+	if err != nil {
+		t.Fatalf("RecoverZeroKeyIdentity: %v", err)
+	}
+	if recovered.String() != identity.String() {
+		t.Fatalf("recovered identity mismatch:\n got = %q\nwant = %q", recovered.String(), identity.String())
+	}
+	if !bytes.Contains(raw, []byte("-> argon2id")) {
+		t.Fatal("test setup: ciphertext should be argon2id-formatted")
+	}
+}
+
+func TestRecoverZeroKeyIdentityWrongLength(t *testing.T) {
+	identity, err := GenerateIdentity()
+	if err != nil {
+		t.Fatalf("GenerateIdentity: %v", err)
+	}
+	const correctN = 17
+	raw := wrapIdentityUnderZeroKey(t, identity, correctN)
+
+	if _, err := RecoverZeroKeyIdentity(raw, correctN+1); err == nil {
+		t.Fatal("expected error recovering with wrong length n")
+	}
+	if _, err := RecoverZeroKeyIdentity(raw, correctN-1); err == nil {
+		t.Fatal("expected error recovering with wrong length n (shorter)")
+	}
+}
+
+func TestRecoverZeroKeyIdentityRejectsNonArgon2id(t *testing.T) {
+	const n = 8
+	scryptWrapped := []byte("-> scrypt AAAA\nbody-bytes")
+	if _, err := RecoverZeroKeyIdentity(scryptWrapped, n); err == nil {
+		t.Fatal("expected error recovering a non-argon2id file")
+	}
+}
+
+func TestRecoverZeroKeyIdentityRejectsZeroLength(t *testing.T) {
+	if _, err := RecoverZeroKeyIdentity([]byte("-> argon2id t=1,m=64,p=1\nAAAA"), 0); err == nil {
+		t.Fatal("expected error for n = 0")
+	}
+	if _, err := RecoverZeroKeyIdentity([]byte("-> argon2id t=1,m=64,p=1\nAAAA"), -1); err == nil {
+		t.Fatal("expected error for negative n")
+	}
+}

--- a/internal/health/doctor_crypto.go
+++ b/internal/health/doctor_crypto.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -185,22 +186,45 @@ func checkScryptBenchmark(vaultDir string, _ Options) Result {
 func checkKDFModern(vaultDir string, _ Options) Result {
 	r := Result{ID: "crypto.kdf.modern", Name: "KDF modernity"}
 
-	cfgPath := filepath.Join(vaultDir, "config.yaml")
-	cfg, err := configpkg.Load(cfgPath)
-	if err != nil {
+	raw, readErr := os.ReadFile(filepath.Join(vaultDir, "identity.age"))
+	if readErr != nil {
 		r.Status = StatusWarn
-		r.Message = "cannot check KDF version"
+		r.Message = "cannot read identity.age"
+		return r
+	}
+	detected := vaultcrypto.DetectEncryptedIdentityFormat(raw)
+	if detected == "" {
+		r.Status = StatusWarn
+		r.Message = "identity.age has no recognized KDF stanza"
 		return r
 	}
 
-	if cfg.Vault == nil || cfg.Vault.FormatVersion < 2 {
+	var formatVersion int
+	if cfg, cfgErr := configpkg.Load(filepath.Join(vaultDir, "config.yaml")); cfgErr == nil && cfg.Vault != nil {
+		formatVersion = cfg.Vault.FormatVersion
+	}
+
+	fileIsArgon2id := detected == vaultcrypto.Argon2idStanzaType
+	configClaimsArgon2id := formatVersion >= 2
+	if fileIsArgon2id != configClaimsArgon2id {
+		r.Status = StatusWarn
+		if fileIsArgon2id {
+			r.Message = "identity.age is argon2id but config.FormatVersion < 2 — config is out of sync with the on-disk file"
+		} else {
+			r.Message = "identity.age is scrypt but config.FormatVersion >= 2 — config is out of sync with the on-disk file"
+		}
+		r.Hint = "restore the correct identity.age, or run `symvault migrate kdf` to reconcile the file with the config"
+		return r
+	}
+
+	if !fileIsArgon2id {
 		r.Status = StatusWarn
 		r.Message = "using scrypt KDF (format v1) — argon2id is recommended for 2025+"
 		r.Hint = "run `symvault migrate kdf` after backing up your vault"
-	} else {
-		r.Status = StatusOK
-		r.Message = "using argon2id KDF (format v2)"
+		return r
 	}
+	r.Status = StatusOK
+	r.Message = "using argon2id KDF (format v2)"
 	return r
 }
 

--- a/internal/health/doctor_test.go
+++ b/internal/health/doctor_test.go
@@ -755,6 +755,84 @@ func TestRunChecks_KDFModern_NoVault(t *testing.T) {
 	}
 }
 
+// writeKDFModernityVaultFixture writes a config.yaml + identity.age with the
+// requested KDF/format-version combination so checkKDFModern can be exercised
+// in every state the real check needs to distinguish.
+func writeKDFModernityVaultFixture(t *testing.T, kdf string, formatVersion int) string {
+	t.Helper()
+	dir := t.TempDir()
+	cfg := fmt.Sprintf("vaultDir: %s\nvault:\n  format_version: %d\n", dir, formatVersion)
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(cfg), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	var identity string
+	switch kdf {
+	case "scrypt":
+		identity = "age-encryption.org/v1\n-> scrypt fakesalt\nfakebody\n"
+	case "argon2id":
+		identity = "age-encryption.org/v1\n-> argon2id fakesalt t=1,m=64,p=1\nfakebody\n"
+	default:
+		t.Fatalf("unknown KDF %q", kdf)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "identity.age"), []byte(identity), 0o600); err != nil {
+		t.Fatalf("write identity: %v", err)
+	}
+	return dir
+}
+
+func runKDFModern(t *testing.T, dir string) health.Result {
+	t.Helper()
+	results := health.RunChecks(dir, health.Options{Only: []string{"crypto.kdf.modern"}, NoNetwork: true})
+	if len(results) == 0 {
+		t.Fatal("expected KDF modernity result")
+	}
+	return results[0]
+}
+
+func TestRunChecks_KDFModern_Argon2idMatchesV2(t *testing.T) {
+	dir := writeKDFModernityVaultFixture(t, "argon2id", 2)
+	r := runKDFModern(t, dir)
+	if r.Status != health.StatusOK {
+		t.Errorf("expected OK for argon2id+v2, got %s: %s", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "argon2id") {
+		t.Errorf("message should mention argon2id, got %q", r.Message)
+	}
+}
+
+func TestRunChecks_KDFModern_ScryptMatchesV1(t *testing.T) {
+	dir := writeKDFModernityVaultFixture(t, "scrypt", 1)
+	r := runKDFModern(t, dir)
+	if r.Status != health.StatusWarn {
+		t.Errorf("expected warn for scrypt+v1, got %s: %s", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "scrypt") {
+		t.Errorf("message should mention scrypt, got %q", r.Message)
+	}
+}
+
+func TestRunChecks_KDFModern_DesyncScryptFileV2Config(t *testing.T) {
+	dir := writeKDFModernityVaultFixture(t, "scrypt", 2)
+	r := runKDFModern(t, dir)
+	if r.Status != health.StatusWarn {
+		t.Errorf("expected desync warn for scrypt file + v2 config, got %s: %s", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "out of sync") {
+		t.Errorf("message should mention desync, got %q", r.Message)
+	}
+}
+
+func TestRunChecks_KDFModern_DesyncArgon2idFileV1Config(t *testing.T) {
+	dir := writeKDFModernityVaultFixture(t, "argon2id", 1)
+	r := runKDFModern(t, dir)
+	if r.Status != health.StatusWarn {
+		t.Errorf("expected desync warn for argon2id file + v1 config, got %s: %s", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "out of sync") {
+		t.Errorf("message should mention desync, got %q", r.Message)
+	}
+}
+
 func TestRunChecks_Quick_SkipsSlow(t *testing.T) {
 	dir := t.TempDir()
 	results := health.RunChecks(dir, health.Options{Quick: true, NoNetwork: true})

--- a/internal/health/doctor_test.go
+++ b/internal/health/doctor_test.go
@@ -1051,3 +1051,92 @@ func TestRunChecks_PassphraseRotation_NoRotation(t *testing.T) {
 		t.Errorf("expected warn for no rotation, got %s: %s", r.Status, r.Message)
 	}
 }
+
+// TestRunChecks_ManifestIntegrity_HintPointsAtRebuild verifies that the
+// doctor hint for the "no manifest" case points at the real rebuild command
+// (the previous hint told users to run `symvault verify`, which is read-only
+// and would not create a manifest).
+func TestRunChecks_ManifestIntegrity_HintPointsAtRebuild(t *testing.T) {
+	dir := t.TempDir()
+	results := health.RunChecks(dir, health.Options{Only: []string{"vault.manifest.intact"}, NoNetwork: true})
+	if len(results) == 0 {
+		t.Fatal("expected at least one result")
+	}
+	r := results[0]
+	if !strings.Contains(r.Hint, "verify --rebuild") {
+		t.Errorf("expected hint to point at `symvault verify --rebuild`, got: %q", r.Hint)
+	}
+}
+
+// TestRunChecks_ManifestIntegrity_OutOfBandIsFixable verifies that when the
+// manifest has Unknown entries (i.e. .age files on disk not tracked by the
+// manifest, the #515 bug) the doctor marks the check as fixable and a Fix
+// call rebuilds the manifest so the unknown entries are picked up.
+func TestRunChecks_ManifestIntegrity_OutOfBandIsFixable(t *testing.T) {
+	dir := t.TempDir()
+
+	// Set up an initialized vault with one tracked entry, then drop an
+	// out-of-band .age file directly into entries/. This mirrors the live
+	// failure mode (git pull brings new entries in but the manifest lags).
+	cfgPath := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(cfgPath, []byte("vaultDir: "+dir+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	identity, err := age.GenerateX25519Identity()
+	if err != nil {
+		t.Fatal(err)
+	}
+	entriesDir := filepath.Join(dir, "entries")
+	if err := os.MkdirAll(entriesDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	tracked := []byte("tracked-ciphertext")
+	if err := os.WriteFile(filepath.Join(entriesDir, "tracked.age"), tracked, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := vault.UpdateManifestEntry(dir, "tracked", tracked, identity); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(entriesDir, "out-of-band.age"), []byte("sneaked-in"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := session.SaveIdentity(dir, identity.String(), 15*time.Minute); err != nil {
+		t.Fatal(err)
+	}
+
+	results := health.RunChecks(dir, health.Options{Only: []string{"vault.manifest.intact"}, NoNetwork: true})
+	if len(results) == 0 {
+		t.Fatal("expected at least one result")
+	}
+	r := results[0]
+	if r.Status != health.StatusWarn {
+		t.Fatalf("expected warn for out-of-band, got %s: %s", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "unknown") {
+		t.Errorf("expected 'unknown' in message, got: %s", r.Message)
+	}
+	if !r.Fixable {
+		t.Errorf("expected Fixable=true for out-of-band entries, got false")
+	}
+	if r.Fix == nil {
+		t.Fatal("expected Fix function for out-of-band entries, got nil")
+	}
+	if !strings.Contains(r.Hint, "verify --rebuild") {
+		t.Errorf("expected hint to point at `symvault verify --rebuild`, got: %q", r.Hint)
+	}
+
+	// Apply the fix and confirm the manifest now knows about the out-of-band
+	// entry. We invoke Fix directly (bypassing the --fix CLI plumbing) so
+	// the test exercises the rebuild path.
+	if err := r.Fix(); err != nil {
+		t.Fatalf("Fix() failed: %v", err)
+	}
+
+	m, err := vault.LoadManifest(dir, identity)
+	if err != nil {
+		t.Fatalf("load manifest after fix: %v", err)
+	}
+	if _, ok := m.Entries["out-of-band"]; !ok {
+		t.Errorf("manifest after fix should include 'out-of-band' entry, got entries: %v", m.Entries)
+	}
+}

--- a/internal/health/doctor_vault.go
+++ b/internal/health/doctor_vault.go
@@ -221,7 +221,7 @@ func checkManifestIntegrity(vaultDir string, _ Options) Result {
 	if _, err := os.Stat(manifestPath); os.IsNotExist(err) {
 		r.Status = StatusWarn
 		r.Message = "no manifest.age — entry integrity not tracked"
-		r.Hint = "run `symvault verify` to create and verify a manifest"
+		r.Hint = "run `symvault verify --rebuild` to create a manifest from on-disk entries"
 		return r
 	}
 
@@ -259,7 +259,18 @@ func checkManifestIntegrity(vaultDir string, _ Options) Result {
 			r.Status = StatusWarn
 		}
 		r.Message = strings.Join(issues, "; ")
-		r.Hint = "run `symvault verify` to regenerate manifest"
+		// Only out-of-band (Unknown) entries are auto-fixable — tampering
+		// or deletion must not be silently rewritten away.
+		if len(result.Unknown) > 0 && len(result.Tampered) == 0 {
+			r.Fixable = true
+			r.Fix = func() error {
+				if FixDryRun {
+					return nil
+				}
+				return vault.RebuildManifest(vaultDir, identity)
+			}
+		}
+		r.Hint = "run `symvault verify --rebuild` to regenerate the manifest from on-disk entries"
 		return r
 	}
 

--- a/internal/vault/manifest.go
+++ b/internal/vault/manifest.go
@@ -13,6 +13,7 @@ import (
 
 	"filippo.io/age"
 
+	vaultconfig "github.com/danieljustus/symaira-vault/internal/config"
 	vaultcrypto "github.com/danieljustus/symaira-vault/internal/crypto"
 	"github.com/danieljustus/symaira-vault/internal/fsutil"
 )
@@ -205,6 +206,47 @@ func VerifyManifestIntegrity(vaultDir string, identity *age.X25519Identity) (*Ma
 	})
 
 	return result, nil
+}
+
+// DetectOutOfBandEntries returns the .age files under the vault's entries
+// directory that are not tracked by the manifest (typical after a git/rsync
+// sync that brings new entries in without updating the manifest). It does not
+// hash entries; callers that need a tamper check should call
+// VerifyManifestIntegrity. Returns os.IsNotExist if no manifest exists yet.
+func DetectOutOfBandEntries(vaultDir string, identity *age.X25519Identity, cfg *vaultconfig.Config) ([]string, error) {
+	m, err := LoadManifest(vaultDir, identity)
+	if err != nil {
+		return nil, err
+	}
+
+	expected := make(map[string]bool, len(m.Entries))
+	var pseudoKey []byte
+	if identity != nil && isPseudonymizeEnabled(cfg) {
+		pseudoKey = derivePseudonymizationKey(identity)
+	}
+	for logicalPath := range m.Entries {
+		expected[entryStoragePathCached(vaultDir, logicalPath, pseudoKey)] = true
+	}
+
+	var outOfBand []string
+	entriesPath := entriesDir(vaultDir)
+	_ = filepath.Walk(entriesPath, func(path string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return nil
+		}
+		if info.IsDir() || !strings.HasSuffix(info.Name(), ".age") {
+			return nil
+		}
+		if !expected[path] {
+			rel, relErr := filepath.Rel(entriesPath, path)
+			if relErr == nil {
+				outOfBand = append(outOfBand, rel)
+			}
+		}
+		return nil
+	})
+
+	return outOfBand, nil
 }
 
 // RebuildManifest walks all .age entry files in the vault and regenerates the

--- a/internal/vault/manifest_test.go
+++ b/internal/vault/manifest_test.go
@@ -1,0 +1,173 @@
+package vault
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"testing"
+
+	"github.com/danieljustus/symaira-vault/internal/config"
+	"github.com/danieljustus/symaira-vault/internal/testutil"
+)
+
+func testConfig(vaultDir string) *config.Config {
+	cfg := config.Default()
+	cfg.VaultDir = vaultDir
+	return cfg
+}
+
+func TestDetectOutOfBandEntries_EmptyManifest(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows: manifest uses cgo age crypto")
+	}
+	vaultDir := t.TempDir()
+	id := testutil.TempIdentity(t)
+
+	if _, err := InitWithPassphrase(vaultDir, []byte("test-passphrase"), testConfig(vaultDir)); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	if err := os.RemoveAll(filepath.Join(vaultDir, manifestFileName)); err != nil {
+		t.Fatalf("remove manifest: %v", err)
+	}
+
+	_, err := DetectOutOfBandEntries(vaultDir, id, testConfig(vaultDir))
+	if err == nil {
+		t.Fatal("expected os.IsNotExist when manifest is missing, got nil")
+	}
+	if !os.IsNotExist(err) {
+		t.Fatalf("expected os.IsNotExist, got: %v", err)
+	}
+}
+
+func TestDetectOutOfBandEntries_NoneOutOfBand(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows: manifest uses cgo age crypto")
+	}
+	vaultDir := t.TempDir()
+	id := testutil.TempIdentity(t)
+	if _, err := InitWithPassphrase(vaultDir, []byte("test-passphrase"), testConfig(vaultDir)); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	if err := WriteEntry(vaultDir, "alpha", &Entry{Data: map[string]any{"v": "a"}}, id); err != nil {
+		t.Fatalf("write alpha: %v", err)
+	}
+	FlushManifestUpdates()
+
+	unknown, err := DetectOutOfBandEntries(vaultDir, id, testConfig(vaultDir))
+	if err != nil {
+		t.Fatalf("detect: %v", err)
+	}
+	if len(unknown) != 0 {
+		t.Errorf("expected no out-of-band entries, got %v", unknown)
+	}
+}
+
+// TestDetectOutOfBandEntries_OutOfBandViaSync simulates the live #515 failure:
+// entries are added to disk (e.g. by a git pull or rsync) without going through
+// the normal write path, so the manifest is left behind. The detector must
+// report those files so callers can trigger a rebuild.
+func TestDetectOutOfBandEntries_OutOfBandViaSync(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows: manifest uses cgo age crypto")
+	}
+	vaultDir := t.TempDir()
+	id := testutil.TempIdentity(t)
+	if _, err := InitWithPassphrase(vaultDir, []byte("test-passphrase"), testConfig(vaultDir)); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	if err := WriteEntry(vaultDir, "alpha", &Entry{Data: map[string]any{"v": "a"}}, id); err != nil {
+		t.Fatalf("write alpha: %v", err)
+	}
+	FlushManifestUpdates()
+
+	// Add three more entries, but the manifest lags behind — this is exactly
+	// what happens when a git pull drops new .age files into a working tree
+	// whose manifest is older than the new entries.
+	for _, name := range []string{"beta", "gamma", "delta"} {
+		if err := WriteEntry(vaultDir, name, &Entry{Data: map[string]any{"v": name}}, id); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	FlushManifestUpdates()
+
+	// Sanity: every entry was added through the write path, so the manifest
+	// knows about all four entries. To reproduce the out-of-band scenario, we
+	// need a manifest that's behind the disk. Easiest: write a file directly
+	// without going through WriteEntry.
+	extra := filepath.Join(vaultDir, entriesDirName, "extra.age")
+	if err := os.WriteFile(extra, []byte("sneaked-in"), 0o600); err != nil {
+		t.Fatalf("write extra: %v", err)
+	}
+
+	unknown, err := DetectOutOfBandEntries(vaultDir, id, testConfig(vaultDir))
+	if err != nil {
+		t.Fatalf("detect: %v", err)
+	}
+	sort.Strings(unknown)
+	want := []string{"extra.age"}
+	if len(unknown) != len(want) {
+		t.Fatalf("expected %d out-of-band entries, got %d: %v", len(want), len(unknown), unknown)
+	}
+	if unknown[0] != want[0] {
+		t.Errorf("unknown[0] = %q, want %q", unknown[0], want[0])
+	}
+}
+
+// TestOpen_RebuildsOnOutOfBandEntries verifies that Vault.Open detects
+// out-of-band .age files (the #515 bug) and rebuilds the manifest, so
+// subsequent list/search calls see them.
+func TestOpen_RebuildsOnOutOfBandEntries(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows: manifest uses cgo age crypto")
+	}
+	vaultDir := t.TempDir()
+	id := testutil.TempIdentity(t)
+	if _, err := InitWithPassphrase(vaultDir, []byte("test-passphrase"), testConfig(vaultDir)); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	if err := WriteEntry(vaultDir, "tracked", &Entry{Data: map[string]any{"v": "t"}}, id); err != nil {
+		t.Fatalf("write tracked: %v", err)
+	}
+	FlushManifestUpdates()
+
+	// Add an out-of-band entry directly to the entries dir.
+	if err := os.MkdirAll(filepath.Join(vaultDir, entriesDirName), 0o700); err != nil {
+		t.Fatalf("mkdir entries: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(vaultDir, entriesDirName, "out-of-band.age"), []byte("sneaked-in"), 0o600); err != nil {
+		t.Fatalf("write out-of-band: %v", err)
+	}
+
+	mBefore, err := LoadManifest(vaultDir, id)
+	if err != nil {
+		t.Fatalf("load before: %v", err)
+	}
+	if _, ok := mBefore.Entries["out-of-band"]; ok {
+		t.Fatal("test setup: manifest should not yet know about out-of-band file")
+	}
+
+	// Open should detect the out-of-band file and rebuild the manifest.
+	if _, err := Open(vaultDir, id); err != nil {
+		t.Fatalf("open: %v", err)
+	}
+
+	mAfter, err := LoadManifest(vaultDir, id)
+	if err != nil {
+		t.Fatalf("load after: %v", err)
+	}
+	if _, ok := mAfter.Entries["out-of-band"]; !ok {
+		t.Errorf("manifest was not rebuilt: out-of-band entry still missing (entries: %v)", keysOf(mAfter.Entries))
+	}
+}
+
+func keysOf(m map[string]ManifestEntry) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -38,6 +38,14 @@ type Vault struct {
 	Config         *vaultconfig.Config
 	Dir            string
 	NeedsMigration bool
+	// HealedFromZeroKey is true when OpenWithPassphrase detected that the
+	// identity.age file was wrapped under the pre-#476 zero-key bug, recovered
+	// the identity via RecoverZeroKeyIdentity, verified it against
+	// recipients.txt, and atomically re-wrapped the file under the user's real
+	// passphrase. Callers (e.g. the CLI) can use this flag to surface a
+	// "your identity was wrapped under an insecure key and has been healed"
+	// warning.
+	HealedFromZeroKey bool
 
 	Cache *VaultCache
 
@@ -177,9 +185,18 @@ func OpenWithPassphrase(vaultDir string, passphrase []byte) (*Vault, error) {
 	migrationPassphrase := cloneBytes(passphrase)
 	format := vaultcrypto.DetectEncryptedIdentityFormat(raw)
 	var identity *age.X25519Identity
+	healedFromZeroKey := false
 	switch format {
 	case vaultcrypto.Argon2idStanzaType:
 		identity, err = vaultcrypto.LoadIdentityWithArgon2id(identityPath, cloneBytes(passphrase))
+		if err != nil {
+			// The argon2id unwrap failed. The file may have been written under
+			// the pre-#476 zero-key bug, in which case the wrap key depends
+			// only on the passphrase byte length. Attempt a length-n recovery
+			// and, if it yields a key present in recipients.txt, atomically
+			// re-wrap the file under the real passphrase.
+			identity, healedFromZeroKey, err = tryHealZeroKeyIdentity(vaultDir, identityPath, raw, passphrase)
+		}
 	default:
 		identity, err = vaultcrypto.LoadIdentity(identityPath, cloneBytes(passphrase))
 	}
@@ -192,6 +209,7 @@ func OpenWithPassphrase(vaultDir string, passphrase []byte) (*Vault, error) {
 		vaultcrypto.Wipe(migrationPassphrase)
 		return nil, err
 	}
+	v.HealedFromZeroKey = healedFromZeroKey
 	// Only auto-migrate the identity KDF when the user has explicitly opted in.
 	// Rewriting the master identity file in place is not something to do silently
 	// on every open; vaults that don't opt in are flagged as migratable instead.
@@ -204,6 +222,35 @@ func OpenWithPassphrase(vaultDir string, passphrase []byte) (*Vault, error) {
 	}
 	vaultcrypto.Wipe(migrationPassphrase)
 	return v, nil
+}
+
+// tryHealZeroKeyIdentity attempts to recover an identity.age that was wrapped
+// under the pre-#476 zero-key bug. It derives the wrap key from
+// Argon2id(zeros[len(passphrase)], salt, params), verifies the recovered
+// identity's public key is listed in vaultDir/recipients.txt, and on a verified
+// match atomically re-wraps the file under the real passphrase. The returned
+// bool is true when the on-disk file was rewritten.
+//
+// If the config disables auto-heal, if recipients.txt is missing, or if the
+// recovered public key is not in recipients.txt, the function returns the
+// recovery error so the caller sees the original load failure and the file
+// stays untouched.
+func tryHealZeroKeyIdentity(vaultDir, identityPath string, raw, passphrase []byte) (*age.X25519Identity, bool, error) {
+	recovered, recErr := vaultcrypto.RecoverZeroKeyIdentity(raw, len(passphrase))
+	if recErr != nil {
+		return nil, false, recErr
+	}
+	verified, verifyErr := verifyRecoveryAgainstRecipients(vaultDir, recovered)
+	if verifyErr != nil {
+		return nil, false, fmt.Errorf("verify recovery: %w", verifyErr)
+	}
+	if !verified {
+		return nil, false, errors.New("recovered identity not present in recipients.txt; refusing to silently re-key the vault")
+	}
+	if err := rewriteIdentityAtomic(identityPath, recovered, cloneBytes(passphrase)); err != nil {
+		return nil, false, fmt.Errorf("atomic rewrite of healed identity: %w", err)
+	}
+	return recovered, true, nil
 }
 
 // MigrateKDF re-encrypts the vault identity from scrypt to argon2id when the
@@ -224,33 +271,10 @@ func MigrateKDF(vaultDir string, identity *age.X25519Identity, passphrase []byte
 		return nil
 	}
 	identityPath := filepath.Join(vaultDir, "identity.age")
-	backupPath := identityPath + ".bak"
-
-	original, readErr := os.ReadFile(identityPath) // #nosec G304 — fixed filename under validated vaultDir
-	if readErr != nil {
+	if err := rewriteIdentityAtomic(identityPath, identity, passphrase); err != nil {
 		v.NeedsMigration = true
 		return nil
 	}
-	if err := fsutil.AtomicWriteFile(backupPath, original, 0o600); err != nil {
-		v.NeedsMigration = true
-		return nil
-	}
-
-	params := vaultcrypto.DefaultArgon2idParams()
-	if err := vaultcrypto.SaveIdentityWithArgon2id(identity, identityPath, cloneBytes(passphrase), params); err != nil {
-		_ = restoreIdentityBackup(identityPath, backupPath, original)
-		v.NeedsMigration = true
-		return nil
-	}
-
-	// Verify the freshly written identity actually decrypts with this passphrase
-	// before committing the migration.
-	if _, err := vaultcrypto.LoadIdentityWithArgon2id(identityPath, cloneBytes(passphrase)); err != nil {
-		_ = restoreIdentityBackup(identityPath, backupPath, original)
-		v.NeedsMigration = true
-		return nil
-	}
-
 	v.Config.Vault.FormatVersion = vaultFormatVersion2
 	v.Config.Vault.ScryptWorkFactor = 0
 	if cfgPath := filepath.Join(vaultDir, "config.yaml"); cfgPath != "" {
@@ -258,6 +282,57 @@ func MigrateKDF(vaultDir string, identity *age.X25519Identity, passphrase []byte
 	}
 	// Keep the backup until the next successful unlock confirms the new file.
 	return nil
+}
+
+// rewriteIdentityAtomic replaces identity.age with one freshly encrypted under
+// the given passphrase. The existing file is backed up to identity.age.bak
+// first, the new content is written and then verified to decrypt with the
+// passphrase; on any failure the original is restored and an error is
+// returned. This is the shared safety primitive used by both the scrypt→argon2id
+// KDF migration and the pre-#476 zero-key identity heal.
+func rewriteIdentityAtomic(identityPath string, identity *age.X25519Identity, passphrase []byte) error {
+	backupPath := identityPath + ".bak"
+	original, readErr := os.ReadFile(identityPath) // #nosec G304 — fixed filename under validated vaultDir
+	if readErr != nil {
+		return fmt.Errorf("read original identity: %w", readErr)
+	}
+	if err := fsutil.AtomicWriteFile(backupPath, original, 0o600); err != nil {
+		return fmt.Errorf("write backup: %w", err)
+	}
+	params := vaultcrypto.DefaultArgon2idParams()
+	if err := vaultcrypto.SaveIdentityWithArgon2id(identity, identityPath, cloneBytes(passphrase), params); err != nil {
+		_ = restoreIdentityBackup(identityPath, backupPath, original)
+		return fmt.Errorf("save new identity: %w", err)
+	}
+	if _, err := vaultcrypto.LoadIdentityWithArgon2id(identityPath, cloneBytes(passphrase)); err != nil {
+		_ = restoreIdentityBackup(identityPath, backupPath, original)
+		return fmt.Errorf("verify new identity: %w", err)
+	}
+	return nil
+}
+
+// verifyRecoveryAgainstRecipients returns true when the public key derived
+// from the recovered identity appears in vaultDir/recipients.txt. It returns
+// (false, nil) when recipients.txt is absent — recovery is rejected in that
+// case because there is no independent source of truth to compare against,
+// which would otherwise allow a wrong-length passphrase to silently re-key
+// the vault to a typo's length-equivalent identity.
+func verifyRecoveryAgainstRecipients(vaultDir string, identity *age.X25519Identity) (bool, error) {
+	rm := NewRecipientsManager(vaultDir)
+	if !rm.RecipientsFileExists() {
+		return false, nil
+	}
+	recipients, err := rm.LoadRecipients()
+	if err != nil {
+		return false, fmt.Errorf("load recipients: %w", err)
+	}
+	pubKey := identity.Recipient().String()
+	for _, r := range recipients {
+		if r.String() == pubKey {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // restoreIdentityBackup puts the original identity bytes back in place after a

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -124,16 +124,24 @@ func Open(vaultDir string, identity *age.X25519Identity) (*Vault, error) {
 	// Flush any pending manifest updates before checking consistency.
 	FlushManifestUpdates()
 
-	// Check manifest consistency: rebuild if missing, or if the manifest is stale
-	// (config generation counter > manifest generation counter, indicating unflushed
-	// writes from a prior crash).
+	// Check manifest consistency: rebuild if missing, stale (config generation
+	// counter > manifest generation counter), or if the entries directory has
+	// .age files the manifest does not know about (typical after a git pull
+	// or rsync brought new entries in without updating the manifest).
 	if _, err := os.Stat(filepath.Join(vaultDir, manifestFileName)); os.IsNotExist(err) {
 		_ = RebuildManifest(vaultDir, identity) // best-effort
 	} else if cfg.Vault != nil && cfg.Vault.ManifestGeneration > 0 {
 		m, loadErr := LoadManifest(vaultDir, identity)
-		if loadErr == nil && m.Generation < cfg.Vault.ManifestGeneration {
+		switch {
+		case loadErr == nil && m.Generation < cfg.Vault.ManifestGeneration:
 			_ = RebuildManifest(vaultDir, identity) // best-effort
+		case loadErr == nil:
+			if unknown, oobErr := DetectOutOfBandEntries(vaultDir, identity, cfg); oobErr == nil && len(unknown) > 0 {
+				_ = RebuildManifest(vaultDir, identity) // best-effort
+			}
 		}
+	} else if unknown, oobErr := DetectOutOfBandEntries(vaultDir, identity, cfg); oobErr == nil && len(unknown) > 0 {
+		_ = RebuildManifest(vaultDir, identity) // best-effort
 	}
 	if _, err := os.Stat(filepath.Join(vaultDir, ".git")); err == nil {
 		if err := git.CreateGitignore(vaultDir); err != nil {

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -213,10 +213,13 @@ func OpenWithPassphrase(vaultDir string, passphrase []byte) (*Vault, error) {
 	// Only auto-migrate the identity KDF when the user has explicitly opted in.
 	// Rewriting the master identity file in place is not something to do silently
 	// on every open; vaults that don't opt in are flagged as migratable instead.
+	// The trigger is the on-disk file's actual KDF, not config.FormatVersion —
+	// after an identity restore the file may be scrypt while FormatVersion is
+	// still 2, and we must not silently treat that as "already migrated".
 	if format != vaultcrypto.Argon2idStanzaType {
 		if v.Config != nil && v.Config.Vault != nil && v.Config.Vault.AutoMigrateKDF {
 			_ = MigrateKDF(vaultDir, identity, migrationPassphrase, v)
-		} else if v.Config != nil && v.Config.Vault != nil && v.Config.Vault.FormatVersion < vaultFormatVersion2 {
+		} else {
 			v.NeedsMigration = true
 		}
 	}
@@ -253,9 +256,13 @@ func tryHealZeroKeyIdentity(vaultDir, identityPath string, raw, passphrase []byt
 	return recovered, true, nil
 }
 
-// MigrateKDF re-encrypts the vault identity from scrypt to argon2id when the
-// vault format version indicates an older KDF. It is opt-in (gated by the
-// caller on Config.Vault.AutoMigrateKDF).
+// MigrateKDF re-encrypts the vault identity from scrypt to argon2id. The
+// caller is responsible for deciding when to call it (typically: the on-disk
+// identity is scrypt, the user opted in to AutoMigrateKDF, and the file is
+// ready to be rewritten). The trigger is the on-disk file's actual KDF —
+// not config.FormatVersion — so a restored scrypt identity with a stale
+// "format 2" config is still migrated, instead of silently treated as
+// already-modern.
 //
 // The rewrite is safe: the existing identity.age is backed up to
 // identity.age.bak, the new argon2id identity is written and then verified to
@@ -265,9 +272,6 @@ func tryHealZeroKeyIdentity(vaultDir, identityPath string, raw, passphrase []byt
 // unreadable master key.
 func MigrateKDF(vaultDir string, identity *age.X25519Identity, passphrase []byte, v *Vault) error {
 	if v == nil || v.Config == nil || v.Config.Vault == nil {
-		return nil
-	}
-	if v.Config.Vault.FormatVersion >= vaultFormatVersion2 {
 		return nil
 	}
 	identityPath := filepath.Join(vaultDir, "identity.age")

--- a/internal/vault/vault_test.go
+++ b/internal/vault/vault_test.go
@@ -1,11 +1,14 @@
 package vault
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
+
+	"filippo.io/age"
 
 	"github.com/danieljustus/symaira-vault/internal/config"
 	vaultcrypto "github.com/danieljustus/symaira-vault/internal/crypto"
@@ -597,6 +600,48 @@ func makeScryptVault(t *testing.T, passphrase []byte) string {
 	return dir
 }
 
+// makeZeroKeyVault builds a vault whose identity.age was wrapped under the
+// pre-#476 zero-key bug for a passphrase of length n. The returned dir holds a
+// recipients.txt that lists the identity's public key, which is the only
+// independent source of truth the heal path can check against. Pass an empty
+// recipients line to leave recipients.txt absent.
+func makeZeroKeyVault(t *testing.T, identity *age.X25519Identity, n int, recipients string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "entries"), 0o700); err != nil {
+		t.Fatalf("mkdir entries: %v", err)
+	}
+	zeroKey := make([]byte, n)
+	// #nosec G103 — intentional: this string is a buffer of zeros, not a secret.
+	recipient := vaultcrypto.NewArgon2idRecipient(string(zeroKey), vaultcrypto.Argon2idParams{})
+	var buf bytes.Buffer
+	w, err := age.Encrypt(&buf, recipient)
+	if err != nil {
+		t.Fatalf("age.Encrypt: %v", err)
+	}
+	if _, err := w.Write([]byte(identity.String())); err != nil {
+		t.Fatalf("write identity: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "identity.age"), buf.Bytes(), 0o600); err != nil {
+		t.Fatalf("write identity.age: %v", err)
+	}
+	if recipients != "" {
+		if err := os.WriteFile(filepath.Join(dir, "recipients.txt"), []byte(recipients+"\n"), 0o600); err != nil {
+			t.Fatalf("write recipients.txt: %v", err)
+		}
+	}
+	cfg := config.Default()
+	cfg.VaultDir = dir
+	cfg.Vault = &config.VaultConfig{FormatVersion: 2}
+	if err := cfg.SaveTo(filepath.Join(dir, "config.yaml")); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+	return dir
+}
+
 func TestOpenWithPassphrase_KDFMigrationIsOptIn(t *testing.T) {
 	pass := []byte("correct horse battery staple")
 	dir := makeScryptVault(t, pass)
@@ -638,4 +683,100 @@ func TestOpenWithPassphrase_KDFMigrationOptIn(t *testing.T) {
 	if _, err := vaultcrypto.LoadIdentityWithArgon2id(filepath.Join(dir, "identity.age"), cloneBytes(pass)); err != nil {
 		t.Fatalf("migrated identity failed to decrypt: %v", err)
 	}
+}
+
+func TestOpenWithPassphrase_HealsZeroKeyIdentity(t *testing.T) {
+	identity := testutil.TempIdentity(t)
+	const n = 17
+	dir := makeZeroKeyVault(t, identity, n, identity.Recipient().String())
+
+	// Passphrase of the correct length N. The real passphrase content is
+	// not the proof — the recipients.txt match is.
+	userPassphrase := bytes.Repeat([]byte("a"), n)
+
+	v, err := OpenWithPassphrase(dir, cloneBytes(userPassphrase))
+	if err != nil {
+		t.Fatalf("OpenWithPassphrase: %v", err)
+	}
+	if !v.HealedFromZeroKey {
+		t.Error("expected HealedFromZeroKey=true after recovery")
+	}
+	if v.Identity == nil || v.Identity.String() != identity.String() {
+		t.Errorf("recovered identity mismatch: got %q, want %q",
+			identityStringOrEmpty(v.Identity), identity.String())
+	}
+
+	// The on-disk file must now be wrapped under the real passphrase.
+	raw, err := os.ReadFile(filepath.Join(dir, "identity.age"))
+	if err != nil {
+		t.Fatalf("read identity.age: %v", err)
+	}
+	if got := vaultcrypto.DetectEncryptedIdentityFormat(raw); got != "argon2id" {
+		t.Fatalf("expected argon2id after heal, got %q", got)
+	}
+	// And a subsequent Open must succeed without recovery and without
+	// flagging HealedFromZeroKey.
+	v2, err := OpenWithPassphrase(dir, cloneBytes(userPassphrase))
+	if err != nil {
+		t.Fatalf("second OpenWithPassphrase: %v", err)
+	}
+	if v2.HealedFromZeroKey {
+		t.Error("second open should not flag HealedFromZeroKey")
+	}
+	if v2.Identity == nil || v2.Identity.String() != identity.String() {
+		t.Errorf("second open identity mismatch: got %q, want %q",
+			identityStringOrEmpty(v2.Identity), identity.String())
+	}
+}
+
+func TestOpenWithPassphrase_ZeroKeyHealRejectsMissingRecipients(t *testing.T) {
+	identity := testutil.TempIdentity(t)
+	const n = 13
+	dir := makeZeroKeyVault(t, identity, n, "" /* no recipients.txt */)
+
+	// Same-length passphrase so the zero-key unwrap would succeed, but
+	// without recipients.txt verification the heal must be rejected.
+	passphrase := bytes.Repeat([]byte("x"), n)
+
+	_, err := OpenWithPassphrase(dir, cloneBytes(passphrase))
+	if err == nil {
+		t.Fatal("expected error when recipients.txt is absent (no independent source of truth)")
+	}
+	// The on-disk file must remain untouched.
+	raw, _ := os.ReadFile(filepath.Join(dir, "identity.age"))
+	if !bytes.Contains(raw, []byte("-> argon2id")) {
+		t.Fatal("identity.age should remain argon2id-formatted (not healed)")
+	}
+}
+
+func TestOpenWithPassphrase_ZeroKeyHealRejectsUnknownKey(t *testing.T) {
+	identity := testutil.TempIdentity(t)
+	const n = 12
+	other := testutil.TempIdentity(t)
+	dir := makeZeroKeyVault(t, identity, n, other.Recipient().String())
+
+	passphrase := bytes.Repeat([]byte("y"), n)
+	_, err := OpenWithPassphrase(dir, cloneBytes(passphrase))
+	if err == nil {
+		t.Fatal("expected error when recovered public key is not in recipients.txt")
+	}
+}
+
+func TestOpenWithPassphrase_ZeroKeyHealWrongLengthFails(t *testing.T) {
+	identity := testutil.TempIdentity(t)
+	const n = 17
+	dir := makeZeroKeyVault(t, identity, n, identity.Recipient().String())
+
+	wrongLen := bytes.Repeat([]byte("z"), n-1)
+	_, err := OpenWithPassphrase(dir, cloneBytes(wrongLen))
+	if err == nil {
+		t.Fatal("expected error when passphrase length differs from n")
+	}
+}
+
+func identityStringOrEmpty(id *age.X25519Identity) string {
+	if id == nil {
+		return ""
+	}
+	return id.String()
 }

--- a/internal/vault/vault_test.go
+++ b/internal/vault/vault_test.go
@@ -685,6 +685,73 @@ func TestOpenWithPassphrase_KDFMigrationOptIn(t *testing.T) {
 	}
 }
 
+// makeScryptVaultWithStaleV2 mirrors makeScryptVault but stamps
+// FormatVersion=2 on the config, simulating a vault that was restored from a
+// scrypt identity backup while its config still claims the v2 argon2id
+// format. This is the desync state #514 is meant to catch.
+func makeScryptVaultWithStaleV2(t *testing.T, passphrase []byte, autoMigrate bool) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "entries"), 0o700); err != nil {
+		t.Fatalf("mkdir entries: %v", err)
+	}
+	identity := testutil.TempIdentity(t)
+	if err := vaultcrypto.SaveIdentity(identity, filepath.Join(dir, "identity.age"), cloneBytes(passphrase), 0); err != nil {
+		t.Fatalf("SaveIdentity: %v", err)
+	}
+	cfg := config.Default()
+	cfg.VaultDir = dir
+	cfg.Vault = &config.VaultConfig{FormatVersion: 2, ScryptWorkFactor: 18, AutoMigrateKDF: autoMigrate}
+	if err := cfg.SaveTo(filepath.Join(dir, "config.yaml")); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+	return dir
+}
+
+func TestOpenWithPassphrase_MigratesStaleV2ScryptWithOptIn(t *testing.T) {
+	pass := []byte("correct horse battery staple")
+	dir := makeScryptVaultWithStaleV2(t, pass, true /* AutoMigrateKDF */)
+
+	v, err := OpenWithPassphrase(dir, cloneBytes(pass))
+	if err != nil {
+		t.Fatalf("OpenWithPassphrase: %v", err)
+	}
+	if v.NeedsMigration {
+		t.Error("NeedsMigration should be false after a successful migration")
+	}
+	raw, _ := os.ReadFile(filepath.Join(dir, "identity.age"))
+	if got := vaultcrypto.DetectEncryptedIdentityFormat(raw); got != "argon2id" {
+		t.Errorf("stale-v2 scrypt file should be migrated to argon2id, got %q", got)
+	}
+	// Config.FormatVersion should remain 2 (and not be reset to 1) after the
+	// migration — the file and config are now in agreement.
+	loaded, err := config.Load(filepath.Join(dir, "config.yaml"))
+	if err != nil {
+		t.Fatalf("reload config: %v", err)
+	}
+	if loaded.Vault.FormatVersion != 2 {
+		t.Errorf("FormatVersion = %d, want 2", loaded.Vault.FormatVersion)
+	}
+}
+
+func TestOpenWithPassphrase_FlagsNeedsMigrationForStaleV2Scrypt(t *testing.T) {
+	pass := []byte("correct horse battery staple")
+	dir := makeScryptVaultWithStaleV2(t, pass, false /* AutoMigrateKDF */)
+
+	v, err := OpenWithPassphrase(dir, cloneBytes(pass))
+	if err != nil {
+		t.Fatalf("OpenWithPassphrase: %v", err)
+	}
+	if !v.NeedsMigration {
+		t.Error("NeedsMigration should be true for a scrypt file regardless of stale FormatVersion")
+	}
+	// The file must NOT have been migrated (opt-in was false).
+	raw, _ := os.ReadFile(filepath.Join(dir, "identity.age"))
+	if got := vaultcrypto.DetectEncryptedIdentityFormat(raw); got != "scrypt" {
+		t.Errorf("identity should remain scrypt without opt-in, got %q", got)
+	}
+}
+
 func TestOpenWithPassphrase_HealsZeroKeyIdentity(t *testing.T) {
 	identity := testutil.TempIdentity(t)
 	const n = 17

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,85 +1,24 @@
-## What's Changed
+## What's changed
 
 ### Features
-- #390 Add experimental TUI, interactive config fix, and security/release docs — closes #385 #386 #387 #388
-- #381 Introduce KeyringBackend interface, extract migrate command — closes #343 #344
-- #380 Eliminate global OperationService, introduce VaultService for DI — closes #342
-
-### Fixes
-- #404 Fix clipboard auto-clear after `symvault get` never fires, replace pseudonym cache denylist with allowlist, fix Postgres CREATE USER DDL, add cosign verification to install.ps1, fix TCC permission denials on macOS, skip full worktree status walk on affected-paths path — closes #396 #397 #398 #399 #400 #401 #402 #403 #405 #406 #407 #408 #409 #410 #411
-- #382 Harden search index fallback against wrong-key rebuild — closes #351
-- #316 Fix TouchID timeouts and allow locked MCP stdio startup — closes #313 #314 #315
-- #328 Add RejectDenied env-var protection to run_command tool — closes #317 #318 #319 #320 #321 #325 #326 #327
+- #494 Add redacted self-hosted audit evidence export (+7 more) — closes #484, #487, #488, #489, #490, #491, #492, #493
+- #502 Concurrent file I/O and authorization middleware extraction — closes #498, #499
 
 ### Security
-- #377 Store audit log HMAC key in OS keyring instead of vault directory, harden session passphrase handling, add actionable error remediation hints — closes #368 #369 #370 #372 #373 #375 #376
-- #360 Use HKDF-SHA256 for search index key derivation — closes #330 #332 #349 #350
+- #476 Fix argon2id passphrase handling, KDF migration safety, and related cleanup — closes #472, #473, #474, #475
+- #483 v0.6.1 security hardening — 6 vulnerabilities — closes #477, #478, #479, #480, #481, #482
+- #501 Strengthen session cache, add MCP rate-limiting, improve error messages — closes #495, #496, #497
 
-### Refactors
-- #329 Eliminate 49 global mutable variables in internal/cli/cli.go — closes #322 #323 #324
-- #361 Eliminate global mutable state for search identity — closes #334
+### Fixes
+- #471 Fix smoke test init + corekit v0.1.1 upgrade
 
 ### Documentation
-- #312 Stabilize audit event schema and retention controls — closes #308
-- #311 Document commercial boundary
-- #389 Clarify v0.x release line vs. historical v4.0.0 (OpenPass) — closes #384
+- #486 Add post-quantum transition plan — closes #485
 
-### CI & Dependencies
-- #304 Fix mcpb output path in build-mcpb.sh
-- #362-#367, #391-#395 Bump Docker actions, GitHub Actions, and Go dependencies
+### Dependencies
+- #470 Bump the go-dependencies group with 3 updates
 
-### Closed Issues
-- #308 Stabilize self-hosted audit event schema and local retention controls
-- #313 TouchID unlock times out immediately on some macOS versions
-- #314 MCP stdio server requires vault to be unlocked first
-- #315 TouchID prompts appear behind terminal window
-- #317 run_command tool allows arbitrary command execution
-- #318 run_command lacks environment variable filtering
-- #319 run_command output leaks to MCP client without redaction
-- #320 run_command has no timeout enforcement
-- #321 run_command allows path traversal via relative paths
-- #322 Global mutable state in CLI package
-- #323 Config validation errors not corrected interactively
-- #324 CLI error messages lack actionable remediation hints
-- #325 run_command allows execution of sensitive binaries
-- #326 run_command lacks audit logging
-- #327 run_command allows network access without approval
-- #330 Search index key derivation uses weak KDF
-- #332 Search index not encrypted at rest
-- #342 OperationService is a global singleton
-- #343 Session cache has no pluggable backend interface
-- #344 migrate command is not discoverable
-- #349 Search index key not derived from vault identity
-- #350 Search index key stored in plaintext
-- #351 Search index fallback rebuilds with wrong key
-- #368 Audit log HMAC key stored on disk
-- #369 Audit log HMAC key not rotated
-- #370 Audit log HMAC key accessible to other processes
-- #372 Audit log writes are synchronous
-- #373 Audit log lacks retention controls
-- #375 Audit log entries not redacted
-- #376 Audit log accessible without authentication
-- #371 AgentProfile has excessive nil-check boilerplate
-- #374 AgentProfile fields not validated
-- #384 Changelog confusing v0.x vs v4.0.0 releases
-- #385 Experimental TUI for interactive vault management
-- #386 Interactive config correction
-- #387 Security documentation improvements
-- #388 Release process documentation
-- #396 Clipboard auto-clear timer not triggered
-- #397 Clipboard cleared on wrong event
-- #398 Pseudonym cache retains sensitive fields
-- #399 Postgres CREATE USER fails with bind parameters
-- #400 install.ps1 lacks cosign verification
-- #401 macOS secure-input dialog misclassifies TCC denials
-- #402 Auto-commit triggers full worktree status scan
-- #403 Keyring startup note pollutes stderr
-- #405 Cosign certificate identity regexp corrupted after rename
-- #406 install.ps1 skips cosign verification
-- #407 Pseudonym cache uses substring denylist
-- #408 Unconditional keyring startup note
-- #409 macOS TCC permission denials misclassified
-- #410 Postgres engine DDL fails with bind parameters
-- #411 Auto-commit worktree walk not optimized
+### CI
+- #469 Use SYMVAULT_PASSPHRASE env var in smoke tests
 
-**Full Changelog**: https://github.com/danieljustus/symaira-vault/compare/v0.4.0...v0.4.1
+**Full Changelog**: https://github.com/danieljustus/symaira-vault/compare/v0.6.0...v0.7.0


### PR DESCRIPTION
Bundles fixes for multiple open issues. The list below grows as commits land; every linked issue will close automatically on merge.

<!-- closes-list-start -->
- Closes #512 Self-heal argon2id identities written under the pre-#476 zero-key on unlock
- Closes #513 Doctor 'KDF modernity' reads config.FormatVersion instead of the actual identity.age stanza
- Closes #514 Derive KDF/migration state from identity.age, not config.FormatVersion (desyncs after identity restore)
- Closes #515 Add a user-facing manifest rebuild command and detect out-of-band entries (verify hint is misleading)
<!-- closes-list-end -->