### PR TITLE
Document v0.9.0 run/template features and fix .goreleaser.yml license

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -161,7 +161,7 @@ brews:
     directory: Formula
     homepage: "https://github.com/danieljustus/symaira-vault"
     description: "Modern CLI password manager with age encryption"
-    license: "MIT"
+    license: "Apache-2.0"
     custom_block: |
       version_scheme 1
     install: |
@@ -196,7 +196,7 @@ scoops:
     directory: bucket
     homepage: "https://github.com/danieljustus/symaira-vault"
     description: "Modern CLI password manager with age encryption"
-    license: MIT
+    license: Apache-2.0
     persist:
       - config.yaml
 
@@ -208,7 +208,7 @@ nfpms:
     homepage: "https://github.com/danieljustus/symaira-vault"
     maintainer: "danieljustus <88160656+danieljustus@users.noreply.github.com>"
     description: "Secure password management CLI tool"
-    license: "MIT"
+    license: "Apache-2.0"
     formats:
       - deb
       - rpm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > and [docs/commercial-boundary.md](docs/commercial-boundary.md) for the
 > current release-line policy. (Added 2026-06-10, see #384.)
 
-## [v0.8.1] - 2026-06-29
+## [v0.9.0] - 2026-07-01
+
+v0.9.0 extends secret execution and adds a template engine for generating configuration files from vault secrets.
+
+### Added
+
+- **`symvault run --env-file`** — load multiple secret-to-environment mappings from a file, one `NAME=path.field` per line, with comment and blank-line support (#594).
+- **`symvault run --passthrough`** — pass through selected parent environment variables to the child process, so variables such as `NODE_ENV` and `PORT` stay available (#594).
+- **`symvault template generate`** — generate `.env`, Docker Compose, Kubernetes Secret, GitHub Actions, and Terraform files from vault secrets (#594).
+- **Positional `KEY=ref` template arguments** — map arbitrary template keys to specific vault refs on the command line (#594).
+- **`symvault template generate --prefix`** — auto-select every entry under a vault path prefix (for example, `work/`) and include each field as a template variable (#594).
+
+### Fixed
+
+- **Stdin forwarding in `symvault run`** — child processes now receive stdin, enabling heredocs and piped input (#594).
+
 
 ### Security
 
@@ -790,3 +805,4 @@ Interactive TUI, vault management, and observability release.
 [v2.8.2]: https://github.com/danieljustus/symaira-vault/releases/tag/v2.8.2
 [v2.8.1]: https://github.com/danieljustus/symaira-vault/releases/tag/v2.8.1
 [v2.8.0]: https://github.com/danieljustus/symaira-vault/releases/tag/v2.8.0
+[v0.9.0]: https://github.com/danieljustus/symaira-vault/releases/tag/v0.9.0

--- a/README.md
+++ b/README.md
@@ -133,6 +133,15 @@ symvault git push
 # Secret execution (injects vault secrets as env vars)
 symvault run --env API_KEY=api.kimi-key -- curl -H "Authorization: Bearer $API_KEY" https://api.example.com
 
+# Load mappings from a file (each line: NAME=path.field)
+symvault run --env-file .env.symvault -- npm run dev
+
+# Pass through parent env vars such as NODE_ENV and PORT
+NODE_ENV=production PORT=8080 symvault run --passthrough NODE_ENV,PORT --env DB_PASS=prod/db.password -- ./deploy.sh
+
+# Forward stdin to the child process (heredocs and pipes work)
+cat input.json | symvault run --env API_KEY=api.kimi-key -- node process.js
+
 # Backup/Restore
 symvault backup ~/backups/symvault-$(date +%Y%m%d).tar.gz
 symvault restore ~/backups/symvault-20260427.tar.gz
@@ -151,6 +160,29 @@ symvault import pass ~/.password-store
 ```
 
 See [docs/migration.md](docs/migration.md) for export steps, format details, and verification guidance.
+
+## Configuration templates
+
+Generate configuration files from vault secrets without exposing values in shell history or intermediate files. Templates support positional `KEY=ref` arguments and the `--prefix` flag to auto-select every entry under a vault path.
+
+```bash
+# Generate a .env file from specific vault secrets
+symvault template generate --type env DB_PASS=prod/db.password API_KEY=stripe.token
+
+# Generate a .env file from every entry under work/ (key becomes entry.field)
+symvault template generate --type env --prefix work/ > .env
+
+# Generate a Kubernetes Secret manifest, mixing a prefix with one explicit ref
+symvault template generate --type k8s-secret --name prod-secrets --prefix work/ DB_HOST=infra.db.host
+
+# Preview output with secrets masked
+symvault template generate --type env --prefix work/ --dry-run
+
+# Write output to a file (created with 0600 permissions)
+symvault template generate --type docker-compose --prefix work/ --output docker-compose.env
+```
+
+Supported template types: `env`, `docker-compose`, `k8s-secret`, `github-actions`, and `terraform`. Custom templates can be added in `$HOME/.config/symvault/templates`.
 
 ## MCP Server
 


### PR DESCRIPTION
Bundles fixes for multiple open issues. The list below grows as commits land; every linked issue will close automatically on merge.

<!-- closes-list-start -->
- Closes #597 Document v0.9.0 run/template features in CHANGELOG and README
- Closes #598 Fix .goreleaser.yml license from MIT to Apache-2.0
<!-- closes-list-end -->