### PR TITLE
docs: repair post-rename contributor setup and config examples

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ Use the automated setup script to install all required tools:
 
 ```bash
 git clone https://github.com/danieljustus/symaira-vault
-cd Symaira Vault
+cd symaira-vault
 ./scripts/setup-dev.sh
 ```
 
@@ -40,7 +40,7 @@ If you prefer manual setup, ensure you have:
 
 ```bash
 git clone https://github.com/danieljustus/symaira-vault
-cd Symaira Vault
+cd symaira-vault
 go build -o symvault .
 ```
 
@@ -68,13 +68,13 @@ Use `make test-fast` during development for fast feedback. Run `make test` befor
 ### Running from Source
 
 ```bash
-./openpass --help
+./symvault --help
 ```
 
 ### Project Structure
 
 ```
-openpass/
+symaira-vault/
 ├── main.go              # Entry point
 ├── cmd/                 # CLI commands (Cobra)
 │   ├── root.go          # Root command

--- a/Makefile
+++ b/Makefile
@@ -242,6 +242,12 @@ docs-check:
 			errors=$$((errors + 1)); \
 		fi; \
 	done; \
+	for pattern in "./openpass" "cd Symaira Vault"; do \
+		if grep -rF "$$pattern" CONTRIBUTING.md 2>/dev/null; then \
+			echo "Found stale post-rename example in CONTRIBUTING.md: $$pattern"; \
+			errors=$$((errors + 1)); \
+		fi; \
+	done; \
 	echo "Checking README.md links..."; \
 	for link in $$(grep -oE '\[([^]]+)\]\(([^)]+)\)' README.md | grep -v '^http' | grep -v '^#' | sed 's/.*](\([^)]*\)).*/\1/'); do \
 		case "$$link" in \

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -1,10 +1,15 @@
 # Symaira Vault configuration example.
-# Copy this file to ~/.symvault/config.yaml for global settings or to a vault
+# Copy this file to $XDG_CONFIG_HOME/symaira-vault/config.yaml (defaults to
+# ~/.config/symaira-vault/config.yaml) for global settings, or to a vault
 # directory as config.yaml for vault-specific settings.
+# Legacy installs that still have a ~/.symvault directory keep reading and
+# writing config.yaml there until migrated; see internal/config/paths.go.
 
 # Default vault directory used when SYMVAULT_VAULT and --vault are not set.
-# The default subdirectory name is defined by internal/config.DefaultVaultSubdir.
-vaultDir: ~/.symvault
+# New installs default to the XDG data directory (see
+# internal/config.DefaultDataDir), typically ~/.local/share/symaira-vault.
+# Legacy installs keep using ~/.symvault until migrated.
+vaultDir: ~/.local/share/symaira-vault
 
 # Default MCP agent profile used when --agent is not set.
 defaultAgent: default
@@ -51,8 +56,10 @@ agents:
 # Vault-specific settings. These can also live inside <vault>/config.yaml.
 vault:
   # Vault directory path.
-  # The default subdirectory name is defined by internal/config.DefaultVaultSubdir.
-  path: ~/.symvault
+  # New installs default to the XDG data directory (see
+  # internal/config.DefaultDataDir), typically ~/.local/share/symaira-vault.
+  # Legacy installs keep using ~/.symvault until migrated.
+  path: ~/.local/share/symaira-vault
   # Age recipients used for newly written entries.
   default_recipients: []
   #  - age1...


### PR DESCRIPTION
Update CONTRIBUTING.md quickstart and build instructions to use the
current symvault binary and symaira-vault clone directory instead of
stale openpass/"Symaira Vault" references. Update config.yaml.example
to show current XDG default paths instead of the legacy ~/.symvault
path, and add a docs-check guard against stale post-rename examples
in CONTRIBUTING.md.

Closes #632

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
