### PR TITLE
bug: --stdin-value fails on EOF when input has no trailing newline (+3 more)

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,8 +119,8 @@ symvault auth status
 symvault auth set touchid      # macOS Touch ID unlock
 symvault auth set passphrase   # passphrase-only unlock
 
-# Interactive Terminal UI (Experimental)
-symvault ui --experimental
+# Interactive Terminal UI
+symvault ui
 
 # Recipients for multi-user vaults
 symvault recipients list

--- a/cmd/crud/add.go
+++ b/cmd/crud/add.go
@@ -120,14 +120,14 @@ func readStdinValues() error {
 
 	if AddStdinValue {
 		line, err := stdinReader.ReadString('\n')
-		if err != nil {
+		if err != nil && line == "" {
 			return errorspkg.ReadFailed(err, "read --stdin-value")
 		}
 		stdinLines = append(stdinLines, strings.TrimRight(line, "\n\r"))
 	}
 	if AddStdinTOTP {
 		line, err := stdinReader.ReadString('\n')
-		if err != nil {
+		if err != nil && line == "" {
 			return errorspkg.ReadFailed(err, "read --stdin-totp-secret")
 		}
 		stdinLines = append(stdinLines, strings.TrimRight(line, "\n\r"))

--- a/cmd/crud/add_test.go
+++ b/cmd/crud/add_test.go
@@ -1,0 +1,102 @@
+package crud
+
+import (
+	"io"
+	"os"
+	"testing"
+)
+
+func TestReadStdinValues_AcceptsEOFWithData(t *testing.T) {
+	tests := []struct {
+		name         string
+		input        string
+		setValueFlag bool
+		setTOTPFlag  bool
+		wantValue    string
+		wantTOTP     string
+		wantErr      bool
+	}{
+		{
+			name:         "value with trailing newline",
+			input:        "secret\n",
+			setValueFlag: true,
+			wantValue:    "secret",
+			wantErr:      false,
+		},
+		{
+			name:         "value without trailing newline",
+			input:        "secret",
+			setValueFlag: true,
+			wantValue:    "secret",
+			wantErr:      false,
+		},
+		{
+			name:         "empty stdin",
+			input:        "",
+			setValueFlag: true,
+			wantErr:      true,
+		},
+		{
+			name:        "totp secret without trailing newline",
+			input:       "totp-secret",
+			setTOTPFlag: true,
+			wantTOTP:    "totp-secret",
+			wantErr:     false,
+		},
+		{
+			name:         "value and totp without trailing newlines",
+			input:        "value\ntotp",
+			setValueFlag: true,
+			setTOTPFlag:  true,
+			wantValue:    "value",
+			wantTOTP:     "totp",
+			wantErr:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			oldStdin := os.Stdin
+			defer func() { os.Stdin = oldStdin }()
+
+			r, w, err := os.Pipe()
+			if err != nil {
+				t.Fatalf("os.Pipe() = %v", err)
+			}
+			os.Stdin = r
+
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				_, _ = io.WriteString(w, tt.input)
+				_ = w.Close()
+			}()
+
+			oldValueFlag, oldTOTPFlag := AddStdinValue, AddStdinTOTP
+			oldAddValue, oldAddTOTPSecret := AddValue, AddTOTPSecret
+			defer func() {
+				AddStdinValue, AddStdinTOTP = oldValueFlag, oldTOTPFlag
+				AddValue, AddTOTPSecret = oldAddValue, oldAddTOTPSecret
+			}()
+
+			AddStdinValue = tt.setValueFlag
+			AddStdinTOTP = tt.setTOTPFlag
+
+			err = readStdinValues()
+			<-done
+
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("readStdinValues() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if AddValue != tt.wantValue {
+				t.Errorf("AddValue = %q, want %q", AddValue, tt.wantValue)
+			}
+			if AddTOTPSecret != tt.wantTOTP {
+				t.Errorf("AddTOTPSecret = %q, want %q", AddTOTPSecret, tt.wantTOTP)
+			}
+		})
+	}
+}

--- a/cmd/ui.go
+++ b/cmd/ui.go
@@ -16,10 +16,8 @@ var uiExperimental bool
 
 var uiCmd = &cobra.Command{
 	Use:   "ui",
-	Short: "Launch the Symaira Vault terminal UI (Experimental)",
+	Short: "Launch the interactive terminal UI",
 	Long: `Launches the interactive terminal UI for browsing and managing the vault.
-
-NOTE: The terminal UI is currently experimental and must be enabled using the --experimental flag.
 
 Inside the TUI:
   ↑/↓ or j/k   move
@@ -32,10 +30,10 @@ Inside the TUI:
   ?            toggle full keybinding help
   q or Ctrl+C  quit`,
 	Example: `  # Launch the TUI
-  symvault ui --experimental
+  symvault ui
 
   # Combined with a specific profile
-  symvault ui --profile work --experimental`,
+  symvault ui --profile work`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if uiPrintKeybindings {
@@ -45,9 +43,6 @@ Inside the TUI:
 			}
 			fmt.Print(tbl.Render())
 			return nil
-		}
-		if !uiExperimental {
-			return fmt.Errorf("the terminal UI is currently experimental and must be enabled with the --experimental flag: symvault ui --experimental")
 		}
 		return cli.WithVault(func(v *vaultpkg.Vault, vs *cli.VaultService) error {
 			if err := ui.Run(v); err != nil {
@@ -61,6 +56,8 @@ Inside the TUI:
 
 func init() {
 	uiCmd.Flags().BoolVar(&uiPrintKeybindings, "print-keybindings", false, "Print the TUI keybinding reference and exit")
-	uiCmd.Flags().BoolVar(&uiExperimental, "experimental", false, "Enable the experimental terminal UI")
+	// --experimental is kept as a no-op for backward compatibility with scripts
+	// that used it while the TUI was gated. It no longer has any effect.
+	uiCmd.Flags().BoolVar(&uiExperimental, "experimental", false, "(deprecated, no longer needed)")
 	rootCmd.AddCommand(uiCmd)
 }

--- a/cmd/ui_test.go
+++ b/cmd/ui_test.go
@@ -1,38 +1,10 @@
 package cmd
 
 import (
-	"bytes"
-	"strings"
 	"testing"
 )
 
-func TestUICommandExperimentalRequired(t *testing.T) {
-	// Snapshot the flag-bound package variables; the cobra flag bound to
-	// --experimental shares its address with the package-level `uiExperimental`
-	// var, so toggling the bound value is enough to simulate a flag flip.
-	origExperimental := uiExperimental
-	origPrintKeybindings := uiPrintKeybindings
-	t.Cleanup(func() {
-		uiExperimental = origExperimental
-		uiPrintKeybindings = origPrintKeybindings
-	})
-
-	// Disable the early --print-keybindings shortcut so the gate runs.
-	uiPrintKeybindings = false
-	uiExperimental = false
-
-	var errBuf bytes.Buffer
-	rootCmd.SetErr(&errBuf)
-	rootCmd.SetArgs([]string{"ui"})
-
-	if err := rootCmd.Execute(); err == nil {
-		t.Fatal("expected ui command to fail without --experimental flag")
-	} else if !strings.Contains(err.Error(), "experimental") {
-		t.Errorf("expected error message to mention 'experimental', got: %q", err.Error())
-	}
-}
-
-func TestUICommandExperimentalFlagRegistered(t *testing.T) {
+func TestUICommandExperimentalFlagRegisteredAsNoOp(t *testing.T) {
 	flag := uiCmd.Flags().Lookup("experimental")
 	if flag == nil {
 		t.Fatal("expected --experimental flag to be registered on uiCmd")
@@ -41,3 +13,13 @@ func TestUICommandExperimentalFlagRegistered(t *testing.T) {
 		t.Errorf("expected --experimental default value 'false', got %q", flag.DefValue)
 	}
 }
+
+func TestUICommandLaunchWithoutExperimental(t *testing.T) {
+	// The ui command no longer requires --experimental. With no vault set up,
+	// it will fail during vault loading rather than at the experimental gate.
+	flag := uiCmd.Flags().Lookup("experimental")
+	if flag == nil {
+		t.Fatal("expected --experimental flag to be registered on uiCmd")
+	}
+}
+

--- a/cmd/ui_test.go
+++ b/cmd/ui_test.go
@@ -22,4 +22,3 @@ func TestUICommandLaunchWithoutExperimental(t *testing.T) {
 		t.Fatal("expected --experimental flag to be registered on uiCmd")
 	}
 }
-

--- a/internal/git/git_push.go
+++ b/internal/git/git_push.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -33,13 +34,31 @@ func getSSHAuth() (*ssh.PublicKeysCallback, error) {
 	return auth, nil
 }
 
+func systemGitAvailable() bool {
+	_, err := exec.LookPath("git")
+	return err == nil
+}
+
+func pushWithSystemGit(vaultDir string) error {
+	var stderr strings.Builder
+	cmd := exec.Command("git", "-C", vaultDir, "push", "origin", "HEAD")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = &stderr
+	cmd.Stdin = os.Stdin
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("system git push failed: %w (%s)", err, strings.TrimSpace(stderr.String()))
+	}
+	return nil
+}
+
 func pushWithSSHAuth(repo *gogit.Repository, remoteURL string) error {
 	opts := &gogit.PushOptions{RemoteName: "origin"}
 	if isSSHURL(remoteURL) {
 		auth, err := getSSHAuth()
-		if err == nil {
-			opts.Auth = auth
+		if err != nil {
+			return err
 		}
+		opts.Auth = auth
 	}
 	return repo.Push(opts)
 }
@@ -78,7 +97,27 @@ func PushWithResult(vaultDir string) PushResult {
 		return result
 	}
 
-	err = pushWithSSHAuth(repo, originRemote.Config().URLs[0])
+	remoteURL := originRemote.Config().URLs[0]
+
+	// For SSH remotes, prefer the user's system git/OpenSSH setup so that
+	// ~/.ssh/config, the SSH agent, and known_hosts behave exactly like normal git.
+	if isSSHURL(remoteURL) && systemGitAvailable() {
+		sysErr := pushWithSystemGit(vaultDir)
+		if sysErr == nil {
+			result.Success = true
+			return result
+		}
+		// "Everything up-to-date" is a successful no-op.
+		if strings.Contains(sysErr.Error(), "Everything up-to-date") {
+			result.Success = true
+			result.Skipped = true
+			return result
+		}
+		result.Error = classifyPushError(sysErr)
+		return result
+	}
+
+	err = pushWithSSHAuth(repo, remoteURL)
 	if err == nil {
 		result.Success = true
 		return result

--- a/internal/ui/tui.go
+++ b/internal/ui/tui.go
@@ -4,6 +4,7 @@ package ui
 import (
 	"fmt"
 	"os"
+	"sort"
 	"time"
 
 	"github.com/atotto/clipboard"
@@ -404,10 +405,32 @@ func (m TUIModel) copySelectedPassword() tea.Cmd {
 		if err != nil {
 			return copiedMsg{err: fmt.Errorf("read password: %w", err)}
 		}
-		value, ok := entry.Data["password"]
-		if !ok {
-			return copiedMsg{err: fmt.Errorf("password field not found")}
+		fieldName, value := selectCopyField(entry.Data)
+		if fieldName == "" {
+			return copiedMsg{err: fmt.Errorf("no fields found in entry")}
 		}
-		return copyTextMsg(fmt.Sprint(value), fmt.Sprintf("Copied password for %s", path))
+		return copyTextMsg(fmt.Sprint(value), fmt.Sprintf("Copied %s for %s", fieldName, path))
 	}
+}
+
+// selectCopyField chooses the best field to copy from an entry.
+// It prefers common secret field names, then falls back to the first
+// field sorted alphabetically so the choice is deterministic.
+func selectCopyField(data map[string]any) (string, any) {
+	if len(data) == 0 {
+		return "", nil
+	}
+	//nolint:goconst // field names reused across the vault core
+	candidates := []string{string(vaultpkg.SecretTypePassword), "secret", "token", "seed_phrase", string(vaultpkg.SecretTypeAPIKey), "private_key"}
+	for _, name := range candidates {
+		if v, ok := data[name]; ok {
+			return name, v
+		}
+	}
+	names := make([]string, 0, len(data))
+	for name := range data {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names[0], data[names[0]]
 }

--- a/internal/ui/tui_filter.go
+++ b/internal/ui/tui_filter.go
@@ -130,7 +130,9 @@ func isSensitiveField(field string) bool {
 		strings.Contains(field, "token") ||
 		strings.Contains(field, "key") ||
 		strings.Contains(field, "otp") ||
-		strings.Contains(field, "pin")
+		strings.Contains(field, "pin") ||
+		strings.Contains(field, "backup") ||
+		strings.Contains(field, "seed")
 }
 
 func truncate(value string, width int) string {

--- a/internal/ui/tui_test.go
+++ b/internal/ui/tui_test.go
@@ -244,3 +244,86 @@ func TestLoadEntriesCmdIntegration(t *testing.T) {
 		t.Errorf("expected 'test/entry', got %q", entries[0])
 	}
 }
+
+func TestSelectCopyField(t *testing.T) {
+	tests := []struct {
+		name      string
+		data      map[string]any
+		wantField string
+		wantValue any
+	}{
+		{
+			name:      "password field",
+			data:      map[string]any{"password": "secret"},
+			wantField: "password",
+			wantValue: "secret",
+		},
+		{
+			name:      "seed phrase fallback",
+			data:      map[string]any{"seed_phrase": "word1 word2"},
+			wantField: "seed_phrase",
+			wantValue: "word1 word2",
+		},
+		{
+			name:      "api key fallback",
+			data:      map[string]any{"api_key": "ak-123"},
+			wantField: "api_key",
+			wantValue: "ak-123",
+		},
+		{
+			name:      "first alphabetical fallback",
+			data:      map[string]any{"host": "h", "port": "p", "username": "u"},
+			wantField: "host",
+			wantValue: "h",
+		},
+		{
+			name:      "candidate precedence over alphabetical",
+			data:      map[string]any{"aaa": "x", "password": "y"},
+			wantField: "password",
+			wantValue: "y",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			field, value := selectCopyField(tt.data)
+			if field != tt.wantField {
+				t.Errorf("selectCopyField() field = %q, want %q", field, tt.wantField)
+			}
+			if value != tt.wantValue {
+				t.Errorf("selectCopyField() value = %v, want %v", value, tt.wantValue)
+			}
+		})
+	}
+}
+
+func TestSelectCopyFieldEmpty(t *testing.T) {
+	field, value := selectCopyField(map[string]any{})
+	if field != "" || value != nil {
+		t.Errorf("selectCopyField(empty) = (%q, %v), want (\"\", nil)", field, value)
+	}
+}
+
+func TestIsSensitiveField(t *testing.T) {
+	tests := []struct {
+		field string
+		want  bool
+	}{
+		{"password", true},
+		{"api_key", true},
+		{"seed_phrase", true},
+		{"backup_codes", true},
+		{"token", true},
+		{"host", false},
+		{"port", false},
+		{"username", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.field, func(t *testing.T) {
+			if got := isSensitiveField(tt.field); got != tt.want {
+				t.Errorf("isSensitiveField(%q) = %v, want %v", tt.field, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
fix(add): accept stdin values that end without a trailing newline

This session PR addresses the selected open issues.

<!-- closes-list-start -->
- Closes #559 bug: --stdin-value fails on EOF when input has no trailing newline

- Closes #560 bug: symvault git push fails with go-git SSH agent/known_hosts while system git succeeds

- Closes #561 TUI: 'copy' (Enter) fails with 'password field not found' for non-password entries

- Closes #565 TUI: remove experimental gate, make it a first-class feature
<!-- closes-list-end -->