### PR TITLE
vault: surface encrypted search-index persistence failures

### DIFF
--- a/internal/health/doctor.go
+++ b/internal/health/doctor.go
@@ -94,6 +94,7 @@ var allChecks = []checkDef{
 	{fn: checkAuditLog},
 	{fn: checkUpdateAvailable, tags: []string{"network", "slow"}},
 	{fn: checkVaultSize},
+	{fn: checkSearchIndexPersistence},
 	{fn: checkScryptBenchmark, tags: []string{"slow"}},
 	{fn: checkKDFModern},
 	{fn: checkManifestIntegrity},

--- a/internal/health/doctor_test.go
+++ b/internal/health/doctor_test.go
@@ -1140,3 +1140,21 @@ func TestRunChecks_ManifestIntegrity_OutOfBandIsFixable(t *testing.T) {
 		t.Errorf("manifest after fix should include 'out-of-band' entry, got entries: %v", m.Entries)
 	}
 }
+
+func TestRunChecks_SearchIndexPersistence_NoFailureRecorded(t *testing.T) {
+	dir := t.TempDir()
+
+	results := health.RunChecks(dir, health.Options{NoNetwork: true})
+	byID := map[string]health.Result{}
+	for _, r := range results {
+		byID[r.ID] = r
+	}
+
+	r, ok := byID["vault.search_index.persistence"]
+	if !ok {
+		t.Fatal("expected vault.search_index.persistence check to run")
+	}
+	if r.Status != health.StatusOK {
+		t.Errorf("expected ok for vault.search_index.persistence with no prior build, got %s: %s", r.Status, r.Message)
+	}
+}

--- a/internal/health/doctor_vault.go
+++ b/internal/health/doctor_vault.go
@@ -319,6 +319,19 @@ func checkVaultSize(vaultDir string, _ Options) Result {
 	return r
 }
 
+func checkSearchIndexPersistence(vaultDir string, _ Options) Result {
+	r := Result{ID: "vault.search_index.persistence", Name: "Search index persistence"}
+	if err := vault.SearchIndexPersistError(vaultDir); err != nil {
+		r.Status = StatusWarn
+		r.Message = "search index failed to persist to disk: " + err.Error()
+		r.Hint = "search results stay correct in this session, but the index will rebuild from scratch on the next restart; check disk space and permissions in " + vaultDir
+		return r
+	}
+	r.Status = StatusOK
+	r.Message = "no search index persistence failures recorded this session"
+	return r
+}
+
 func checkPassphraseRotation(vaultDir string, _ Options) Result {
 	r := Result{ID: "auth.passphrase.rotation", Name: "Passphrase rotation"}
 

--- a/internal/vault/search_index.go
+++ b/internal/vault/search_index.go
@@ -662,7 +662,7 @@ func writeIndexFile(vaultDir string, salt, ciphertext []byte) error {
 		return err
 	}
 	tmpPath := tmp.Name()
-	defer os.Remove(tmpPath) // no-op once the rename below succeeds
+	defer func() { _ = os.Remove(tmpPath) }() // no-op once the rename below succeeds
 
 	if _, err := tmp.Write(data); err != nil {
 		_ = tmp.Close()

--- a/internal/vault/search_index.go
+++ b/internal/vault/search_index.go
@@ -55,6 +55,21 @@ type EncryptedIndex struct {
 	salt       []byte            // 16-byte HKDF salt (nil for legacy)
 	vaultDir   string            // vault directory the index covers
 	idHash     [sha256.Size]byte // sha256 of identity recipient for change detection
+	persistErr error             // last on-disk persistence failure, if any
+}
+
+// LastPersistError returns the error from the most recent attempt to persist
+// the search index to disk (full build, incremental update, or delete), or
+// nil if the last attempt succeeded or none has been attempted yet. A failed
+// persist never affects the correctness of in-memory search — the index
+// keeps serving matches — but it does mean the next process start rebuilds
+// the index from scratch instead of loading it from disk. Exposed so
+// `symvault doctor` can surface persistent write failures instead of the
+// vault silently losing this performance optimization.
+func (idx *EncryptedIndex) LastPersistError() error {
+	idx.mu.RLock()
+	defer idx.mu.RUnlock()
+	return idx.persistErr
 }
 
 func indexFilePath(vaultDir string) string {
@@ -175,6 +190,14 @@ var searchIndexStore = indexStore{indices: make(map[string]*EncryptedIndex)}
 // index for Build, MatchEntries, Covers, and incremental updates.
 func searchIndexForVault(vaultDir string) *EncryptedIndex {
 	return searchIndexStore.get(vaultDir)
+}
+
+// SearchIndexPersistError returns the error from the most recent attempt to
+// persist vaultDir's search index to disk, or nil if the last attempt
+// succeeded or no index has been built for this vault in this process yet.
+// Used by `symvault doctor` to surface a silently failing persistence path.
+func SearchIndexPersistError(vaultDir string) error {
+	return searchIndexForVault(vaultDir).LastPersistError()
 }
 
 // Build constructs the encrypted search index by scanning all entries in the
@@ -334,7 +357,10 @@ func (idx *EncryptedIndex) buildIndex(vaultDir string, identity *age.X25519Ident
 	idx.mu.Unlock()
 
 	if persist {
-		_ = idx.saveToDisk(vaultDir)
+		persistErr := idx.saveToDisk(vaultDir)
+		idx.mu.Lock()
+		idx.persistErr = persistErr
+		idx.mu.Unlock()
 	}
 	return nil
 }
@@ -537,7 +563,9 @@ func (idx *EncryptedIndex) UpdateEntry(vaultDir, path string, identity *age.X255
 	// write. Without this the edited entry's previous value would remain on
 	// disk and, because an in-place edit leaves the entry count unchanged, be
 	// reloaded as a valid index after a restart — returning stale results.
-	return writeIndexFile(vaultDir, storedSalt, newCiphertext)
+	persistErr := writeIndexFile(vaultDir, storedSalt, newCiphertext)
+	idx.persistErr = persistErr
+	return persistErr
 }
 
 // RemoveEntry removes a single path from the encrypted index.
@@ -605,7 +633,7 @@ func (idx *EncryptedIndex) RemoveEntry(path string, identity *age.X25519Identity
 
 	idx.ciphertext = newCiphertext
 	// Persist so the deletion is reflected on disk and survives a restart.
-	_ = writeIndexFile(vaultDir, storedSalt, newCiphertext)
+	idx.persistErr = writeIndexFile(vaultDir, storedSalt, newCiphertext)
 }
 
 const indexFormatVersion = byte(0x01)
@@ -614,6 +642,11 @@ const indexFormatVersion = byte(0x01)
 // file. It deliberately does not touch idx.mu, so callers that already hold the
 // write lock (UpdateEntry, RemoveEntry) can persist without deadlocking against
 // the non-reentrant RWMutex that saveToDisk's RLock would otherwise take.
+//
+// The write is atomic: data is written to a temporary file in the same
+// directory and then renamed into place, so a process crash or write error
+// partway through can never leave a truncated or half-written index file
+// that a later loadFromDisk would accept as valid.
 func writeIndexFile(vaultDir string, salt, ciphertext []byte) error {
 	if ciphertext == nil {
 		return nil
@@ -622,7 +655,30 @@ func writeIndexFile(vaultDir string, salt, ciphertext []byte) error {
 	data = append(data, indexFormatVersion)
 	data = append(data, salt...)
 	data = append(data, ciphertext...)
-	return os.WriteFile(indexFilePath(vaultDir), data, 0600)
+
+	finalPath := indexFilePath(vaultDir)
+	tmp, err := os.CreateTemp(vaultDir, ".search-index.tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath) // no-op once the rename below succeeds
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Chmod(tmpPath, 0600); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, finalPath)
 }
 
 // clearLocked resets the in-memory index to the unbuilt state. The caller must
@@ -706,7 +762,10 @@ func (idx *EncryptedIndex) loadFromDisk(vaultDir string, identity *age.X25519Ide
 	idx.mu.Unlock()
 
 	if len(salt) == 0 {
-		_ = idx.saveToDisk(vaultDir)
+		persistErr := idx.saveToDisk(vaultDir)
+		idx.mu.Lock()
+		idx.persistErr = persistErr
+		idx.mu.Unlock()
 	}
 
 	return nil

--- a/internal/vault/search_index_persist_test.go
+++ b/internal/vault/search_index_persist_test.go
@@ -1,6 +1,10 @@
 package vault
 
 import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/danieljustus/symaira-vault/internal/testutil"
@@ -104,5 +108,163 @@ func TestRemoveEntryPersistsDeleteToDisk(t *testing.T) {
 	}
 	if _, ok := keepMatch["keep"]; !ok {
 		t.Error("on-disk index lost the surviving entry after a delete")
+	}
+}
+
+// skipIfRoot skips permission-based failure-injection tests when running as
+// root, since root bypasses the write-permission checks these tests rely on.
+func skipIfRoot(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS != "windows" && os.Geteuid() == 0 {
+		t.Skip("skipping permission-based test: running as root")
+	}
+}
+
+// TestBuildPersistFailureRecordedButIndexStaysUsable verifies that when the
+// on-disk write fails during a full build, the failure is recorded via
+// LastPersistError but the in-memory index is still built and usable for
+// search — a failed persist must never corrupt or discard correct in-memory
+// search state.
+func TestBuildPersistFailureRecordedButIndexStaysUsable(t *testing.T) {
+	skipIfRoot(t)
+	searchIndexStore.invalidateAll()
+	t.Cleanup(searchIndexStore.invalidateAll)
+
+	vaultDir := t.TempDir()
+	identity := testutil.TempIdentity(t)
+	mustWriteEntry(t, vaultDir, identity, "acct", map[string]interface{}{"user": "somevalue"})
+
+	idx := &EncryptedIndex{}
+	if err := idx.Build(vaultDir, identity); err != nil {
+		t.Fatalf("Build() error = %v (unwanted before permission change)", err)
+	}
+	if idx.LastPersistError() != nil {
+		t.Fatalf("LastPersistError() = %v, want nil before permission change", idx.LastPersistError())
+	}
+
+	// Remove write permission on the vault directory so the atomic write's
+	// os.CreateTemp cannot create its temp file there.
+	if err := os.Chmod(vaultDir, 0o500); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(vaultDir, 0o700) })
+
+	if err := idx.Build(vaultDir, identity); err != nil {
+		t.Fatalf("Build() error = %v, want nil (persist failure must not fail the build)", err)
+	}
+	if idx.LastPersistError() == nil {
+		t.Fatal("LastPersistError() = nil, want a recorded persistence failure")
+	}
+
+	match, err := idx.MatchEntries(vaultDir, identity, []string{"acct"}, "somevalue")
+	if err != nil {
+		t.Fatalf("MatchEntries() error = %v", err)
+	}
+	if _, ok := match["acct"]; !ok {
+		t.Error("in-memory index lost correctness after a persist failure")
+	}
+}
+
+// TestUpdateEntryPersistFailureRecorded verifies that a persistence failure
+// during the incremental UpdateEntry path is both returned to the caller and
+// recorded via LastPersistError.
+func TestUpdateEntryPersistFailureRecorded(t *testing.T) {
+	skipIfRoot(t)
+	searchIndexStore.invalidateAll()
+	t.Cleanup(searchIndexStore.invalidateAll)
+
+	vaultDir := t.TempDir()
+	identity := testutil.TempIdentity(t)
+	mustWriteEntry(t, vaultDir, identity, "acct", map[string]interface{}{"user": "oldvalue"})
+
+	idx := &EncryptedIndex{}
+	if err := idx.Build(vaultDir, identity); err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+
+	mustWriteEntry(t, vaultDir, identity, "acct", map[string]interface{}{"user": "newvalue"})
+
+	if err := os.Chmod(vaultDir, 0o500); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(vaultDir, 0o700) })
+
+	if err := idx.UpdateEntry(vaultDir, "acct", identity); err == nil {
+		t.Fatal("UpdateEntry() error = nil, want a persistence error")
+	}
+	if idx.LastPersistError() == nil {
+		t.Fatal("LastPersistError() = nil, want a recorded persistence failure")
+	}
+}
+
+// TestRemoveEntryPersistFailureRecorded verifies that a persistence failure
+// during the incremental RemoveEntry path is recorded via LastPersistError
+// even though RemoveEntry itself has no error return.
+func TestRemoveEntryPersistFailureRecorded(t *testing.T) {
+	skipIfRoot(t)
+	searchIndexStore.invalidateAll()
+	t.Cleanup(searchIndexStore.invalidateAll)
+
+	vaultDir := t.TempDir()
+	identity := testutil.TempIdentity(t)
+	mustWriteEntry(t, vaultDir, identity, "keep", map[string]interface{}{"user": "keepvalue"})
+	mustWriteEntry(t, vaultDir, identity, "gone", map[string]interface{}{"user": "gonevalue"})
+
+	idx := &EncryptedIndex{}
+	if err := idx.Build(vaultDir, identity); err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+
+	if err := DeleteEntry(vaultDir, "gone", identity); err != nil {
+		t.Fatalf("DeleteEntry() error = %v", err)
+	}
+
+	if err := os.Chmod(vaultDir, 0o500); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(vaultDir, 0o700) })
+
+	idx.RemoveEntry("gone", identity)
+
+	if idx.LastPersistError() == nil {
+		t.Fatal("LastPersistError() = nil, want a recorded persistence failure")
+	}
+}
+
+// TestWriteIndexFileAtomicNoStrayTempFiles verifies that a successful
+// writeIndexFile call leaves exactly the final index file behind and no
+// leftover ".search-index.tmp-*" temp files, confirming the write-then-rename
+// sequence completed and cleaned up as expected.
+func TestWriteIndexFileAtomicNoStrayTempFiles(t *testing.T) {
+	vaultDir := t.TempDir()
+
+	if err := writeIndexFile(vaultDir, []byte("saltsaltsaltsalt"), []byte("some-ciphertext")); err != nil {
+		t.Fatalf("writeIndexFile() error = %v", err)
+	}
+
+	entries, err := os.ReadDir(vaultDir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+
+	var names []string
+	for _, e := range entries {
+		names = append(names, e.Name())
+		if strings.Contains(e.Name(), ".tmp-") {
+			t.Errorf("stray temp file left behind: %s", e.Name())
+		}
+	}
+	if len(names) != 1 || names[0] != filepath.Base(indexFilePath(vaultDir)) {
+		t.Fatalf("vaultDir contents = %v, want exactly [%s]", names, filepath.Base(indexFilePath(vaultDir)))
+	}
+}
+
+// TestWriteIndexFileMissingDirReturnsError verifies that writing to a
+// nonexistent directory surfaces a clear error rather than silently
+// succeeding or panicking.
+func TestWriteIndexFileMissingDirReturnsError(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+	if err := writeIndexFile(missing, []byte("saltsaltsaltsalt"), []byte("ct")); err == nil {
+		t.Fatal("writeIndexFile() error = nil, want error for missing directory")
 	}
 }


### PR DESCRIPTION
Full-build, incremental-update, incremental-delete and legacy-index
resave all previously discarded writeIndexFile/saveToDisk errors.
An unwritable or full vault directory could therefore appear healthy
while silently losing the persisted search index and falling back to
a full rebuild on every restart, with no way to observe the failure.

writeIndexFile now writes to a temp file in the vault directory and
renames it into place, so an interrupted write can never leave a
partial or truncated index file behind. EncryptedIndex tracks the
outcome of its last persistence attempt via LastPersistError(),
exposed at the package level as SearchIndexPersistError(vaultDir).
A new symvault doctor check, vault.search_index.persistence, warns
when a persistence failure is on record while making clear that
in-memory search correctness for the current session is unaffected.

Closes #635

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
