### PR TITLE
chore: ignore local agent reports and session artefacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,9 @@ docker/caddy/config/
 .agentsroom/handoff-summary-*.md
 # Agent/developer workspace run logs
 .omo/
+
+# Local agent reports / session state
+.github/coverage/
+.github/audit/
+.omo/run-continuation/
+.omo/notepads/


### PR DESCRIPTION
Add .gitignore entries for local agent-generated reports, coverage files, and session state.

No functional changes.