### PR TITLE
fix: wrap codesign hook in shell for GoReleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -57,11 +57,7 @@ builds:
     hooks:
       post:
         - 'scripts/build-mcpb.sh --version "{{ .Version }}" --os "{{ .Os }}" --arch "{{ .Arch }}" --binary "{{ .Path }}"'
-        - cmd: |
-            if [ -n "${CODESIGN_IDENTITY:-}" ]; then
-              codesign -s "$CODESIGN_IDENTITY" --timestamp --options runtime "{{ .Path }}"
-              echo "Signed {{ .Path }}"
-            fi
+        - cmd: sh -c 'if [ -n "${CODESIGN_IDENTITY:-}" ]; then codesign -s "$CODESIGN_IDENTITY" --timestamp --options runtime "{{ .Path }}"; echo "Signed {{ .Path }}"; fi'
     env:
       - CGO_ENABLED=1
       - GOWORK=off


### PR DESCRIPTION
GoReleaser executes cmd directly without a shell, so multi-line if/fi blocks fail. Wrap in sh -c to ensure proper execution.

This fixes the v0.8.1 release workflow failure.