### PR TITLE
fix(crypto): measure password strength by rune count, not byte length

### DIFF
--- a/internal/crypto/password.go
+++ b/internal/crypto/password.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"math/big"
 	"unicode"
+	"unicode/utf8"
 )
 
 // MaxPasswordLength is the upper bound for generated password length.
@@ -67,7 +68,12 @@ type PasswordStrength struct {
 func AssessPasswordStrength(password string) PasswordStrength {
 	var s PasswordStrength
 
-	if len(password) < 10 {
+	// Measure length in Unicode characters, not bytes. A multi-byte rune must
+	// count as a single character so that a short non-ASCII passphrase cannot
+	// satisfy the minimum-length requirement purely through its byte width.
+	runeCount := utf8.RuneCountInString(password)
+
+	if runeCount < 10 {
 		s.Weak = true
 		s.Message = "password too short: must be at least 10 characters"
 		return s
@@ -78,6 +84,11 @@ func AssessPasswordStrength(password string) PasswordStrength {
 	hasUpper := false
 	hasDigit := false
 	hasSymbol := false
+	// Distinct characters that fall outside the Latin classes (e.g. CJK or
+	// other scripts). Their alphabet size is unknown, so we credit only the
+	// distinct runes actually observed — a conservative lower bound — instead
+	// of assuming a full 256-symbol alphabet.
+	otherRunes := make(map[rune]struct{})
 
 	for _, r := range password {
 		switch {
@@ -89,6 +100,8 @@ func AssessPasswordStrength(password string) PasswordStrength {
 			hasDigit = true
 		case unicode.IsPunct(r), unicode.IsSymbol(r):
 			hasSymbol = true
+		default:
+			otherRunes[r] = struct{}{}
 		}
 	}
 
@@ -117,11 +130,14 @@ func AssessPasswordStrength(password string) PasswordStrength {
 	if hasSymbol {
 		charsetSize += 32
 	}
+	// Credit non-Latin characters by the number of distinct runes actually
+	// used, a conservative lower bound on their alphabet size.
+	charsetSize += len(otherRunes)
 	if charsetSize == 0 {
-		charsetSize = 256
+		charsetSize = 1
 	}
 
-	s.Entropy = float64(len(password)) * math.Log2(float64(charsetSize))
+	s.Entropy = float64(runeCount) * math.Log2(float64(charsetSize))
 	if s.Entropy < 60 {
 		s.Weak = true
 		s.Message = fmt.Sprintf("password too weak: estimated entropy %.1f bits, need at least 60 bits", s.Entropy)

--- a/internal/crypto/password_test.go
+++ b/internal/crypto/password_test.go
@@ -258,6 +258,37 @@ func TestAssessPasswordStrength_ExactBoundary(t *testing.T) {
 	}
 }
 
+func TestAssessPasswordStrength_ShortNonLatin(t *testing.T) {
+	// 5 CJK characters: only 5 runes despite 15 bytes. Must be reported as too
+	// short, not credited for its byte width.
+	s := AssessPasswordStrength("日本語テスト")
+	if !s.Weak {
+		t.Errorf("expected Weak=true for 5-character non-Latin password, got %q", s.Message)
+	}
+	if !strings.Contains(s.Message, "too short") {
+		t.Errorf("expected 'too short' message, got %q", s.Message)
+	}
+}
+
+func TestValidatePasswordStrength_ShortNonLatin(t *testing.T) {
+	if err := ValidatePasswordStrength("日本語テスト"); err == nil {
+		t.Error("expected error for 5-character non-Latin password, got nil")
+	}
+}
+
+func TestAssessPasswordStrength_WeakNonLatinLowEntropy(t *testing.T) {
+	// 10 runes drawn from only 5 distinct CJK characters. The old byte-length +
+	// 256-symbol-fallback estimate scored this ≈240 bits (strong); by rune count
+	// and observed-alphabet crediting it is ≈10*log2(5) ≈ 23 bits → weak.
+	s := AssessPasswordStrength("あいうえおあいうえお")
+	if !s.Weak {
+		t.Errorf("expected Weak=true for low-entropy non-Latin password, got entropy %.1f", s.Entropy)
+	}
+	if s.Entropy >= 60 {
+		t.Errorf("expected entropy well below 60 bits, got %.1f", s.Entropy)
+	}
+}
+
 func TestGeneratePassword_NoAmbiguousChars(t *testing.T) {
 	ambiguousChars := "lI1O0"
 	password, cleanup, err := GeneratePassword(1000, true)


### PR DESCRIPTION
## Summary

Fixes a correctness bug in the password-strength estimator. `AssessPasswordStrength`
measured both length and entropy in bytes and assumed a full 256-symbol alphabet for
characters outside the Latin classes, so a short non-ASCII passphrase (for example a
5-character CJK phrase) was scored at ~120 bits and accepted by the blocking
`ValidatePasswordStrength` gate used on entry creation.

Strength is now measured by Unicode rune count for both the minimum-length check and
the entropy length factor, and non-Latin characters are credited only by the number of
distinct runes actually observed — a conservative lower bound — instead of assuming a
256-symbol alphabet. Regression tests cover short and low-entropy non-Latin passwords;
the existing strong-Unicode case still passes.

<!-- closes-list-start -->
- Closes #525 — Password-strength check overestimates entropy for non-ASCII passwords, letting weak passphrases pass the gate
<!-- closes-list-end -->

Planned for release v0.7.2.
