### PR TITLE
secrets: bound subprocess output capture during execution

### DIFF
--- a/internal/secrets/runner.go
+++ b/internal/secrets/runner.go
@@ -1,7 +1,6 @@
 package secrets
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -12,10 +11,12 @@ import (
 
 // RunResult contains the result of a command execution.
 type RunResult struct {
-	ExitCode int
-	Stdout   string
-	Stderr   string
-	Duration time.Duration
+	ExitCode        int
+	Stdout          string
+	Stderr          string
+	Duration        time.Duration
+	StdoutTruncated bool
+	StderrTruncated bool
 }
 
 // RunOptions configures a command execution.
@@ -33,10 +34,41 @@ type RunOptions struct {
 	Timeout time.Duration
 }
 
+// boundedBuffer captures up to max bytes of written data while still reporting
+// every byte as consumed, so a child process pipe is drained (not blocked)
+// even once the retained capture is full. This keeps peak memory bounded to
+// max regardless of how much output the child actually produces.
+type boundedBuffer struct {
+	max       int
+	data      []byte
+	truncated bool
+}
+
+func newBoundedBuffer(max int) *boundedBuffer {
+	return &boundedBuffer{max: max, data: make([]byte, 0, max)}
+}
+
+func (b *boundedBuffer) Write(p []byte) (int, error) {
+	if remaining := b.max - len(b.data); remaining > 0 {
+		n := len(p)
+		if n > remaining {
+			n = remaining
+		}
+		b.data = append(b.data, p[:n]...)
+		if n < len(p) {
+			b.truncated = true
+		}
+	} else if len(p) > 0 {
+		b.truncated = true
+	}
+	return len(p), nil
+}
+
 // RunCommand executes a command with the given options and captures the result.
 // Environment variables from opts.Env are merged on top of the current process
-// environment. Stdout and stderr are each capped at 100KB to prevent memory
-// exhaustion from excessive output.
+// environment. Stdout and stderr are each bounded at 100KB during capture to
+// prevent memory exhaustion from excessive output; child pipes are drained in
+// full so the process is never blocked by the cap.
 func RunCommand(opts RunOptions) (*RunResult, error) {
 	if len(opts.Command) == 0 {
 		return nil, fmt.Errorf("command must have at least one element")
@@ -71,21 +103,23 @@ func RunCommand(opts RunOptions) (*RunResult, error) {
 		cmd.Env = append(cmd.Env, k+"="+v)
 	}
 
-	var stdout, stderr bytes.Buffer
+	const maxOutput = 100 * 1024
+	stdout := newBoundedBuffer(maxOutput)
+	stderr := newBoundedBuffer(maxOutput)
 	cmd.Stdin = os.Stdin
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
 
 	start := time.Now()
 	runErr := cmd.Run()
 	duration := time.Since(start)
 
-	const maxOutput = 100 * 1024
-
 	result := &RunResult{
-		Duration: duration,
-		Stdout:   string(truncateBytes(stdout.Bytes(), maxOutput)),
-		Stderr:   string(truncateBytes(stderr.Bytes(), maxOutput)),
+		Duration:        duration,
+		Stdout:          string(stdout.data),
+		Stderr:          string(stderr.data),
+		StdoutTruncated: stdout.truncated,
+		StderrTruncated: stderr.truncated,
 	}
 
 	if runErr != nil {
@@ -102,14 +136,4 @@ func RunCommand(opts RunOptions) (*RunResult, error) {
 	}
 
 	return result, nil
-}
-
-// truncateBytes returns a copy of data truncated to maxLen bytes.
-func truncateBytes(data []byte, maxLen int) []byte {
-	if len(data) <= maxLen {
-		return data
-	}
-	truncated := make([]byte, maxLen)
-	copy(truncated, data)
-	return truncated
 }

--- a/internal/secrets/runner_test.go
+++ b/internal/secrets/runner_test.go
@@ -119,6 +119,77 @@ func TestRunCommand_OutputCap(t *testing.T) {
 	if len(result.Stderr) > maxOutput {
 		t.Fatalf("Stderr length = %d exceeds cap %d", len(result.Stderr), maxOutput)
 	}
+	if !result.StdoutTruncated {
+		t.Fatal("StdoutTruncated = false, want true for output exceeding the cap")
+	}
+}
+
+func TestRunCommand_StderrOutputCap(t *testing.T) {
+	result, err := RunCommand(RunOptions{
+		Command: []string{"sh", "-c", "i=0; while [ $i -lt 2000 ]; do printf '%-100s\n' 'x' >&2; i=$((i+1)); done"},
+	})
+	if err != nil {
+		t.Fatalf("RunCommand() unexpected error: %v", err)
+	}
+
+	const maxOutput = 100 * 1024
+	if len(result.Stderr) != maxOutput {
+		t.Fatalf("Stderr length = %d, want exactly %d (capped)", len(result.Stderr), maxOutput)
+	}
+	if !result.StderrTruncated {
+		t.Fatal("StderrTruncated = false, want true for output exceeding the cap")
+	}
+	if result.StdoutTruncated {
+		t.Fatal("StdoutTruncated = true, want false when stdout stayed under the cap")
+	}
+}
+
+func TestRunCommand_OutputUnderCapNotTruncated(t *testing.T) {
+	result, err := RunCommand(RunOptions{
+		Command: []string{"echo", "small"},
+	})
+	if err != nil {
+		t.Fatalf("RunCommand() unexpected error: %v", err)
+	}
+	if result.StdoutTruncated || result.StderrTruncated {
+		t.Fatalf("expected no truncation for small output, got stdout=%v stderr=%v",
+			result.StdoutTruncated, result.StderrTruncated)
+	}
+}
+
+func TestBoundedBuffer_DrainsBeyondCapWithoutGrowing(t *testing.T) {
+	const max = 16
+	b := newBoundedBuffer(max)
+
+	chunk := make([]byte, 1024)
+	for i := range chunk {
+		chunk[i] = 'x'
+	}
+
+	var totalWritten int
+	for i := 0; i < 100; i++ {
+		n, err := b.Write(chunk)
+		if err != nil {
+			t.Fatalf("Write() unexpected error: %v", err)
+		}
+		if n != len(chunk) {
+			t.Fatalf("Write() returned n = %d, want %d (child must never see a short write)", n, len(chunk))
+		}
+		totalWritten += n
+	}
+
+	if len(b.data) != max {
+		t.Fatalf("retained data length = %d, want exactly %d", len(b.data), max)
+	}
+	if cap(b.data) != max {
+		t.Fatalf("retained data capacity = %d, want exactly %d (must not grow past the cap)", cap(b.data), max)
+	}
+	if !b.truncated {
+		t.Fatal("truncated = false, want true after writing far beyond the cap")
+	}
+	if totalWritten <= max {
+		t.Fatalf("totalWritten = %d, want > %d to actually exercise draining", totalWritten, max)
+	}
 }
 
 func TestRunCommand_WorkingDir(t *testing.T) {


### PR DESCRIPTION
RunCommand previously buffered complete stdout/stderr into unbounded
bytes.Buffer values and only truncated after cmd.Run() returned, so a
permitted command with large output could exhaust process memory
before the documented 100KB cap ever applied.

Replace both buffers with a bounded writer that retains at most
100KB per stream while still reporting every byte as written, so the
child's pipes are drained (never blocked) regardless of how much
output it produces. RunResult gains StdoutTruncated/StderrTruncated
so callers can tell capped output from output that fit.

Closes #634

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
