### PR TITLE
release: v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > and [docs/commercial-boundary.md](docs/commercial-boundary.md) for the
 > current release-line policy. (Added 2026-06-10, see #384.)
 
+## [v0.8.0] - Unreleased
+
+### Added
+
+- Type detection: infer secret type from path and field names (#567)
+- TUI: sort entries by type with grouped headers (#567)
+- Backup codes: structured data model and migration (#567)
+
+### Fixed
+
+- stdin-value: accept values without trailing newline (#566)
+- Git push: use system git for SSH remotes (#566)
+- Generated-password field storage: force SecretTypePassword with --generate (#568)
+- Goroutine leak in ReencryptAll on early error (#579)
+
 ## [v0.7.1] - 2026-06-23
 
 Security hardening, KDF improvements, search-index persistence, and bug

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thank you for your interest in contributing to Symaira Vault! This document prov
 
 ## License and Commercial Boundary
 
-Contributions to this public repository are made under the MIT License used by
+Contributions to this public repository are made under the Apache-2.0 License used by
 Symaira Vault self-hosted. The self-hosted product must remain buildable,
 testable, and runnable without any private commercial code.
 
@@ -435,4 +435,4 @@ For full details, see [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).
 
 ## License
 
-By contributing, you agree that your contributions will be licensed under the MIT License.
+By contributing, you agree that your contributions will be licensed under the Apache-2.0 License.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/danieljustus/symaira-vault/actions/workflows/ci.yml/badge.svg)](https://github.com/danieljustus/symaira-vault/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/danieljustus/symaira-vault)](https://github.com/danieljustus/symaira-vault/releases/latest)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Go Reference](https://pkg.go.dev/badge/github.com/danieljustus/symaira-vault.svg)](https://pkg.go.dev/github.com/danieljustus/symaira-vault)
 [![Go Report Card](https://goreportcard.com/badge/github.com/danieljustus/symaira-vault)](https://goreportcard.com/report/github.com/danieljustus/symaira-vault)
 
@@ -242,10 +242,10 @@ For the full configuration reference, see [docs/configuration.md](docs/configura
 | **Encryption** | age (X25519 + ChaCha20-Poly1305) | AES-256 | AES-256 | GPG | None (plaintext) |
 | **Primary Interface** | Terminal-first | GUI-first (CLI available) | GUI-first (CLI available) | Terminal-only | Chat interface |
 | **AI Integration** | MCP server (stdio + HTTP) with scoped tokens | Agentic Autofill, SDKs for AI agents | MCP server, Agent Access SDK | No AI integration | Paste secrets into prompts |
-| **Pricing** | Free (MIT) | Subscription ($47.88/yr Individual) | Freemium / Subscription ($19.80/yr Premium) | Free (GPL) | Free (but risky) |
+| **Pricing** | Free (Apache-2.0) | Subscription ($47.88/yr Individual) | Freemium / Subscription ($19.80/yr Premium) | Free (GPL) | Free (but risky) |
 | **Sync** | Git (built-in) | Cloud (1Password servers) | Cloud (Bitwarden servers) or self-host | Git (automatic commits) | Manual copy-paste |
 | **Self-hosting** | Full control (local vault + git) | Partial (Connect Server, SCIM Bridge) | Yes (official Docker/K8s or Vaultwarden) | Full control | N/A |
-| **Open Source** | Yes (MIT) | Partial (SDKs open, core proprietary) | Mostly (core GPL/AGPL, Enterprise Bitwarden License) | Yes (GPLv2+) | N/A |
+| **Open Source** | Yes (Apache-2.0) | Partial (SDKs open, core proprietary) | Mostly (core GPL/AGPL, Enterprise Bitwarden \
 | **TOTP** | Built-in | Built-in | Premium feature | Extension only | Manual entry |
 | **Autotype** | Built-in (cross-platform) | Built-in (Windows Auto-Type, macOS Universal Autofill) | Browser autofill only (desktop autotype in development) | No built-in | Manual entry |
 | **Secret Execution** | Built-in (`symvault run`) | Built-in (`op run`) | Built-in (`bws run`) | No built-in | Not applicable |
@@ -301,7 +301,7 @@ Some tests are skipped automatically:
 
 ## License
 
-MIT License
+Apache-2.0 License
 
 ## Acknowledgments
 

--- a/docs/commercial-boundary.md
+++ b/docs/commercial-boundary.md
@@ -1,6 +1,6 @@
 # Commercial Boundary
 
-Symaira Vault self-hosted remains free and open source under the MIT License.
+Symaira Vault self-hosted remains free and open source under the Apache-2.0 License.
 
 The public repository contains the self-hosted core, CLI, runtime behavior,
 documentation, and release artifacts that users can run independently. Public
@@ -12,7 +12,7 @@ cloud deployment automation, compliance operations, and monitoring.
 
 ## Rules
 
-- Keep self-hosted functionality free and MIT-licensed in this repository.
+- Keep self-hosted functionality free and Apache-2.0 licensed in this repository.
 - Do not require private code to build, test, or run the public self-hosted
   product.
 - Do not copy private Pro code into the public repository.

--- a/docs/research-handoff-eu-commercialization.md
+++ b/docs/research-handoff-eu-commercialization.md
@@ -6,7 +6,7 @@ This document preserves the actionable findings from the local research folders:
 - `sonstiges/Research/Kimi_Research_symvault-exopenpass-kommerzialisierung`
 
 The original folders can be deleted once the linked GitHub issues are visible.
-This file keeps only the parts that belong in the public MIT self-hosted core.
+This file keeps only the parts that belong in the public Apache-2.0 self-hosted core.
 Hosted service, billing, tenant operations, SSO/SCIM, hosted RBAC, SIEM export,
 and compliance operations belong to `symaira-vault-pro`.
 
@@ -31,7 +31,7 @@ and compliance operations belong to `symaira-vault-pro`.
 
 ## Core Decisions
 
-- Keep Symaira Vault self-hosted free and MIT licensed.
+- Keep Symaira Vault self-hosted free and Apache-2.0 licensed.
 - Do not add Cloud Pro, billing, customer-support, tenant-management, or hosted
   compliance code to this repo.
 - General core/runtime capabilities that Pro needs must be implemented here

--- a/editors/nvim/README.md
+++ b/editors/nvim/README.md
@@ -107,4 +107,4 @@ lua/symvault/
 
 ## License
 
-MIT — see [LICENSE](../../LICENSE) in the Symaira Vault repository.
+Apache-2.0 — see [LICENSE](../../LICENSE) in the Symaira Vault repository.

--- a/editors/nvim/doc/symaira.txt
+++ b/editors/nvim/doc/symaira.txt
@@ -1,7 +1,7 @@
 *symvault.txt*	Symaira Neovim plugin
 
 Author:  Symaira contributors <https://github.com/danieljustus/symaira-vault>
-License: MIT
+License: Apache-2.0
 
 ==============================================================================
 CONTENTS                                                *symvault-contents*

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -4,7 +4,7 @@
   "description": "VS Code extension for Symaira Vault secret manager",
   "version": "1.0.0",
   "publisher": "symvault",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "engines": {
     "vscode": "^1.85.0"
   },

--- a/homebrew/README.md
+++ b/homebrew/README.md
@@ -73,4 +73,4 @@ Full documentation is available at: https://github.com/danieljustus/symaira-vaul
 
 ## License
 
-MIT License - see https://github.com/danieljustus/symaira-vault/blob/main/LICENSE
+Apache-2.0 License - see https://github.com/danieljustus/symaira-vault/blob/main/LICENSE

--- a/scoop/symvault.json
+++ b/scoop/symvault.json
@@ -2,7 +2,7 @@
     "version": "1.3.0",
     "description": "Modern CLI password manager with age encryption",
     "homepage": "https://github.com/danieljustus/symaira-vault",
-    "license": "MIT",
+    "license": "Apache-2.0",
     "architecture": {
         "64bit": {
             "url": "https://github.com/danieljustus/symaira-vault/releases/download/v1.3.0/symvault_1.3.0_windows_amd64.zip",


### PR DESCRIPTION
## What's changed

### Features
- Type detection: infer secret type from path and field names (closes #563)
- TUI: sort entries by type with grouped headers (closes #564)
- Backup codes: structured data model and migration (closes #562)

### Fixes
- stdin-value: accept values without trailing newline (closes #559)
- Git push: use system git for SSH remotes (closes #560)
- TUI: 'copy' (Enter) works for non-password entries (closes #561)
- TUI: remove experimental gate, make it first-class (closes #565)
- Generated-password storage: force SecretTypePassword with --generate (closes #568)
- Goroutine leak in ReencryptAll on early error (closes #577)

### Chores
- License reference updates: MIT → Apache-2.0 across all documentation
- CHANGELOG: v0.8.0 release section

Release readiness verified by /06-gh-prerelease.