### PR TITLE
Fix go vet failure in passphrase_env_test.go and goconst finding in authorizer.go

### DIFF
--- a/internal/cli/passphrase_env_test.go
+++ b/internal/cli/passphrase_env_test.go
@@ -76,10 +76,8 @@ func TestConsumeCachedEnvPassphrase_EmptyCache(t *testing.T) {
 
 func TestSniffAndClearEnvPassphrase_SetsCache(t *testing.T) {
 	orig := cachedEnvPassphrase
-	origOnce := cachedEnvPassphraseOnce
 	t.Cleanup(func() {
 		cachedEnvPassphrase = orig
-		cachedEnvPassphraseOnce = origOnce
 	})
 
 	cachedEnvPassphraseOnce = sync.Once{}
@@ -98,10 +96,8 @@ func TestSniffAndClearEnvPassphrase_SetsCache(t *testing.T) {
 
 func TestSniffAndClearEnvPassphrase_LegacyEnvVar(t *testing.T) {
 	orig := cachedEnvPassphrase
-	origOnce := cachedEnvPassphraseOnce
 	t.Cleanup(func() {
 		cachedEnvPassphrase = orig
-		cachedEnvPassphraseOnce = origOnce
 	})
 
 	cachedEnvPassphraseOnce = sync.Once{}
@@ -117,10 +113,8 @@ func TestSniffAndClearEnvPassphrase_LegacyEnvVar(t *testing.T) {
 
 func TestSniffAndClearEnvPassphrase_EmptyEnv(t *testing.T) {
 	orig := cachedEnvPassphrase
-	origOnce := cachedEnvPassphraseOnce
 	t.Cleanup(func() {
 		cachedEnvPassphrase = orig
-		cachedEnvPassphraseOnce = origOnce
 	})
 
 	cachedEnvPassphraseOnce = sync.Once{}
@@ -137,10 +131,8 @@ func TestSniffAndClearEnvPassphrase_EmptyEnv(t *testing.T) {
 
 func TestSniffAndClearEnvPassphrase_UnsetsEnv(t *testing.T) {
 	orig := cachedEnvPassphrase
-	origOnce := cachedEnvPassphraseOnce
 	t.Cleanup(func() {
 		cachedEnvPassphrase = orig
-		cachedEnvPassphraseOnce = origOnce
 		os.Unsetenv("SYMVAULT_PASSPHRASE")
 	})
 
@@ -157,10 +149,8 @@ func TestSniffAndClearEnvPassphrase_UnsetsEnv(t *testing.T) {
 
 func TestSniffAndClearEnvPassphrase_SymvaultTakesPrecedence(t *testing.T) {
 	orig := cachedEnvPassphrase
-	origOnce := cachedEnvPassphraseOnce
 	t.Cleanup(func() {
 		cachedEnvPassphrase = orig
-		cachedEnvPassphraseOnce = origOnce
 		os.Unsetenv("SYMVAULT_PASSPHRASE")
 		os.Unsetenv("OPENPASS_PASSPHRASE")
 	})
@@ -180,10 +170,8 @@ func TestSniffAndClearEnvPassphrase_SymvaultTakesPrecedence(t *testing.T) {
 
 func TestConsumeCachedEnvPassphrase_OnlyConsumesOnce(t *testing.T) {
 	orig := cachedEnvPassphrase
-	origOnce := cachedEnvPassphraseOnce
 	t.Cleanup(func() {
 		cachedEnvPassphrase = orig
-		cachedEnvPassphraseOnce = origOnce
 	})
 
 	cachedEnvPassphraseOnce = sync.Once{}

--- a/internal/policy/authorizer.go
+++ b/internal/policy/authorizer.go
@@ -89,14 +89,19 @@ func NewAuthorizer(config AuthorizerConfig, opts ...AuthorizerOption) Authorizer
 	return a
 }
 
+const (
+	actionRead  = "read"
+	actionWrite = "write"
+)
+
 func (a *authorizerImpl) Authorize(ctx context.Context, path string, write bool, approved bool) error {
 	if path == "" {
 		return errors.New("empty path")
 	}
 
-	actionType := "read"
+	actionType := actionRead
 	if write {
-		actionType = "write"
+		actionType = actionWrite
 	}
 
 	if err := a.checkPolicy(ctx, path, actionType); err != nil {


### PR DESCRIPTION
This PR addresses the selected cohesion unit of open issues for the v0.8.2 milestone.

## Issues

<!-- closes-list-start -->
- Closes #595 Fix go vet failure: sync.Once copied in internal/cli/passphrase_env_test.go
- Closes #596 Fix goconst lint finding in internal/policy/authorizer.go
<!-- closes-list-end -->

_Deferred: group docs-release (#597, #598), group coverage-run (#599) — will be picked up by a follow-up run._