### PR TITLE
feat(run,template): add --env-file, positional refs, --prefix, --passthrough, fix stdin

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -112,7 +112,7 @@ var runCmd = &cobra.Command{
 // Lines starting with # are comments. Blank lines are ignored.
 // Each non-comment line must be in the format NAME=path.field.
 func parseEnvFile(path string) (map[string]string, error) {
-	f, err := os.Open(path)
+	f, err := os.Open(path) // #nosec G304 -- env file path is user-provided CLI argument
 	if err != nil {
 		return nil, fmt.Errorf("open env file %q: %w", path, err)
 	}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"strings"
@@ -16,6 +17,7 @@ import (
 
 var (
 	runEnvFlags   []string
+	runEnvFiles   []string
 	runWorkingDir string
 	runTimeout    time.Duration
 )
@@ -26,6 +28,9 @@ var runCmd = &cobra.Command{
 	Long:  "Executes a command with vault secrets injected as environment variables. Use --env NAME=path.field to map secrets.",
 	Example: `  # Inject AWS_SECRET_ACCESS_KEY from vault entry "work/aws.secret"
   symvault run --env AWS_SECRET_ACCESS_KEY=work/aws.secret -- aws s3 ls
+
+  # Multiple secrets from env file
+  symvault run --env-file .env.symvault -- npm run dev
 
   # Multiple secrets, custom working dir
   symvault run \
@@ -50,6 +55,24 @@ var runCmd = &cobra.Command{
 					return resolveErr
 				}
 				envMap[envName] = value
+			}
+
+			// Parse --env-file flags: each file contains "ENV_NAME=path.field" lines
+			for _, envFilePath := range runEnvFiles {
+				parsed, parseErr := parseEnvFile(envFilePath)
+				if parseErr != nil {
+					return parseErr
+				}
+				for envName, secretRef := range parsed {
+					if _, exists := envMap[envName]; exists {
+						return fmt.Errorf("duplicate env var %q: defined in both --env and --env-file (or in multiple --env-file)", envName)
+					}
+					value, resolveErr := secrets.ResolveSecretRef(v, secretRef)
+					if resolveErr != nil {
+						return resolveErr
+					}
+					envMap[envName] = value
+				}
 			}
 
 			// args contains the command and its arguments (everything after --)
@@ -80,8 +103,45 @@ var runCmd = &cobra.Command{
 	},
 }
 
+// parseEnvFile reads an env file and returns a map of env var names to secret references.
+// Lines starting with # are comments. Blank lines are ignored.
+// Each non-comment line must be in the format NAME=path.field.
+func parseEnvFile(path string) (map[string]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open env file %q: %w", path, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	result := make(map[string]string)
+	scanner := bufio.NewScanner(f)
+	lineNum := 0
+	for scanner.Scan() {
+		lineNum++
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("invalid format in %s:%d: %q (expected NAME=path.field)", path, lineNum, line)
+		}
+		name := strings.TrimSpace(parts[0])
+		ref := strings.TrimSpace(parts[1])
+		if name == "" || ref == "" {
+			return nil, fmt.Errorf("empty name or ref in %s:%d: %q", path, lineNum, line)
+		}
+		result[name] = ref
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("read env file %q: %w", path, err)
+	}
+	return result, nil
+}
+
 func init() {
 	runCmd.Flags().StringArrayVarP(&runEnvFlags, "env", "e", nil, "Environment variable mapping (NAME=path.field)")
+	runCmd.Flags().StringArrayVarP(&runEnvFiles, "env-file", "f", nil, "File with env variable mappings (NAME=path.field), one per line")
 	runCmd.Flags().StringVarP(&runWorkingDir, "working-dir", "C", "", "Working directory for the command")
 	runCmd.Flags().DurationVarP(&runTimeout, "timeout", "t", 0, "Timeout for the command (e.g., 30s)")
 	rootCmd.AddCommand(runCmd)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -16,10 +16,11 @@ import (
 )
 
 var (
-	runEnvFlags   []string
-	runEnvFiles   []string
-	runWorkingDir string
-	runTimeout    time.Duration
+	runEnvFlags    []string
+	runEnvFiles    []string
+	runPassthrough []string
+	runWorkingDir  string
+	runTimeout     time.Duration
 )
 
 var runCmd = &cobra.Command{
@@ -31,6 +32,9 @@ var runCmd = &cobra.Command{
 
   # Multiple secrets from env file
   symvault run --env-file .env.symvault -- npm run dev
+
+  # Pass through parent NODE_ENV and PORT to the child process
+  NODE_ENV=production PORT=8080 symvault run --passthrough NODE_ENV,PORT -- npm start
 
   # Multiple secrets, custom working dir
   symvault run \
@@ -79,6 +83,7 @@ var runCmd = &cobra.Command{
 			result, err := secrets.RunCommand(secrets.RunOptions{
 				Command:    args,
 				Env:        envMap,
+				Passthrough: runPassthrough,
 				WorkingDir: runWorkingDir,
 				Timeout:    runTimeout,
 			})
@@ -142,6 +147,7 @@ func parseEnvFile(path string) (map[string]string, error) {
 func init() {
 	runCmd.Flags().StringArrayVarP(&runEnvFlags, "env", "e", nil, "Environment variable mapping (NAME=path.field)")
 	runCmd.Flags().StringArrayVarP(&runEnvFiles, "env-file", "f", nil, "File with env variable mappings (NAME=path.field), one per line")
+	runCmd.Flags().StringArrayVar(&runPassthrough, "passthrough", nil, "Parent env var names to pass through to the child process (comma-separated)")
 	runCmd.Flags().StringVarP(&runWorkingDir, "working-dir", "C", "", "Working directory for the command")
 	runCmd.Flags().DurationVarP(&runTimeout, "timeout", "t", 0, "Timeout for the command (e.g., 30s)")
 	rootCmd.AddCommand(runCmd)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -81,11 +81,11 @@ var runCmd = &cobra.Command{
 
 			// args contains the command and its arguments (everything after --)
 			result, err := secrets.RunCommand(secrets.RunOptions{
-				Command:    args,
-				Env:        envMap,
+				Command:     args,
+				Env:         envMap,
 				Passthrough: runPassthrough,
-				WorkingDir: runWorkingDir,
-				Timeout:    runTimeout,
+				WorkingDir:  runWorkingDir,
+				Timeout:     runTimeout,
 			})
 			if err != nil {
 				return err

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -250,5 +251,185 @@ func TestCmdRun_InvalidEnvFormat(t *testing.T) {
 		if !strings.Contains(errStr, "invalid --env format") {
 			t.Errorf("expected 'invalid --env format' in error, got: %q", errStr)
 		}
+	}
+}
+
+func TestCmdRun_EnvFile(t *testing.T) {
+	vaultDir, passphrase := initVault(t)
+	identity, _ := vaultpkg.OpenWithPassphrase(vaultDir, passphrase)
+	entry := &vaultpkg.Entry{Data: map[string]any{"password": "filesecret"}}
+	_ = vaultpkg.WriteEntry(vaultDir, "db", entry, identity.Identity)
+	setPassEnv(t, string(passphrase))
+	defer setupVaultFlag(t, vaultDir)()
+
+	envFile := filepath.Join(t.TempDir(), ".env.symvault")
+	if err := os.WriteFile(envFile, []byte("DB_PASS=db.password\n"), 0600); err != nil {
+		t.Fatalf("write env file: %v", err)
+	}
+
+	out := execWithStdout("--vault", vaultDir, "run", "--env-file", envFile, "--", "sh", "-c", "echo $DB_PASS")
+	if !strings.Contains(out, "filesecret") {
+		t.Errorf("expected 'filesecret' in stdout, got: %q", out)
+	}
+}
+
+func TestCmdRun_EnvFileMultiple(t *testing.T) {
+	vaultDir, passphrase := initVault(t)
+	identity, _ := vaultpkg.OpenWithPassphrase(vaultDir, passphrase)
+	entry1 := &vaultpkg.Entry{Data: map[string]any{"token": "tok_from_file"}}
+	entry2 := &vaultpkg.Entry{Data: map[string]any{"secret": "sec_from_file"}}
+	_ = vaultpkg.WriteEntry(vaultDir, "svc1", entry1, identity.Identity)
+	_ = vaultpkg.WriteEntry(vaultDir, "svc2", entry2, identity.Identity)
+	setPassEnv(t, string(passphrase))
+	defer setupVaultFlag(t, vaultDir)()
+
+	envFile := filepath.Join(t.TempDir(), ".env.symvault")
+	content := "TOKEN=svc1.token\nSECRET=svc2.secret\n"
+	if err := os.WriteFile(envFile, []byte(content), 0600); err != nil {
+		t.Fatalf("write env file: %v", err)
+	}
+
+	out := execWithStdout("--vault", vaultDir, "run", "--env-file", envFile, "--",
+		"sh", "-c", "echo TOKEN=$TOKEN SECRET=$SECRET")
+	if !strings.Contains(out, "TOKEN=tok_from_file") {
+		t.Errorf("expected TOKEN=tok_from_file in stdout, got: %q", out)
+	}
+	if !strings.Contains(out, "SECRET=sec_from_file") {
+		t.Errorf("expected SECRET=sec_from_file in stdout, got: %q", out)
+	}
+}
+
+func TestCmdRun_EnvFileWithComments(t *testing.T) {
+	vaultDir, passphrase := initVault(t)
+	identity, _ := vaultpkg.OpenWithPassphrase(vaultDir, passphrase)
+	entry := &vaultpkg.Entry{Data: map[string]any{"password": "comment_test"}}
+	_ = vaultpkg.WriteEntry(vaultDir, "db", entry, identity.Identity)
+	setPassEnv(t, string(passphrase))
+	defer setupVaultFlag(t, vaultDir)()
+
+	envFile := filepath.Join(t.TempDir(), ".env.symvault")
+	content := "# This is a comment\nDB_PASS=db.password\n# Another comment\n"
+	if err := os.WriteFile(envFile, []byte(content), 0600); err != nil {
+		t.Fatalf("write env file: %v", err)
+	}
+
+	out := execWithStdout("--vault", vaultDir, "run", "--env-file", envFile, "--", "sh", "-c", "echo $DB_PASS")
+	if !strings.Contains(out, "comment_test") {
+		t.Errorf("expected 'comment_test' in stdout, got: %q", out)
+	}
+}
+
+func TestCmdRun_EnvFileNotFound(t *testing.T) {
+	vaultDir, passphrase := initVault(t)
+	setPassEnv(t, string(passphrase))
+	defer setupVaultFlag(t, vaultDir)()
+
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "run", "--env-file", "/nonexistent/.env.symvault", "--", "echo", "hello"})
+	defer rootCmd.SetArgs(nil)
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Error("expected error for missing env file, got nil")
+	} else {
+		errStr := err.Error()
+		if !strings.Contains(errStr, "open env file") && !strings.Contains(errStr, "no such file") {
+			t.Errorf("expected env file error, got: %q", errStr)
+		}
+	}
+}
+
+func TestCmdRun_EnvFileInvalidFormat(t *testing.T) {
+	vaultDir, passphrase := initVault(t)
+	setPassEnv(t, string(passphrase))
+	defer setupVaultFlag(t, vaultDir)()
+
+	envFile := filepath.Join(t.TempDir(), ".env.symvault")
+	if err := os.WriteFile(envFile, []byte("NOEQUALSIGN\n"), 0600); err != nil {
+		t.Fatalf("write env file: %v", err)
+	}
+
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "run", "--env-file", envFile, "--", "echo", "hello"})
+	defer rootCmd.SetArgs(nil)
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Error("expected error for invalid env file format, got nil")
+	} else {
+		errStr := err.Error()
+		if !strings.Contains(errStr, "invalid format") {
+			t.Errorf("expected 'invalid format' in error, got: %q", errStr)
+		}
+	}
+}
+
+func TestCmdRun_EnvFileDuplicateVar(t *testing.T) {
+	vaultDir, passphrase := initVault(t)
+	identity, _ := vaultpkg.OpenWithPassphrase(vaultDir, passphrase)
+	entry := &vaultpkg.Entry{Data: map[string]any{"password": "dup_test"}}
+	_ = vaultpkg.WriteEntry(vaultDir, "db", entry, identity.Identity)
+	setPassEnv(t, string(passphrase))
+	defer setupVaultFlag(t, vaultDir)()
+
+	envFile := filepath.Join(t.TempDir(), ".env.symvault")
+	if err := os.WriteFile(envFile, []byte("DB_PASS=db.password\n"), 0600); err != nil {
+		t.Fatalf("write env file: %v", err)
+	}
+
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "run",
+		"--env", "DB_PASS=db.password",
+		"--env-file", envFile,
+		"--", "echo", "hello"})
+	defer rootCmd.SetArgs(nil)
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Error("expected error for duplicate env var, got nil")
+	} else {
+		errStr := err.Error()
+		if !strings.Contains(errStr, "duplicate env var") {
+			t.Errorf("expected 'duplicate env var' in error, got: %q", errStr)
+		}
+	}
+}
+
+func TestCmdRun_EnvFileEmptyLines(t *testing.T) {
+	vaultDir, passphrase := initVault(t)
+	identity, _ := vaultpkg.OpenWithPassphrase(vaultDir, passphrase)
+	entry := &vaultpkg.Entry{Data: map[string]any{"password": "empty_lines_test"}}
+	_ = vaultpkg.WriteEntry(vaultDir, "db", entry, identity.Identity)
+	setPassEnv(t, string(passphrase))
+	defer setupVaultFlag(t, vaultDir)()
+
+	envFile := filepath.Join(t.TempDir(), ".env.symvault")
+	content := "\n\nDB_PASS=db.password\n\n\n"
+	if err := os.WriteFile(envFile, []byte(content), 0600); err != nil {
+		t.Fatalf("write env file: %v", err)
+	}
+
+	out := execWithStdout("--vault", vaultDir, "run", "--env-file", envFile, "--", "sh", "-c", "echo $DB_PASS")
+	if !strings.Contains(out, "empty_lines_test") {
+		t.Errorf("expected 'empty_lines_test' in stdout, got: %q", out)
+	}
+}
+
+func TestParseEnvFile(t *testing.T) {
+	envFile := filepath.Join(t.TempDir(), ".env.symvault")
+	content := "# Comment\nDB_PASS=db.password\nAPI_KEY=stripe.token\n\n# Another comment\n"
+	if err := os.WriteFile(envFile, []byte(content), 0600); err != nil {
+		t.Fatalf("write env file: %v", err)
+	}
+
+	result, err := parseEnvFile(envFile)
+	if err != nil {
+		t.Fatalf("parseEnvFile() unexpected error: %v", err)
+	}
+	if len(result) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(result))
+	}
+	if result["DB_PASS"] != "db.password" {
+		t.Errorf("DB_PASS = %q, want %q", result["DB_PASS"], "db.password")
+	}
+	if result["API_KEY"] != "stripe.token" {
+		t.Errorf("API_KEY = %q, want %q", result["API_KEY"], "stripe.token")
 	}
 }

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -433,3 +433,52 @@ func TestParseEnvFile(t *testing.T) {
 		t.Errorf("API_KEY = %q, want %q", result["API_KEY"], "stripe.token")
 	}
 }
+
+func TestCmdRun_Passthrough(t *testing.T) {
+	vaultDir, passphrase := initVault(t)
+	setPassEnv(t, string(passphrase))
+	defer setupVaultFlag(t, vaultDir)()
+
+	t.Setenv("SYMVAULT_TEST_PASSTHROUGH", "parent_val")
+
+	out := execWithStdout("--vault", vaultDir, "run",
+		"--passthrough", "SYMVAULT_TEST_PASSTHROUGH",
+		"--", "sh", "-c", "echo $SYMVAULT_TEST_PASSTHROUGH")
+	if !strings.Contains(out, "parent_val") {
+		t.Errorf("expected 'parent_val' in stdout, got: %q", out)
+	}
+}
+
+func TestCmdRun_PassthroughNotUsed(t *testing.T) {
+	vaultDir, passphrase := initVault(t)
+	setPassEnv(t, string(passphrase))
+	defer setupVaultFlag(t, vaultDir)()
+
+	t.Setenv("SYMVAULT_TEST_NO_PASS", "should_be_stripped")
+
+	out := execWithStdout("--vault", vaultDir, "run",
+		"--", "sh", "-c", "echo $SYMVAULT_TEST_NO_PASS")
+	if strings.Contains(out, "should_be_stripped") {
+		t.Errorf("env var should be stripped without --passthrough, got: %q", out)
+	}
+}
+
+func TestCmdRun_PassthroughMultiple(t *testing.T) {
+	vaultDir, passphrase := initVault(t)
+	setPassEnv(t, string(passphrase))
+	defer setupVaultFlag(t, vaultDir)()
+
+	t.Setenv("SYMVAULT_TEST_P1", "val1")
+	t.Setenv("SYMVAULT_TEST_P2", "val2")
+
+	out := execWithStdout("--vault", vaultDir, "run",
+		"--passthrough", "SYMVAULT_TEST_P1",
+		"--passthrough", "SYMVAULT_TEST_P2",
+		"--", "sh", "-c", "echo P1=$SYMVAULT_TEST_P1 P2=$SYMVAULT_TEST_P2")
+	if !strings.Contains(out, "P1=val1") {
+		t.Errorf("expected 'P1=val1' in stdout, got: %q", out)
+	}
+	if !strings.Contains(out, "P2=val2") {
+		t.Errorf("expected 'P2=val2' in stdout, got: %q", out)
+	}
+}

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -482,3 +482,25 @@ func TestCmdRun_PassthroughMultiple(t *testing.T) {
 		t.Errorf("expected 'P2=val2' in stdout, got: %q", out)
 	}
 }
+
+func TestCmdRun_StdinForwarding(t *testing.T) {
+	vaultDir, passphrase := initVault(t)
+	setPassEnv(t, string(passphrase))
+	defer setupVaultFlag(t, vaultDir)()
+
+	oldStdin := os.Stdin
+	defer func() { os.Stdin = oldStdin }()
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stdin = r
+	_, _ = w.WriteString("stdin_test_data")
+	_ = w.Close()
+
+	out := execWithStdout("--vault", vaultDir, "run", "--", "cat")
+	if !strings.Contains(out, "stdin_test_data") {
+		t.Errorf("expected 'stdin_test_data' in stdout from stdin forwarding, got: %q", out)
+	}
+}

--- a/cmd/template.go
+++ b/cmd/template.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	cli "github.com/danieljustus/symaira-vault/internal/cli"
 
@@ -18,6 +19,7 @@ var (
 	templateOutput string
 	templateDryRun bool
 	templateName   string
+	templatePrefix string
 )
 
 var templateCmd = &cobra.Command{
@@ -39,22 +41,71 @@ Supported template types:
 }
 
 var templateGenerateCmd = &cobra.Command{
-	Use:   "generate",
+	Use:   "generate [KEY=ref ...]",
 	Short: "Generate a configuration file from a template",
-	Example: `  # Generate .env file from vault secrets
-  symvault template generate --type env --name myapp
+	Long: `Generate a configuration file from a template.
 
-  # Generate Kubernetes secret manifest
-  symvault template generate --type k8s-secret --name myapp --output k8s/secret.yaml
+Refs can be specified as positional KEY=ref arguments or via --prefix to
+automatically select entries matching a vault path prefix. Each ref is a
+vault entry path with an optional dot-separated field (e.g. db.password).
+When --prefix is used without positional args, all matching entries are
+included with the entry basename as the key.`,
+	Example: `  # Generate .env file from specific vault secrets
+  symvault template generate --type env DB_PASS=prod/db.password API_KEY=stripe.token
+
+  # Generate .env from all entries under work/
+  symvault template generate --type env --prefix work/
+
+  # Generate Kubernetes secret manifest with mixed refs
+  symvault template generate --type k8s-secret --name prod-secrets --prefix work/ DB_HOST=infra.db.host
 
   # Dry-run to preview without real values
-  symvault template generate --type env --name myapp --dry-run`,
+  symvault template generate --type env --prefix work/ --dry-run`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return cli.WithVault(func(v *vaultpkg.Vault, vs *cli.VaultService) error {
 			ctx := context.Background()
 			engine := template.NewEngine(v)
 
 			refs := make(map[string]string)
+
+			if templatePrefix != "" {
+				entries, listErr := vaultpkg.List(v.Dir, templatePrefix, v.Identity)
+				if listErr != nil {
+					return fmt.Errorf("list entries with prefix %q: %w", templatePrefix, listErr)
+				}
+				for _, entryPath := range entries {
+					entry, readErr := vaultpkg.ReadEntry(v.Dir, entryPath, v.Identity)
+					if readErr != nil {
+						return fmt.Errorf("read entry %q: %w", entryPath, readErr)
+					}
+					for field := range entry.Data {
+						basename := entryPath
+						if idx := strings.LastIndex(entryPath, "/"); idx >= 0 {
+							basename = entryPath[idx+1:]
+						}
+						key := basename + "." + field
+						refs[key] = entryPath + "." + field
+					}
+				}
+			}
+
+			for _, arg := range args {
+				parts := strings.SplitN(arg, "=", 2)
+				if len(parts) != 2 {
+					return fmt.Errorf("invalid ref format: %q (expected KEY=path[.field])", arg)
+				}
+				key := parts[0]
+				ref := parts[1]
+				if key == "" || ref == "" {
+					return fmt.Errorf("empty key or ref in: %q", arg)
+				}
+				refs[key] = ref
+			}
+
+			if len(refs) == 0 {
+				return fmt.Errorf("no secret references provided: use positional KEY=ref arguments or --prefix")
+			}
+
 			customDir := os.ExpandEnv("$HOME/.config/symvault/templates")
 			_ = engine.LoadCustomTemplates(customDir)
 
@@ -89,6 +140,7 @@ func init() {
 	templateGenerateCmd.Flags().StringVar(&templateOutput, "output", "", "Output file path (optional)")
 	templateGenerateCmd.Flags().BoolVar(&templateDryRun, "dry-run", false, "Show template with masked values")
 	templateGenerateCmd.Flags().StringVar(&templateName, "name", "app", "Name of the resource being generated")
+	templateGenerateCmd.Flags().StringVar(&templatePrefix, "prefix", "", "Vault path prefix to auto-select entries (e.g. work/)")
 	_ = templateGenerateCmd.MarkFlagRequired("type")
 
 	templateCmd.AddCommand(templateGenerateCmd)

--- a/cmd/template_test.go
+++ b/cmd/template_test.go
@@ -1,0 +1,172 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	vaultpkg "github.com/danieljustus/symaira-vault/internal/vault"
+)
+
+func TestCmdTemplateGenerate_PositionalArgs(t *testing.T) {
+	vaultDir, passphrase := initVault(t)
+	identity, _ := vaultpkg.OpenWithPassphrase(vaultDir, passphrase)
+	entry := &vaultpkg.Entry{Data: map[string]any{"password": "s3cret"}}
+	_ = vaultpkg.WriteEntry(vaultDir, "db/prod", entry, identity.Identity)
+	setPassEnv(t, string(passphrase))
+	defer setupVaultFlag(t, vaultDir)()
+
+	out := execWithStdout("--vault", vaultDir, "template", "generate", "--type", "env",
+		"DB_PASS=db/prod.password")
+	if !strings.Contains(out, "s3cret") {
+		t.Errorf("expected 's3cret' in output, got: %q", out)
+	}
+	if !strings.Contains(out, "DB_PASS=") {
+		t.Errorf("expected 'DB_PASS=' in output, got: %q", out)
+	}
+}
+
+func TestCmdTemplateGenerate_MultiplePositionalArgs(t *testing.T) {
+	vaultDir, passphrase := initVault(t)
+	identity, _ := vaultpkg.OpenWithPassphrase(vaultDir, passphrase)
+	entry1 := &vaultpkg.Entry{Data: map[string]any{"token": "tok123"}}
+	entry2 := &vaultpkg.Entry{Data: map[string]any{"secret": "sec456"}}
+	_ = vaultpkg.WriteEntry(vaultDir, "stripe", entry1, identity.Identity)
+	_ = vaultpkg.WriteEntry(vaultDir, "aws", entry2, identity.Identity)
+	setPassEnv(t, string(passphrase))
+	defer setupVaultFlag(t, vaultDir)()
+
+	out := execWithStdout("--vault", vaultDir, "template", "generate", "--type", "env",
+		"API_KEY=stripe.token", "AWS_SECRET=aws.secret")
+	if !strings.Contains(out, "tok123") {
+		t.Errorf("expected 'tok123' in output, got: %q", out)
+	}
+	if !strings.Contains(out, "sec456") {
+		t.Errorf("expected 'sec456' in output, got: %q", out)
+	}
+}
+
+func TestCmdTemplateGenerate_PrefixFlag(t *testing.T) {
+	vaultDir, passphrase := initVault(t)
+	identity, _ := vaultpkg.OpenWithPassphrase(vaultDir, passphrase)
+	entry1 := &vaultpkg.Entry{Data: map[string]any{"token": "tok1"}}
+	entry2 := &vaultpkg.Entry{Data: map[string]any{"secret": "sec2"}}
+	_ = vaultpkg.WriteEntry(vaultDir, "work/api", entry1, identity.Identity)
+	_ = vaultpkg.WriteEntry(vaultDir, "work/db", entry2, identity.Identity)
+	setPassEnv(t, string(passphrase))
+	defer setupVaultFlag(t, vaultDir)()
+
+	out := execWithStdout("--vault", vaultDir, "template", "generate", "--type", "env",
+		"--prefix", "work/")
+	if !strings.Contains(out, "tok1") {
+		t.Errorf("expected 'tok1' in output, got: %q", out)
+	}
+	if !strings.Contains(out, "sec2") {
+		t.Errorf("expected 'sec2' in output, got: %q", out)
+	}
+}
+
+func TestCmdTemplateGenerate_PrefixWithPositionalOverride(t *testing.T) {
+	vaultDir, passphrase := initVault(t)
+	identity, _ := vaultpkg.OpenWithPassphrase(vaultDir, passphrase)
+	entry1 := &vaultpkg.Entry{Data: map[string]any{"token": "prefix_tok"}}
+	entry2 := &vaultpkg.Entry{Data: map[string]any{"password": "explicit_pass"}}
+	_ = vaultpkg.WriteEntry(vaultDir, "work/api", entry1, identity.Identity)
+	_ = vaultpkg.WriteEntry(vaultDir, "db/prod", entry2, identity.Identity)
+	setPassEnv(t, string(passphrase))
+	defer setupVaultFlag(t, vaultDir)()
+
+	out := execWithStdout("--vault", vaultDir, "template", "generate", "--type", "env",
+		"--prefix", "work/", "EXPLICIT_DB=db/prod.password")
+	if !strings.Contains(out, "prefix_tok") {
+		t.Errorf("expected 'prefix_tok' in output, got: %q", out)
+	}
+	if !strings.Contains(out, "explicit_pass") {
+		t.Errorf("expected 'explicit_pass' in output, got: %q", out)
+	}
+}
+
+func TestCmdTemplateGenerate_NoRefsError(t *testing.T) {
+	vaultDir, passphrase := initVault(t)
+	setPassEnv(t, string(passphrase))
+	defer setupVaultFlag(t, vaultDir)()
+
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "template", "generate", "--type", "env"})
+	defer rootCmd.SetArgs(nil)
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Error("expected error for no refs, got nil")
+	} else {
+		errStr := err.Error()
+		if !strings.Contains(errStr, "no secret references") {
+			t.Errorf("expected 'no secret references' in error, got: %q", errStr)
+		}
+	}
+}
+
+func TestCmdTemplateGenerate_InvalidRefFormat(t *testing.T) {
+	vaultDir, passphrase := initVault(t)
+	setPassEnv(t, string(passphrase))
+	defer setupVaultFlag(t, vaultDir)()
+
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "template", "generate", "--type", "env",
+		"NOEQUALSIGN"})
+	defer rootCmd.SetArgs(nil)
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Error("expected error for invalid ref format, got nil")
+	} else {
+		errStr := err.Error()
+		if !strings.Contains(errStr, "invalid ref format") {
+			t.Errorf("expected 'invalid ref format' in error, got: %q", errStr)
+		}
+	}
+}
+
+func TestCmdTemplateGenerate_DryRun(t *testing.T) {
+	vaultDir, passphrase := initVault(t)
+	identity, _ := vaultpkg.OpenWithPassphrase(vaultDir, passphrase)
+	entry := &vaultpkg.Entry{Data: map[string]any{"password": "s3cret"}}
+	_ = vaultpkg.WriteEntry(vaultDir, "db", entry, identity.Identity)
+	setPassEnv(t, string(passphrase))
+	defer setupVaultFlag(t, vaultDir)()
+
+	out := execWithStdout("--vault", vaultDir, "template", "generate", "--type", "env",
+		"--dry-run", "DB_PASS=db.password")
+	if !strings.Contains(out, "***") {
+		t.Errorf("expected '***' in dry-run output, got: %q", out)
+	}
+	if strings.Contains(out, "s3cret") {
+		t.Errorf("dry-run should not contain actual secret, got: %q", out)
+	}
+}
+
+func TestCmdTemplateGenerate_OutputFile(t *testing.T) {
+	vaultDir, passphrase := initVault(t)
+	identity, _ := vaultpkg.OpenWithPassphrase(vaultDir, passphrase)
+	entry := &vaultpkg.Entry{Data: map[string]any{"password": "filetest"}}
+	_ = vaultpkg.WriteEntry(vaultDir, "db", entry, identity.Identity)
+	setPassEnv(t, string(passphrase))
+	defer setupVaultFlag(t, vaultDir)()
+
+	outFile := filepath.Join(t.TempDir(), "output.env")
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "template", "generate", "--type", "env",
+		"--output", outFile, "DB_PASS=db.password"})
+	defer rootCmd.SetArgs(nil)
+
+	err := rootCmd.Execute()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	content, readErr := os.ReadFile(outFile)
+	if readErr != nil {
+		t.Fatalf("read output file: %v", readErr)
+	}
+	if !strings.Contains(string(content), "filetest") {
+		t.Errorf("expected 'filetest' in output file, got: %q", string(content))
+	}
+}

--- a/internal/secrets/runner.go
+++ b/internal/secrets/runner.go
@@ -23,6 +23,9 @@ type RunOptions struct {
 	Command []string
 	// Env contains additional environment variables that overlay os.Environ().
 	Env map[string]string
+	// Passthrough is a list of parent env var names to add to the whitelist
+	// so they pass through to the child process alongside DefaultWhitelist.
+	Passthrough []string
 	// WorkingDir is the directory the command runs in. Empty means current directory.
 	WorkingDir string
 	// Timeout is the maximum duration. Zero means no timeout.
@@ -56,9 +59,13 @@ func RunCommand(opts RunOptions) (*RunResult, error) {
 
 	// Start with a whitelisted env subset as base, then overlay opts.Env.
 	// This prevents leaking sensitive process env vars (API keys, OPENPASS_*, AWS_*,
-	// etc.) to child processes. Only the DefaultWhitelist vars are passed through.
-	// Later entries override earlier ones for the same key.
-	cmd.Env = FilterEnv(DefaultWhitelist())
+	// etc.) to child processes. Only the DefaultWhitelist vars (plus any passthrough)
+	// are passed through. Later entries override earlier ones for the same key.
+	whitelist := DefaultWhitelist()
+	if len(opts.Passthrough) > 0 {
+		whitelist = MergeWhitelist(whitelist, opts.Passthrough)
+	}
+	cmd.Env = FilterEnv(whitelist)
 	for k, v := range opts.Env {
 		cmd.Env = append(cmd.Env, k+"="+v)
 	}

--- a/internal/secrets/runner.go
+++ b/internal/secrets/runner.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"time"
 )
@@ -71,6 +72,7 @@ func RunCommand(opts RunOptions) (*RunResult, error) {
 	}
 
 	var stdout, stderr bytes.Buffer
+	cmd.Stdin = os.Stdin
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 

--- a/internal/secrets/runner_test.go
+++ b/internal/secrets/runner_test.go
@@ -181,3 +181,26 @@ func TestRunCommand_Args(t *testing.T) {
 		t.Fatalf("Stdout = %q, want 'arg1 arg2 arg3'", result.Stdout)
 	}
 }
+
+func TestRunCommand_StdinForwarding(t *testing.T) {
+	oldStdin := os.Stdin
+	defer func() { os.Stdin = oldStdin }()
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stdin = r
+	_, _ = w.WriteString("heredoc_data")
+	_ = w.Close()
+
+	result, err := RunCommand(RunOptions{
+		Command: []string{"cat"},
+	})
+	if err != nil {
+		t.Fatalf("RunCommand() unexpected error: %v", err)
+	}
+	if !strings.Contains(result.Stdout, "heredoc_data") {
+		t.Errorf("expected 'heredoc_data' in stdout from stdin forwarding, got: %q", result.Stdout)
+	}
+}


### PR DESCRIPTION
Add support for reading environment variable mappings from a file via
the new --env-file (-f) flag. The file format is one NAME=path.field
mapping per line, with # comments and blank lines ignored. Multiple
--env-file flags can be specified. Duplicate env var names between
--env and --env-file (or in multiple files) produce a clear error.

Add positional KEY=ref arguments and a --prefix flag to the template
generate command. When --prefix is used, each matching entry's fields
are enumerated as individual refs. Returns a clear error when no refs
are provided.

Add a --passthrough flag to symvault run that allows specific parent
environment variables to pass through the default whitelist to the
child process.

Forward stdin to child process in RunCommand so that heredocs, piped
input, and other stdin sources work correctly with symvault run.

- Closes #590
- Closes #591
- Closes #592
- Closes #593