### PR TITLE
docs: complete v0.7.1 prerelease gate blockers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [v0.7.1] - unreleased
 
-### Added — repository operations
+Security hardening, KDF improvements, search-index persistence, and bug
+fixes since v0.7.0.
 
+### Security
+
+- **Argon2id zero-key self-heal** — automatically replaces a corrupted
+  zero-length Argon2id key derived from `identity.age`, preventing silent
+  decryption failures on restored or migrated vaults. KDF state is now
+  derived from `identity.age` instead of recomputing on every unlock
+  (#516).
+- **Harden policy storage and MCP policy loading** — search isolation
+  improvements and a resolved gosec gate ensure that policy files and
+  MCP-loaded policies cannot be tampered with at rest or in transit
+  (#524).
+- **Cursor path sanitizer** — escape backslashes first in the cursor
+  path sanitizer to prevent path-traversal bypasses via backslash
+  sequences (#527).
+- **Weak-sensitive-data-hashing** — fix `go/weak-sensitive-data-hashing`
+  finding in `internal/vault/search_index.go` by replacing the weak hash
+  with a safe alternative (#543, #540).
+- **G304 false positive annotation** — annotate a known false positive
+  in the KDF doctor check where the file path is user-controlled but
+  validated before use (#518).
+
+### Added
+
+- **Search-index persistence** — the search index is now persisted to
+  disk and restored on server startup, eliminating a cold-start re-scan
+  of the full vault on every `serve` invocation (#532).
+- **Manifest rebuild** — a new manifest-rebuild path ensures the vault
+  manifest stays consistent after entry create, update, or delete
+  operations (#516).
 - **Projects v2 board** — a new GitHub Projects v2 board named `Symaira
   Vault` (number 11) is linked to this repository. The board includes a
   `Status` single-select (Todo / In Progress / Done), a `Priority`
@@ -26,6 +56,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   v0.10.x). The previous Projects v2 board (`symaira-vault`, number 1)
   remains read-only historical context. Tracked issues can now be
   assigned to an iteration alongside the milestone. See #508.
+
+### Fixed
+
+- **Recipients remove no longer revokes access** — removing a recipient
+  from the vault no longer invalidates access to entries that were
+  already encrypted for that recipient (#537).
+- **Password strength by rune count** — measure password strength by
+  rune count instead of byte length so multi-byte characters (CJK,
+  emoji, accented letters) are counted correctly (#526).
+
+### Changed
+
+- **Search-index refactor** — the search index internals were refactored
+  for clarity and the Argon2id KDF path was hardened against edge cases;
+  build artifacts were cleaned up (#543).
+- **Server-bootstrap cleanup** — the MCP server bootstrap sequence was
+  simplified to reduce startup latency and remove dead code (#532).
+
+### CI
+
+- **Pin `docker/*` GitHub Actions** — pin `docker/build-push-action` and
+  `docker/login-action` to SHA-pinned versions and fix an invalid
+  `github-script` pin to prevent supply-chain drift (#511).
 
 ## [v4.0.0] - 2026-05-21
 

--- a/docs/agent-integration.md
+++ b/docs/agent-integration.md
@@ -50,7 +50,7 @@ so Symaira Vault does not expose a listening socket and Hermes does not need a b
 token in config:
 
 ```bash
-symvault --vault ~/.symvault-vault agent install hermes --config-only
+symvault --vault ~/.symvault agent install hermes --config-only
 ```
 
 Add the output under `mcp_servers` in `~/.hermes/config.yaml` only after the
@@ -114,13 +114,13 @@ symvault agent install openclaw --config-only
 For agents that support HTTP MCP with custom headers, use:
 
 ```bash
-symvault --vault ~/.symvault-vault agent install openclaw --http --config-only
+symvault --vault ~/.symvault agent install openclaw --http --config-only
 ```
 
 HTTP mode requires a running Symaira Vault server:
 
 ```bash
-symvault --vault ~/.symvault-vault serve --port 8090
+symvault --vault ~/.symvault serve --port 8090
 ```
 
 By default, the HTTP server starts with a self-signed TLS certificate auto-generated
@@ -154,7 +154,7 @@ and port as needed:
   <array>
     <string>/usr/local/bin/symvault</string>
     <string>--vault</string>
-    <string>/Users/USER/.openpass-vault</string>
+    <string>/Users/USER/.symvault</string>
     <string>serve</string>
     <string>--port</string>
     <string>8090</string>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -147,7 +147,7 @@ Add profiles to your `config.yaml`:
 ```yaml
 profiles:
   work:
-    vault: ~/.openpass-work
+    vault: ~/.symvault-work
   family:
     vault: ~/vaults/family
 defaultProfile: work
@@ -171,7 +171,7 @@ Vault selection follows this priority, from highest to lowest:
 symvault profile list
 
 # Add a profile
-symvault profile add work --vault ~/.openpass-work
+symvault profile add work --vault ~/.symvault-work
 
 # Set default profile
 symvault profile use work

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -195,7 +195,7 @@ sha256sum -c symaira-vault_<version>_checksums.txt --ignore-missing
 
 ### Cosign Signature Verification
 
-Release artifacts are signed using [Cosign](https://github.com/sigstore/cosign) for SLSA-compliant supply-chain security. To verify the signature of a downloaded archive (e.g., `symaira-vault_0.4.1_linux_amd64.tar.gz`):
+Release artifacts are signed using [Cosign](https://github.com/sigstore/cosign) for SLSA-compliant supply-chain security. To verify the signature of a downloaded archive (e.g., `symaira-vault_<version>_linux_amd64.tar.gz`):
 
 1. Install Cosign: https://docs.sigstore.dev/cosign/system_config/installation/
 2. Download the artifact's certificate and signature:

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,24 +1,25 @@
 ## What's changed
 
-### Features
-- #494 Add redacted self-hosted audit evidence export (+7 more) — closes #484, #487, #488, #489, #490, #491, #492, #493
-- #502 Concurrent file I/O and authorization middleware extraction — closes #498, #499
-
 ### Security
-- #476 Fix argon2id passphrase handling, KDF migration safety, and related cleanup — closes #472, #473, #474, #475
-- #483 v0.6.1 security hardening — 6 vulnerabilities — closes #477, #478, #479, #480, #481, #482
-- #501 Strengthen session cache, add MCP rate-limiting, improve error messages — closes #495, #496, #497
+- #516 Argon2id zero-key self-heal and KDF state from identity.age
+- #524 Harden policy storage, MCP policy loading, search isolation, and the gosec gate
+- #527 Escape backslashes first in cursor path sanitizer
+- #518 Annotate G304 false positive in KDF doctor check
+- #543 Fix weak-sensitive-data-hashing in search index — closes #540, #541, #542
 
 ### Fixes
-- #471 Fix smoke test init + corekit v0.1.1 upgrade
+- #537 Recipients remove no longer revokes access to existing entries
+- #526 Measure password strength by rune count, not byte length
 
-### Documentation
-- #486 Add post-quantum transition plan — closes #485
+### Added
+- #532 Search-index persistence, MCP coverage gate, and server-bootstrap cleanup
+- #516 Manifest rebuild capability
+- #517 Projects v2 board with Status/Priority/Iteration fields
 
 ### Dependencies
-- #470 Bump the go-dependencies group with 3 updates
+- #543 Clean build artifacts and harden Argon2id KDF path
 
 ### CI
-- #469 Use SYMVAULT_PASSPHRASE env var in smoke tests
+- #511 Pin docker/* actions and fix invalid github-script pin
 
-**Full Changelog**: https://github.com/danieljustus/symaira-vault/compare/v0.6.0...v0.7.0
+**Full Changelog**: https://github.com/danieljustus/symaira-vault/compare/v0.7.0...v0.7.1


### PR DESCRIPTION
## Summary

Completes the documentation blockers flagged by the v0.7.1 prerelease gate report.

- Expands the CHANGELOG.md [v0.7.1] section with Security, Added, Fixed, Changed, and CI entries for all changes since v0.7.0.
- Updates release-notes.md to v0.7.1 with grouped highlights and the correct v0.7.0...v0.7.1 compare link.
- Fixes the hardcoded 0.4.1 version example in docs/distribution.md.
- Replaces stale pre-rename paths (~/.openpass-work, ~/.symvault-vault, ~/.openpass-vault) with ~/.symvault / ~/.symvault-work in docs/configuration.md and docs/agent-integration.md.

## Verification

- make docs-check passes.
- go build ./... passes.
- No production code changed.