### PR TITLE
Fix js/incomplete-sanitization in cursorContext.ts (+10 dismissed)

### DIFF
--- a/editors/cursor/src/cursorContext.ts
+++ b/editors/cursor/src/cursorContext.ts
@@ -10,13 +10,19 @@ const CONTEXT_MARKER_END = "<!-- END SYMAIRA VAULT CONTEXT -->";
  * Sanitize an entry path to prevent prompt injection when writing to
  * .cursorrules or similar context files.
  *
+ * - Escapes pre-existing backslashes first so the escape sequences added
+ *   below cannot be subverted by attacker-controlled backslashes
  * - Replaces newlines (LF, CR, CRLF) with escaped sequences
  * - Escapes backticks to prevent code injection
  * - Escapes pipe characters to prevent markdown table injection
  */
 export function sanitizeEntryPath(entryPath: string): string {
+  // Escape backslashes before introducing any new backslash escapes below;
+  // otherwise an input backslash could combine with an added escape and break
+  // out of the intended escaping (js/incomplete-sanitization).
+  let sanitized = entryPath.replace(/\\/g, "\\\\");
   // CRLF must be replaced before LF/CR to avoid partial escapes
-  let sanitized = entryPath.replace(/\r\n/g, "\\r\\n");
+  sanitized = sanitized.replace(/\r\n/g, "\\r\\n");
   sanitized = sanitized.replace(/\n/g, "\\n");
   sanitized = sanitized.replace(/\r/g, "\\r");
   sanitized = sanitized.replace(/`/g, "\\`");

--- a/editors/cursor/tests/cursorContext.test.ts
+++ b/editors/cursor/tests/cursorContext.test.ts
@@ -30,6 +30,15 @@ describe("sanitizeEntryPath", () => {
     expect(sanitizeEntryPath("github|injection")).toBe("github\\|injection");
   });
 
+  it("escapes pre-existing backslashes before other escapes", () => {
+    // A raw backslash must not be able to combine with an added escape and
+    // break out of the intended escaping (js/incomplete-sanitization).
+    expect(sanitizeEntryPath("github\\injection")).toBe("github\\\\injection");
+    expect(sanitizeEntryPath("github\\`injection")).toBe(
+      "github\\\\\\`injection"
+    );
+  });
+
   it("handles multiple injection vectors in one path", () => {
     const malicious = "github\n`malicious`|table";
     expect(sanitizeEntryPath(malicious)).toBe(


### PR DESCRIPTION
Resolves the open code-scanning alerts. One required a code change; the remaining ten are documented false positives or accepted risk and were dismissed with reasons.

### Code scanning — fixed
- #190, #191 `js/incomplete-sanitization` in `editors/cursor/src/cursorContext.ts` — `sanitizeEntryPath` added backslash escape sequences (`\n`, `\r`, backtick, pipe) without first escaping pre-existing backslashes, so an attacker-controlled backslash could combine with an added escape and break out of the intended escaping. Now escapes raw backslashes before all other replacements, with a regression test.

### Code scanning — dismissed (false positive)
- #192 `go/unvalidated-url-redirection` in `internal/mcp/serverbootstrap/oauth.go` — the redirect target is validated against the registered client's allowlist (exact match) at every call site before the redirect.
- #193 `go/clear-text-logging` in `internal/cli/output/output.go` — this is the CLI's generic stdout printer (`fmt.Println` of arbitrary values), the intended user-facing output, not a logging sink.
- #195 `go/weak-sensitive-data-hashing` in `internal/metrics/tracing_stub.go` — hashes an entry *path* (truncated) for privacy-preserving trace attributes; the input is a path, not a password.
- #196, #197, #198 `go/weak-sensitive-data-hashing` in `internal/vault/entry_validate.go` and `internal/vault/search_index.go` — derive keys from a high-entropy age X25519 identity, not a low-entropy user password, so slow password hashing does not apply.
- #199, #200, #202 `go/zipslip` in `cmd/admin/backup.go` and `internal/update/extract.go` — archive extraction is contained by `os.OpenRoot` syscall-level confinement plus archive-entry name validation / explicit prefix-containment checks; CodeQL does not model `os.Root` as a barrier.

### Code scanning — dismissed (won't fix)
- #194 `go/weak-sensitive-data-hashing` in `internal/health/doctor_crypto.go` — transient in-memory equality grouping to detect reused passwords in a local doctor check; nothing is persisted, and deterministic equality is required so per-hash-salted slow hashing cannot be used.