### PR TITLE
feat(version): integrate versionkit and add --json flag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/creack/pty v1.1.24
-	github.com/danieljustus/symaira-corekit v0.2.1
+	github.com/danieljustus/symaira-corekit v0.3.0
 	github.com/go-git/go-git/v5 v5.19.1
 	github.com/google/uuid v1.6.0
 	github.com/invopop/jsonschema v0.14.0

--- a/go.sum
+++ b/go.sum
@@ -92,8 +92,8 @@ github.com/cyphar/filepath-securejoin v0.6.1 h1:5CeZ1jPXEiYt3+Z6zqprSAgSWiggmpVy
 github.com/cyphar/filepath-securejoin v0.6.1/go.mod h1:A8hd4EnAeyujCJRrICiOWqjS1AX0a9kM5XL+NwKoYSc=
 github.com/danieljoos/wincred v1.2.3 h1:v7dZC2x32Ut3nEfRH+vhoZGvN72+dQ/snVXo/vMFLdQ=
 github.com/danieljoos/wincred v1.2.3/go.mod h1:6qqX0WNrS4RzPZ1tnroDzq9kY3fu1KwE7MRLQK4X0bs=
-github.com/danieljustus/symaira-corekit v0.2.1 h1:k7NBJtzAfaSuB3Ks5zr43xEAGsaoQLEMk5Ck7b9Riuk=
-github.com/danieljustus/symaira-corekit v0.2.1/go.mod h1:45ccz9S14g649OsZyzfgLp77od3WImLRPHaeO414fng=
+github.com/danieljustus/symaira-corekit v0.3.0 h1:46bRjT6kY1z67dli+R8sGYarlPU0NVTRkenRawPBoaA=
+github.com/danieljustus/symaira-corekit v0.3.0/go.mod h1:45ccz9S14g649OsZyzfgLp77od3WImLRPHaeO414fng=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/cli/version.go
+++ b/internal/cli/version.go
@@ -43,13 +43,12 @@ var versionCmd = &cobra.Command{
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		flagJSON, _ := cmd.Flags().GetBool("json")
-		
 		info := versionkit.New("symvault", AppVersion, 1)
 		if WantJSONOutput(flagJSON) {
 			return info.Write(cmd.OutOrStdout())
 		}
-		fmt.Fprintln(cmd.OutOrStdout(), info.String())
-		return nil
+		_, err := fmt.Fprintln(cmd.OutOrStdout(), info.String())
+		return err
 	},
 }
 

--- a/internal/cli/version.go
+++ b/internal/cli/version.go
@@ -1,7 +1,11 @@
 package cli
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
+
+	"github.com/danieljustus/symaira-corekit/versionkit"
 )
 
 var (
@@ -33,20 +37,23 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print the version of Symaira Vault",
 	Example: `  symvault version
-  symvault version --output json`,
+  symvault version --json`,
 	Annotations: map[string]string{
 		RequiresVaultAnnotation: "false",
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		result := VersionResult{
-			Version: AppVersion,
-			Commit:  AppCommit,
-			Built:   AppDate,
+		flagJSON, _ := cmd.Flags().GetBool("json")
+		
+		info := versionkit.New("symvault", AppVersion, 1)
+		if WantJSONOutput(flagJSON) {
+			return info.Write(cmd.OutOrStdout())
 		}
-		return PrintResult(result)
+		fmt.Fprintln(cmd.OutOrStdout(), info.String())
+		return nil
 	},
 }
 
 func init() {
+	versionCmd.Flags().Bool("json", false, "Emit version as machine-readable JSON")
 	RootCmd.AddCommand(versionCmd)
 }

--- a/internal/cli/version_test.go
+++ b/internal/cli/version_test.go
@@ -145,3 +145,44 @@ func marshalYAML(t *testing.T, v interface{}) string {
 func contains(s, substr string) bool {
 	return strings.Contains(s, substr)
 }
+
+func TestVersionCommand(t *testing.T) {
+	// Reset/Save original version info
+	origVersion := AppVersion
+	t.Cleanup(func() { AppVersion = origVersion })
+	AppVersion = "2.3.4"
+
+	var out strings.Builder
+	RootCmd.SetOut(&out)
+	RootCmd.SetErr(&out)
+	t.Cleanup(func() {
+		RootCmd.SetOut(nil)
+		RootCmd.SetErr(nil)
+		RootCmd.SetArgs(nil)
+	})
+
+	RootCmd.SetArgs([]string{"version"})
+	if err := RootCmd.Execute(); err != nil {
+		t.Fatalf("version execute error: %v", err)
+	}
+	if got := strings.TrimSpace(out.String()); got != "symvault 2.3.4" {
+		t.Errorf("expected version output 'symvault 2.3.4', got %q", got)
+	}
+
+	out.Reset()
+	RootCmd.SetArgs([]string{"version", "--json"})
+	if err := RootCmd.Execute(); err != nil {
+		t.Fatalf("version json execute error: %v", err)
+	}
+	var resp struct {
+		Tool          string `json:"tool"`
+		Version       string `json:"version"`
+		SchemaVersion int    `json:"schema_version"`
+	}
+	if err := json.Unmarshal([]byte(out.String()), &resp); err != nil {
+		t.Fatalf("parse JSON version: %v, output was %q", err, out.String())
+	}
+	if resp.Tool != "symvault" || resp.Version != "2.3.4" || resp.SchemaVersion != 1 {
+		t.Errorf("unexpected JSON version payload: %+v", resp)
+	}
+}


### PR DESCRIPTION
Bumps symaira-corekit to v0.3.0 and updates the version subcommand to emit the standardized versionkit handshake payload.