### PR TITLE
chore: ignore local prerelease gate reports in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,7 @@ CLAUDE.md
 
 # Code review artifacts (local working files, not for release)
 .github/review/
+.github/prerelease/
 
 # New binary name (post-rename)
 symvault


### PR DESCRIPTION
Adds  to  alongside the existing  exclusion. These are local-only generated gate reports and should not be tracked.