### PR TITLE
test(vault): cover manifest update/remove/verify and vault method wrappers

### DIFF
--- a/internal/vault/manifest_test.go
+++ b/internal/vault/manifest_test.go
@@ -171,3 +171,171 @@ func keysOf(m map[string]ManifestEntry) []string {
 	}
 	return out
 }
+
+// TestUpdateManifestEntry_CreatesAndUpdates covers UpdateManifestEntry when the
+// manifest does not exist yet and when it updates an existing entry.
+func TestUpdateManifestEntry_CreatesAndUpdates(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows: manifest uses cgo age crypto")
+	}
+	vaultDir := t.TempDir()
+	id := testutil.TempIdentity(t)
+	if _, err := InitWithPassphrase(vaultDir, []byte("test-passphrase"), testConfig(vaultDir)); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	entryData := []byte("first-version")
+	if err := UpdateManifestEntry(vaultDir, "alpha", entryData, id); err != nil {
+		t.Fatalf("UpdateManifestEntry first: %v", err)
+	}
+
+	m, err := LoadManifest(vaultDir, id)
+	if err != nil {
+		t.Fatalf("LoadManifest: %v", err)
+	}
+	if _, ok := m.Entries["alpha"]; !ok {
+		t.Fatal("expected alpha entry in manifest after create")
+	}
+	if m.Entries["alpha"].Size != int64(len(entryData)) {
+		t.Errorf("size = %d, want %d", m.Entries["alpha"].Size, len(entryData))
+	}
+
+	updatedData := []byte("second-version-longer")
+	if err := UpdateManifestEntry(vaultDir, "alpha", updatedData, id); err != nil {
+		t.Fatalf("UpdateManifestEntry update: %v", err)
+	}
+
+	m, err = LoadManifest(vaultDir, id)
+	if err != nil {
+		t.Fatalf("LoadManifest after update: %v", err)
+	}
+	if m.Entries["alpha"].Size != int64(len(updatedData)) {
+		t.Errorf("size after update = %d, want %d", m.Entries["alpha"].Size, len(updatedData))
+	}
+}
+
+// TestUpdateManifestEntry_LoadError covers UpdateManifestEntry when the manifest
+// file exists but cannot be decrypted.
+func TestUpdateManifestEntry_LoadError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows: manifest uses cgo age crypto")
+	}
+	vaultDir := t.TempDir()
+	id := testutil.TempIdentity(t)
+	if _, err := InitWithPassphrase(vaultDir, []byte("test-passphrase"), testConfig(vaultDir)); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(vaultDir, manifestFileName), []byte("not-valid-age"), 0o600); err != nil {
+		t.Fatalf("write bad manifest: %v", err)
+	}
+
+	if err := UpdateManifestEntry(vaultDir, "alpha", []byte("data"), id); err == nil {
+		t.Fatal("expected error when manifest cannot be loaded")
+	}
+}
+
+// TestRemoveManifestEntry_RemovesExisting covers RemoveManifestEntry deleting an
+// entry and persisting the manifest.
+func TestRemoveManifestEntry_RemovesExisting(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows: manifest uses cgo age crypto")
+	}
+	vaultDir := t.TempDir()
+	id := testutil.TempIdentity(t)
+	if _, err := InitWithPassphrase(vaultDir, []byte("test-passphrase"), testConfig(vaultDir)); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	if err := WriteEntry(vaultDir, "alpha", &Entry{Data: map[string]any{"v": "a"}}, id); err != nil {
+		t.Fatalf("write alpha: %v", err)
+	}
+	FlushManifestUpdates()
+
+	if err := RemoveManifestEntry(vaultDir, "alpha", id); err != nil {
+		t.Fatalf("RemoveManifestEntry: %v", err)
+	}
+
+	m, err := LoadManifest(vaultDir, id)
+	if err != nil {
+		t.Fatalf("LoadManifest: %v", err)
+	}
+	if _, ok := m.Entries["alpha"]; ok {
+		t.Fatal("expected alpha entry removed from manifest")
+	}
+}
+
+// TestRemoveManifestEntry_MissingManifestNoOp covers RemoveManifestEntry when no
+// manifest exists yet.
+func TestRemoveManifestEntry_MissingManifestNoOp(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows: manifest uses cgo age crypto")
+	}
+	vaultDir := t.TempDir()
+	id := testutil.TempIdentity(t)
+	if _, err := InitWithPassphrase(vaultDir, []byte("test-passphrase"), testConfig(vaultDir)); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	if err := os.RemoveAll(filepath.Join(vaultDir, manifestFileName)); err != nil {
+		t.Fatalf("remove manifest: %v", err)
+	}
+
+	if err := RemoveManifestEntry(vaultDir, "alpha", id); err != nil {
+		t.Fatalf("RemoveManifestEntry on missing manifest: %v", err)
+	}
+}
+
+// TestVerifyManifestIntegrity_OKMissingTamperedUnknown covers the four main
+// integrity verdicts: matching entry, missing file, tampered file, and unknown
+// file on disk.
+func TestVerifyManifestIntegrity_OKMissingTamperedUnknown(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows: manifest uses cgo age crypto")
+	}
+	vaultDir := t.TempDir()
+	id := testutil.TempIdentity(t)
+	if _, err := InitWithPassphrase(vaultDir, []byte("test-passphrase"), testConfig(vaultDir)); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	if err := WriteEntry(vaultDir, "alpha", &Entry{Data: map[string]any{"v": "a"}}, id); err != nil {
+		t.Fatalf("write alpha: %v", err)
+	}
+	if err := WriteEntry(vaultDir, "beta", &Entry{Data: map[string]any{"v": "b"}}, id); err != nil {
+		t.Fatalf("write beta: %v", err)
+	}
+	FlushManifestUpdates()
+
+	// Tamper with beta's ciphertext and add an unknown file.
+	betaPath := entryFilePath(vaultDir, "beta")
+	if err := os.WriteFile(betaPath, []byte("tampered"), 0o600); err != nil {
+		t.Fatalf("tamper beta: %v", err)
+	}
+	unknownPath := filepath.Join(vaultDir, entriesDirName, "unknown.age")
+	if err := os.WriteFile(unknownPath, []byte("sneaked-in"), 0o600); err != nil {
+		t.Fatalf("write unknown: %v", err)
+	}
+
+	// Remove alpha's file so it is reported missing.
+	alphaPath := entryFilePath(vaultDir, "alpha")
+	if err := os.Remove(alphaPath); err != nil {
+		t.Fatalf("remove alpha: %v", err)
+	}
+
+	result, err := VerifyManifestIntegrity(vaultDir, id)
+	if err != nil {
+		t.Fatalf("VerifyManifestIntegrity: %v", err)
+	}
+	if result.OK != 0 {
+		t.Errorf("OK = %d, want 0", result.OK)
+	}
+	if len(result.Missing) != 1 || result.Missing[0] != "alpha" {
+		t.Errorf("Missing = %v, want [alpha]", result.Missing)
+	}
+	if len(result.Tampered) != 1 || result.Tampered[0] != "beta" {
+		t.Errorf("Tampered = %v, want [beta]", result.Tampered)
+	}
+	if len(result.Unknown) != 1 || result.Unknown[0] != "unknown.age" {
+		t.Errorf("Unknown = %v, want [unknown.age]", result.Unknown)
+	}
+}

--- a/internal/vault/vault_method_test.go
+++ b/internal/vault/vault_method_test.go
@@ -1,0 +1,158 @@
+package vault
+
+import (
+	"testing"
+
+	"github.com/danieljustus/symaira-vault/internal/testutil"
+)
+
+func TestVaultList_NilVault(t *testing.T) {
+	var v *Vault
+	_, err := v.List("prefix")
+	if err == nil {
+		t.Fatal("expected error when vault is nil")
+	}
+}
+
+func TestVaultList_ReturnsEntries(t *testing.T) {
+	vaultDir := t.TempDir()
+	id := testutil.TempIdentity(t)
+	if _, err := InitWithPassphrase(vaultDir, []byte("test-passphrase"), testConfig(vaultDir)); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	if err := WriteEntry(vaultDir, "alpha", &Entry{Data: map[string]any{"v": "a"}}, id); err != nil {
+		t.Fatalf("write alpha: %v", err)
+	}
+	if err := WriteEntry(vaultDir, "beta", &Entry{Data: map[string]any{"v": "b"}}, id); err != nil {
+		t.Fatalf("write beta: %v", err)
+	}
+	FlushManifestUpdates()
+
+	v, err := Open(vaultDir, id)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+
+	entries, err := v.List("")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("List returned %d entries, want 2: %v", len(entries), entries)
+	}
+}
+
+func TestVaultList_FilteredByPrefix(t *testing.T) {
+	vaultDir := t.TempDir()
+	id := testutil.TempIdentity(t)
+	if _, err := InitWithPassphrase(vaultDir, []byte("test-passphrase"), testConfig(vaultDir)); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	if err := WriteEntry(vaultDir, "work/aws", &Entry{Data: map[string]any{"v": "a"}}, id); err != nil {
+		t.Fatalf("write work/aws: %v", err)
+	}
+	if err := WriteEntry(vaultDir, "personal/github", &Entry{Data: map[string]any{"v": "g"}}, id); err != nil {
+		t.Fatalf("write personal/github: %v", err)
+	}
+	FlushManifestUpdates()
+
+	v, err := Open(vaultDir, id)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+
+	entries, err := v.List("work")
+	if err != nil {
+		t.Fatalf("List(work): %v", err)
+	}
+	if len(entries) != 1 || entries[0] != "work/aws" {
+		t.Fatalf("List(work) = %v, want [work/aws]", entries)
+	}
+}
+
+func TestVaultFindWithOptions_NilVault(t *testing.T) {
+	var v *Vault
+	_, err := v.FindWithOptions("query", FindOptions{})
+	if err == nil {
+		t.Fatal("expected error when vault is nil")
+	}
+}
+
+func TestVaultFindWithOptions_ReturnsMatches(t *testing.T) {
+	vaultDir := t.TempDir()
+	id := testutil.TempIdentity(t)
+	if _, err := InitWithPassphrase(vaultDir, []byte("test-passphrase"), testConfig(vaultDir)); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	if err := WriteEntry(vaultDir, "work/aws", &Entry{Data: map[string]any{"service": "aws", "key": "AKIA123"}}, id); err != nil {
+		t.Fatalf("write work/aws: %v", err)
+	}
+	FlushManifestUpdates()
+
+	v, err := Open(vaultDir, id)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+
+	matches, err := v.FindWithOptions("aws", FindOptions{MaxWorkers: 1})
+	if err != nil {
+		t.Fatalf("FindWithOptions: %v", err)
+	}
+	if len(matches) == 0 {
+		t.Fatal("expected at least one match for 'aws'")
+	}
+}
+
+func TestVaultReadEntry_NilVault(t *testing.T) {
+	var v *Vault
+	_, err := v.ReadEntry("path")
+	if err == nil {
+		t.Fatal("expected error when vault is nil")
+	}
+}
+
+func TestVaultReadEntry_ReturnsEntry(t *testing.T) {
+	vaultDir := t.TempDir()
+	id := testutil.TempIdentity(t)
+	if _, err := InitWithPassphrase(vaultDir, []byte("test-passphrase"), testConfig(vaultDir)); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	if err := WriteEntry(vaultDir, "test/entry", &Entry{Data: map[string]any{"username": "alice"}}, id); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	FlushManifestUpdates()
+
+	v, err := Open(vaultDir, id)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+
+	entry, err := v.ReadEntry("test/entry")
+	if err != nil {
+		t.Fatalf("ReadEntry: %v", err)
+	}
+	if entry == nil {
+		t.Fatal("ReadEntry returned nil entry")
+	}
+	if entry.Data["username"] != "alice" {
+		t.Errorf("username = %v, want alice", entry.Data["username"])
+	}
+}
+
+func TestVaultReadEntry_MissingPath(t *testing.T) {
+	vaultDir := t.TempDir()
+	id := testutil.TempIdentity(t)
+	if _, err := InitWithPassphrase(vaultDir, []byte("test-passphrase"), testConfig(vaultDir)); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	v, err := Open(vaultDir, id)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+
+	_, err = v.ReadEntry("nonexistent")
+	if err == nil {
+		t.Fatal("expected error for missing entry")
+	}
+}


### PR DESCRIPTION
Add unit tests for UpdateManifestEntry, RemoveManifestEntry, and
VerifyManifestIntegrity covering create/update, missing manifest no-op,
error paths, and OK/missing/tampered/unknown integrity verdicts.

Add tests for Vault.List, Vault.FindWithOptions, and Vault.ReadEntry
covering nil-vault error paths and normal delegation to package-level
functions.

Coverage before: UpdateManifestEntry 0%, RemoveManifestEntry 0%,
VerifyManifestIntegrity 0%, Vault.List 0%, Vault.FindWithOptions 0%,
Vault.ReadEntry 0%.
Coverage after: 100%, 85.7%, 83.3%, 100%, 100%, 100%.
Overall package coverage: 84.3% → 84.6% (no regression).

Closes #569
Closes #570
