### PR TITLE
test: improve patch coverage for run/template/runner error branches

### DIFF
--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -434,6 +434,77 @@ func TestParseEnvFile(t *testing.T) {
 	}
 }
 
+func TestParseEnvFile_EmptyName(t *testing.T) {
+	envFile := filepath.Join(t.TempDir(), ".env.symvault")
+	if err := os.WriteFile(envFile, []byte("=db.password\n"), 0600); err != nil {
+		t.Fatalf("write env file: %v", err)
+	}
+
+	_, err := parseEnvFile(envFile)
+	if err == nil {
+		t.Fatal("expected error for empty name in env file, got nil")
+	}
+	if !strings.Contains(err.Error(), "empty name or ref") {
+		t.Errorf("expected 'empty name or ref' in error, got: %q", err.Error())
+	}
+}
+
+func TestParseEnvFile_EmptyRef(t *testing.T) {
+	envFile := filepath.Join(t.TempDir(), ".env.symvault")
+	if err := os.WriteFile(envFile, []byte("DB_PASS=\n"), 0600); err != nil {
+		t.Fatalf("write env file: %v", err)
+	}
+
+	_, err := parseEnvFile(envFile)
+	if err == nil {
+		t.Fatal("expected error for empty ref in env file, got nil")
+	}
+	if !strings.Contains(err.Error(), "empty name or ref") {
+		t.Errorf("expected 'empty name or ref' in error, got: %q", err.Error())
+	}
+}
+
+func TestParseEnvFile_VeryLongLine(t *testing.T) {
+	envFile := filepath.Join(t.TempDir(), ".env.symvault")
+	// bufio.Scanner default buffer is 64KB; a line exceeding this triggers scanner.Err
+	longLine := strings.Repeat("A", 65*1024)
+	if err := os.WriteFile(envFile, []byte(longLine+"=value\n"), 0600); err != nil {
+		t.Fatalf("write env file: %v", err)
+	}
+
+	_, err := parseEnvFile(envFile)
+	if err == nil {
+		t.Fatal("expected error for very long line in env file, got nil")
+	}
+	if !strings.Contains(err.Error(), "read env file") {
+		t.Errorf("expected 'read env file' in error, got: %q", err.Error())
+	}
+}
+
+func TestCmdRun_EnvFileMissingSecret(t *testing.T) {
+	vaultDir, passphrase := initVault(t)
+	setPassEnv(t, string(passphrase))
+	defer setupVaultFlag(t, vaultDir)()
+
+	envFile := filepath.Join(t.TempDir(), ".env.symvault")
+	if err := os.WriteFile(envFile, []byte("MISSING=nonexistent.entry\n"), 0600); err != nil {
+		t.Fatalf("write env file: %v", err)
+	}
+
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "run", "--env-file", envFile, "--", "echo", "hello"})
+	defer rootCmd.SetArgs(nil)
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Error("expected error for missing secret in env file, got nil")
+	} else {
+		errStr := err.Error()
+		if !strings.Contains(errStr, "not found") && !strings.Contains(errStr, "secret ref") {
+			t.Errorf("expected 'not found' or 'secret ref' in error, got: %q", errStr)
+		}
+	}
+}
+
 func TestCmdRun_Passthrough(t *testing.T) {
 	vaultDir, passphrase := initVault(t)
 	setPassEnv(t, string(passphrase))

--- a/cmd/template_test.go
+++ b/cmd/template_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	cli "github.com/danieljustus/symaira-vault/internal/cli"
 	vaultpkg "github.com/danieljustus/symaira-vault/internal/vault"
 )
 
@@ -168,5 +169,146 @@ func TestCmdTemplateGenerate_OutputFile(t *testing.T) {
 	}
 	if !strings.Contains(string(content), "filetest") {
 		t.Errorf("expected 'filetest' in output file, got: %q", string(content))
+	}
+}
+
+func TestCmdTemplateGenerate_EmptyKeyInRef(t *testing.T) {
+	vaultDir, passphrase := initVault(t)
+	setPassEnv(t, string(passphrase))
+	defer setupVaultFlag(t, vaultDir)()
+
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "template", "generate", "--type", "env",
+		"=db.password"})
+	defer rootCmd.SetArgs(nil)
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Error("expected error for empty key in ref, got nil")
+	} else {
+		if !strings.Contains(err.Error(), "empty key or ref") {
+			t.Errorf("expected 'empty key or ref' in error, got: %q", err.Error())
+		}
+	}
+}
+
+func TestCmdTemplateGenerate_EmptyRefInRef(t *testing.T) {
+	vaultDir, passphrase := initVault(t)
+	setPassEnv(t, string(passphrase))
+	defer setupVaultFlag(t, vaultDir)()
+
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "template", "generate", "--type", "env",
+		"DB_PASS="})
+	defer rootCmd.SetArgs(nil)
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Error("expected error for empty ref in positional arg, got nil")
+	} else {
+		if !strings.Contains(err.Error(), "empty key or ref") {
+			t.Errorf("expected 'empty key or ref' in error, got: %q", err.Error())
+		}
+	}
+}
+
+func TestCmdTemplateGenerate_InvalidTemplateType(t *testing.T) {
+	vaultDir, passphrase := initVault(t)
+	identity, _ := vaultpkg.OpenWithPassphrase(vaultDir, passphrase)
+	entry := &vaultpkg.Entry{Data: map[string]any{"password": "s3cret"}}
+	_ = vaultpkg.WriteEntry(vaultDir, "db", entry, identity.Identity)
+	setPassEnv(t, string(passphrase))
+	defer setupVaultFlag(t, vaultDir)()
+
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "template", "generate", "--type", "nonexistent",
+		"DB_PASS=db.password"})
+	defer rootCmd.SetArgs(nil)
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Error("expected error for invalid template type, got nil")
+	} else {
+		if !strings.Contains(err.Error(), "render template") && !strings.Contains(err.Error(), "unknown template") {
+			t.Errorf("expected template render error, got: %q", err.Error())
+		}
+	}
+}
+
+func TestCmdTemplateGenerate_OutputFilePermissionError(t *testing.T) {
+	vaultDir, passphrase := initVault(t)
+	identity, _ := vaultpkg.OpenWithPassphrase(vaultDir, passphrase)
+	entry := &vaultpkg.Entry{Data: map[string]any{"password": "permtest"}}
+	_ = vaultpkg.WriteEntry(vaultDir, "db", entry, identity.Identity)
+	setPassEnv(t, string(passphrase))
+	defer setupVaultFlag(t, vaultDir)()
+
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "template", "generate", "--type", "env",
+		"--output", "/nonexistent/dir/output.env", "DB_PASS=db.password"})
+	defer rootCmd.SetArgs(nil)
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Error("expected error for unwritable output path, got nil")
+	} else {
+		if !strings.Contains(err.Error(), "write output file") {
+			t.Errorf("expected 'write output file' in error, got: %q", err.Error())
+		}
+	}
+}
+
+func TestCmdTemplateGenerate_JSONOutputWithFile(t *testing.T) {
+	vaultDir, passphrase := initVault(t)
+	identity, _ := vaultpkg.OpenWithPassphrase(vaultDir, passphrase)
+	entry := &vaultpkg.Entry{Data: map[string]any{"password": "json_out_test"}}
+	_ = vaultpkg.WriteEntry(vaultDir, "db", entry, identity.Identity)
+	setPassEnv(t, string(passphrase))
+	defer setupVaultFlag(t, vaultDir)()
+
+	cli.OutputFormat = "json"
+	t.Cleanup(func() { cli.OutputFormat = "text" })
+
+	outFile := filepath.Join(t.TempDir(), "output.env")
+	stdout := captureStdout(func() {
+		rootCmd.SetArgs([]string{"--vault", vaultDir, "template", "generate", "--type", "env",
+			"--output", outFile, "DB_PASS=db.password"})
+		_ = rootCmd.Execute()
+		rootCmd.SetArgs(nil)
+	})
+
+	fileContent, readErr := os.ReadFile(outFile)
+	if readErr != nil {
+		t.Fatalf("read output file: %v", readErr)
+	}
+	if !strings.Contains(string(fileContent), "json_out_test") {
+		t.Errorf("expected 'json_out_test' in output file, got: %q", string(fileContent))
+	}
+	if !strings.Contains(stdout, "output_path") {
+		t.Errorf("expected 'output_path' in JSON stdout, got: %q", stdout)
+	}
+}
+
+func TestCmdTemplateGenerate_PrefixReadError(t *testing.T) {
+	vaultDir, passphrase := initVault(t)
+	identity, _ := vaultpkg.OpenWithPassphrase(vaultDir, passphrase)
+	entry := &vaultpkg.Entry{Data: map[string]any{"token": "good_token"}}
+	_ = vaultpkg.WriteEntry(vaultDir, "work/api", entry, identity.Identity)
+	setPassEnv(t, string(passphrase))
+	defer setupVaultFlag(t, vaultDir)()
+
+	entryDir := filepath.Join(vaultDir, "entries", "work")
+	badFile := filepath.Join(entryDir, "bad_entry.age")
+	if err := os.WriteFile(badFile, []byte("not-valid-age-data"), 0600); err != nil {
+		t.Fatalf("write bad entry file: %v", err)
+	}
+
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "template", "generate", "--type", "env",
+		"--prefix", "work/"})
+	defer rootCmd.SetArgs(nil)
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Error("expected error for unreadable entry in prefix, got nil")
+	} else {
+		if !strings.Contains(err.Error(), "read entry") {
+			t.Errorf("expected 'read entry' in error, got: %q", err.Error())
+		}
 	}
 }

--- a/internal/secrets/runner_test.go
+++ b/internal/secrets/runner_test.go
@@ -204,3 +204,46 @@ func TestRunCommand_StdinForwarding(t *testing.T) {
 		t.Errorf("expected 'heredoc_data' in stdout from stdin forwarding, got: %q", result.Stdout)
 	}
 }
+
+func TestRunCommand_Passthrough(t *testing.T) {
+	t.Setenv("SYMVAULT_TEST_PASSTHROUGH_VAR", "from_parent")
+
+	result, err := RunCommand(RunOptions{
+		Command: []string{"sh", "-c", "echo $SYMVAULT_TEST_PASSTHROUGH_VAR"},
+		Passthrough: []string{"SYMVAULT_TEST_PASSTHROUGH_VAR"},
+	})
+	if err != nil {
+		t.Fatalf("RunCommand() unexpected error: %v", err)
+	}
+	if !strings.Contains(result.Stdout, "from_parent") {
+		t.Errorf("expected passthrough env var 'from_parent' in stdout, got: %q", result.Stdout)
+	}
+}
+
+func TestRunCommand_PassthroughMultiple(t *testing.T) {
+	t.Setenv("SYMVAULT_TEST_PT_A", "alpha")
+	t.Setenv("SYMVAULT_TEST_PT_B", "beta")
+
+	result, err := RunCommand(RunOptions{
+		Command: []string{"sh", "-c", "echo $SYMVAULT_TEST_PT_A $SYMVAULT_TEST_PT_B"},
+		Passthrough: []string{"SYMVAULT_TEST_PT_A", "SYMVAULT_TEST_PT_B"},
+	})
+	if err != nil {
+		t.Fatalf("RunCommand() unexpected error: %v", err)
+	}
+	if !strings.Contains(result.Stdout, "alpha beta") {
+		t.Errorf("expected 'alpha beta' in stdout, got: %q", result.Stdout)
+	}
+}
+
+func TestRunCommand_NonExitError(t *testing.T) {
+	_, err := RunCommand(RunOptions{
+		Command: []string{"symvault_nonexistent_command_xyz"},
+	})
+	if err == nil {
+		t.Fatal("expected error for nonexistent command, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to run command") {
+		t.Errorf("expected 'failed to run command' in error, got: %q", err.Error())
+	}
+}

--- a/internal/secrets/runner_test.go
+++ b/internal/secrets/runner_test.go
@@ -209,7 +209,7 @@ func TestRunCommand_Passthrough(t *testing.T) {
 	t.Setenv("SYMVAULT_TEST_PASSTHROUGH_VAR", "from_parent")
 
 	result, err := RunCommand(RunOptions{
-		Command: []string{"sh", "-c", "echo $SYMVAULT_TEST_PASSTHROUGH_VAR"},
+		Command:     []string{"sh", "-c", "echo $SYMVAULT_TEST_PASSTHROUGH_VAR"},
 		Passthrough: []string{"SYMVAULT_TEST_PASSTHROUGH_VAR"},
 	})
 	if err != nil {
@@ -225,7 +225,7 @@ func TestRunCommand_PassthroughMultiple(t *testing.T) {
 	t.Setenv("SYMVAULT_TEST_PT_B", "beta")
 
 	result, err := RunCommand(RunOptions{
-		Command: []string{"sh", "-c", "echo $SYMVAULT_TEST_PT_A $SYMVAULT_TEST_PT_B"},
+		Command:     []string{"sh", "-c", "echo $SYMVAULT_TEST_PT_A $SYMVAULT_TEST_PT_B"},
 		Passthrough: []string{"SYMVAULT_TEST_PT_A", "SYMVAULT_TEST_PT_B"},
 	})
 	if err != nil {


### PR DESCRIPTION
Add 14 tests covering previously uncovered error paths and edge cases

in cmd/run.go, cmd/template.go, and internal/secrets/runner.go:

- env-file: empty name/ref validation, scanner buffer overflow, missing secret resolve

- template: empty positional refs, invalid template type, output file write error, JSON output format, prefix read error

- runner: passthrough whitelist merge, non-ExitError (command not found)

Closes #599
