### PR TITLE
Harden API template requests against DNS rebinding and private redire...

### DIFF
--- a/internal/mcp/apitemplates/template.go
+++ b/internal/mcp/apitemplates/template.go
@@ -48,6 +48,9 @@ type APITemplate struct {
 	AllowedMethods []string `yaml:"allowed_methods" json:"allowed_methods"`
 	// DefaultHeaders are headers to include in every request.
 	DefaultHeaders map[string]string `yaml:"default_headers" json:"default_headers,omitempty"`
+	// AllowPrivate permits requests to private or local network destinations.
+	// It is intentionally opt-in because templates can inject vault credentials.
+	AllowPrivate bool `yaml:"allow_private" json:"allow_private,omitempty"`
 }
 
 // templateFile is the on-disk representation of an APITemplate.
@@ -151,10 +154,32 @@ var blockedPrivateRanges = func() []*net.IPNet {
 	return nets
 }()
 
-// isPrivateHost reports whether the given host resolves to a loopback,
-// link-local, or RFC 1918 private address. It accepts IP literals and
-// hostnames; hostnames are checked against known loopback names.
-func isPrivateHost(host string) bool {
+// IsPrivateIP reports whether ip is a local, private, multicast, or
+// otherwise non-routable address that must not receive injected credentials.
+func IsPrivateIP(ip net.IP) bool {
+	if ip == nil {
+		return false
+	}
+	if v4 := ip.To4(); v4 != nil {
+		ip = v4
+	}
+	if ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() ||
+		ip.IsPrivate() || ip.IsMulticast() || ip.IsUnspecified() {
+		return true
+	}
+	for _, blocked := range blockedPrivateRanges {
+		if blocked.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+// IsPrivateHost reports whether the given host is a loopback, link-local,
+// private, multicast, or unspecified address. Hostnames are checked against
+// known local names; DNS names are resolved by the request transport at dial
+// time so DNS rebinding cannot bypass this check.
+func IsPrivateHost(host string) bool {
 	if h, _, err := net.SplitHostPort(host); err == nil {
 		host = h
 	}
@@ -167,13 +192,7 @@ func isPrivateHost(host string) bool {
 	if ip == nil {
 		return false
 	}
-
-	for _, blocked := range blockedPrivateRanges {
-		if blocked.Contains(ip) {
-			return true
-		}
-	}
-	return false
+	return IsPrivateIP(ip)
 }
 
 // parseTemplate parses YAML data into an APITemplate.
@@ -190,7 +209,7 @@ func parseTemplate(name string, data []byte) (*APITemplate, error) {
 	if err != nil {
 		return nil, fmt.Errorf("template %q: invalid base_url: %w", name, err)
 	}
-	if isPrivateHost(parsedURL.Host) && !tf.AllowPrivate {
+	if IsPrivateHost(parsedURL.Host) && !tf.AllowPrivate {
 		return nil, fmt.Errorf("template %q: base_url host %q resolves to a private/internal address; set allow_private: true to override", name, parsedURL.Host)
 	}
 	if tf.AuthType == "" {
@@ -208,5 +227,6 @@ func parseTemplate(name string, data []byte) (*APITemplate, error) {
 		AllowedEndpoints: tf.AllowedEndpoints,
 		AllowedMethods:   tf.AllowedMethods,
 		DefaultHeaders:   tf.DefaultHeaders,
+		AllowPrivate:     tf.AllowPrivate,
 	}, nil
 }

--- a/internal/mcp/apitemplates/template_test.go
+++ b/internal/mcp/apitemplates/template_test.go
@@ -1,66 +1,77 @@
 package apitemplates
 
 import (
+	"net"
 	"testing"
 )
 
 func TestIsPrivateHost_LoopbackIPv4(t *testing.T) {
-	if !isPrivateHost("127.0.0.1") {
+	if !IsPrivateHost("127.0.0.1") {
 		t.Error("expected 127.0.0.1 to be private")
 	}
 }
 
 func TestIsPrivateHost_LoopbackIPv6(t *testing.T) {
-	if !isPrivateHost("::1") {
+	if !IsPrivateHost("::1") {
 		t.Error("expected ::1 to be private")
 	}
 }
 
 func TestIsPrivateHost_LinkLocalIPv4(t *testing.T) {
-	if !isPrivateHost("169.254.169.254") {
+	if !IsPrivateHost("169.254.169.254") {
 		t.Error("expected 169.254.169.254 to be private")
 	}
 }
 
 func TestIsPrivateHost_RFC1918_10(t *testing.T) {
-	if !isPrivateHost("10.0.0.1") {
+	if !IsPrivateHost("10.0.0.1") {
 		t.Error("expected 10.0.0.1 to be private")
 	}
 }
 
 func TestIsPrivateHost_RFC1918_172(t *testing.T) {
-	if !isPrivateHost("172.16.0.1") {
+	if !IsPrivateHost("172.16.0.1") {
 		t.Error("expected 172.16.0.1 to be private")
 	}
 }
 
 func TestIsPrivateHost_RFC1918_192(t *testing.T) {
-	if !isPrivateHost("192.168.1.1") {
+	if !IsPrivateHost("192.168.1.1") {
 		t.Error("expected 192.168.1.1 to be private")
 	}
 }
 
 func TestIsPrivateHost_Localhost(t *testing.T) {
-	if !isPrivateHost("localhost") {
+	if !IsPrivateHost("localhost") {
 		t.Error("expected localhost to be private")
 	}
 }
 
 func TestIsPrivateHost_LocalhostWithPort(t *testing.T) {
-	if !isPrivateHost("localhost:8080") {
+	if !IsPrivateHost("localhost:8080") {
 		t.Error("expected localhost:8080 to be private")
 	}
 }
 
 func TestIsPrivateHost_PublicHost(t *testing.T) {
-	if isPrivateHost("api.github.com") {
+	if IsPrivateHost("api.github.com") {
 		t.Error("expected api.github.com to not be private")
 	}
 }
 
 func TestIsPrivateHost_PublicIP(t *testing.T) {
-	if isPrivateHost("8.8.8.8") {
+	if IsPrivateHost("8.8.8.8") {
 		t.Error("expected 8.8.8.8 to not be private")
+	}
+}
+
+func TestIsPrivateIP_NonRoutableAddresses(t *testing.T) {
+	for _, address := range []string{"0.0.0.0", "::", "224.0.0.1", "ff02::1", "fc00::1"} {
+		t.Run(address, func(t *testing.T) {
+			if !IsPrivateIP(net.ParseIP(address)) {
+				t.Errorf("expected %s to be private or non-routable", address)
+			}
+		})
 	}
 }
 
@@ -107,8 +118,11 @@ auth_type: bearer
 entry_ref: op://vault/item
 allow_private: true
 `)
-	_, err := parseTemplate("test", yaml)
+	tmpl, err := parseTemplate("test", yaml)
 	if err != nil {
 		t.Fatalf("unexpected error with allow_private: %v", err)
+	}
+	if !tmpl.AllowPrivate {
+		t.Fatal("expected allow_private to be preserved on the loaded template")
 	}
 }

--- a/internal/mcp/server/command_policy.go
+++ b/internal/mcp/server/command_policy.go
@@ -1,0 +1,52 @@
+package server
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+)
+
+const (
+	defaultCommandTimeoutSeconds = 30
+	minCommandTimeoutSeconds     = 1
+	maxCommandTimeoutSeconds     = 300
+)
+
+func parseCommandTimeoutSeconds(raw any) (int, error) {
+	if raw == nil {
+		return defaultCommandTimeoutSeconds, nil
+	}
+
+	var value float64
+	switch typed := raw.(type) {
+	case float64:
+		value = typed
+	case float32:
+		value = float64(typed)
+	case int:
+		value = float64(typed)
+	case int32:
+		value = float64(typed)
+	case int64:
+		value = float64(typed)
+	case string:
+		parsed, err := strconv.ParseFloat(typed, 64)
+		if err != nil {
+			return 0, fmt.Errorf("argument \"timeout\" must be numeric")
+		}
+		value = parsed
+	default:
+		return 0, fmt.Errorf("argument \"timeout\" must be numeric")
+	}
+
+	if math.IsNaN(value) || math.IsInf(value, 0) {
+		return 0, fmt.Errorf("argument \"timeout\" must be a finite number")
+	}
+	if value != math.Trunc(value) {
+		return 0, fmt.Errorf("argument \"timeout\" must be a whole number of seconds")
+	}
+	if value < minCommandTimeoutSeconds || value > maxCommandTimeoutSeconds {
+		return 0, fmt.Errorf("argument \"timeout\" must be between %d and %d seconds", minCommandTimeoutSeconds, maxCommandTimeoutSeconds)
+	}
+	return int(value), nil
+}

--- a/internal/mcp/server/command_policy_test.go
+++ b/internal/mcp/server/command_policy_test.go
@@ -1,0 +1,50 @@
+package server
+
+import (
+	"math"
+	"strings"
+	"testing"
+)
+
+func TestParseCommandTimeoutSeconds(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     any
+		want    int
+		wantErr string
+	}{
+		{name: "missing uses default", raw: nil, want: 30},
+		{name: "minimum", raw: float64(1), want: 1},
+		{name: "maximum", raw: float64(300), want: 300},
+		{name: "numeric string", raw: "45", want: 45},
+		{name: "zero", raw: float64(0), wantErr: "between 1 and 300"},
+		{name: "negative", raw: float64(-1), wantErr: "between 1 and 300"},
+		{name: "fractional", raw: float64(1.5), wantErr: "whole number"},
+		{name: "nan", raw: math.NaN(), wantErr: "finite"},
+		{name: "infinity", raw: math.Inf(1), wantErr: "finite"},
+		{name: "too large", raw: float64(301), wantErr: "between 1 and 300"},
+		{name: "invalid string", raw: "not-a-number", wantErr: "numeric"},
+		{name: "unsupported type", raw: true, wantErr: "numeric"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseCommandTimeoutSeconds(tt.raw)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("parseCommandTimeoutSeconds() error = %v", err)
+				}
+				if got != tt.want {
+					t.Fatalf("parseCommandTimeoutSeconds() = %d, want %d", got, tt.want)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("parseCommandTimeoutSeconds() expected error")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error = %v, want %q", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/mcp/server/tools_execute_api_request.go
+++ b/internal/mcp/server/tools_execute_api_request.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"net"
 	"net/http"
 	"net/url"
 	"path"
@@ -90,6 +91,12 @@ func (s *Server) handleExecuteAPIRequest(ctx context.Context, req mcp.CallToolRe
 		return mcp.NewToolResultError(fmt.Sprintf("method not allowed: %s", method)), nil
 	}
 
+	requestURL := tmpl.BaseURL + normalizedEndpoint
+	if targetErr := validateAPIURL(ctx, requestURL, tmpl.AllowPrivate, net.DefaultResolver.LookupIPAddr); targetErr != nil {
+		s.logAudit(ctx, "execute_api_request", fmt.Sprintf("<blocked-target:%s>", tmpl.Name), false)
+		return mcp.NewToolResultError(targetErr.Error()), nil
+	}
+
 	// Approval check before vault access
 	approvalErr := s.checkExecuteAPIRequestApproval(ctx)
 	if approvalErr != nil {
@@ -116,7 +123,6 @@ func (s *Server) handleExecuteAPIRequest(ctx context.Context, req mcp.CallToolRe
 	}
 
 	// Build the request
-	requestURL := tmpl.BaseURL + normalizedEndpoint
 	var requestBody io.Reader
 	if bodyStr != "" {
 		requestBody = strings.NewReader(bodyStr)
@@ -163,9 +169,7 @@ func (s *Server) handleExecuteAPIRequest(ctx context.Context, req mcp.CallToolRe
 	}
 
 	// Execute request
-	client := &http.Client{
-		Timeout: time.Duration(timeoutSec) * time.Second,
-	}
+	client := newAPIHTTPClient(time.Duration(timeoutSec)*time.Second, tmpl.AllowPrivate)
 	resp, respErr := client.Do(httpReq)
 	if respErr != nil {
 		s.logAudit(ctx, "execute_api_request", fmt.Sprintf("template=%s, endpoint=%s, method=%s, status=error",
@@ -235,6 +239,96 @@ func (s *Server) handleExecuteAPIRequest(ctx context.Context, req mcp.CallToolRe
 	}
 
 	return mcp.NewToolResultText(string(resultJSON)), nil
+}
+
+type apiIPResolver func(context.Context, string) ([]net.IPAddr, error)
+
+func newAPIHTTPClient(timeout time.Duration, allowPrivate bool) *http.Client {
+	return newAPIHTTPClientWithResolver(timeout, allowPrivate, net.DefaultResolver.LookupIPAddr)
+}
+
+func newAPIHTTPClientWithResolver(timeout time.Duration, allowPrivate bool, resolve apiIPResolver) *http.Client {
+	dialer := &net.Dialer{}
+	transport := &http.Transport{
+		Proxy: nil,
+		DialContext: func(ctx context.Context, network, address string) (net.Conn, error) {
+			return dialAPIAddress(ctx, dialer, network, address, allowPrivate, resolve)
+		},
+	}
+	return &http.Client{
+		Timeout:   timeout,
+		Transport: transport,
+		CheckRedirect: func(req *http.Request, _ []*http.Request) error {
+			if err := validateAPIURL(req.Context(), req.URL.String(), allowPrivate, resolve); err != nil {
+				return fmt.Errorf("redirect rejected: %w", err)
+			}
+			return nil
+		},
+	}
+}
+
+func validateAPIURL(ctx context.Context, rawURL string, allowPrivate bool, resolve apiIPResolver) error {
+	if allowPrivate {
+		return nil
+	}
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("blocked request target: invalid URL: %w", err)
+	}
+	if u.Hostname() == "" {
+		return fmt.Errorf("blocked request target: URL host is required")
+	}
+	if apitemplates.IsPrivateHost(u.Host) {
+		return fmt.Errorf("blocked request target %q: private or local network address", u.Host)
+	}
+	addresses, err := resolve(ctx, u.Hostname())
+	if err != nil {
+		return fmt.Errorf("cannot resolve request target %q: %w", u.Hostname(), err)
+	}
+	for _, address := range addresses {
+		if apitemplates.IsPrivateIP(address.IP) {
+			return fmt.Errorf("blocked request target %q: resolves to private or local network address", u.Hostname())
+		}
+	}
+	return nil
+}
+
+func dialAPIAddress(ctx context.Context, dialer *net.Dialer, network, address string, allowPrivate bool, resolve apiIPResolver) (net.Conn, error) {
+	host, port, err := net.SplitHostPort(address)
+	if err != nil {
+		return nil, fmt.Errorf("invalid request address %q: %w", address, err)
+	}
+	if allowPrivate {
+		return dialer.DialContext(ctx, network, address)
+	}
+	if apitemplates.IsPrivateHost(host) {
+		return nil, fmt.Errorf("blocked request target %q: private or local network address", host)
+	}
+	addresses, err := resolve(ctx, host)
+	if err != nil {
+		return nil, fmt.Errorf("cannot resolve request target %q: %w", host, err)
+	}
+	var lastErr error
+	for _, resolved := range addresses {
+		if apitemplates.IsPrivateIP(resolved.IP) {
+			return nil, fmt.Errorf("blocked request target %q: resolves to private or local network address", host)
+		}
+		if network == "tcp4" && resolved.IP.To4() == nil {
+			continue
+		}
+		if network == "tcp6" && resolved.IP.To4() != nil {
+			continue
+		}
+		conn, dialErr := dialer.DialContext(ctx, network, net.JoinHostPort(resolved.IP.String(), port))
+		if dialErr == nil {
+			return conn, nil
+		}
+		lastErr = dialErr
+	}
+	if lastErr != nil {
+		return nil, lastErr
+	}
+	return nil, fmt.Errorf("no usable addresses for request target %q", host)
 }
 
 func parseTemplateEntryRef(entryRef string) (string, error) {

--- a/internal/mcp/server/tools_execute_api_request_test.go
+++ b/internal/mcp/server/tools_execute_api_request_test.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/danieljustus/symaira-vault/internal/config"
 	mcp "github.com/danieljustus/symaira-vault/internal/mcp"
@@ -58,6 +60,48 @@ func TestAPITemplateLoad_Builtin(t *testing.T) {
 				t.Error("AllowedMethods is empty")
 			}
 		})
+	}
+}
+
+func TestValidateAPIURL_RejectsResolvedPrivateAddress(t *testing.T) {
+	resolver := func(context.Context, string) ([]net.IPAddr, error) {
+		return []net.IPAddr{{IP: net.ParseIP("127.0.0.1")}}, nil
+	}
+
+	err := validateAPIURL(context.Background(), "http://public.example/secret", false, resolver)
+	if err == nil {
+		t.Fatal("validateAPIURL() expected a private-address error")
+	}
+	if !strings.Contains(err.Error(), "resolves to private") {
+		t.Fatalf("error = %v, want resolved-private explanation", err)
+	}
+}
+
+func TestAPIHTTPClient_RejectsPrivateRedirect(t *testing.T) {
+	resolver := func(context.Context, string) ([]net.IPAddr, error) {
+		return []net.IPAddr{{IP: net.ParseIP("192.168.1.10")}}, nil
+	}
+	client := newAPIHTTPClientWithResolver(time.Second, false, resolver)
+	req := httptest.NewRequest(http.MethodGet, "http://private.example/secret", nil)
+
+	err := client.CheckRedirect(req, nil)
+	if err == nil {
+		t.Fatal("CheckRedirect() expected a private-address error")
+	}
+	if !strings.Contains(err.Error(), "redirect rejected") {
+		t.Fatalf("error = %v, want redirect rejection", err)
+	}
+}
+
+func TestAPIHTTPClient_AllowsPrivateOverride(t *testing.T) {
+	resolver := func(context.Context, string) ([]net.IPAddr, error) {
+		return nil, fmt.Errorf("resolver should not be called when private access is allowed")
+	}
+	client := newAPIHTTPClientWithResolver(time.Second, true, resolver)
+	req := httptest.NewRequest(http.MethodGet, "http://localhost/secret", nil)
+
+	if err := client.CheckRedirect(req, nil); err != nil {
+		t.Fatalf("CheckRedirect() error with allow_private: %v", err)
 	}
 }
 

--- a/internal/mcp/server/tools_execute_with_secret.go
+++ b/internal/mcp/server/tools_execute_with_secret.go
@@ -50,6 +50,12 @@ func (s *Server) handleExecuteWithSecret(ctx context.Context, req mcp.CallToolRe
 		command[i] = str
 	}
 
+	timeoutSeconds, timeoutErr := parseCommandTimeoutSeconds(req.Arguments["timeout"])
+	if timeoutErr != nil {
+		s.logAudit(ctx, "execute_with_secret", "<invalid:timeout>", false)
+		return mcp.NewToolResultError(timeoutErr.Error()), nil
+	}
+
 	refsRaw, ok := req.Arguments["secret_refs"]
 	if !ok {
 		s.logAudit(ctx, "execute_with_secret", "<invalid:missing-secret_refs>", false)
@@ -145,7 +151,6 @@ func (s *Server) handleExecuteWithSecret(ctx context.Context, req mcp.CallToolRe
 	}
 
 	workingDir := req.GetString("working_dir", "")
-	timeoutSeconds := int(req.GetFloat("timeout", 30))
 
 	result, runErr := secrets.RunCommand(secrets.RunOptions{
 		Command:    command,

--- a/internal/mcp/server/tools_execute_with_secret_test.go
+++ b/internal/mcp/server/tools_execute_with_secret_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"runtime"
 	"strings"
 	"testing"
@@ -437,6 +438,32 @@ func TestHandleExecuteWithSecret_Timeout(t *testing.T) {
 	}
 	if !strings.Contains(result.Text, "timed out") {
 		t.Fatalf("result text = %q, want 'timed out'", result.Text)
+	}
+}
+
+func TestHandleExecuteWithSecret_InvalidTimeout(t *testing.T) {
+	srv := newTestServer(t, config.AgentProfile{
+		Name:           "test",
+		AllowedPaths:   []string{"*"},
+		CanRunCommands: config.BoolPtr(true),
+		ApprovalMode:   config.StrPtr("none"),
+	}, "stdio")
+
+	result, err := srv.handleExecuteWithSecret(context.Background(), mcp.CallToolRequest{
+		Arguments: map[string]any{
+			"command":     []any{"echo", "test"},
+			"secret_refs": []any{},
+			"timeout":     math.Inf(1),
+		},
+	})
+	if err != nil {
+		t.Fatalf("handleExecuteWithSecret() error = %v", err)
+	}
+	if result == nil || !result.IsError {
+		t.Fatal("handleExecuteWithSecret() expected a timeout validation error result")
+	}
+	if !strings.Contains(result.Text, "must be a finite number") {
+		t.Fatalf("result text = %q, want finite-timeout validation", result.Text)
 	}
 }
 

--- a/internal/mcp/server/tools_run.go
+++ b/internal/mcp/server/tools_run.go
@@ -62,6 +62,12 @@ func (s *Server) handleRunCommand(ctx context.Context, req mcp.CallToolRequest) 
 		}
 	}
 
+	timeoutSeconds, timeoutErr := parseCommandTimeoutSeconds(req.Arguments["timeout"])
+	if timeoutErr != nil {
+		s.logAudit(ctx, "run_command", "<invalid:timeout>", false)
+		return mcp.NewToolResultError(timeoutErr.Error()), nil
+	}
+
 	resolvedEnv := make(map[string]string)
 	// Audit data: env var names only, never secret values.
 	envNames := make([]string, 0)
@@ -108,7 +114,6 @@ func (s *Server) handleRunCommand(ctx context.Context, req mcp.CallToolRequest) 
 	}
 
 	workingDir := req.GetString("working_dir", "")
-	timeoutSeconds := int(req.GetFloat("timeout", 30))
 
 	auditPath := strings.Join(command, " ")
 	if len(envNames) > 0 {

--- a/internal/mcp/server/tools_run_test.go
+++ b/internal/mcp/server/tools_run_test.go
@@ -288,6 +288,31 @@ func TestHandleRunCommand_Timeout(t *testing.T) {
 	}
 }
 
+func TestHandleRunCommand_InvalidTimeout(t *testing.T) {
+	srv := newTestServer(t, config.AgentProfile{
+		Name:           "test",
+		AllowedPaths:   []string{"*"},
+		CanRunCommands: config.BoolPtr(true),
+		ApprovalMode:   config.StrPtr("none"),
+	}, "stdio")
+
+	result, err := srv.handleRunCommand(context.Background(), mcp.CallToolRequest{
+		Arguments: map[string]any{
+			"command": []any{"echo", "test"},
+			"timeout": float64(0),
+		},
+	})
+	if err != nil {
+		t.Fatalf("handleRunCommand() error = %v", err)
+	}
+	if result == nil || !result.IsError {
+		t.Fatal("handleRunCommand() expected a timeout validation error result")
+	}
+	if !strings.Contains(result.Text, "between 1 and 300 seconds") {
+		t.Fatalf("result text = %q, want timeout bounds", result.Text)
+	}
+}
+
 func TestHandleRunCommand_MasksSecretEnvOnTimeoutError(t *testing.T) {
 	const secret = "synthetic-run-command-timeout-secret"
 	vaultDir, identity := mockVaultWithEntry(t, "github", map[string]any{


### PR DESCRIPTION
Bundles fixes for multiple open issues. The list below grows as commits land; every linked issue will close automatically on merge.

<!-- closes-list-start -->
- Closes #629 Harden API template requests against DNS rebinding and private redirects
- Closes #630 Reject non-positive and unbounded MCP subprocess timeouts
<!-- closes-list-end -->