### PR TITLE
Annotate G304 false positive in internal/health/doctor_crypto.go

### DIFF
--- a/internal/health/doctor_crypto.go
+++ b/internal/health/doctor_crypto.go
@@ -186,7 +186,7 @@ func checkScryptBenchmark(vaultDir string, _ Options) Result {
 func checkKDFModern(vaultDir string, _ Options) Result {
 	r := Result{ID: "crypto.kdf.modern", Name: "KDF modernity"}
 
-	raw, readErr := os.ReadFile(filepath.Join(vaultDir, "identity.age"))
+	raw, readErr := os.ReadFile(filepath.Join(vaultDir, "identity.age")) // #nosec G304 — fixed filename under vaultDir, the trusted vault path from the caller
 	if readErr != nil {
 		r.Status = StatusWarn
 		r.Message = "cannot read identity.age"


### PR DESCRIPTION
Resolves a static-analysis finding from gosec ("Golang security checks by gosec").

### Code scanning
- **Alert #189** — `G304` (potential file inclusion via variable) in `internal/health/doctor_crypto.go:189`.

The KDF modernity health check reads `identity.age` from the vault directory via `os.ReadFile(filepath.Join(vaultDir, "identity.age"))`. The filename is a fixed constant and `vaultDir` is the trusted vault path supplied by the caller — not untrusted input — so the finding is a false positive. This adds the repository's standard `#nosec G304` justification comment, matching the identical suppression already in place for the same `identity.age` read at `internal/vault/vault.go:189`. No behavior change.

gosec honors the `#nosec` annotation, so the code-scanning alert auto-closes on the next gosec SARIF scan of this branch / after merge.

Verified locally: `go build` and `go vet` pass; `gosec -include=G304 ./internal/health/...` reports `Issues : 0`.

Closes alert #189 (Rule: G304)