### PR TITLE
recipients remove does not revoke access to existing entries (+3 more)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -236,13 +236,54 @@ graph LR
 - `CanWrite` — Whether write operations are allowed
 - `ApprovalMode` — `none`, `deny`, or `prompt` (degrades to deny in MCP)
 
-**Available tools:**
-- `list_entries` — List vault entries
-- `get_entry` — Retrieve entry
-- `find_entries` — Search entries
-- `set_entry_field` — Update entry field
-- `generate_password` — Generate password
-- `symvault_delete` — Delete entry
+**Available tools (34 registered, excluding the deprecated `symaira_delete` alias):**
+
+Vault operations:
+- `list_entries` — List vault entries matching a prefix
+- `get_entry` — Get entry metadata (fields, type) without secrets
+- `get_entry_value` — Get actual secret values
+- `get_entry_metadata` — Get metadata without sensitive data
+- `set_entry_field` — Set a field on an entry
+- `delete_entry` — Delete an entry by path
+- `find_entries` — Search entries by query
+- `generate_password` — Generate a secure password
+- `generate_totp` — Generate a TOTP code
+
+Secret execution:
+- `run_command` — Execute a command with secrets injected as env vars
+- `execute_with_secret` — Execute command with op:// secret references
+- `execute_api_request` — Execute HTTP API request with template-injected credentials
+- `secret_unseal` — Unseal a secret handle to reveal its value
+
+Agent & session:
+- `symaira_whoami` — Return agent profile, tool availability, quotas
+- `symaira_search` — Discover tools by intent matching
+- `symaira_audit_self` — Return recent audit events for this agent
+- `get_auth_status` — Return vault unlock authentication status
+- `set_auth_method` — Set unlock authentication method
+- `health` — Return MCP server health information
+
+Sharing:
+- `request_share` — Request to share a secret with another agent
+- `approve_share` — Approve a pending share request
+- `revoke_share` — Revoke an active share grant
+- `list_shares` — List share grants with filters
+
+Input/Output:
+- `request_credential` — Prompt user to securely enter a credential (native dialog)
+- `secure_input` — Prompt user for sensitive data via TTY/GUI dialog
+- `copy_to_clipboard` — Copy entry field to clipboard without exposing value
+- `autotype` — Type entry field as keyboard input into focused application
+- `sanitize_output` — Scan text for secrets and mask them
+
+Web & AI:
+- `perplexity_search` — Search the web via Perplexity AI
+- `perplexity_ask` — Ask Perplexity AI a question with vault context
+- `search` — Search vault entries (OpenAI-compatible)
+- `fetch` — Fetch vault entry by path (OpenAI-compatible)
+
+Templates:
+- `generate_template` — Generate config file from template (env, docker-compose, k8s, etc.)
 
 ### `internal/audit/` — Audit Logger
 
@@ -261,6 +302,39 @@ Shared utilities for testing.
 ### `internal/clipboard/` — Clipboard Application Logic
 
 Application-level clipboard utilities: auto-clear timer, countdown display, and cross-platform clipboard integration. Imported by CLI commands (e.g., `cmd/get.go`) as `clipboardapp`.
+
+### Additional `internal/` Packages
+
+| Package | Purpose |
+|---------|---------|
+| `internal/agentctx` | Agent context propagation through MCP call chain |
+| `internal/agentskill` | Agent skill management and version compatibility |
+| `internal/anomaly` | Anomaly detection for vault operations |
+| `internal/authguard` | Authorization guard layer for MCP tool access |
+| `internal/autotype` | Cross-platform keyboard autotype backend |
+| `internal/cli` | CLI helper utilities (vault path, output, with-vault) |
+| `internal/daemon` | Background service management |
+| `internal/dynamicsecret` | Dynamic secret generation with time-limited leases |
+| `internal/envutil` | Environment variable utilities |
+| `internal/errors` | Structured error types and CLI error formatting |
+| `internal/exporter` | Vault entry export (CSV, JSON) |
+| `internal/fsutil` | Filesystem utilities (safe read/write, traversal checks) |
+| `internal/health` | Vault health check logic |
+| `internal/i18n` | Internationalization and localization |
+| `internal/importer` | Import from other password managers |
+| `internal/logging` | Structured logging infrastructure |
+| `internal/metrics` | Operational metrics collection |
+| `internal/notify` | Desktop notification support |
+| `internal/pairing` | Device pairing protocol |
+| `internal/policy` | Declarative vault policy engine |
+| `internal/quotas` | MCP tool usage quotas and rate limiting |
+| `internal/secrets` | Secret handle resolution and sealed-ref management |
+| `internal/secureedit` | Secure in-place entry editing |
+| `internal/secureui` | Native OS dialog integration for secure input |
+| `internal/template` | Configuration template generation |
+| `internal/ui` | Terminal UI (TUI) rendering |
+| `internal/update` | Self-update mechanism |
+
 
 ## Data Flow
 
@@ -362,7 +436,7 @@ graph TD
 ### MCP Security
 
 - **Stdio:** Agent fixed at startup; process isolation provides security
-- **HTTP:** Bearer token required; agent identified per-request via `X-Symaira Vault-Agent` header
+- **HTTP:** Bearer token required; agent identified per-request via `X-Symaira-Agent` header
 - **Path restrictions:** Agents can only access allowed path patterns
 - **Write restrictions:** `CanWrite: false` blocks all write operations
 - **Approval modes:** `deny` blocks writes; `prompt` degrades to deny (no stdin)
@@ -393,7 +467,7 @@ Vaults created with the older root-level entry layout are migrated to `entries/`
 
 ## Tool Addition Review
 
-Symaira Vault caps the MCP tool registry at `MaxToolDefinitions` (32, defined in `internal/mcp/server/tool_registry.go`). Each tool is a potential prompt injection vector — an attacker-controlled agent can exploit any exposed tool. The cap forces deliberate tradeoffs: every new tool must displace another or justify raising the limit.
+Symaira Vault caps the MCP tool registry at `MaxToolDefinitions` (34, defined in `internal/mcp/server/tool_registry.go`). Each tool is a potential prompt injection vector — an attacker-controlled agent can exploit any exposed tool. The cap forces deliberate tradeoffs: every new tool must displace another or justify raising the limit.
 
 **Adding a new tool** requires:
 

--- a/cmd/recipients.go
+++ b/cmd/recipients.go
@@ -14,6 +14,7 @@ import (
 
 var (
 	confirmRemove bool
+	noReencrypt   bool
 )
 
 var recipientsCmd = &cobra.Command{
@@ -153,7 +154,21 @@ Use --yes to skip confirmation (useful for scripts).`,
 				return errorspkg.WriteFailed(err, "cannot remove recipient")
 			}
 
-			printlnQuietAware("Recipient removed successfully.")
+			if noReencrypt {
+				printlnQuietAware("Recipient removed successfully.")
+				printQuietAware("Warning: existing entries are still encrypted to the removed recipient. ")
+				printlnQuietAware("Run 'symvault auth rotate' to re-encrypt all entries and fully revoke access.")
+			} else {
+				recipients, err := v.GetAllRecipientsForEncryption()
+				if err != nil {
+					return fmt.Errorf("get remaining recipients: %w", err)
+				}
+				printQuietAware("Recipient removed. Re-encrypting %d entries for %d recipient(s)...\n", 0, len(recipients))
+				if err := vaultpkg.ReencryptAll(v.Dir, v.Identity, recipients); err != nil {
+					return fmt.Errorf("re-encrypt entries: %w", err)
+				}
+				printlnQuietAware("Recipient removed and all entries re-encrypted successfully.")
+			}
 			return nil
 		})
 	},
@@ -165,4 +180,5 @@ func init() {
 	recipientsCmd.AddCommand(recipientsAddCmd)
 	recipientsCmd.AddCommand(recipientsRemoveCmd)
 	recipientsRemoveCmd.Flags().BoolVarP(&confirmRemove, "yes", "y", false, "Skip confirmation prompt")
+	recipientsRemoveCmd.Flags().BoolVar(&noReencrypt, "no-reencrypt", false, "Skip re-encrypting existing entries after removal")
 }

--- a/cmd/recipients.go
+++ b/cmd/recipients.go
@@ -13,8 +13,9 @@ import (
 )
 
 var (
-	confirmRemove bool
-	noReencrypt   bool
+	confirmRemove     bool
+	noReencrypt       bool
+	reencryptAfterAdd bool
 )
 
 var recipientsCmd = &cobra.Command{
@@ -113,7 +114,21 @@ Once added, all new entries will be encrypted for this recipient.`,
 				return errorspkg.WriteFailed(err, "cannot add recipient")
 			}
 
-			printlnQuietAware("Recipient added successfully.")
+			if reencryptAfterAdd {
+				recipients, err := v.GetAllRecipientsForEncryption()
+				if err != nil {
+					return fmt.Errorf("get recipients: %w", err)
+				}
+				printQuietAware("Recipient added. Re-encrypting all entries for %d recipient(s)...\n", len(recipients))
+				if err := vaultpkg.ReencryptAll(v.Dir, v.Identity, recipients); err != nil {
+					return fmt.Errorf("re-encrypt entries: %w", err)
+				}
+				printlnQuietAware("Recipient added and all entries re-encrypted successfully.")
+			} else {
+				printlnQuietAware("Recipient added successfully.")
+				printQuietAware("Note: existing entries are not yet shared with this recipient. ")
+				printlnQuietAware("Run 'symvault recipients add <key> --reencrypt' or 'symvault auth rotate' to re-encrypt existing entries.")
+			}
 			return nil
 		})
 	},
@@ -179,6 +194,7 @@ func init() {
 	recipientsCmd.AddCommand(recipientsListCmd)
 	recipientsCmd.AddCommand(recipientsAddCmd)
 	recipientsCmd.AddCommand(recipientsRemoveCmd)
+	recipientsAddCmd.Flags().BoolVar(&reencryptAfterAdd, "reencrypt", false, "Re-encrypt existing entries for the new recipient")
 	recipientsRemoveCmd.Flags().BoolVarP(&confirmRemove, "yes", "y", false, "Skip confirmation prompt")
 	recipientsRemoveCmd.Flags().BoolVar(&noReencrypt, "no-reencrypt", false, "Skip re-encrypting existing entries after removal")
 }

--- a/cmd/recipients_test.go
+++ b/cmd/recipients_test.go
@@ -562,11 +562,11 @@ func TestCmdRecipientsRemove_WithYesFlag(t *testing.T) {
 	})
 
 	if !strings.Contains(output, "Recipient removed") {
-			t.Errorf("expected output containing 'Recipient removed', got: %q", output)
-		}
-		if !strings.Contains(output, "re-encrypted successfully") {
-			t.Errorf("expected output containing 're-encrypted successfully', got: %q", output)
-		}
+		t.Errorf("expected output containing 'Recipient removed', got: %q", output)
+	}
+	if !strings.Contains(output, "re-encrypted successfully") {
+		t.Errorf("expected output containing 're-encrypted successfully', got: %q", output)
+	}
 }
 
 func TestCmdRecipientsRemove_InvalidKey(t *testing.T) {

--- a/cmd/recipients_test.go
+++ b/cmd/recipients_test.go
@@ -561,9 +561,12 @@ func TestCmdRecipientsRemove_WithYesFlag(t *testing.T) {
 		_ = rootCmd.Execute()
 	})
 
-	if !strings.Contains(output, "Recipient removed successfully") {
-		t.Errorf("expected 'Recipient removed successfully', got: %q", output)
-	}
+	if !strings.Contains(output, "Recipient removed") {
+			t.Errorf("expected output containing 'Recipient removed', got: %q", output)
+		}
+		if !strings.Contains(output, "re-encrypted successfully") {
+			t.Errorf("expected output containing 're-encrypted successfully', got: %q", output)
+		}
 }
 
 func TestCmdRecipientsRemove_InvalidKey(t *testing.T) {

--- a/docs/dependency-evaluations/golang-protobuf-migration.md
+++ b/docs/dependency-evaluations/golang-protobuf-migration.md
@@ -222,6 +222,7 @@ Acknowledge the deprecated transitive dependency, document it, and move on. Re-a
 | 2026-04-20 | Sisyphus-Junior | DEFER | groupcache issue #150 still open; no upstream migration |
 | 2026-04-28 | Sisyphus | DEFER | Quarterly check: no upstream changes; scheduled workflow active |
 | 2026-05-05 | Sisyphus | DEFER | Re-audit discovered **second path**: `grpc` → `golang/protobuf`. Tested grpc v1.81.0 upgrade — deprecated dep persists. No viable resolution path. |
+| 2026-06-22 | Sisyphus-Junior | DEFER | Re-audit for #536: grpc at v1.81.1, still depends on `golang/protobuf`. groupcache #150 still open (no new activity since Apr 2024). No upstream changes. |
 
 ---
 


### PR DESCRIPTION
Bundles fixes for multiple open issues. The list below grows as commits land; every linked issue will close automatically on merge.

<!-- closes-list-start -->
- Closes #533 recipients remove does not revoke access to existing entries
- Closes #534 recipients add silently leaves existing entries unreadable by the new recipient
- Closes #535 ARCHITECTURE.md is out of date: wrong agent header, stale tool/package lists
- Closes #536 Deferred dependency still present: golang/protobuf v1.5.4
<!-- closes-list-end -->