### PR TITLE
Harden policy storage, MCP policy loading, search isolation, and the gosec gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,10 +97,9 @@ jobs:
           args: --timeout=5m --verbose
 
       - name: Run gosec SAST scanner
-        continue-on-error: true
         run: |
           go install github.com/securego/gosec/v2/cmd/gosec@${{ env.GOSEC_VERSION }}
-          gosec -fmt sarif -out gosec.sarif ./...
+          gosec -exclude-generated -exclude-dir=testdata -fmt sarif -out gosec.sarif ./...
 
       - name: Upload gosec SARIF report
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,10 +42,9 @@ jobs:
           args: --timeout=5m --verbose
 
       - name: Run gosec SAST scanner
-        continue-on-error: true
         run: |
           go install github.com/securego/gosec/v2/cmd/gosec@${{ env.GOSEC_VERSION }}
-          gosec -fmt sarif -out gosec.sarif ./...
+          gosec -exclude-generated -exclude-dir=testdata -fmt sarif -out gosec.sarif ./...
 
       - name: Upload gosec SARIF report
         if: always()

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -163,11 +163,11 @@ sequenceDiagram
 
 ### `internal/config/` — Configuration
 
-YAML-based configuration at `~/.symvault/config.yaml` or `~/.symvault/<vault>/config.yaml`.
+YAML-based configuration at `~/.config/symaira-vault/config.yaml` (XDG default). Installs created before the XDG layout continue to read from the legacy `~/.symvault/config.yaml`.
 
 **Config structure:**
 ```yaml
-vaultDir: ~/.symvault
+vaultDir: ~/.local/share/symaira-vault   # XDG default; legacy installs: ~/.symvault
 defaultAgent: claude-code
 agents:
   claude-code:
@@ -370,7 +370,7 @@ graph TD
 ## Vault Structure
 
 ```
-~/.symvault/
+~/.local/share/symaira-vault/   # XDG data dir (legacy installs: ~/.symvault/)
 ├── identity.age      # Encrypted age identity
 ├── config.yaml       # Vault configuration
 ├── mcp-token         # Bearer token for HTTP MCP (auto-generated)

--- a/README.md
+++ b/README.md
@@ -187,18 +187,18 @@ For detailed agent setup, profiles, token management, and observability, see [do
 
 ## Configuration
 
-Global config: `~/.symvault/config.yaml`. See [`config.yaml.example`](config.yaml.example) for a commented starting point.
+Global config lives in the XDG config directory: `$XDG_CONFIG_HOME/symaira-vault/config.yaml` (default `~/.config/symaira-vault/config.yaml`). Installs created before the XDG layout continue to read from the legacy `~/.symvault/config.yaml`. See [`config.yaml.example`](config.yaml.example) for a commented starting point.
 
 For the full configuration reference, see [docs/configuration.md](docs/configuration.md).
 
 ### Environment Variables
 
-- `SYMVAULT_VAULT` — Path to vault directory (default: `~/.symvault`)
+- `SYMVAULT_VAULT` — Path to vault directory (default: `$XDG_DATA_HOME/symaira-vault`, i.e. `~/.local/share/symaira-vault`; legacy installs use `~/.symvault`)
 
 ### Vault Structure
 
 ```
-~/.symvault/
+~/.local/share/symaira-vault/   # XDG data dir (legacy installs: ~/.symvault/)
 ├── identity.age      # Encrypted age identity
 ├── config.yaml       # Vault configuration
 ├── mcp-token         # Bearer token for HTTP MCP

--- a/cmd/mcp/serve.go
+++ b/cmd/mcp/serve.go
@@ -1,9 +1,12 @@
 package mcp
 
 import (
+	"fmt"
 	"os/signal"
+	"path/filepath"
 
 	cli "github.com/danieljustus/symaira-vault/internal/cli"
+	"github.com/danieljustus/symaira-vault/internal/config"
 
 	"github.com/spf13/cobra"
 )
@@ -11,15 +14,26 @@ import (
 var ServeSignalNotify = signal.Notify
 var Version = "dev"
 
+// serveLongDescription builds the serve help text, deriving the advertised
+// config location from the same resolver the binary uses so help and behavior
+// cannot drift. New installs use the XDG default; existing installs may still
+// read from the legacy ~/.symvault directory.
+func serveLongDescription() string {
+	return fmt.Sprintf(`Start an MCP server that exposes vault operations to AI agents.
+
+Each agent must be configured in the agents section of the config file
+(default: %s; existing installs may use the legacy
+~/%s/config.yaml) with specific permissions and scope restrictions.
+
+The server can run in HTTP mode or stdio mode.`,
+		filepath.Join(config.DefaultConfigDir(), "config.yaml"),
+		config.LegacyVaultSubdir)
+}
+
 var ServeCmd = &cobra.Command{
 	Use:   "serve",
 	Short: "Start MCP server for agent access",
-	Long: `Start an MCP server that exposes vault operations to AI agents.
-
-Each agent must be configured in ~/.symvault/config.yaml with specific
-permissions and scope restrictions.
-
-The server can run in HTTP mode or stdio mode.`,
+	Long:  serveLongDescription(),
 	Example: `  # HTTP mode bound to localhost:8080
   symvault serve --bind 127.0.0.1 --port 8080
 

--- a/cmd/mcp/serve_help_test.go
+++ b/cmd/mcp/serve_help_test.go
@@ -1,0 +1,32 @@
+package mcp
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/danieljustus/symaira-vault/internal/config"
+)
+
+// TestServeLongDescription_AdvertisesResolvedConfigPath guards against the
+// serve help text drifting away from the actual path resolver. New installs
+// resolve to the XDG config directory, so the advertised default must be the
+// resolver-derived path, with the legacy location clearly marked as a fallback.
+func TestServeLongDescription_AdvertisesResolvedConfigPath(t *testing.T) {
+	long := serveLongDescription()
+
+	wantDefault := filepath.Join(config.DefaultConfigDir(), "config.yaml")
+	if !strings.Contains(long, wantDefault) {
+		t.Errorf("serve help does not advertise the resolved default config path %q; got:\n%s", wantDefault, long)
+	}
+
+	if !strings.Contains(long, config.LegacyVaultSubdir) {
+		t.Errorf("serve help does not mention the legacy %q fallback; got:\n%s", config.LegacyVaultSubdir, long)
+	}
+
+	// The legacy path may appear, but only when marked as legacy — it must not
+	// be presented as the default.
+	if strings.Contains(long, "~/"+config.LegacyVaultSubdir) && !strings.Contains(long, "legacy") {
+		t.Errorf("serve help advertises the legacy path without marking it legacy:\n%s", long)
+	}
+}

--- a/cmd/policy.go
+++ b/cmd/policy.go
@@ -4,12 +4,40 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
 
 	cli "github.com/danieljustus/symaira-vault/internal/cli"
+	"github.com/danieljustus/symaira-vault/internal/fsutil"
 	"github.com/danieljustus/symaira-vault/internal/policy"
 )
+
+// safePolicyPath validates name as a bare policy file name and returns its
+// absolute path inside policiesDir. It rejects path separators, parent
+// traversal and any extension other than .yaml/.yml, and verifies the cleaned
+// result stays directly within policiesDir, so an argument such as
+// "../identity.age" cannot escape the policies directory and delete or
+// overwrite another vault file.
+func safePolicyPath(policiesDir, name string) (string, error) {
+	if name == "" || name != filepath.Base(name) || name == "." || name == ".." {
+		return "", fmt.Errorf("policy name %q must be a bare file name without path separators", name)
+	}
+	if err := fsutil.ValidatePath(name); err != nil {
+		return "", fmt.Errorf("invalid policy name %q: %w", name, err)
+	}
+	switch strings.ToLower(filepath.Ext(name)) {
+	case ".yaml", ".yml":
+	default:
+		return "", fmt.Errorf("policy name %q must end in .yaml or .yml", name)
+	}
+	dir := filepath.Clean(policiesDir)
+	dest := filepath.Join(dir, name)
+	if filepath.Dir(dest) != dir {
+		return "", fmt.Errorf("policy name %q escapes the policies directory", name)
+	}
+	return dest, nil
+}
 
 var policyValidateCmd = &cobra.Command{
 	Use:   "validate <file>",
@@ -72,8 +100,8 @@ prompted, or require biometric authentication.`,
   # List active policies
   symvault policy list
 
-  # Remove a named policy
-  symvault policy remove dev-readonly`,
+  # Remove a named policy (use the file name shown by 'policy list')
+  symvault policy remove dev.yaml`,
 	Annotations: map[string]string{
 		requiresVaultAnnotation: "false",
 	},
@@ -108,16 +136,22 @@ Example:
 
 		vaultDir, _ := cli.VaultPath()
 		policiesDir := filepath.Join(vaultDir, "policies")
-		_ = os.MkdirAll(policiesDir, 0750)
 
-		destPath := filepath.Join(policiesDir, filepath.Base(sourcePath))
-		data, err := os.ReadFile(sourcePath) //#nosec G304 -- sourcePath is validated by caller
+		destPath, err := safePolicyPath(policiesDir, filepath.Base(sourcePath))
+		if err != nil {
+			return err
+		}
+
+		if err := fsutil.SafeMkdirAll(policiesDir, 0750); err != nil {
+			return fmt.Errorf("create policies directory: %w", err)
+		}
+
+		data, err := os.ReadFile(sourcePath) //#nosec G304 -- sourcePath is validated by LoadPolicy above
 		if err != nil {
 			return fmt.Errorf("read policy file: %w", err)
 		}
 
-		// #nosec G306 -- 0640 is intentional for policy files within vault
-		if err := os.WriteFile(destPath, data, 0640); err != nil {
+		if err := fsutil.SafeWriteFile(destPath, data, 0640); err != nil {
 			return fmt.Errorf("write policy file: %w", err)
 		}
 
@@ -172,13 +206,17 @@ var policyRemoveCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		vaultDir, _ := cli.VaultPath()
 		policiesDir := filepath.Join(vaultDir, "policies")
-		policyPath := filepath.Join(policiesDir, args[0])
 
-		if _, err := os.Stat(policyPath); os.IsNotExist(err) {
+		policyPath, err := safePolicyPath(policiesDir, args[0])
+		if err != nil {
+			return err
+		}
+
+		if _, statErr := os.Stat(policyPath); os.IsNotExist(statErr) {
 			return fmt.Errorf("policy %q not found", args[0])
 		}
 
-		if err := os.Remove(policyPath); err != nil {
+		if err := fsutil.SafeRemove(policyPath); err != nil {
 			return fmt.Errorf("remove policy: %w", err)
 		}
 

--- a/cmd/policy.go
+++ b/cmd/policy.go
@@ -88,7 +88,9 @@ var policyCmd = &cobra.Command{
 	Short: "Manage declarative policies",
 	Long: `Manage context-aware auto-approval policies for MCP tool calls.
 
-Policies are YAML files stored in ~/.config/symvault/policies/.
+Policies are YAML files stored in the vault's "policies" directory
+(<vault>/policies). The MCP server loads policies from this same location,
+so a policy applied with "policy apply" is enforced by the server.
 They define rules for when tool calls should be allowed, denied,
 prompted, or require biometric authentication.`,
 	Example: `  # Validate a policy file before activating it
@@ -135,7 +137,7 @@ Example:
 		}
 
 		vaultDir, _ := cli.VaultPath()
-		policiesDir := filepath.Join(vaultDir, "policies")
+		policiesDir := policy.VaultPolicyDir(vaultDir)
 
 		destPath, err := safePolicyPath(policiesDir, filepath.Base(sourcePath))
 		if err != nil {
@@ -169,7 +171,7 @@ var policyListCmd = &cobra.Command{
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		vaultDir, _ := cli.VaultPath()
-		policiesDir := filepath.Join(vaultDir, "policies")
+		policiesDir := policy.VaultPolicyDir(vaultDir)
 
 		entries, err := os.ReadDir(policiesDir)
 		if err != nil {
@@ -205,7 +207,7 @@ var policyRemoveCmd = &cobra.Command{
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		vaultDir, _ := cli.VaultPath()
-		policiesDir := filepath.Join(vaultDir, "policies")
+		policiesDir := policy.VaultPolicyDir(vaultDir)
 
 		policyPath, err := safePolicyPath(policiesDir, args[0])
 		if err != nil {

--- a/cmd/policy.go
+++ b/cmd/policy.go
@@ -144,8 +144,8 @@ Example:
 			return err
 		}
 
-		if err := fsutil.SafeMkdirAll(policiesDir, 0750); err != nil {
-			return fmt.Errorf("create policies directory: %w", err)
+		if mkdirErr := fsutil.SafeMkdirAll(policiesDir, 0750); mkdirErr != nil {
+			return fmt.Errorf("create policies directory: %w", mkdirErr)
 		}
 
 		data, err := os.ReadFile(sourcePath) //#nosec G304 -- sourcePath is validated by LoadPolicy above
@@ -153,8 +153,8 @@ Example:
 			return fmt.Errorf("read policy file: %w", err)
 		}
 
-		if err := fsutil.SafeWriteFile(destPath, data, 0640); err != nil {
-			return fmt.Errorf("write policy file: %w", err)
+		if writeErr := fsutil.SafeWriteFile(destPath, data, 0640); writeErr != nil {
+			return fmt.Errorf("write policy file: %w", writeErr)
 		}
 
 		cmd.Printf("✅ Policy %q applied (%d rules)\n", p.Version, len(p.Rules))

--- a/cmd/policy_test.go
+++ b/cmd/policy_test.go
@@ -68,3 +68,159 @@ rules:
 		t.Fatal("Execute() expected error, got nil")
 	}
 }
+
+func TestSafePolicyPath(t *testing.T) {
+	dir := filepath.Join("vault", "policies")
+	cases := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{"valid yaml", "dev.yaml", false},
+		{"valid yml", "dev.yml", false},
+		{"uppercase extension", "DEV.YAML", false},
+		{"parent traversal", "../identity.age", true},
+		{"nested traversal", "../../etc/passwd", true},
+		{"traversal to yaml", "../evil.yaml", true},
+		{"path separator", "sub/dev.yaml", true},
+		{"absolute path", "/etc/dev.yaml", true},
+		{"dot", ".", true},
+		{"dotdot", "..", true},
+		{"empty", "", true},
+		{"no extension", "dev", true},
+		{"wrong extension", "identity.age", true},
+		{"null byte", "dev\x00.yaml", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := safePolicyPath(dir, tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("safePolicyPath(%q) = %q, want error", tc.input, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("safePolicyPath(%q) unexpected error: %v", tc.input, err)
+			}
+			if filepath.Dir(got) != filepath.Clean(dir) {
+				t.Errorf("safePolicyPath(%q) = %q, escapes %q", tc.input, got, dir)
+			}
+		})
+	}
+}
+
+const testPolicyContent = `version: "1.0"
+description: "Test policy"
+rules:
+  - name: "allow test"
+    priority: 100
+    conditions:
+      agent_id: "*"
+    action: "allow"
+`
+
+func TestPolicyRemoveCmd_RejectsTraversal(t *testing.T) {
+	resetVaultState(t)
+	vaultDir := t.TempDir()
+	restore := setupVaultFlag(t, vaultDir)
+	defer restore()
+
+	// A sensitive sibling file that "../identity.age" would target.
+	sentinel := filepath.Join(vaultDir, "identity.age")
+	if err := os.WriteFile(sentinel, []byte("secret"), 0o600); err != nil {
+		t.Fatalf("write sentinel: %v", err)
+	}
+
+	var out strings.Builder
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"policy", "remove", "../identity.age"})
+	defer rootCmd.SetArgs(nil)
+
+	if err := rootCmd.Execute(); err == nil {
+		t.Fatal("policy remove with traversal name: expected error, got nil")
+	}
+	if _, err := os.Stat(sentinel); err != nil {
+		t.Fatalf("sentinel file was removed via traversal: %v", err)
+	}
+}
+
+func TestPolicyApplyCmd_RejectsSymlinkDest(t *testing.T) {
+	resetVaultState(t)
+	vaultDir := t.TempDir()
+	restore := setupVaultFlag(t, vaultDir)
+	defer restore()
+
+	policiesDir := filepath.Join(vaultDir, "policies")
+	if err := os.MkdirAll(policiesDir, 0o750); err != nil {
+		t.Fatalf("mkdir policies: %v", err)
+	}
+
+	// Plant a symlink where the applied file would land, pointing at an
+	// outside file. SafeWriteFile must refuse to follow it.
+	outside := filepath.Join(t.TempDir(), "target.txt")
+	if err := os.WriteFile(outside, []byte("original"), 0o600); err != nil {
+		t.Fatalf("write outside: %v", err)
+	}
+	link := filepath.Join(policiesDir, "evil.yaml")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Skipf("symlinks unsupported on this platform: %v", err)
+	}
+
+	src := filepath.Join(t.TempDir(), "evil.yaml")
+	if err := os.WriteFile(src, []byte(testPolicyContent), 0o600); err != nil {
+		t.Fatalf("write source policy: %v", err)
+	}
+
+	var out strings.Builder
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"policy", "apply", src})
+	defer rootCmd.SetArgs(nil)
+
+	if err := rootCmd.Execute(); err == nil {
+		t.Fatal("policy apply over a symlink: expected error, got nil")
+	}
+	data, err := os.ReadFile(outside)
+	if err != nil {
+		t.Fatalf("read outside target: %v", err)
+	}
+	if string(data) != "original" {
+		t.Fatalf("symlink target was overwritten through the policy directory: %q", data)
+	}
+}
+
+func TestPolicyApplyRemoveCmd_RoundTrip(t *testing.T) {
+	resetVaultState(t)
+	vaultDir := t.TempDir()
+	restore := setupVaultFlag(t, vaultDir)
+	defer restore()
+
+	src := filepath.Join(t.TempDir(), "dev.yaml")
+	if err := os.WriteFile(src, []byte(testPolicyContent), 0o600); err != nil {
+		t.Fatalf("write source policy: %v", err)
+	}
+
+	var out strings.Builder
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"policy", "apply", src})
+	defer rootCmd.SetArgs(nil)
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("policy apply: %v", err)
+	}
+
+	applied := filepath.Join(vaultDir, "policies", "dev.yaml")
+	if _, err := os.Stat(applied); err != nil {
+		t.Fatalf("applied policy missing: %v", err)
+	}
+
+	rootCmd.SetArgs([]string{"policy", "remove", "dev.yaml"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("policy remove: %v", err)
+	}
+	if _, err := os.Stat(applied); !os.IsNotExist(err) {
+		t.Fatalf("policy file still present after remove: %v", err)
+	}
+}

--- a/internal/mcp/auth/auth.go
+++ b/internal/mcp/auth/auth.go
@@ -23,8 +23,7 @@ type contextKey string
 
 const agentContextKey contextKey = "symaira-agent"
 
-//nolint:gosec // context key identifier, not a credential
-const tokenContextKey contextKey = "symvault-scoped-token"
+const tokenContextKey contextKey = "symvault-scoped-token" // #nosec G101 -- context key identifier, not a credential
 
 func WithToken(ctx context.Context, token *ScopedToken) context.Context {
 	return context.WithValue(ctx, tokenContextKey, token)

--- a/internal/mcp/auth/token.go
+++ b/internal/mcp/auth/token.go
@@ -216,10 +216,11 @@ func (r *TokenRegistry) Load() error {
 
 	if r.identity != nil {
 		encryptedPath := TokenRegistryEncryptedFilePath(filepath.Dir(r.path))
-		if data, err := os.ReadFile(encryptedPath); err == nil { // #nosec G304
-			plaintext, err := crypto.Decrypt(data, r.identity)
-			if err != nil {
-				return fmt.Errorf("decrypt token registry: %w", err)
+		data, err := os.ReadFile(encryptedPath) // #nosec G304 -- path derived from the validated token registry directory
+		if err == nil {
+			plaintext, decErr := crypto.Decrypt(data, r.identity)
+			if decErr != nil {
+				return fmt.Errorf("decrypt token registry: %w", decErr)
 			}
 			defer crypto.Wipe(plaintext)
 			return r.unmarshalEntries(plaintext)

--- a/internal/mcp/errors/codes.go
+++ b/internal/mcp/errors/codes.go
@@ -35,7 +35,7 @@ const (
 	ErrFieldNotFound         = "ERR_FIELD_NOT_FOUND"
 	ErrFieldRedacted         = "ERR_FIELD_REDACTED"
 	ErrQuotaExceeded         = "ERR_QUOTA_EXCEEDED"
-	ErrTokenExpired          = "ERR_TOKEN_EXPIRED"
+	ErrTokenExpired          = "ERR_TOKEN_EXPIRED" // #nosec G101 -- MCP error code identifier, not a credential
 	ErrInvalidInput          = "ERR_INVALID_INPUT"
 	ErrDryRun                = "ERR_DRY_RUN"
 	ErrTierUpgradeNoTTY      = "ERR_TIER_UPGRADE_NO_TTY"

--- a/internal/mcp/server/server.go
+++ b/internal/mcp/server/server.go
@@ -146,13 +146,25 @@ func New(v *vault.Vault, agentName string, transport string) (*Server, error) {
 		return nil, err
 	}
 
-	// Load policy engine
-	policyDir := policy.DefaultPolicyDir()
+	// Load the policy engine from the vault's policy directory — the same
+	// location the CLI writes to via "policy apply" — so applied policies are
+	// actually enforced here.
+	policyDir := policy.VaultPolicyDir(v.Dir)
 	var policyEngine *policy.Engine
 	if policyDir != "" {
 		policies, loadErr := policy.LoadPoliciesFromDir(policyDir)
 		if loadErr == nil && len(policies) > 0 {
 			policyEngine = policy.NewEngine(policies)
+		}
+	}
+
+	// Detect policies left in the legacy, vault-independent location and warn
+	// that they are no longer loaded; they must be re-applied with
+	// "symvault policy apply" so they live under the vault.
+	if legacyDir := policy.DefaultPolicyDir(); legacyDir != "" && legacyDir != policyDir {
+		if legacyPolicies, err := policy.LoadPoliciesFromDir(legacyDir); err == nil && len(legacyPolicies) > 0 {
+			slog.Default().Warn("ignoring policies in legacy location; re-apply them with 'symvault policy apply'",
+				"legacy_dir", legacyDir, "active_dir", policyDir)
 		}
 	}
 

--- a/internal/mcp/server/server.go
+++ b/internal/mcp/server/server.go
@@ -162,7 +162,8 @@ func New(v *vault.Vault, agentName string, transport string) (*Server, error) {
 	// that they are no longer loaded; they must be re-applied with
 	// "symvault policy apply" so they live under the vault.
 	if legacyDir := policy.DefaultPolicyDir(); legacyDir != "" && legacyDir != policyDir {
-		if legacyPolicies, err := policy.LoadPoliciesFromDir(legacyDir); err == nil && len(legacyPolicies) > 0 {
+		legacyPolicies, legacyErr := policy.LoadPoliciesFromDir(legacyDir)
+		if legacyErr == nil && len(legacyPolicies) > 0 {
 			slog.Default().Warn("ignoring policies in legacy location; re-apply them with 'symvault policy apply'",
 				"legacy_dir", legacyDir, "active_dir", policyDir)
 		}

--- a/internal/mcp/server/server_test.go
+++ b/internal/mcp/server/server_test.go
@@ -105,6 +105,75 @@ func TestNew_LoadConfig(t *testing.T) {
 	_ = srv.Close()
 }
 
+// TestNew_LoadsPolicyFromVaultDir is the server half of the end-to-end proof
+// that an applied policy changes MCP authorization: the CLI's "policy apply"
+// writes into policy.VaultPolicyDir(vault) (covered by the cmd round-trip
+// test), and here New() loads and enforces a policy from that same directory.
+func TestNew_LoadsPolicyFromVaultDir(t *testing.T) {
+	dir := t.TempDir()
+	identity, err := age.GenerateX25519Identity()
+	if err != nil {
+		t.Fatalf("generate identity: %v", err)
+	}
+	cfg := &config.Config{
+		DefaultAgent: "test",
+		Agents: map[string]config.AgentProfile{
+			"test": {
+				Name:         "test",
+				AllowedPaths: []string{"*"},
+				CanWrite:     config.BoolPtr(true),
+				ApprovalMode: config.StrPtr("none"),
+			},
+		},
+	}
+	v := &vault.Vault{Dir: dir, Identity: identity, Config: cfg}
+
+	// Before any policy is applied, the server loads no policy engine and
+	// applies no policy-level restriction.
+	srv, err := New(v, "test", "stdio")
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	if srv.policyEngine != nil {
+		t.Fatal("policyEngine is non-nil before any policy is applied")
+	}
+	if err := srv.checkPolicy(context.Background(), "secret/path", "read"); err != nil {
+		t.Fatalf("checkPolicy without a policy should pass, got %v", err)
+	}
+	_ = srv.Close()
+
+	// Apply a deny-all policy into the vault's policy directory — the same
+	// location the CLI's "policy apply" writes to.
+	policiesDir := policy.VaultPolicyDir(dir)
+	if err := os.MkdirAll(policiesDir, 0o750); err != nil {
+		t.Fatalf("mkdir policies: %v", err)
+	}
+	denyPolicy := `version: "1.0"
+rules:
+  - name: "deny all"
+    priority: 100
+    conditions:
+      agent_id: "test"
+    action: "deny"
+`
+	if err := os.WriteFile(filepath.Join(policiesDir, "deny.yaml"), []byte(denyPolicy), 0o600); err != nil {
+		t.Fatalf("write policy: %v", err)
+	}
+
+	// A new server now loads and enforces the applied policy.
+	srv2, err := New(v, "test", "stdio")
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	defer func() { _ = srv2.Close() }()
+	if srv2.policyEngine == nil {
+		t.Fatal("policyEngine is nil after a policy was applied to the vault dir")
+	}
+	if err := srv2.checkPolicy(context.Background(), "secret/path", "read"); err == nil {
+		t.Fatal("applied deny policy was not enforced by the MCP server")
+	}
+}
+
 func TestNew_EmptyAgentName(t *testing.T) {
 	dir := t.TempDir()
 	identity, err := age.GenerateX25519Identity()

--- a/internal/policy/parser.go
+++ b/internal/policy/parser.go
@@ -56,7 +56,22 @@ func LoadPoliciesFromDir(dir string) ([]*Policy, error) {
 	return policies, nil
 }
 
-// DefaultPolicyDir returns the default directory for policy files.
+// VaultPolicyDir returns the authoritative directory for a vault's policy
+// files: the "policies" subdirectory of the vault data directory. Both the CLI
+// (policy apply/list/remove) and the MCP server resolve the policy location
+// through this function, so a policy written by "policy apply" is the same one
+// the server loads and enforces.
+func VaultPolicyDir(vaultDir string) string {
+	if vaultDir == "" {
+		return ""
+	}
+	return filepath.Join(vaultDir, "policies")
+}
+
+// DefaultPolicyDir returns the legacy, vault-independent policy directory
+// (~/.config/symaira/policies) used by older versions that loaded policies from
+// a fixed path. It is retained only so the server can detect and warn about
+// policies left in the old location; new code must use VaultPolicyDir.
 func DefaultPolicyDir() string {
 	home, err := os.UserHomeDir()
 	if err != nil || home == "" {

--- a/internal/update/extract.go
+++ b/internal/update/extract.go
@@ -11,7 +11,6 @@ import (
 	"math"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/danieljustus/symaira-vault/internal/fsutil"
 )
@@ -30,24 +29,17 @@ var (
 // decompression bomb attacks (G110).
 const maxExtractSize = 100 * 1024 * 1024 // 100 MB
 
-// safeArchivePath validates that entryPath does not escape destDir. It checks
-// for parent-directory traversal segments and verifies that the cleaned,
-// resolved path is a child of destDir.
-func safeArchivePath(destDir, entryPath string) (string, error) {
-	if fsutil.HasTraversal(entryPath) {
-		return "", fmt.Errorf("%w: %q", ErrPathTraversal, entryPath)
+// validateArchiveEntryName rejects archive entry names that reference an
+// absolute path or contain a parent-directory traversal segment before they
+// ever reach a filesystem call. Containment is additionally enforced at the
+// syscall level by os.Root in ExtractTarGz/ExtractZip, which refuses any
+// access that would escape the destination directory even if this check were
+// bypassed (e.g. via a symlinked path component).
+func validateArchiveEntryName(entryPath string) error {
+	if entryPath == "" || filepath.IsAbs(entryPath) || fsutil.HasTraversal(entryPath) {
+		return fmt.Errorf("%w: %q", ErrPathTraversal, entryPath)
 	}
-
-	cleanDest := filepath.Clean(destDir)
-	fullPath := filepath.Clean(filepath.Join(cleanDest, entryPath))
-
-	// Ensure the resolved path is within destDir (or is destDir itself for
-	// the root directory entry).
-	if !strings.HasPrefix(fullPath, cleanDest+string(filepath.Separator)) && fullPath != cleanDest {
-		return "", fmt.Errorf("%w: %q resolves outside %q", ErrPathTraversal, entryPath, destDir)
-	}
-
-	return fullPath, nil
+	return nil
 }
 
 // ExtractTarGz extracts a gzip-compressed tar archive to destDir and returns
@@ -60,8 +52,14 @@ func ExtractTarGz(data []byte, destDir, expectedBinaryName string) (string, erro
 	}
 	defer func() { _ = gr.Close() }()
 
+	root, err := os.OpenRoot(destDir)
+	if err != nil {
+		return "", fmt.Errorf("open destination directory %q: %w", destDir, err)
+	}
+	defer func() { _ = root.Close() }()
+
 	tr := tar.NewReader(gr)
-	var binaryPath string
+	var binaryName string
 	var totalSize int64
 
 	for {
@@ -73,46 +71,46 @@ func ExtractTarGz(data []byte, destDir, expectedBinaryName string) (string, erro
 			return "", fmt.Errorf("read tar header: %w", err)
 		}
 
-		safePath, err := safeArchivePath(destDir, header.Name)
-		if err != nil {
+		if err := validateArchiveEntryName(header.Name); err != nil {
 			return "", err
 		}
+		name := filepath.Clean(filepath.ToSlash(header.Name))
 
 		switch header.Typeflag {
 		case tar.TypeDir:
-			if err := os.MkdirAll(safePath, 0o750); err != nil {
-				return "", fmt.Errorf("create directory %q: %w", safePath, err)
+			if err := root.MkdirAll(name, 0o750); err != nil {
+				return "", fmt.Errorf("create directory %q: %w", name, err)
 			}
 
 		case tar.TypeReg:
-			if err := os.MkdirAll(filepath.Dir(safePath), 0o750); err != nil {
-				return "", fmt.Errorf("create parent dir for %q: %w", safePath, err)
+			if err := root.MkdirAll(filepath.Dir(name), 0o750); err != nil {
+				return "", fmt.Errorf("create parent dir for %q: %w", name, err)
 			}
 
 			var mode os.FileMode
 			if header.Mode < 0 || header.Mode > math.MaxUint32 {
 				mode = 0o600
 			} else {
-				mode = os.FileMode(header.Mode)
+				mode = os.FileMode(header.Mode).Perm()
 			}
 
-			f, err := os.OpenFile(filepath.Clean(safePath), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode) // #nosec G304 -- safePath is validated by safeArchivePath() against path traversal
+			f, err := root.OpenFile(name, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
 			if err != nil {
-				return "", fmt.Errorf("create file %q: %w", safePath, err)
+				return "", fmt.Errorf("create file %q: %w", name, err)
 			}
 
 			n, err := io.Copy(f, io.LimitReader(tr, maxExtractSize-totalSize))
 			totalSize += n
 			_ = f.Close()
 			if err != nil {
-				return "", fmt.Errorf("write file %q: %w", safePath, err)
+				return "", fmt.Errorf("write file %q: %w", name, err)
 			}
 			if totalSize >= maxExtractSize {
 				return "", fmt.Errorf("archive exceeds maximum extraction size of %d bytes", maxExtractSize)
 			}
 
-			if filepath.Base(header.Name) == expectedBinaryName {
-				binaryPath = safePath
+			if filepath.Base(name) == expectedBinaryName {
+				binaryName = name
 			}
 
 		default:
@@ -121,11 +119,11 @@ func ExtractTarGz(data []byte, destDir, expectedBinaryName string) (string, erro
 		}
 	}
 
-	if binaryPath == "" {
+	if binaryName == "" {
 		return "", fmt.Errorf("%w: %s", ErrBinaryNotFound, expectedBinaryName)
 	}
 
-	return binaryPath, nil
+	return filepath.Join(destDir, binaryName), nil
 }
 
 // ExtractZip extracts a zip archive to destDir and returns the path to the
@@ -137,24 +135,30 @@ func ExtractZip(data []byte, destDir, expectedBinaryName string) (string, error)
 		return "", fmt.Errorf("open zip archive: %w", err)
 	}
 
-	var binaryPath string
+	root, err := os.OpenRoot(destDir)
+	if err != nil {
+		return "", fmt.Errorf("open destination directory %q: %w", destDir, err)
+	}
+	defer func() { _ = root.Close() }()
+
+	var binaryName string
 	var totalSize int64
 
 	for _, f := range zr.File {
-		safePath, err := safeArchivePath(destDir, f.Name)
-		if err != nil {
+		if err := validateArchiveEntryName(f.Name); err != nil {
 			return "", err
 		}
+		name := filepath.Clean(filepath.ToSlash(f.Name))
 
 		if f.FileInfo().IsDir() {
-			if mkdirErr := os.MkdirAll(safePath, 0o750); mkdirErr != nil {
-				return "", fmt.Errorf("create directory %q: %w", safePath, mkdirErr)
+			if mkdirErr := root.MkdirAll(name, 0o750); mkdirErr != nil {
+				return "", fmt.Errorf("create directory %q: %w", name, mkdirErr)
 			}
 			continue
 		}
 
-		if mkdirErr := os.MkdirAll(filepath.Dir(safePath), 0o750); mkdirErr != nil {
-			return "", fmt.Errorf("create parent dir for %q: %w", safePath, mkdirErr)
+		if mkdirErr := root.MkdirAll(filepath.Dir(name), 0o750); mkdirErr != nil {
+			return "", fmt.Errorf("create parent dir for %q: %w", name, mkdirErr)
 		}
 
 		rc, err := f.Open()
@@ -162,10 +166,10 @@ func ExtractZip(data []byte, destDir, expectedBinaryName string) (string, error)
 			return "", fmt.Errorf("open zip entry %q: %w", f.Name, err)
 		}
 
-		out, err := os.OpenFile(filepath.Clean(safePath), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, f.Mode())
+		out, err := root.OpenFile(name, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, f.Mode().Perm())
 		if err != nil {
 			_ = rc.Close()
-			return "", fmt.Errorf("create file %q: %w", safePath, err)
+			return "", fmt.Errorf("create file %q: %w", name, err)
 		}
 
 		n, err := io.Copy(out, io.LimitReader(rc, maxExtractSize-totalSize))
@@ -173,20 +177,20 @@ func ExtractZip(data []byte, destDir, expectedBinaryName string) (string, error)
 		_ = out.Close()
 		_ = rc.Close()
 		if err != nil {
-			return "", fmt.Errorf("write file %q: %w", safePath, err)
+			return "", fmt.Errorf("write file %q: %w", name, err)
 		}
 		if totalSize >= maxExtractSize {
 			return "", fmt.Errorf("archive exceeds maximum extraction size of %d bytes", maxExtractSize)
 		}
 
-		if filepath.Base(f.Name) == expectedBinaryName {
-			binaryPath = safePath
+		if filepath.Base(name) == expectedBinaryName {
+			binaryName = name
 		}
 	}
 
-	if binaryPath == "" {
+	if binaryName == "" {
 		return "", fmt.Errorf("%w: %s", ErrBinaryNotFound, expectedBinaryName)
 	}
 
-	return binaryPath, nil
+	return filepath.Join(destDir, binaryName), nil
 }

--- a/internal/update/extract.go
+++ b/internal/update/extract.go
@@ -96,8 +96,7 @@ func ExtractTarGz(data []byte, destDir, expectedBinaryName string) (string, erro
 				mode = os.FileMode(header.Mode)
 			}
 
-			//nolint:gosec G304 — safePath is validated by safeArchivePath() against path traversal.
-			f, err := os.OpenFile(filepath.Clean(safePath), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
+			f, err := os.OpenFile(filepath.Clean(safePath), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode) // #nosec G304 -- safePath is validated by safeArchivePath() against path traversal
 			if err != nil {
 				return "", fmt.Errorf("create file %q: %w", safePath, err)
 			}

--- a/internal/update/extract.go
+++ b/internal/update/extract.go
@@ -11,6 +11,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/danieljustus/symaira-vault/internal/fsutil"
 )
@@ -36,7 +37,11 @@ const maxExtractSize = 100 * 1024 * 1024 // 100 MB
 // access that would escape the destination directory even if this check were
 // bypassed (e.g. via a symlinked path component).
 func validateArchiveEntryName(entryPath string) error {
-	if entryPath == "" || filepath.IsAbs(entryPath) || fsutil.HasTraversal(entryPath) {
+	// Archive entries use POSIX-style forward slashes regardless of the host
+	// OS, so a leading slash means "rooted" even on Windows, where
+	// filepath.IsAbs requires a drive letter and would otherwise miss it.
+	if entryPath == "" || filepath.IsAbs(entryPath) ||
+		strings.HasPrefix(filepath.ToSlash(entryPath), "/") || fsutil.HasTraversal(entryPath) {
 		return fmt.Errorf("%w: %q", ErrPathTraversal, entryPath)
 	}
 	return nil

--- a/internal/update/extract_test.go
+++ b/internal/update/extract_test.go
@@ -221,21 +221,21 @@ func TestExtractZip_EmptyArchive(t *testing.T) {
 	}
 }
 
-func TestSafeArchivePath_RejectsTraversal(t *testing.T) {
-	_, err := safeArchivePath("/tmp/dest", "../etc/passwd")
-	if err == nil {
+func TestValidateArchiveEntryName_RejectsTraversal(t *testing.T) {
+	if err := validateArchiveEntryName("../etc/passwd"); err == nil {
 		t.Fatal("expected path traversal error")
 	}
 }
 
-func TestSafeArchivePath_AcceptsNestedPath(t *testing.T) {
-	path, err := safeArchivePath("/tmp/dest", "subdir/file.txt")
-	if err != nil {
-		t.Fatalf("safeArchivePath() error = %v", err)
+func TestValidateArchiveEntryName_RejectsAbsolute(t *testing.T) {
+	if err := validateArchiveEntryName("/etc/passwd"); err == nil {
+		t.Fatal("expected path traversal error for absolute path")
 	}
-	expected := filepath.Join("/tmp/dest", "subdir/file.txt")
-	if path != expected {
-		t.Fatalf("got %q, want %q", path, expected)
+}
+
+func TestValidateArchiveEntryName_AcceptsNestedPath(t *testing.T) {
+	if err := validateArchiveEntryName("subdir/file.txt"); err != nil {
+		t.Fatalf("validateArchiveEntryName() error = %v", err)
 	}
 }
 

--- a/internal/update/replace.go
+++ b/internal/update/replace.go
@@ -68,8 +68,7 @@ func rollback(backupPath, binaryPath string) error {
 		perm = fi.Mode().Perm()
 	}
 
-	//nolint:gosec G304 — binaryPath is the current executable path, validated by caller.
-	dst, err := os.OpenFile(filepath.Clean(binaryPath), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm)
+	dst, err := os.OpenFile(filepath.Clean(binaryPath), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm) // #nosec G304 -- binaryPath is the current executable path, validated by caller
 	if err != nil {
 		return fmt.Errorf("rollback: create %q: %w", binaryPath, err)
 	}

--- a/internal/vault/search.go
+++ b/internal/vault/search.go
@@ -802,8 +802,12 @@ func filterPathsUsingIndex(vaultDir string, candidates []string, needle string, 
 		return candidates
 	}
 
-	if !globalIndex.IsBuilt() {
-		if err := globalIndex.loadFromDisk(vaultDir, identity); err != nil || !globalIndex.IsBuilt() {
+	// Build or load the index only when the shared slot does not already cover
+	// this exact vault directory and identity. Covers (rather than IsBuilt)
+	// ensures a second vault opened with the same identity does not reuse the
+	// first vault's index.
+	if !globalIndex.Covers(vaultDir, identity) {
+		if err := globalIndex.loadFromDisk(vaultDir, identity); err != nil || !globalIndex.Covers(vaultDir, identity) {
 			if err := globalIndex.Build(vaultDir, identity); err != nil {
 				return candidates
 			}
@@ -812,8 +816,9 @@ func filterPathsUsingIndex(vaultDir string, candidates []string, needle string, 
 
 	matching, err := globalIndex.MatchEntries(vaultDir, identity, candidates, needle)
 	if err != nil {
-		// Index stale, rebuild and retry once
-		globalIndex.Invalidate()
+		// The slot now holds a different vault, or the index is stale: rebuild
+		// for this vault and retry once. Build overwrites the in-memory slot and
+		// rewrites this vault's on-disk index without deleting another vault's.
 		if buildErr := globalIndex.Build(vaultDir, identity); buildErr != nil {
 			return candidates
 		}

--- a/internal/vault/search_index.go
+++ b/internal/vault/search_index.go
@@ -57,6 +57,17 @@ func indexFilePath(vaultDir string) string {
 	return filepath.Join(vaultDir, ".search-index")
 }
 
+// canonicalVaultDir returns a canonical form of vaultDir for index-ownership
+// comparison. It resolves symlinks when possible and otherwise falls back to a
+// lexical clean, so two references to the same vault compare equal while two
+// distinct vaults stay distinct.
+func canonicalVaultDir(vaultDir string) string {
+	if resolved, err := filepath.EvalSymlinks(vaultDir); err == nil {
+		return resolved
+	}
+	return filepath.Clean(vaultDir)
+}
+
 // indexDoc stores raw string values per entry path for substring matching.
 // The needle is matched as a substring (case-insensitive) against all stored
 // values when performing a search.
@@ -373,6 +384,7 @@ func (idx *EncryptedIndex) MatchEntries(vaultDir string, identity *age.X25519Ide
 	ct := idx.ciphertext
 	idHash := idx.idHash
 	storedSalt := idx.salt
+	storedDir := idx.vaultDir
 	idx.mu.RUnlock()
 
 	if ct == nil {
@@ -382,6 +394,13 @@ func (idx *EncryptedIndex) MatchEntries(vaultDir string, identity *age.X25519Ide
 	currentHash := sha256.Sum256([]byte(identity.String()))
 	if currentHash != idHash {
 		return nil, errors.New("identity changed")
+	}
+	// The index is a single shared slot. Reject a lookup against a different
+	// vault directory even when the identity matches — otherwise a second vault
+	// opened with the same identity would filter its candidates against the
+	// first vault's index and return incomplete or incorrect results.
+	if canonicalVaultDir(storedDir) != canonicalVaultDir(vaultDir) {
+		return nil, errors.New("vault directory changed")
 	}
 
 	key := deriveIndexKey(identity, storedSalt)
@@ -440,6 +459,24 @@ func (idx *EncryptedIndex) IsBuilt() bool {
 	built := idx.ciphertext != nil
 	idx.mu.RUnlock()
 	return built
+}
+
+// Covers reports whether the built index belongs to the given vault directory
+// and identity. A different vault directory (even with the same identity) or a
+// different identity means the index must be rebuilt before it can be used for
+// this vault's lookups.
+func (idx *EncryptedIndex) Covers(vaultDir string, identity *age.X25519Identity) bool {
+	if identity == nil {
+		return false
+	}
+	idHash := sha256.Sum256([]byte(identity.String()))
+	want := canonicalVaultDir(vaultDir)
+
+	idx.mu.RLock()
+	defer idx.mu.RUnlock()
+	return idx.ciphertext != nil &&
+		idx.idHash == idHash &&
+		canonicalVaultDir(idx.vaultDir) == want
 }
 
 // Invalidate clears the encrypted index from memory and deletes the on-disk

--- a/internal/vault/search_index_test.go
+++ b/internal/vault/search_index_test.go
@@ -16,6 +16,75 @@ import (
 	"github.com/danieljustus/symaira-vault/internal/testutil"
 )
 
+// TestFilterPathsUsingIndex_SameIdentityDifferentVaults guards against the
+// shared global index leaking one vault's contents into another vault's search
+// results when both are opened with the same identity.
+func TestFilterPathsUsingIndex_SameIdentityDifferentVaults(t *testing.T) {
+	identity := testutil.TempIdentity(t)
+
+	// Reset the shared global slot and restore it afterwards so this test is
+	// isolated from the rest of the package.
+	globalIndex.Invalidate()
+	t.Cleanup(globalIndex.Invalidate)
+
+	vaultA := t.TempDir()
+	mustWriteEntry(t, vaultA, identity, "alpha", map[string]interface{}{"user": "alice-in-a"})
+
+	vaultB := t.TempDir()
+	mustWriteEntry(t, vaultB, identity, "beta", map[string]interface{}{"user": "bob-in-b"})
+
+	// Populate the slot with vault A's index.
+	aMatches := filterPathsUsingIndex(vaultA, []string{"alpha"}, "alice-in-a", identity)
+	if len(aMatches) != 1 || aMatches[0] != "alpha" {
+		t.Fatalf("vault A search = %v, want [alpha]", aMatches)
+	}
+
+	// Searching vault B with the same identity must reflect vault B, not the
+	// index still resident from vault A. A value present only in vault B must be
+	// found (the bug returned an incomplete result from vault A's index).
+	bOwn := filterPathsUsingIndex(vaultB, []string{"beta"}, "bob-in-b", identity)
+	if len(bOwn) != 1 || bOwn[0] != "beta" {
+		t.Fatalf("vault B search for its own value = %v, want [beta]", bOwn)
+	}
+
+	// A value that exists only in vault A must not match within vault B.
+	bForeign := filterPathsUsingIndex(vaultB, []string{"beta"}, "alice-in-a", identity)
+	if len(bForeign) != 0 {
+		t.Fatalf("vault B matched a value that only exists in vault A: %v", bForeign)
+	}
+
+	// Switching back to vault A must still return correct results.
+	aAgain := filterPathsUsingIndex(vaultA, []string{"alpha"}, "alice-in-a", identity)
+	if len(aAgain) != 1 || aAgain[0] != "alpha" {
+		t.Fatalf("vault A re-search = %v, want [alpha]", aAgain)
+	}
+}
+
+// TestMatchEntries_RejectsDifferentVaultDir verifies the lookup-time guard:
+// an index built for one vault must refuse to answer lookups for another.
+func TestMatchEntries_RejectsDifferentVaultDir(t *testing.T) {
+	identity := testutil.TempIdentity(t)
+
+	vaultA := t.TempDir()
+	mustWriteEntry(t, vaultA, identity, "alpha", map[string]interface{}{"user": "alice"})
+
+	idx := &EncryptedIndex{}
+	if err := idx.Build(vaultA, identity); err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+
+	vaultB := t.TempDir()
+	if _, err := idx.MatchEntries(vaultB, identity, []string{"alpha"}, "alice"); err == nil {
+		t.Fatal("MatchEntries against a different vault dir: expected error, got nil")
+	}
+	if idx.Covers(vaultB, identity) {
+		t.Fatal("Covers reported true for a vault the index was not built for")
+	}
+	if !idx.Covers(vaultA, identity) {
+		t.Fatal("Covers reported false for the vault the index was built for")
+	}
+}
+
 func TestEncryptedIndexBuildAndMatch(t *testing.T) {
 	vaultDir := t.TempDir()
 	identity := testutil.TempIdentity(t)


### PR DESCRIPTION
Addresses a batch of security, correctness and developer-experience findings from a code review.

<!-- closes-list-start -->
- Closes #519 Make static analysis (gosec) a required CI and release gate
- Closes #520 Contain policy lifecycle file operations inside the policy directory
- Closes #521 Install policies where the MCP server actually loads them
- Closes #522 Align default-path help and onboarding with the XDG resolver
- Closes #523 Scope the encrypted search index by vault directory
<!-- closes-list-end -->

Release scope: v0.7.1

Each item is a separate commit. CI runs the full suite; gosec is now a blocking gate.
