### PR TITLE
Search-index persistence, a working MCP coverage gate, and server-bootstrap cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,19 +167,36 @@ jobs:
 
           echo ""
           echo "=== Per-package coverage checks for security-critical packages ==="
+          # Includes the network-facing MCP auth surface (token/OAuth/registry/rate-limit),
+          # the only remotely reachable code, alongside the local crypto/session/vault core.
+          PKG_COV_TMP=$(mktemp -d)
           for PACKAGE in "./internal/crypto/..." \
                          "./internal/session/..." \
-                         "./internal/vault/..."; do
-            PKG_OUT=$(go test -coverprofile=/dev/null -covermode=atomic -count=1 -timeout=2m \
-                      -skip 'TestFlow|TestBinaryE2E|Integration' "$PACKAGE" 2>&1 | grep "coverage:" | tail -1)
-            PKG_COV=$(echo "$PKG_OUT" | grep -oE '[0-9]+\.[0-9]+' | tail -1 || echo "0")
-            PKG_NAME=$(basename "$PACKAGE")
-            # Phased target: raise to 85.0 in follow-up PRs
+                         "./internal/vault/..." \
+                         "./internal/mcp/auth/..." \
+                         "./internal/mcp/serverbootstrap/..."; do
+            # Derive a stable name from the package path. Note: plain
+            # `basename "./internal/crypto/..."` returns "..." (the glob segment),
+            # so strip the trailing "/..." before taking the basename.
+            PKG_NAME=$(basename "${PACKAGE%/...}")
+            PKG_PROFILE="$PKG_COV_TMP/${PKG_NAME}.out"
+            go test -coverprofile="$PKG_PROFILE" -covermode=atomic -count=1 -timeout=10m \
+              -skip 'TestFlow|TestBinaryE2E|Integration' "$PACKAGE"
+            # Aggregate across the whole package tree. `go test ... | grep coverage: | tail -1`
+            # would report an arbitrary subpackage (e.g. internal/vault/taint) instead of the
+            # combined total, so read the total from the merged profile instead.
+            PKG_COV=$(go tool cover -func="$PKG_PROFILE" | grep '^total:' | grep -oE '[0-9]+\.[0-9]+' | tail -1)
+            [ -z "$PKG_COV" ] && PKG_COV=0
+            # Thresholds sit a few points below current measured coverage so the gate
+            # guards against regression without flaking on minor line-count drift.
+            # Phased target: raise toward 85.0 in follow-up PRs.
             case "$PKG_NAME" in
-              crypto)  PKG_THRESHOLD=85.0 ;;
-              session) PKG_THRESHOLD=75.0 ;;
-              vault)   PKG_THRESHOLD=75.0 ;;
-              *)       PKG_THRESHOLD=65.0 ;;
+              crypto)          PKG_THRESHOLD=85.0 ;;
+              session)         PKG_THRESHOLD=70.0 ;;
+              vault)           PKG_THRESHOLD=72.0 ;;
+              auth)            PKG_THRESHOLD=82.0 ;;
+              serverbootstrap) PKG_THRESHOLD=78.0 ;;
+              *)               PKG_THRESHOLD=65.0 ;;
             esac
             echo "${PKG_NAME}: ${PKG_COV}% (threshold: ${PKG_THRESHOLD}%)"
             if awk "BEGIN {exit !($PKG_COV < $PKG_THRESHOLD)}"; then
@@ -188,6 +205,7 @@ jobs:
             fi
             echo "PASS: ${PKG_NAME} coverage ${PKG_COV}% meets threshold of ${PKG_THRESHOLD}%"
           done
+          rm -rf "$PKG_COV_TMP"
 
       - name: Run smoke tests
         shell: bash

--- a/internal/mcp/serverbootstrap/http.go
+++ b/internal/mcp/serverbootstrap/http.go
@@ -16,7 +16,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/danieljustus/symaira-vault/internal/audit"
 	auth "github.com/danieljustus/symaira-vault/internal/mcp/auth"
 	mcpserver "github.com/danieljustus/symaira-vault/internal/mcp/server"
 	transport "github.com/danieljustus/symaira-vault/internal/mcp/transport"
@@ -65,80 +64,18 @@ func RunHTTPServerOnListener(ctx context.Context, listener net.Listener, v *vaul
 
 	addr := net.JoinHostPort(bind, strconv.Itoa(port))
 
-	// Load token system (registry + legacy fallback)
-	tokenPath := ""
-	if v != nil && v.Config != nil && v.Config.MCP != nil {
-		tf := v.Config.MCP.HTTPTokenFile
-		if tf != "" && tf != "auto" {
-			tokenPath = tf
-		}
-	}
-	registry, legacyToken, err := auth.LoadTokenSystem(vaultDir, tokenPath)
+	// Load the token registry (with legacy fallback), wire its cleanup audit
+	// logging and background cleanup, and build the auth audit logger.
+	ts, err := setupTokenSystem(ctx, v, vaultDir)
 	if err != nil {
-		return fmt.Errorf("load token system: %w", err)
+		return err
 	}
+	defer ts.Close()
+	registry := ts.registry
+	legacyToken := ts.legacyToken
+	authAuditLog := ts.authAuditLog
 
-	// Create a dedicated audit logger for token cleanup events before
-	// starting the cleanup goroutine so it can reference the logger.
-	cleanupAuditLog, err := audit.New("token-cleanup", vaultDir, v.Identity)
-	if err != nil {
-		return fmt.Errorf("create token cleanup audit logger: %w", err)
-	}
-	defer func() { _ = cleanupAuditLog.Close() }()
-
-	// Start background cleanup for token registry
-	if registry != nil {
-		registry.SetRevokedRetention(30 * 24 * time.Hour) // 30-day retention for revoked tokens
-		registry.SetCleanupLogger(func(action, tokenID, label, reason string) {
-			if logErr := cleanupAuditLog.LogEntry(audit.LogEntry{
-				Action:  "token_cleanup",
-				Agent:   "token-cleanup",
-				Reason:  reason,
-				TokenID: tokenID,
-				OK:      true,
-			}); logErr != nil {
-				cliout.Errorf("token cleanup audit log write failed: %v", logErr)
-			}
-		})
-		cleanupInterval := 5 * time.Minute
-		_ = registry.StartCleanup(ctx, cleanupInterval)
-		// Start file watcher to reload token registry when CLI creates new tokens
-		_ = registry.StartFileWatcher(ctx, 2*time.Second)
-	}
-
-	authAuditLog, err := audit.New("auth-failures", vaultDir, v.Identity)
-	if err != nil {
-		return fmt.Errorf("create auth audit logger: %w", err)
-	}
-	defer func() { _ = authAuditLog.Close() }()
-
-	if registry != nil {
-		result := registry.Cleanup()
-		totalRemoved := result.ExpiredRemoved + result.RevokedRemoved
-		if totalRemoved > 0 {
-			_ = authAuditLog.LogEntry(audit.LogEntry{
-				Agent:  "system",
-				Action: "token_cleanup",
-				Reason: fmt.Sprintf("removed %d expired, %d revoked (%d total)", result.ExpiredRemoved, result.RevokedRemoved, totalRemoved),
-				OK:     true,
-			})
-		}
-	}
-
-	rateLimit := 60
-	var trustedProxyIPs []string
-	if v != nil && v.Config != nil && v.Config.MCP != nil {
-		if v.Config.MCP.RateLimit >= 0 {
-			rateLimit = v.Config.MCP.RateLimit
-		}
-		trustedProxyIPs = v.Config.MCP.TrustedProxyIPs
-	}
-	var rateLimiter *auth.RateLimiter
-	var stopCleanup func()
-	if rateLimit > 0 {
-		rateLimiter = auth.NewRateLimiter(rateLimit, time.Minute, trustedProxyIPs...)
-		stopCleanup = rateLimiter.StartCleanup(ctx, 5*time.Minute)
-	}
+	rateLimiter, stopCleanup := setupRateLimiter(ctx, v)
 
 	handlerCache := make(map[string]*mcpserver.ProtocolHandler)
 	var cacheMu sync.RWMutex
@@ -322,32 +259,15 @@ func RunHTTPServerOnListener(ctx context.Context, listener net.Listener, v *vaul
 	}
 	mux.Handle("/mcp", mcpChain)
 
-	readHeaderTimeout := 5 * time.Second
-	readTimeout := 10 * time.Second
-	writeTimeout := 10 * time.Second
-	shutdownTimeout := 5 * time.Second
-	if v != nil && v.Config != nil && v.Config.MCP != nil {
-		mcpCfg := v.Config.MCP
-		if mcpCfg.ReadHeaderTimeout > 0 {
-			readHeaderTimeout = mcpCfg.ReadHeaderTimeout
-		}
-		if mcpCfg.ReadTimeout > 0 {
-			readTimeout = mcpCfg.ReadTimeout
-		}
-		if mcpCfg.WriteTimeout > 0 {
-			writeTimeout = mcpCfg.WriteTimeout
-		}
-		if mcpCfg.ShutdownTimeout > 0 {
-			shutdownTimeout = mcpCfg.ShutdownTimeout
-		}
-	}
+	timeouts := resolveServerTimeouts(v)
+	shutdownTimeout := timeouts.shutdown
 
 	server := &http.Server{
 		Addr:              addr,
 		Handler:           mux,
-		ReadHeaderTimeout: readHeaderTimeout,
-		ReadTimeout:       readTimeout,
-		WriteTimeout:      writeTimeout,
+		ReadHeaderTimeout: timeouts.readHeader,
+		ReadTimeout:       timeouts.read,
+		WriteTimeout:      timeouts.write,
 		IdleTimeout:       120 * time.Second,
 		MaxHeaderBytes:    1 << 20,
 	}

--- a/internal/mcp/serverbootstrap/http_setup.go
+++ b/internal/mcp/serverbootstrap/http_setup.go
@@ -1,0 +1,167 @@
+package serverbootstrap
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/danieljustus/symaira-vault/internal/audit"
+	auth "github.com/danieljustus/symaira-vault/internal/mcp/auth"
+	"github.com/danieljustus/symaira-vault/internal/ui/cliout"
+	vaultpkg "github.com/danieljustus/symaira-vault/internal/vault"
+)
+
+// tokenSystem bundles the token registry, the legacy fallback token and the
+// audit loggers the MCP HTTP server's auth path depends on. It is produced by
+// setupTokenSystem so RunHTTPServerOnListener does not have to inline token
+// loading, cleanup wiring and audit-logger construction.
+//
+// Close releases the audit loggers; the caller owns its lifetime and must
+// defer Close after a successful setup.
+type tokenSystem struct {
+	registry        *auth.TokenRegistry
+	legacyToken     string
+	cleanupAuditLog *audit.Logger
+	authAuditLog    *audit.Logger
+}
+
+// Close releases the audit loggers owned by the token system. It is safe to
+// call on a nil receiver and tolerates partially-initialized loggers.
+func (ts *tokenSystem) Close() {
+	if ts == nil {
+		return
+	}
+	if ts.cleanupAuditLog != nil {
+		_ = ts.cleanupAuditLog.Close()
+	}
+	if ts.authAuditLog != nil {
+		_ = ts.authAuditLog.Close()
+	}
+}
+
+// setupTokenSystem loads the scoped-token registry (with legacy bearer-token
+// fallback), wires the registry's revoked-token retention and cleanup audit
+// logging, starts the background registry cleanup + file watcher bound to ctx,
+// and performs an initial cleanup pass. On any error it closes whatever it has
+// already opened so the caller never has to.
+func setupTokenSystem(ctx context.Context, v *vaultpkg.Vault, vaultDir string) (*tokenSystem, error) {
+	tokenPath := ""
+	if v != nil && v.Config != nil && v.Config.MCP != nil {
+		tf := v.Config.MCP.HTTPTokenFile
+		if tf != "" && tf != "auto" {
+			tokenPath = tf
+		}
+	}
+
+	registry, legacyToken, err := auth.LoadTokenSystem(vaultDir, tokenPath)
+	if err != nil {
+		return nil, fmt.Errorf("load token system: %w", err)
+	}
+
+	// Create the cleanup audit logger before starting the cleanup goroutine so
+	// the goroutine can reference it.
+	cleanupAuditLog, err := audit.New("token-cleanup", vaultDir, v.Identity)
+	if err != nil {
+		return nil, fmt.Errorf("create token cleanup audit logger: %w", err)
+	}
+
+	if registry != nil {
+		registry.SetRevokedRetention(30 * 24 * time.Hour) // 30-day retention for revoked tokens
+		registry.SetCleanupLogger(func(_, tokenID, _, reason string) {
+			if logErr := cleanupAuditLog.LogEntry(audit.LogEntry{
+				Action:  "token_cleanup",
+				Agent:   "token-cleanup",
+				Reason:  reason,
+				TokenID: tokenID,
+				OK:      true,
+			}); logErr != nil {
+				cliout.Errorf("token cleanup audit log write failed: %v", logErr)
+			}
+		})
+		_ = registry.StartCleanup(ctx, 5*time.Minute)
+		// Reload the registry when the CLI creates new tokens out-of-band.
+		_ = registry.StartFileWatcher(ctx, 2*time.Second)
+	}
+
+	authAuditLog, err := audit.New("auth-failures", vaultDir, v.Identity)
+	if err != nil {
+		_ = cleanupAuditLog.Close()
+		return nil, fmt.Errorf("create auth audit logger: %w", err)
+	}
+
+	if registry != nil {
+		result := registry.Cleanup()
+		totalRemoved := result.ExpiredRemoved + result.RevokedRemoved
+		if totalRemoved > 0 {
+			_ = authAuditLog.LogEntry(audit.LogEntry{
+				Agent:  "system",
+				Action: "token_cleanup",
+				Reason: fmt.Sprintf("removed %d expired, %d revoked (%d total)", result.ExpiredRemoved, result.RevokedRemoved, totalRemoved),
+				OK:     true,
+			})
+		}
+	}
+
+	return &tokenSystem{
+		registry:        registry,
+		legacyToken:     legacyToken,
+		cleanupAuditLog: cleanupAuditLog,
+		authAuditLog:    authAuditLog,
+	}, nil
+}
+
+// setupRateLimiter resolves the configured per-minute request limit (default
+// 60; <= 0 disables rate limiting) and, when enabled, constructs the limiter
+// and starts its background cleanup bound to ctx. The returned stop function is
+// nil when rate limiting is disabled.
+func setupRateLimiter(ctx context.Context, v *vaultpkg.Vault) (*auth.RateLimiter, func()) {
+	rateLimit := 60
+	var trustedProxyIPs []string
+	if v != nil && v.Config != nil && v.Config.MCP != nil {
+		if v.Config.MCP.RateLimit >= 0 {
+			rateLimit = v.Config.MCP.RateLimit
+		}
+		trustedProxyIPs = v.Config.MCP.TrustedProxyIPs
+	}
+	if rateLimit <= 0 {
+		return nil, nil
+	}
+	rateLimiter := auth.NewRateLimiter(rateLimit, time.Minute, trustedProxyIPs...)
+	stop := rateLimiter.StartCleanup(ctx, 5*time.Minute)
+	return rateLimiter, stop
+}
+
+// httpServerTimeouts holds the resolved HTTP server timeout configuration.
+type httpServerTimeouts struct {
+	readHeader time.Duration
+	read       time.Duration
+	write      time.Duration
+	shutdown   time.Duration
+}
+
+// resolveServerTimeouts returns the HTTP server timeouts, applying any positive
+// overrides from the vault's MCP config over the built-in defaults.
+func resolveServerTimeouts(v *vaultpkg.Vault) httpServerTimeouts {
+	t := httpServerTimeouts{
+		readHeader: 5 * time.Second,
+		read:       10 * time.Second,
+		write:      10 * time.Second,
+		shutdown:   5 * time.Second,
+	}
+	if v != nil && v.Config != nil && v.Config.MCP != nil {
+		mcpCfg := v.Config.MCP
+		if mcpCfg.ReadHeaderTimeout > 0 {
+			t.readHeader = mcpCfg.ReadHeaderTimeout
+		}
+		if mcpCfg.ReadTimeout > 0 {
+			t.read = mcpCfg.ReadTimeout
+		}
+		if mcpCfg.WriteTimeout > 0 {
+			t.write = mcpCfg.WriteTimeout
+		}
+		if mcpCfg.ShutdownTimeout > 0 {
+			t.shutdown = mcpCfg.ShutdownTimeout
+		}
+	}
+	return t
+}

--- a/internal/mcp/serverbootstrap/http_setup_test.go
+++ b/internal/mcp/serverbootstrap/http_setup_test.go
@@ -1,0 +1,136 @@
+package serverbootstrap
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/danieljustus/symaira-vault/internal/config"
+	vaultpkg "github.com/danieljustus/symaira-vault/internal/vault"
+)
+
+func TestResolveServerTimeouts_Defaults(t *testing.T) {
+	// nil vault and empty MCP config both fall back to the built-in defaults.
+	for name, v := range map[string]*vaultpkg.Vault{
+		"nil vault":      nil,
+		"empty mcp cfg":  {Config: &config.Config{MCP: &config.MCPConfig{}}},
+		"nil mcp config": {Config: &config.Config{}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			got := resolveServerTimeouts(v)
+			want := httpServerTimeouts{
+				readHeader: 5 * time.Second,
+				read:       10 * time.Second,
+				write:      10 * time.Second,
+				shutdown:   5 * time.Second,
+			}
+			if got != want {
+				t.Fatalf("resolveServerTimeouts() = %+v, want %+v", got, want)
+			}
+		})
+	}
+}
+
+func TestResolveServerTimeouts_Overrides(t *testing.T) {
+	v := &vaultpkg.Vault{Config: &config.Config{MCP: &config.MCPConfig{
+		ReadHeaderTimeout: 1 * time.Second,
+		ReadTimeout:       2 * time.Second,
+		WriteTimeout:      3 * time.Second,
+		ShutdownTimeout:   4 * time.Second,
+	}}}
+	got := resolveServerTimeouts(v)
+	want := httpServerTimeouts{
+		readHeader: 1 * time.Second,
+		read:       2 * time.Second,
+		write:      3 * time.Second,
+		shutdown:   4 * time.Second,
+	}
+	if got != want {
+		t.Fatalf("resolveServerTimeouts() = %+v, want %+v", got, want)
+	}
+}
+
+func TestResolveServerTimeouts_PartialOverrideKeepsDefaults(t *testing.T) {
+	// A single positive override must not reset the other fields to zero.
+	v := &vaultpkg.Vault{Config: &config.Config{MCP: &config.MCPConfig{ReadTimeout: 30 * time.Second}}}
+	got := resolveServerTimeouts(v)
+	if got.read != 30*time.Second {
+		t.Fatalf("read timeout = %v, want 30s", got.read)
+	}
+	if got.readHeader != 5*time.Second || got.write != 10*time.Second || got.shutdown != 5*time.Second {
+		t.Fatalf("non-overridden timeouts changed: %+v", got)
+	}
+}
+
+func TestSetupRateLimiter(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	t.Run("default enabled", func(t *testing.T) {
+		rl, stop := setupRateLimiter(ctx, nil)
+		if rl == nil {
+			t.Fatal("expected a rate limiter for the default config, got nil")
+		}
+		if stop == nil {
+			t.Fatal("expected a non-nil stop function when rate limiting is enabled")
+		}
+		stop()
+		_ = rl.Close()
+	})
+
+	t.Run("disabled when limit is zero", func(t *testing.T) {
+		v := &vaultpkg.Vault{Config: &config.Config{MCP: &config.MCPConfig{RateLimit: 0}}}
+		rl, stop := setupRateLimiter(ctx, v)
+		if rl != nil || stop != nil {
+			t.Fatalf("expected (nil, nil) when rate limit is 0, got rl!=nil=%t stop!=nil=%t", rl != nil, stop != nil)
+		}
+	})
+
+	t.Run("custom positive limit enabled", func(t *testing.T) {
+		v := &vaultpkg.Vault{Config: &config.Config{MCP: &config.MCPConfig{RateLimit: 120}}}
+		rl, stop := setupRateLimiter(ctx, v)
+		if rl == nil || stop == nil {
+			t.Fatalf("expected an enabled limiter for RateLimit=120, got rl!=nil=%t stop!=nil=%t", rl != nil, stop != nil)
+		}
+		stop()
+		_ = rl.Close()
+	})
+}
+
+func TestSetupTokenSystem(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	v := newTestVault(t)
+	ts, err := setupTokenSystem(ctx, v, v.Dir)
+	if err != nil {
+		t.Fatalf("setupTokenSystem() error = %v", err)
+	}
+	if ts == nil {
+		t.Fatal("setupTokenSystem() returned nil token system without error")
+	}
+	t.Cleanup(ts.Close)
+
+	if ts.registry == nil {
+		t.Error("expected a non-nil token registry")
+	}
+	if ts.authAuditLog == nil {
+		t.Error("expected a non-nil auth audit logger")
+	}
+	if ts.cleanupAuditLog == nil {
+		t.Error("expected a non-nil cleanup audit logger")
+	}
+	// The pre-seeded legacy mcp-token is migrated into the registry and also
+	// returned as the legacy fallback.
+	if ts.legacyToken == "" {
+		t.Error("expected the migrated legacy token to be returned")
+	}
+}
+
+func TestTokenSystemCloseNilSafe(t *testing.T) {
+	var ts *tokenSystem
+	ts.Close() // must not panic on a nil receiver
+
+	// A partially-initialized token system (no auth logger) must also be safe.
+	(&tokenSystem{}).Close()
+}

--- a/internal/vault/search.go
+++ b/internal/vault/search.go
@@ -20,8 +20,9 @@
 //
 // Bounded Parallelism Rationale:
 // -----------------------------
-// We use a bounded worker pool (default: 4 concurrent decryptions) rather than
-// unbounded parallelism for these reasons:
+// We use a bounded worker pool (default: one worker per CPU core, capped at 8;
+// configurable up to 64 — see SearchWorkerCount) rather than unbounded
+// parallelism for these reasons:
 //
 //  1. Memory Pressure: Each decrypted entry consumes memory. With unbounded
 //     parallelism on a 50k entry vault, we could spawn 50k goroutines all
@@ -35,11 +36,12 @@
 //     (X25519 key exchange, ChaCha20-Poly1305). Too many concurrent operations
 //     can cause CPU cache thrashing.
 //
-//  4. Practical Results: Testing shows 4 workers provides near-optimal throughput
-//     for typical user machines while keeping memory bounded.
+//  4. Practical Results: Testing shows one worker per core (capped at 8)
+//     provides near-optimal throughput for typical user machines while
+//     keeping memory bounded.
 //
-// Performance Targets (4 workers):
-// --------------------------------
+// Performance Targets (approximate, default worker count on a multi-core machine):
+// -------------------------------------------------------------------------------
 // - 50k entries, path-only: ~500ms (no decryption needed)
 // - 50k entries, field-search: ~2-4s (bounded by decrypt parallelism)
 // - 10k entries, field-search: ~500ms-1s

--- a/internal/vault/search_index.go
+++ b/internal/vault/search_index.go
@@ -42,8 +42,12 @@ var ErrIndexBuildEmpty = errors.New("search index build produced no entries")
 //   - Built lazily on first search after vault unlock
 //   - Saved to disk after building so it persists across restarts
 //   - Loaded from disk on first search if available and valid
-//   - Invalidated on any write operation (clears both memory and disk)
-//   - Rebuilt automatically on the next search
+//   - Updated incrementally on single-entry add/update/delete: UpdateEntry and
+//     RemoveEntry re-index just that path and re-persist the ciphertext, so a
+//     write no longer discards the whole index
+//   - Fully invalidated only by bulk/structural operations (recipient changes,
+//     migrations, manifest rebuild) via InvalidateSearchIndex, then rebuilt on
+//     the next search
 //   - Encrypted with a key derived from the vault identity
 type EncryptedIndex struct {
 	mu         sync.RWMutex
@@ -512,20 +516,16 @@ func (idx *EncryptedIndex) UpdateEntry(vaultDir, path string, identity *age.X255
 
 	plaintext, err := vaultcrypto.DecryptWithKey(idx.ciphertext, key)
 	if err != nil {
-		idx.ciphertext = nil
-		idx.salt = nil
-		idx.vaultDir = ""
-		idx.idHash = [sha256.Size]byte{}
+		idx.clearLocked()
+		_ = os.Remove(indexFilePath(vaultDir))
 		return nil
 	}
 	defer vaultcrypto.Wipe(plaintext)
 
 	var doc indexDoc
 	if err = json.Unmarshal(plaintext, &doc); err != nil {
-		idx.ciphertext = nil
-		idx.salt = nil
-		idx.vaultDir = ""
-		idx.idHash = [sha256.Size]byte{}
+		idx.clearLocked()
+		_ = os.Remove(indexFilePath(vaultDir))
 		return nil
 	}
 
@@ -563,7 +563,12 @@ func (idx *EncryptedIndex) UpdateEntry(vaultDir, path string, identity *age.X255
 	idx.ciphertext = newCiphertext
 	idx.vaultDir = vaultDir
 	idx.idHash = sha256.Sum256([]byte(identity.String()))
-	return nil
+
+	// Persist the incrementally-updated index so the on-disk copy tracks the
+	// write. Without this the edited entry's previous value would remain on
+	// disk and, because an in-place edit leaves the entry count unchanged, be
+	// reloaded as a valid index after a restart — returning stale results.
+	return writeIndexFile(vaultDir, storedSalt, newCiphertext)
 }
 
 // RemoveEntry removes a single path from the encrypted index.
@@ -576,26 +581,33 @@ func (idx *EncryptedIndex) RemoveEntry(path string, identity *age.X25519Identity
 		return
 	}
 
+	vaultDir := idx.vaultDir
+	dropDisk := func() {
+		idx.clearLocked()
+		if vaultDir != "" {
+			_ = os.Remove(indexFilePath(vaultDir))
+		}
+	}
+
 	if identity == nil {
-		idx.ciphertext = nil
-		idx.salt = nil
+		dropDisk()
 		return
 	}
 
-	key := deriveIndexKey(identity, idx.salt)
+	storedSalt := idx.salt
+	key := deriveIndexKey(identity, storedSalt)
 	defer vaultcrypto.Wipe(key)
 
 	plaintext, err := vaultcrypto.DecryptWithKey(idx.ciphertext, key)
 	if err != nil {
-		idx.ciphertext = nil
-		idx.salt = nil
+		dropDisk()
 		return
 	}
 	defer vaultcrypto.Wipe(plaintext)
 
 	var doc indexDoc
 	if err = json.Unmarshal(plaintext, &doc); err != nil {
-		idx.ciphertext = nil
+		dropDisk()
 		return
 	}
 
@@ -603,24 +615,55 @@ func (idx *EncryptedIndex) RemoveEntry(path string, identity *age.X25519Identity
 	if doc.TokenIndex != nil {
 		removeFromTokenIndex(doc.TokenIndex, path)
 	}
+	// A delete removes exactly one vault entry; keep the persisted entry count
+	// in step so the on-disk index stays valid (not flagged stale) on reload.
+	if doc.EntryCount > 0 {
+		doc.EntryCount--
+	}
 
 	newPlaintext, err := json.Marshal(doc)
 	if err != nil {
-		idx.ciphertext = nil
+		dropDisk()
 		return
 	}
 	defer vaultcrypto.Wipe(newPlaintext)
 
 	newCiphertext, err := vaultcrypto.EncryptWithKey(newPlaintext, key)
 	if err != nil {
-		idx.ciphertext = nil
+		dropDisk()
 		return
 	}
 
 	idx.ciphertext = newCiphertext
+	// Persist so the deletion is reflected on disk and survives a restart.
+	_ = writeIndexFile(vaultDir, storedSalt, newCiphertext)
 }
 
 const indexFormatVersion = byte(0x01)
+
+// writeIndexFile serializes the salted index ciphertext to the on-disk index
+// file. It deliberately does not touch idx.mu, so callers that already hold the
+// write lock (UpdateEntry, RemoveEntry) can persist without deadlocking against
+// the non-reentrant RWMutex that saveToDisk's RLock would otherwise take.
+func writeIndexFile(vaultDir string, salt, ciphertext []byte) error {
+	if ciphertext == nil {
+		return nil
+	}
+	data := make([]byte, 0, 1+len(salt)+len(ciphertext))
+	data = append(data, indexFormatVersion)
+	data = append(data, salt...)
+	data = append(data, ciphertext...)
+	return os.WriteFile(indexFilePath(vaultDir), data, 0600)
+}
+
+// clearLocked resets the in-memory index to the unbuilt state. The caller must
+// hold idx.mu.
+func (idx *EncryptedIndex) clearLocked() {
+	idx.ciphertext = nil
+	idx.salt = nil
+	idx.vaultDir = ""
+	idx.idHash = [sha256.Size]byte{}
+}
 
 func (idx *EncryptedIndex) saveToDisk(vaultDir string) error {
 	idx.mu.RLock()
@@ -628,16 +671,7 @@ func (idx *EncryptedIndex) saveToDisk(vaultDir string) error {
 	storedSalt := idx.salt
 	idx.mu.RUnlock()
 
-	if ct == nil {
-		return nil
-	}
-
-	indexPath := indexFilePath(vaultDir)
-	data := make([]byte, 0, 1+len(storedSalt)+len(ct))
-	data = append(data, indexFormatVersion)
-	data = append(data, storedSalt...)
-	data = append(data, ct...)
-	return os.WriteFile(indexPath, data, 0600)
+	return writeIndexFile(vaultDir, storedSalt, ct)
 }
 
 func (idx *EncryptedIndex) loadFromDisk(vaultDir string, identity *age.X25519Identity) error {

--- a/internal/vault/search_index_persist_test.go
+++ b/internal/vault/search_index_persist_test.go
@@ -1,0 +1,108 @@
+package vault
+
+import (
+	"testing"
+
+	"github.com/danieljustus/symaira-vault/internal/testutil"
+)
+
+// TestUpdateEntryPersistsEditToDisk verifies that an in-place edit applied via
+// the incremental UpdateEntry path is written to the on-disk index, so a fresh
+// process reloading the index sees the new value rather than the stale one. An
+// in-place edit leaves the vault entry count unchanged, so the on-disk
+// staleness check (entry count) would otherwise happily accept a stale index.
+func TestUpdateEntryPersistsEditToDisk(t *testing.T) {
+	globalIndex.Invalidate()
+	t.Cleanup(globalIndex.Invalidate)
+
+	vaultDir := t.TempDir()
+	identity := testutil.TempIdentity(t)
+	mustWriteEntry(t, vaultDir, identity, "acct", map[string]interface{}{"user": "oldvalue"})
+
+	idx := &EncryptedIndex{}
+	if err := idx.Build(vaultDir, identity); err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+
+	// Edit the entry in place, then update the index incrementally.
+	mustWriteEntry(t, vaultDir, identity, "acct", map[string]interface{}{"user": "newvalue"})
+	if err := idx.UpdateEntry(vaultDir, "acct", identity); err != nil {
+		t.Fatalf("UpdateEntry() error = %v", err)
+	}
+
+	// Simulate a restart: a fresh index loads only what is on disk.
+	fresh := &EncryptedIndex{}
+	if err := fresh.loadFromDisk(vaultDir, identity); err != nil {
+		t.Fatalf("loadFromDisk() error = %v", err)
+	}
+	if !fresh.IsBuilt() {
+		t.Fatal("fresh index not built from disk after UpdateEntry persist")
+	}
+
+	newMatch, err := fresh.MatchEntries(vaultDir, identity, []string{"acct"}, "newvalue")
+	if err != nil {
+		t.Fatalf("MatchEntries(new) error = %v", err)
+	}
+	if _, ok := newMatch["acct"]; !ok {
+		t.Error("on-disk index is missing the edited value after restart")
+	}
+
+	oldMatch, err := fresh.MatchEntries(vaultDir, identity, []string{"acct"}, "oldvalue")
+	if err != nil {
+		t.Fatalf("MatchEntries(old) error = %v", err)
+	}
+	if _, ok := oldMatch["acct"]; ok {
+		t.Error("on-disk index still matches the stale pre-edit value after restart")
+	}
+}
+
+// TestRemoveEntryPersistsDeleteToDisk verifies that a delete applied via the
+// incremental RemoveEntry path is persisted AND that the stored entry count is
+// decremented, so the reloaded index passes the staleness check and no longer
+// matches the removed entry.
+func TestRemoveEntryPersistsDeleteToDisk(t *testing.T) {
+	globalIndex.Invalidate()
+	t.Cleanup(globalIndex.Invalidate)
+
+	vaultDir := t.TempDir()
+	identity := testutil.TempIdentity(t)
+	mustWriteEntry(t, vaultDir, identity, "keep", map[string]interface{}{"user": "keepvalue"})
+	mustWriteEntry(t, vaultDir, identity, "gone", map[string]interface{}{"user": "gonevalue"})
+
+	idx := &EncryptedIndex{}
+	if err := idx.Build(vaultDir, identity); err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+
+	if err := DeleteEntry(vaultDir, "gone", identity); err != nil {
+		t.Fatalf("DeleteEntry() error = %v", err)
+	}
+	idx.RemoveEntry("gone", identity)
+
+	// Simulate a restart. The reloaded index must be accepted (entry count was
+	// decremented to match the now-smaller vault) and must not match the
+	// deleted entry.
+	fresh := &EncryptedIndex{}
+	if err := fresh.loadFromDisk(vaultDir, identity); err != nil {
+		t.Fatalf("loadFromDisk() error = %v", err)
+	}
+	if !fresh.IsBuilt() {
+		t.Fatal("fresh index not built from disk after RemoveEntry (entry count not decremented?)")
+	}
+
+	goneMatch, err := fresh.MatchEntries(vaultDir, identity, []string{"gone"}, "gonevalue")
+	if err != nil {
+		t.Fatalf("MatchEntries(gone) error = %v", err)
+	}
+	if len(goneMatch) != 0 {
+		t.Error("on-disk index still matches the deleted entry after restart")
+	}
+
+	keepMatch, err := fresh.MatchEntries(vaultDir, identity, []string{"keep"}, "keepvalue")
+	if err != nil {
+		t.Fatalf("MatchEntries(keep) error = %v", err)
+	}
+	if _, ok := keepMatch["keep"]; !ok {
+		t.Error("on-disk index lost the surviving entry after a delete")
+	}
+}


### PR DESCRIPTION
Implements four reviewed improvements to the search subsystem, the MCP HTTP server, and CI.

<!-- closes-list-start -->
- Closes #528 — make the per-package coverage gate functional and extend it to the network-facing MCP auth packages
- Closes #529 — extract HTTP server setup (token system, audit loggers, rate limiter, timeouts) into testable helpers
- Closes #530 — persist incremental search-index updates so edits/deletes survive a restart instead of returning stale results
- Closes #531 — correct the stale worker-count numbers in the search design doc
<!-- closes-list-end -->

## Notes for review
- **#528** also fixes two latent bugs in the existing gate that meant the crypto/session/vault thresholds were never actually enforced: `basename "./internal/crypto/..."` returns `...` (so every package used the 65% default), and reading coverage via `grep coverage: | tail -1` reported an arbitrary subpackage instead of the tree total. Thresholds are now set a few points below current measured coverage (crypto 85, session 70, vault 72, auth 82, serverbootstrap 78) so the gate passes on HEAD while guarding against regression.
- **#530** is the substantive correctness fix: the incremental update path already existed but never persisted, so an in-place edit left the old value on disk to be reloaded (with a matching entry count) on the next start. New tests cover the edit- and delete-then-reload paths.
- Milestone v0.7.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
