### PR TITLE
passlint: add explicit diagnostic assertions to analyzer tests

### DIFF
--- a/cmd/passlint/passlint_test.go
+++ b/cmd/passlint/passlint_test.go
@@ -2,6 +2,7 @@
 package passlint_test
 
 import (
+	"strings"
 	"testing"
 
 	"golang.org/x/tools/go/analysis/analysistest"
@@ -9,27 +10,104 @@ import (
 	"github.com/danieljustus/symaira-vault/cmd/passlint"
 )
 
+func countDiagnostics(results []*analysistest.Result) int {
+	var n int
+	for _, r := range results {
+		n += len(r.Diagnostics)
+	}
+	return n
+}
+
+func diagnosticMessages(results []*analysistest.Result) []string {
+	var msgs []string
+	for _, r := range results {
+		for _, d := range r.Diagnostics {
+			msgs = append(msgs, d.Message)
+		}
+	}
+	return msgs
+}
+
 func TestAnalyzer(t *testing.T) {
 	testdata := analysistest.TestData()
-	analysistest.Run(t, testdata, passlint.Analyzer, "p/a")
+	results := analysistest.Run(t, testdata, passlint.Analyzer, "p/a")
+	if len(results) == 0 {
+		t.Fatal("expected at least one analysistest result")
+	}
+	got := countDiagnostics(results)
+	if got != 11 {
+		t.Errorf("passlint Analyzer: expected 11 diagnostics, got %d", got)
+	}
+	msgs := diagnosticMessages(results)
+	for _, m := range msgs {
+		if !strings.Contains(m, "use of taint.Untrusted") {
+			t.Errorf("unexpected diagnostic message: %q", m)
+		}
+	}
 }
 
 func TestMCPCkeckScopeAnalyzer(t *testing.T) {
 	testdata := analysistest.TestData()
-	analysistest.Run(t, testdata, passlint.MCPCkeckScopeAnalyzer, "mcp/handlers")
+	results := analysistest.Run(t, testdata, passlint.MCPCkeckScopeAnalyzer, "mcp/handlers")
+	if len(results) == 0 {
+		t.Fatal("expected at least one analysistest result")
+	}
+	got := countDiagnostics(results)
+	if got != 1 {
+		t.Errorf("MCPCkeckScopeAnalyzer: expected 1 diagnostic, got %d", got)
+	}
+	msgs := diagnosticMessages(results)
+	if len(msgs) > 0 && !strings.Contains(msgs[0], "does not call s.checkScope()") {
+		t.Errorf("unexpected diagnostic message: %q", msgs[0])
+	}
 }
 
 func TestMCPStringSafelyAnalyzer(t *testing.T) {
 	testdata := analysistest.TestData()
-	analysistest.Run(t, testdata, passlint.MCPStringSafelyAnalyzer, "mcp/strings")
+	results := analysistest.Run(t, testdata, passlint.MCPStringSafelyAnalyzer, "mcp/strings")
+	if len(results) == 0 {
+		t.Fatal("expected at least one analysistest result")
+	}
+	got := countDiagnostics(results)
+	if got != 1 {
+		t.Errorf("MCPStringSafelyAnalyzer: expected 1 diagnostic, got %d", got)
+	}
+	msgs := diagnosticMessages(results)
+	if len(msgs) > 0 && !strings.Contains(msgs[0], "string() cast on taint.Untrusted") {
+		t.Errorf("unexpected diagnostic message: %q", msgs[0])
+	}
 }
 
 func TestMCPMarshalAnalyzer(t *testing.T) {
 	testdata := analysistest.TestData()
-	analysistest.Run(t, testdata, passlint.MCPMarshalAnalyzer, "mcp/marshal")
+	results := analysistest.Run(t, testdata, passlint.MCPMarshalAnalyzer, "mcp/marshal")
+	if len(results) == 0 {
+		t.Fatal("expected at least one analysistest result")
+	}
+	got := countDiagnostics(results)
+	if got != 2 {
+		t.Errorf("MCPMarshalAnalyzer: expected 2 diagnostics, got %d", got)
+	}
+	msgs := diagnosticMessages(results)
+	for _, m := range msgs {
+		if !strings.Contains(m, "json.Marshal in MCP code") {
+			t.Errorf("unexpected diagnostic message: %q", m)
+		}
+	}
 }
 
 func TestCLIErrorAnalyzer(t *testing.T) {
 	testdata := analysistest.TestData()
-	analysistest.Run(t, testdata, passlint.CLIErrorAnalyzer, "clierror/a")
+	results := analysistest.Run(t, testdata, passlint.CLIErrorAnalyzer, "clierror/a")
+	if len(results) == 0 {
+		t.Fatal("expected at least one analysistest result")
+	}
+	got := countDiagnostics(results)
+	if got != 1 {
+		t.Errorf("CLIErrorAnalyzer: expected 1 diagnostic, got %d", got)
+	}
+	msgs := diagnosticMessages(results)
+	if len(msgs) > 0 && !strings.Contains(msgs[0], "fmt.Errorf in RunE handlers") {
+		t.Errorf("unexpected diagnostic message: %q", msgs[0])
+	}
 }

--- a/internal/vault/reencrypt.go
+++ b/internal/vault/reencrypt.go
@@ -84,12 +84,16 @@ func ReencryptAll(vaultDir string, identity *age.X25519Identity, recipients []*a
 	}()
 
 	var processed int64
+	var firstErr error
 	for result := range resultCh {
 		processed++
 		fmt.Fprintf(os.Stderr, "Re-encrypting %d/%d...\r", processed, atomic.LoadInt64(&fileCount))
-		if result.err != nil {
-			return fmt.Errorf("re-encrypt %s: %w", result.path, result.err)
+		if result.err != nil && firstErr == nil {
+			firstErr = fmt.Errorf("re-encrypt %s: %w", result.path, result.err)
 		}
+	}
+	if firstErr != nil {
+		return firstErr
 	}
 
 	walkErrMu.Lock()


### PR DESCRIPTION
Each test now captures analysistest.Run results and asserts on the
returned diagnostics: expected count and message content.

Closes #577
