### PR TITLE
Ignore symvault-local build artifact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,7 @@ CLAUDE.md
 
 # New binary name (post-rename)
 symvault
+symvault-local
 
 # Docker runtime data (environment-specific)
 docker/certs/


### PR DESCRIPTION
Adds the local binary variant to .gitignore alongside the existing
'symvault' entry so it does not show up as an untracked file during
sync and release workflows.
