### PR TITLE
test(cmd): flush manifest updates before temp-dir cleanup

### DIFF
--- a/cmd/test_helpers_test.go
+++ b/cmd/test_helpers_test.go
@@ -61,6 +61,9 @@ func initVault(t *testing.T) (string, []byte) {
 	if _, err := vaultpkg.InitWithPassphrase(vaultDir, passphrase, config.Default()); err != nil {
 		t.Fatalf("init vault: %v", err)
 	}
+	// Flush the async manifest debounce timer before the temp dir is removed;
+	// otherwise the background flush can race with t.TempDir cleanup on macOS.
+	t.Cleanup(vaultpkg.FlushManifestUpdates)
 	return vaultDir, passphrase
 }
 


### PR DESCRIPTION
## Summary

Fixes a flaky macOS test failure where the async manifest debounce timer races with t.TempDir() cleanup.

## Problem

TestAddCommand_TOTPSecretWithSpacesAccepted failed on macOS CI with:

    TempDir RemoveAll cleanup: unlinkat /var/folders/.../001: directory not empty

The manifest updater batches writes with a 50 ms debounce timer. If the timer fires after the test body finishes but while t.TempDir() is still removing the vault directory, the background flush recreates files and macOS refuses to remove the directory.

## Fix

Register vaultpkg.FlushManifestUpdates as a t.Cleanup hook in the initVault test helper. Because t.Cleanup runs LIFO, the flush runs before the temp-dir cleanup that t.TempDir() registered earlier.

## Verification

- go test -run TestAddCommand_TOTPSecretWithSpacesAccepted ./cmd -count=20 passes locally.
- go test -run 'TestAddCommand_|TestSetCommand_|TestCmdAdd_|TestCmdSet_' ./cmd -count=5 passes.
- No production code changed.
