### PR TITLE
Enforce executable allowlists for execute_with_secret (+1 more)

### DIFF
--- a/internal/mcp/server/command_policy.go
+++ b/internal/mcp/server/command_policy.go
@@ -3,6 +3,7 @@ package server
 import (
 	"fmt"
 	"math"
+	"path/filepath"
 	"strconv"
 )
 
@@ -11,6 +12,51 @@ const (
 	minCommandTimeoutSeconds     = 1
 	maxCommandTimeoutSeconds     = 300
 )
+
+// parseCommandArray parses the command argument into a slice of strings.
+// It returns a user-facing formatting error if the input is invalid.
+func parseCommandArray(raw any) ([]string, error) {
+	if raw == nil {
+		return nil, fmt.Errorf("missing required argument \"command\"")
+	}
+	cmdSlice, ok := raw.([]any)
+	if !ok {
+		return nil, fmt.Errorf("argument \"command\" must be an array")
+	}
+	if len(cmdSlice) == 0 {
+		return nil, fmt.Errorf("command array must not be empty")
+	}
+	command := make([]string, len(cmdSlice))
+	for i, v := range cmdSlice {
+		str, ok := v.(string)
+		if !ok {
+			return nil, fmt.Errorf("command[%d] must be a string", i)
+		}
+		command[i] = str
+	}
+	return command, nil
+}
+
+// checkExecutableAllowlist checks if the first element of command is allowed by the agent profile.
+func (s *Server) checkExecutableAllowlist(command []string) error {
+	if len(command) == 0 {
+		return nil
+	}
+	if len(s.agent.AllowedExecutables) > 0 {
+		exe := filepath.Base(command[0])
+		allowed := false
+		for _, a := range s.agent.AllowedExecutables {
+			if exe == a {
+				allowed = true
+				break
+			}
+		}
+		if !allowed {
+			return fmt.Errorf("command execution denied: executable %q not in agent allowlist", exe)
+		}
+	}
+	return nil
+}
 
 func parseCommandTimeoutSeconds(raw any) (int, error) {
 	if raw == nil {

--- a/internal/mcp/server/command_policy_test.go
+++ b/internal/mcp/server/command_policy_test.go
@@ -4,6 +4,8 @@ import (
 	"math"
 	"strings"
 	"testing"
+
+	"github.com/danieljustus/symaira-vault/internal/config"
 )
 
 func TestParseCommandTimeoutSeconds(t *testing.T) {
@@ -41,6 +43,110 @@ func TestParseCommandTimeoutSeconds(t *testing.T) {
 			}
 			if err == nil {
 				t.Fatal("parseCommandTimeoutSeconds() expected error")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error = %v, want %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestParseCommandArray(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     any
+		want    []string
+		wantErr string
+	}{
+		{name: "nil", raw: nil, wantErr: "missing required argument"},
+		{name: "not an array", raw: "string", wantErr: "must be an array"},
+		{name: "empty array", raw: []any{}, wantErr: "must not be empty"},
+		{name: "non-string element", raw: []any{"echo", 123}, wantErr: "must be a string"},
+		{name: "valid", raw: []any{"echo", "hello"}, want: []string{"echo", "hello"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseCommandArray(tt.raw)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("parseCommandArray() error = %v", err)
+				}
+				if len(got) != len(tt.want) {
+					t.Fatalf("parseCommandArray() = %v, want %v", got, tt.want)
+				}
+				for i := range got {
+					if got[i] != tt.want[i] {
+						t.Errorf("got[%d] = %q, want %q", i, got[i], tt.want[i])
+					}
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("parseCommandArray() expected error")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error = %v, want %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestCheckExecutableAllowlist(t *testing.T) {
+	tests := []struct {
+		name      string
+		allowlist []string
+		command   []string
+		wantErr   string
+	}{
+		{
+			name:      "empty allowlist allows everything",
+			allowlist: []string{},
+			command:   []string{"sh", "-c", "echo hello"},
+			wantErr:   "",
+		},
+		{
+			name:      "allowed executable",
+			allowlist: []string{"echo", "cat"},
+			command:   []string{"echo", "hello"},
+			wantErr:   "",
+		},
+		{
+			name:      "path-qualified allowed executable",
+			allowlist: []string{"echo", "cat"},
+			command:   []string{"/bin/echo", "hello"},
+			wantErr:   "",
+		},
+		{
+			name:      "denied executable",
+			allowlist: []string{"echo", "cat"},
+			command:   []string{"sh", "-c", "echo hello"},
+			wantErr:   "not in agent allowlist",
+		},
+		{
+			name:      "empty command is a noop",
+			allowlist: []string{"echo"},
+			command:   []string{},
+			wantErr:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &Server{
+				agent: &config.AgentProfile{
+					AllowedExecutables: tt.allowlist,
+				},
+			}
+			err := s.checkExecutableAllowlist(tt.command)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("checkExecutableAllowlist() error = %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("checkExecutableAllowlist() expected error")
 			}
 			if !strings.Contains(err.Error(), tt.wantErr) {
 				t.Fatalf("error = %v, want %q", err, tt.wantErr)

--- a/internal/mcp/server/tools_execute_with_secret.go
+++ b/internal/mcp/server/tools_execute_with_secret.go
@@ -31,23 +31,26 @@ func (s *Server) handleExecuteWithSecret(ctx context.Context, req mcp.CallToolRe
 		s.logAudit(ctx, "execute_with_secret", "<invalid:missing-command>", false)
 		return mcp.NewToolResultError("missing required argument \"command\""), nil
 	}
-	cmdSlice, ok := cmdRaw.([]any)
-	if !ok {
-		s.logAudit(ctx, "execute_with_secret", "<invalid:command-not-array>", false)
-		return mcp.NewToolResultError("argument \"command\" must be an array"), nil
-	}
-	if len(cmdSlice) == 0 {
-		s.logAudit(ctx, "execute_with_secret", "<invalid:empty-command>", false)
-		return mcp.NewToolResultError("command array must not be empty"), nil
-	}
-	command := make([]string, len(cmdSlice))
-	for i, v := range cmdSlice {
-		str, valid := v.(string)
-		if !valid {
-			s.logAudit(ctx, "execute_with_secret", "<invalid:command-type>", false)
-			return mcp.NewToolResultError(fmt.Sprintf("command[%d] must be a string", i)), nil
+	command, err := parseCommandArray(cmdRaw)
+	if err != nil {
+		var auditTag string
+		switch {
+		case strings.Contains(err.Error(), "must be an array"):
+			auditTag = "<invalid:command-not-array>"
+		case strings.Contains(err.Error(), "must not be empty"):
+			auditTag = "<invalid:empty-command>"
+		default:
+			auditTag = "<invalid:command-type>"
 		}
-		command[i] = str
+		s.logAudit(ctx, "execute_with_secret", auditTag, false)
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	// Enforce per-agent executable allowlist.
+	if allowErr := s.checkExecutableAllowlist(command); allowErr != nil {
+		s.logAudit(ctx, "execute_with_secret", command[0], false)
+		metrics.RecordAuthDenial("executable_denied", s.agent.Name)
+		return nil, allowErr
 	}
 
 	timeoutSeconds, timeoutErr := parseCommandTimeoutSeconds(req.Arguments["timeout"])

--- a/internal/mcp/server/tools_execute_with_secret_test.go
+++ b/internal/mcp/server/tools_execute_with_secret_test.go
@@ -1114,3 +1114,84 @@ func TestHandleExecuteWithSecret_ToolListed(t *testing.T) {
 		t.Fatal("execute_with_secret not in tools list payload")
 	}
 }
+
+func TestHandleExecuteWithSecret_ExecutableAllowlist_Allowed(t *testing.T) {
+	srv := newTestServer(t, config.AgentProfile{
+		Name:               "test",
+		AllowedPaths:       []string{"*"},
+		CanRunCommands:     config.BoolPtr(true),
+		ApprovalMode:       config.StrPtr("none"),
+		AllowedExecutables: []string{"echo", "cat"},
+	}, "stdio")
+
+	req := mcp.CallToolRequest{
+		Arguments: map[string]any{
+			"command":     []any{"echo", "hello"},
+			"secret_refs": []any{},
+		},
+	}
+
+	result, err := srv.handleExecuteWithSecret(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleExecuteWithSecret() error = %v", err)
+	}
+	if result == nil {
+		t.Fatal("handleExecuteWithSecret() returned nil result")
+	}
+	if result.IsError {
+		t.Fatalf("handleExecuteWithSecret() returned error: %s", result.Text)
+	}
+}
+
+func TestHandleExecuteWithSecret_ExecutableAllowlist_Denied(t *testing.T) {
+	srv := newTestServer(t, config.AgentProfile{
+		Name:               "test",
+		AllowedPaths:       []string{"*"},
+		CanRunCommands:     config.BoolPtr(true),
+		ApprovalMode:       config.StrPtr("none"),
+		AllowedExecutables: []string{"echo", "cat"},
+	}, "stdio")
+
+	req := mcp.CallToolRequest{
+		Arguments: map[string]any{
+			"command":     []any{"sh", "-c", "echo hello"},
+			"secret_refs": []any{},
+		},
+	}
+
+	_, err := srv.handleExecuteWithSecret(context.Background(), req)
+	if err == nil {
+		t.Fatal("handleExecuteWithSecret() expected error for disallowed executable, got nil")
+	}
+	if !strings.Contains(err.Error(), "not in agent allowlist") {
+		t.Fatalf("error = %v, want 'not in agent allowlist'", err)
+	}
+}
+
+func TestHandleExecuteWithSecret_ExecutableAllowlist_PathQualified_Allowed(t *testing.T) {
+	srv := newTestServer(t, config.AgentProfile{
+		Name:               "test",
+		AllowedPaths:       []string{"*"},
+		CanRunCommands:     config.BoolPtr(true),
+		ApprovalMode:       config.StrPtr("none"),
+		AllowedExecutables: []string{"echo", "cat"},
+	}, "stdio")
+
+	req := mcp.CallToolRequest{
+		Arguments: map[string]any{
+			"command":     []any{"/bin/echo", "hello"},
+			"secret_refs": []any{},
+		},
+	}
+
+	result, err := srv.handleExecuteWithSecret(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleExecuteWithSecret() error = %v", err)
+	}
+	if result == nil {
+		t.Fatal("handleExecuteWithSecret() returned nil result")
+	}
+	if result.IsError {
+		t.Fatalf("handleExecuteWithSecret() returned error: %s", result.Text)
+	}
+}

--- a/internal/mcp/server/tools_run.go
+++ b/internal/mcp/server/tools_run.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -26,40 +25,17 @@ func (s *Server) handleRunCommand(ctx context.Context, req mcp.CallToolRequest) 
 		s.logAudit(ctx, "run_command", "<invalid>", false)
 		return mcp.NewToolResultError("missing required argument \"command\""), nil
 	}
-	cmdSlice, ok := cmdRaw.([]any)
-	if !ok {
+	command, err := parseCommandArray(cmdRaw)
+	if err != nil {
 		s.logAudit(ctx, "run_command", "<invalid>", false)
-		return mcp.NewToolResultError("argument \"command\" must be an array"), nil
-	}
-	if len(cmdSlice) == 0 {
-		s.logAudit(ctx, "run_command", "<invalid>", false)
-		return mcp.NewToolResultError("command array must not be empty"), nil
-	}
-	command := make([]string, len(cmdSlice))
-	for i, v := range cmdSlice {
-		str, ok := v.(string)
-		if !ok {
-			s.logAudit(ctx, "run_command", "<invalid>", false)
-			return mcp.NewToolResultError(fmt.Sprintf("command[%d] must be a string", i)), nil
-		}
-		command[i] = str
+		return mcp.NewToolResultError(err.Error()), nil
 	}
 
 	// Enforce per-agent executable allowlist.
-	if len(s.agent.AllowedExecutables) > 0 {
-		exe := filepath.Base(command[0])
-		allowed := false
-		for _, a := range s.agent.AllowedExecutables {
-			if exe == a {
-				allowed = true
-				break
-			}
-		}
-		if !allowed {
-			s.logAudit(ctx, "run_command", command[0], false)
-			metrics.RecordAuthDenial("executable_denied", s.agent.Name)
-			return nil, fmt.Errorf("command execution denied: executable %q not in agent allowlist", exe)
-		}
+	if allowErr := s.checkExecutableAllowlist(command); allowErr != nil {
+		s.logAudit(ctx, "run_command", command[0], false)
+		metrics.RecordAuthDenial("executable_denied", s.agent.Name)
+		return nil, allowErr
 	}
 
 	timeoutSeconds, timeoutErr := parseCommandTimeoutSeconds(req.Arguments["timeout"])
@@ -91,9 +67,9 @@ func (s *Server) handleRunCommand(ctx context.Context, req mcp.CallToolRequest) 
 				return nil, fmt.Errorf("access denied: secret ref path %q outside allowed scope", path)
 			}
 
-			value, err := secrets.ResolveSecretRef(s.vault, ref)
-			if err != nil {
-				return mcp.NewToolResultError(fmt.Sprintf("cannot resolve secret ref %q: %v", ref, err)), nil
+			value, resolveErr := secrets.ResolveSecretRef(s.vault, ref)
+			if resolveErr != nil {
+				return mcp.NewToolResultError(fmt.Sprintf("cannot resolve secret ref %q: %v", ref, resolveErr)), nil
 			}
 			resolvedEnv[envName] = value
 			envNames = append(envNames, envName)


### PR DESCRIPTION
Bundles fixes for multiple open issues. The list below grows as commits land; every linked issue will close automatically on merge.

<!-- closes-list-start -->
- Closes #631 Enforce executable allowlists for execute_with_secret
- Closes #633 Centralize agent command-execution validation and policy
<!-- closes-list-end -->