### PR TITLE
feat: add payment entry type with deny-by-default redaction

### DIFF
--- a/cmd/admin/import.go
+++ b/cmd/admin/import.go
@@ -158,6 +158,11 @@ Use --format to override auto-detection or when the file extension does not matc
 				if err := vs.SetFieldsWithProvenance(entryPath, entry.Data, record); err != nil {
 					return fmt.Errorf("cannot write entry: %w", err)
 				}
+				if entry.SecretMetadata != nil {
+					if err := vs.SetSecretMetadata(entryPath, *entry.SecretMetadata); err != nil {
+						return fmt.Errorf("cannot set secret metadata: %w", err)
+					}
+				}
 				cli.PrintQuietAware("Imported: %s\n", entryPath)
 				imported++
 			}

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -56,6 +56,22 @@ agents:
     # agent. Disabled by default — payment sensitive fields are redacted for
     # all agents unless this is explicitly set to true.
     # exposePaymentValues: true
+    # Restrict payment operations via a named payment policy.
+    # paymentPolicy: shopping-limited
+
+# Payment policies constrain prepare_payment requests before the native
+# approval prompt is shown. Link a policy to an agent via its paymentPolicy field.
+# paymentPolicies:
+#   shopping-limited:
+#     instrument: "payments/visa"
+#     allowed_merchants:
+#       - "amazon.de"
+#       - "otto.de"
+#       - "mediamarkt.de"
+#     max_amount:
+#       per_transaction: "75.00"
+#       per_day: "150.00"
+#     currency: "EUR"
 
 # Vault-specific settings. These can also live inside <vault>/config.yaml.
 vault:

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -52,6 +52,10 @@ agents:
     canWrite: true
     canManageConfig: false
     approvalMode: none
+    # Expose raw payment card/bank details (card_number, cvc, iban) to this
+    # agent. Disabled by default — payment sensitive fields are redacted for
+    # all agents unless this is explicitly set to true.
+    # exposePaymentValues: true
 
 # Vault-specific settings. These can also live inside <vault>/config.yaml.
 vault:

--- a/docs/mcp-api.md
+++ b/docs/mcp-api.md
@@ -1341,6 +1341,7 @@ agents:
 | `canUseAutotype` | boolean | `false` | Whether the agent can type passwords via keyboard input through `autotype` |
 | `approvalMode` | string | `"none"` | Write approval behavior: `none` (allow), `deny` (reject), `prompt` (degrades to deny in MCP) |
 | `redactFields` | array | `[]` | Field names to redact from `get_entry` responses (e.g., `["totp.secret"]` shows `[REDACTED]`) |
+| `exposePaymentValues` | boolean | `false` | When `true`, payment entries (`type: payment`) expose sensitive fields (`card_number`, `cvc`, `iban`). Disabled by default — these fields are always redacted for agents unless this flag is set |
 
 ### Built-in Profiles
 
@@ -1406,6 +1407,20 @@ agents:
 ## Field Redaction with `redactFields`
 
 The `redactFields` agent profile setting controls which entry fields are hidden from `get_entry` responses. Redacted fields appear as `[REDACTED]` instead of their actual values.
+
+### Payment Entry Automatic Redaction
+
+Entries with `secret_meta.type = "payment"` have their sensitive fields automatically redacted in all agent responses, independent of the profile's `redactFields` configuration:
+
+| Sensitive Field | Description |
+|----------------|-------------|
+| `card_number` | Full card number (e.g., `4111111111111111`) |
+| `cvc` | Card verification code |
+| `iban` | International bank account number |
+
+Non-sensitive payment fields (`cardholder`, `expiry_month`, `expiry_year`, `bic`, `subtype`) are always returned.
+
+To opt out and expose raw payment values, set `exposePaymentValues: true` on the agent profile. This requires the agent to also have `canReadValues: true` or value-tool access.
 
 ### What Gets Redacted
 

--- a/docs/mcp-api.md
+++ b/docs/mcp-api.md
@@ -1017,6 +1017,76 @@ Validate a payment entry, show a native approval prompt with merchant/amount/cur
 - `not_a_payment_entry`: Entry type is not `payment`
 - `not_found`: Entry does not exist
 - `outside_allowed_scope`: Path is outside the agent's allowed scope
+- `payment.policy_denied`: Payment policy check failed (merchant not allowed, currency mismatch, or amount limit exceeded)
+
+---
+
+## Payment Policies
+
+Payment policies provide declarative guardrails on `prepare_payment` requests. When an agent profile references a policy, the enforcer checks merchant allowlists, per-transaction limits, per-day limits, and currency requirements **before** the native approval prompt is shown.
+
+### Configuration
+
+Define policies under `paymentPolicies` in `config.yaml`:
+
+```yaml
+paymentPolicies:
+  shopping-limited:
+    instrument: "payments/visa"                    # vault entry path of the payment instrument
+    allowed_merchants:
+      - "amazon.de"
+      - "otto.de"
+      - "mediamarkt.de"
+    max_amount:
+      per_transaction: "75.00"
+      per_day: "150.00"
+    currency: "EUR"
+```
+
+Link a policy to an agent profile:
+
+```yaml
+agents:
+  hermes:
+    allowedPaths: ["*"]
+    canWrite: true
+    approvalMode: none
+    paymentPolicy: "shopping-limited"             # reference the policy by name
+```
+
+### Policy Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `instrument` | string | Yes | Vault entry path of the payment instrument (card/bank account) |
+| `allowed_merchants` | array | No | Allowlist of merchant names (case-insensitive exact match) |
+| `max_amount.per_transaction` | string | No | Maximum single-transaction amount (decimal string, e.g. `"75.00"`) |
+| `max_amount.per_day` | string | No | Maximum total per calendar day (decimal string, e.g. `"150.00"`) |
+| `currency` | string | Yes when limits set | Required ISO-4217 currency code (e.g. `"EUR"`, `"USD"`) |
+
+### How Enforcement Works
+
+1. The agent calls `prepare_payment` with `entry_path`, `merchant`, `amount`, `currency`.
+2. If the agent has a `paymentPolicy`, the enforcer checks:
+   - **Merchant allowlist**: if `allowed_merchants` is non-empty, the merchant must match (case-insensitive).
+   - **Currency**: must match the policy's `currency` when limits are set.
+   - **Per-transaction**: `amount` must not exceed `per_transaction`.
+   - **Per-day**: `amount` + today's accumulated total must not exceed `per_day`.
+3. If any check fails, the request is rejected with a `payment.policy_denied` audit event. The native approval prompt is **never** shown.
+4. If all checks pass, the native approval prompt is shown as usual. On approval, the daily total is incremented.
+
+### Per-Day Persistence
+
+Per-day totals are stored on disk at `$XDG_DATA_HOME/symaira-vault/payment-state/<vault-hash>/<policy>/daily-totals.json`. Entries older than today are automatically expired on load and save. Totals survive daemon restarts.
+
+### Error Responses
+
+| Reason | Description |
+|--------|-------------|
+| `merchant_not_allowed` | Merchant is not in the policy's `allowed_merchants` list |
+| `currency_mismatch` | Requested currency does not match the policy's required currency |
+| `over_per_transaction` | Amount exceeds the per-transaction limit |
+| `over_per_day` | Amount + today's total would exceed the per-day limit |
 
 ---
 

--- a/docs/mcp-api.md
+++ b/docs/mcp-api.md
@@ -51,6 +51,7 @@ Symaira Vault exposes a Model Context Protocol (MCP) server that allows AI agent
 | `symvault_delete` | Deprecated alias for delete_entry | **Yes** |
 | `secure_input` | Prompt user for sensitive data via TTY or native GUI dialog | **Yes** |
 | `request_credential` | Agent-initiated: native dialog for a missing credential, stored without exposure | **Yes** |
+| `prepare_payment` | Validate a payment entry, show approval prompt, autotype card/bank fields — card values never returned | No |
 
 ---
 
@@ -955,6 +956,67 @@ requested path and never returned to the agent.
   human-readable sentence
 - Recommended call site: after `find_entries` / `get_entry` returns nothing
   for an expected path, instead of asking the user for the secret in chat
+
+---
+
+### prepare_payment
+
+Validate a payment entry, show a native approval prompt with merchant/amount/currency details, and on user approval autotype the card or bank account fields into the focused checkout window. Card number, CVC, and IBAN values are never returned in the tool response.
+
+**Request**:
+
+```json
+{
+  "tool": "prepare_payment",
+  "arguments": {
+    "entry_path": "payments/mycard",
+    "merchant": "shop.example",
+    "amount": "75.00",
+    "currency": "EUR"
+  }
+}
+```
+
+**Parameters**:
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `entry_path` | string | Yes | - | Vault path of the payment entry |
+| `merchant` | string | Yes | - | Merchant name or origin (e.g. `shop.example`) |
+| `amount` | string | Yes | - | Payment amount (e.g. `75.00`) |
+| `currency` | string | Yes | - | Currency code (e.g. `EUR`, `USD`) |
+| `description` | string | No | - | Optional description shown in the approval prompt |
+
+**Response**:
+
+```json
+{
+  "success": true
+}
+```
+
+**Security guarantees**:
+- Card number, CVC, and IBAN values are **never** returned in the MCP response
+- The user sees a native approval prompt (e.g. "Allow payment of EUR 75.00 to shop.example?") before any autotyping occurs
+- Approval mode must not be `deny`; the tool requires user interaction
+- Risk level: **Critical** — cannot be remembered across sessions
+- Requires `canUseAutotype: true` in agent profile
+
+**Autotype field order**:
+- Card entries: `card_number` → `expiry_month` → `expiry_year` → `cvc`
+- Bank account entries: `iban`
+
+**Notes**:
+- Entry must have `type: "payment"` in its secret metadata
+- Payment subtype (`card` or `bank_account`) is read from the entry's `subtype` field or the request `subtype` argument
+- Same autotype backend as `autotype` tool (macOS, Linux, Windows)
+- Falls back gracefully on unsupported platforms
+
+**Errors**:
+- `denied`: User declined the approval prompt
+- `not_a_payment_entry`: Entry type is not `payment`
+- `not_found`: Entry does not exist
+- `outside_allowed_scope`: Path is outside the agent's allowed scope
 
 ---
 

--- a/internal/agentctx/context.go
+++ b/internal/agentctx/context.go
@@ -46,6 +46,7 @@ var blockedToolsByTier = map[string]map[string]bool{
 		"request_credential":  true,
 		"copy_to_clipboard":   true,
 		"autotype":            true,
+		"prepare_payment":     true,
 	},
 	tierStandard: {
 		"delete_entry":        true,

--- a/internal/cli/vault.go
+++ b/internal/cli/vault.go
@@ -31,6 +31,15 @@ func (s *VaultService) SetFieldsWithProvenance(path string, data map[string]any,
 	return s.vaultService.UpsertEntry(path, data, "set", &record)
 }
 
+func (s *VaultService) SetSecretMetadata(path string, meta vaultpkg.SecretMetadata) error {
+	entry, err := s.vaultService.GetEntry(path)
+	if err != nil {
+		return err
+	}
+	entry.SecretMetadata = meta
+	return s.vaultService.WriteEntry(path, entry)
+}
+
 func (s *VaultService) DeleteEntry(path string) error {
 	return s.vaultService.DeleteEntry(path)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -110,10 +110,35 @@ type Config struct {
 	UseTouchID     *bool                   `yaml:"useTouchID,omitempty"`
 	Profiles       map[string]*Profile     `yaml:"profiles,omitempty"`
 	DefaultProfile string                  `yaml:"defaultProfile,omitempty"`
-	EnvAllowlist   []string                `yaml:"envAllowlist,omitempty"`
-	// EnvWhitelist is the deprecated name for EnvAllowlist; kept for backward compatibility.
-	EnvWhitelist []string        `yaml:"envWhitelist,omitempty"`
-	ScanPatterns []CustomPattern `yaml:"scan_patterns,omitempty"`
+	EnvAllowlist    []string                `yaml:"envAllowlist,omitempty"`
+	EnvWhitelist    []string                `yaml:"envWhitelist,omitempty"`
+	ScanPatterns    []CustomPattern         `yaml:"scan_patterns,omitempty"`
+	PaymentPolicies map[string]PaymentPolicy `yaml:"paymentPolicies,omitempty"`
+}
+
+// PaymentMaxAmount defines per-transaction and per-day spending limits.
+// Both fields are strings to safely represent decimal amounts without
+// floating-point rounding errors.
+type PaymentMaxAmount struct {
+	PerTransaction string `yaml:"per_transaction,omitempty"`
+	PerDay         string `yaml:"per_day,omitempty"`
+}
+
+// PaymentPolicy constrains prepare_payment requests before the native
+// approval prompt is shown. Each policy is referenced by name from an
+// agent profile via the PaymentPolicy field.
+type PaymentPolicy struct {
+	// Instrument is the vault entry path of the payment instrument (card/bank
+	// account) that this policy applies to.
+	Instrument string `yaml:"instrument"`
+	// AllowedMerchants is an allowlist of merchant names (case-insensitive).
+	// When non-empty, only these merchants may proceed.
+	AllowedMerchants []string `yaml:"allowed_merchants,omitempty"`
+	// MaxAmount defines per-transaction and per-day spending limits.
+	MaxAmount PaymentMaxAmount `yaml:"max_amount,omitempty"`
+	// Currency is the required ISO-4217 currency code (e.g. "EUR", "USD").
+	// Must be non-empty when any limit is set.
+	Currency string `yaml:"currency,omitempty"`
 }
 
 type AgentProfile struct {
@@ -146,6 +171,7 @@ type AgentProfile struct {
 	SkillPath           *string             `yaml:"skillPath,omitempty"`
 	SkillVersion        *string             `yaml:"skillVersion,omitempty"`
 	ExposePaymentValues *bool               `yaml:"exposePaymentValues,omitempty"`
+	PaymentPolicy       *string             `yaml:"paymentPolicy,omitempty"`
 }
 
 func (p *AgentProfile) EffectiveRedactFields(toolName string) []string {
@@ -387,6 +413,15 @@ func (p *AgentProfile) ExposePaymentValuesValue() bool {
 		return false
 	}
 	return *p.ExposePaymentValues
+}
+
+// PaymentPolicyValue returns *p.PaymentPolicy or "" when p is nil /
+// p.PaymentPolicy is nil.
+func (p *AgentProfile) PaymentPolicyValue() string {
+	if p == nil || p.PaymentPolicy == nil {
+		return ""
+	}
+	return *p.PaymentPolicy
 }
 
 // AutoUnsealValue returns *p.AutoUnseal or false when p is nil /

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -145,6 +145,7 @@ type AgentProfile struct {
 	PostCallHooks       []string            `yaml:"post_call_hooks,omitempty"`
 	SkillPath           *string             `yaml:"skillPath,omitempty"`
 	SkillVersion        *string             `yaml:"skillVersion,omitempty"`
+	ExposePaymentValues *bool               `yaml:"exposePaymentValues,omitempty"`
 }
 
 func (p *AgentProfile) EffectiveRedactFields(toolName string) []string {
@@ -211,6 +212,9 @@ func (p *AgentProfile) Normalize() {
 	}
 	if p.SkillVersion == nil {
 		p.SkillVersion = StrPtr("")
+	}
+	if p.ExposePaymentValues == nil {
+		p.ExposePaymentValues = BoolPtr(false)
 	}
 	if p.CanWrite == nil {
 		p.CanWrite = BoolPtr(false)
@@ -374,6 +378,15 @@ func (p *AgentProfile) ExposeValueToolsValue() bool {
 		return false
 	}
 	return *p.ExposeValueTools
+}
+
+// ExposePaymentValuesValue returns *p.ExposePaymentValues or false when p is
+// nil / p.ExposePaymentValues is nil.
+func (p *AgentProfile) ExposePaymentValuesValue() bool {
+	if p == nil || p.ExposePaymentValues == nil {
+		return false
+	}
+	return *p.ExposePaymentValues
 }
 
 // AutoUnsealValue returns *p.AutoUnseal or false when p is nil /

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -94,25 +94,25 @@ type CustomPattern struct {
 }
 
 type Config struct {
-	Agents         map[string]AgentProfile `yaml:"agents,omitempty"`
-	Vault          *VaultConfig            `yaml:"vault,omitempty"`
-	Git            *GitConfig              `yaml:"git,omitempty"`
-	MCP            *MCPConfig              `yaml:"mcp,omitempty"`
-	Update         *UpdateConfig           `yaml:"update,omitempty"`
-	Clipboard      *ClipboardConfig        `yaml:"clipboard,omitempty"`
-	Audit          *AuditConfig            `yaml:"audit,omitempty"`
-	Logging        *LoggingConfig          `yaml:"logging,omitempty"`
-	Security       *SecurityConfig         `yaml:"security,omitempty"`
-	VaultDir       string                  `yaml:"vaultDir,omitempty"`
-	DefaultAgent   string                  `yaml:"defaultAgent,omitempty"`
-	SessionTimeout time.Duration           `yaml:"sessionTimeout,omitempty"`
-	AuthMethod     string                  `yaml:"authMethod,omitempty"`
-	UseTouchID     *bool                   `yaml:"useTouchID,omitempty"`
-	Profiles       map[string]*Profile     `yaml:"profiles,omitempty"`
-	DefaultProfile string                  `yaml:"defaultProfile,omitempty"`
-	EnvAllowlist    []string                `yaml:"envAllowlist,omitempty"`
-	EnvWhitelist    []string                `yaml:"envWhitelist,omitempty"`
-	ScanPatterns    []CustomPattern         `yaml:"scan_patterns,omitempty"`
+	Agents          map[string]AgentProfile  `yaml:"agents,omitempty"`
+	Vault           *VaultConfig             `yaml:"vault,omitempty"`
+	Git             *GitConfig               `yaml:"git,omitempty"`
+	MCP             *MCPConfig               `yaml:"mcp,omitempty"`
+	Update          *UpdateConfig            `yaml:"update,omitempty"`
+	Clipboard       *ClipboardConfig         `yaml:"clipboard,omitempty"`
+	Audit           *AuditConfig             `yaml:"audit,omitempty"`
+	Logging         *LoggingConfig           `yaml:"logging,omitempty"`
+	Security        *SecurityConfig          `yaml:"security,omitempty"`
+	VaultDir        string                   `yaml:"vaultDir,omitempty"`
+	DefaultAgent    string                   `yaml:"defaultAgent,omitempty"`
+	SessionTimeout  time.Duration            `yaml:"sessionTimeout,omitempty"`
+	AuthMethod      string                   `yaml:"authMethod,omitempty"`
+	UseTouchID      *bool                    `yaml:"useTouchID,omitempty"`
+	Profiles        map[string]*Profile      `yaml:"profiles,omitempty"`
+	DefaultProfile  string                   `yaml:"defaultProfile,omitempty"`
+	EnvAllowlist    []string                 `yaml:"envAllowlist,omitempty"`
+	EnvWhitelist    []string                 `yaml:"envWhitelist,omitempty"`
+	ScanPatterns    []CustomPattern          `yaml:"scan_patterns,omitempty"`
 	PaymentPolicies map[string]PaymentPolicy `yaml:"paymentPolicies,omitempty"`
 }
 

--- a/internal/config/config_merge.go
+++ b/internal/config/config_merge.go
@@ -90,6 +90,12 @@ func mergeTopLevel(cfg *Config, raw Config) {
 	if raw.ScanPatterns != nil {
 		cfg.ScanPatterns = append([]CustomPattern(nil), raw.ScanPatterns...)
 	}
+	if raw.PaymentPolicies != nil {
+		cfg.PaymentPolicies = make(map[string]PaymentPolicy, len(raw.PaymentPolicies))
+		for name, policy := range raw.PaymentPolicies {
+			cfg.PaymentPolicies[name] = policy
+		}
+	}
 	if raw.Profiles != nil {
 		cfg.Profiles = make(map[string]*Profile, len(raw.Profiles))
 		for name, fp := range raw.Profiles {
@@ -217,6 +223,8 @@ func mergeAgentProfile(current AgentProfile, name string, yamlProfile AgentProfi
 	current.PromptInjectionMode = mergeStringPtr(current.PromptInjectionMode, yamlProfile.PromptInjectionMode)
 	current.SkillPath = mergeStringPtr(current.SkillPath, yamlProfile.SkillPath)
 	current.SkillVersion = mergeStringPtr(current.SkillVersion, yamlProfile.SkillVersion)
+	current.ExposePaymentValues = mergeBoolPtr(current.ExposePaymentValues, yamlProfile.ExposePaymentValues)
+	current.PaymentPolicy = mergeStringPtr(current.PaymentPolicy, yamlProfile.PaymentPolicy)
 
 	return current
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2598,6 +2598,7 @@ func TestCopyAgentProfiles_DeepCopyAllFields(t *testing.T) {
 		PostCallHooks:       []string{"post1"},
 		SkillPath:           sptr("~/.skills/test/SKILL.md"),
 		SkillVersion:        sptr("1.0.0"),
+		PaymentPolicy:       sptr("shopping-limited"),
 	}
 
 	srcMap := map[string]AgentProfile{"agent": src}
@@ -3386,5 +3387,210 @@ func TestAgentProfileValueAccessorsHandleNilAndZero(t *testing.T) {
 	}
 	if got := p2.ApprovalTimeoutValue(); got != 2*time.Minute {
 		t.Errorf("p2.ApprovalTimeoutValue() = %v, want 2m", got)
+	}
+}
+
+func TestValidate_PaymentPolicy_EmptyInstrumentFails(t *testing.T) {
+	t.Parallel()
+	cfg := Default()
+	cfg.PaymentPolicies = map[string]PaymentPolicy{
+		"test": {Instrument: "", Currency: "EUR", MaxAmount: PaymentMaxAmount{PerTransaction: "50"}},
+	}
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("Validate() with empty instrument = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "instrument") {
+		t.Errorf("error = %q, should mention instrument", err.Error())
+	}
+}
+
+func TestValidate_PaymentPolicy_NoLimitNoAllowlistFails(t *testing.T) {
+	t.Parallel()
+	cfg := Default()
+	cfg.PaymentPolicies = map[string]PaymentPolicy{
+		"test": {Instrument: "payments/visa", Currency: "EUR"},
+	}
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("Validate() with no limits and no allowlist = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "at least one") {
+		t.Errorf("error = %q, should mention at least one", err.Error())
+	}
+}
+
+func TestValidate_PaymentPolicy_AllowlistOnly(t *testing.T) {
+	t.Parallel()
+	cfg := Default()
+	cfg.PaymentPolicies = map[string]PaymentPolicy{
+		"test": {Instrument: "payments/visa", AllowedMerchants: []string{"shop.com"}},
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("Validate() = %v, want nil (allowlist only is valid)", err)
+	}
+}
+
+func TestValidate_PaymentPolicy_LimitsWithoutCurrencyFails(t *testing.T) {
+	t.Parallel()
+	cfg := Default()
+	cfg.PaymentPolicies = map[string]PaymentPolicy{
+		"test": {Instrument: "payments/visa", MaxAmount: PaymentMaxAmount{PerTransaction: "50"}},
+	}
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("Validate() with limits but no currency = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "currency") {
+		t.Errorf("error = %q, should mention currency", err.Error())
+	}
+}
+
+func TestValidate_PaymentPolicy_InvalidPerTransactionDecimal(t *testing.T) {
+	t.Parallel()
+	cfg := Default()
+	cfg.PaymentPolicies = map[string]PaymentPolicy{
+		"test": {Instrument: "payments/visa", Currency: "EUR", MaxAmount: PaymentMaxAmount{PerTransaction: "not-a-number"}},
+	}
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("Validate() with invalid per_transaction = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "per_transaction") {
+		t.Errorf("error = %q, should mention per_transaction", err.Error())
+	}
+}
+
+func TestValidate_PaymentPolicy_InvalidPerDayDecimal(t *testing.T) {
+	t.Parallel()
+	cfg := Default()
+	cfg.PaymentPolicies = map[string]PaymentPolicy{
+		"test": {Instrument: "payments/visa", Currency: "EUR", MaxAmount: PaymentMaxAmount{PerDay: "abc"}},
+	}
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("Validate() with invalid per_day = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "per_day") {
+		t.Errorf("error = %q, should mention per_day", err.Error())
+	}
+}
+
+func TestValidate_PaymentPolicy_ValidPolicy(t *testing.T) {
+	t.Parallel()
+	cfg := Default()
+	cfg.PaymentPolicies = map[string]PaymentPolicy{
+		"shopping": {
+			Instrument:      "payments/visa",
+			AllowedMerchants: []string{"amazon.de"},
+			MaxAmount:       PaymentMaxAmount{PerTransaction: "75.00", PerDay: "150.00"},
+			Currency:        "EUR",
+		},
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("Validate() = %v, want nil", err)
+	}
+}
+
+func TestValidate_AgentPaymentPolicy_ReferenceNonexistent(t *testing.T) {
+	t.Parallel()
+	cfg := Default()
+	agent := cfg.Agents["default"]
+	agent.PaymentPolicy = StrPtr("nonexistent")
+	cfg.Agents["default"] = agent
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("Validate() with nonexistent payment policy ref = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "paymentPolicy") {
+		t.Errorf("error = %q, should mention paymentPolicy", err.Error())
+	}
+}
+
+func TestValidate_AgentPaymentPolicy_ReferenceValid(t *testing.T) {
+	t.Parallel()
+	cfg := Default()
+	cfg.PaymentPolicies = map[string]PaymentPolicy{
+		"test-policy": {Instrument: "payments/visa", AllowedMerchants: []string{"shop.com"}},
+	}
+	agent := cfg.Agents["default"]
+	agent.PaymentPolicy = StrPtr("test-policy")
+	cfg.Agents["default"] = agent
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("Validate() = %v, want nil", err)
+	}
+}
+
+func TestAgentProfile_PaymentPolicyValue(t *testing.T) {
+	t.Parallel()
+	if got := (*AgentProfile)(nil).PaymentPolicyValue(); got != "" {
+		t.Errorf("nil PaymentPolicyValue() = %q, want \"\"", got)
+	}
+	p := &AgentProfile{PaymentPolicy: StrPtr("my-policy")}
+	if got := p.PaymentPolicyValue(); got != "my-policy" {
+		t.Errorf("PaymentPolicyValue() = %q, want \"my-policy\"", got)
+	}
+}
+
+func TestLoad_PaymentPolicies(t *testing.T) {
+	t.Parallel()
+	yaml := `
+vaultDir: /tmp/test
+paymentPolicies:
+  shopping:
+    instrument: payments/visa
+    allowed_merchants:
+      - shop.example
+    max_amount:
+      per_transaction: "50.00"
+      per_day: "100.00"
+    currency: EUR
+`
+	path := writeTempFile(t, []byte(yaml))
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	policy, ok := cfg.PaymentPolicies["shopping"]
+	if !ok {
+		t.Fatal("missing payment policy 'shopping'")
+	}
+	if policy.Instrument != "payments/visa" {
+		t.Errorf("Instrument = %q, want %q", policy.Instrument, "payments/visa")
+	}
+	if len(policy.AllowedMerchants) != 1 || policy.AllowedMerchants[0] != "shop.example" {
+		t.Errorf("AllowedMerchants = %v, want [shop.example]", policy.AllowedMerchants)
+	}
+	if policy.MaxAmount.PerTransaction != "50.00" {
+		t.Errorf("PerTransaction = %q, want %q", policy.MaxAmount.PerTransaction, "50.00")
+	}
+	if policy.MaxAmount.PerDay != "100.00" {
+		t.Errorf("PerDay = %q, want %q", policy.MaxAmount.PerDay, "100.00")
+	}
+	if policy.Currency != "EUR" {
+		t.Errorf("Currency = %q, want %q", policy.Currency, "EUR")
+	}
+}
+
+func TestLoad_AgentPaymentPolicy(t *testing.T) {
+	t.Parallel()
+	yaml := `
+vaultDir: /tmp/test
+paymentPolicies:
+  test-policy:
+    instrument: payments/visa
+    allowed_merchants: ["shop.com"]
+agents:
+  default:
+    paymentPolicy: test-policy
+`
+	path := writeTempFile(t, []byte(yaml))
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	agent := cfg.Agents["default"]
+	if agent.PaymentPolicyValue() != "test-policy" {
+		t.Errorf("PaymentPolicyValue() = %q, want %q", agent.PaymentPolicyValue(), "test-policy")
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2582,6 +2582,7 @@ func TestCopyAgentProfiles_DeepCopyAllFields(t *testing.T) {
 		CanUseAutotype:      bptr(true),
 		CanReadValues:       bptr(true),
 		ExposeValueTools:    bptr(true),
+		ExposePaymentValues: bptr(true),
 		AutoUnseal:          bptr(true),
 		RequireApproval:     bptr(true),
 		ApprovalTimeout:     dptr(2 * time.Minute),

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3481,10 +3481,10 @@ func TestValidate_PaymentPolicy_ValidPolicy(t *testing.T) {
 	cfg := Default()
 	cfg.PaymentPolicies = map[string]PaymentPolicy{
 		"shopping": {
-			Instrument:      "payments/visa",
+			Instrument:       "payments/visa",
 			AllowedMerchants: []string{"amazon.de"},
-			MaxAmount:       PaymentMaxAmount{PerTransaction: "75.00", PerDay: "150.00"},
-			Currency:        "EUR",
+			MaxAmount:        PaymentMaxAmount{PerTransaction: "75.00", PerDay: "150.00"},
+			Currency:         "EUR",
 		},
 	}
 	if err := cfg.Validate(); err != nil {

--- a/internal/config/config_validate.go
+++ b/internal/config/config_validate.go
@@ -42,6 +42,41 @@ func validateAgents(agents map[string]AgentProfile) error {
 	return nil
 }
 
+func validateDecimalString(s, field string) error {
+	if len(s) == 0 || len(s) > 30 {
+		return fmt.Errorf("%s: %q is not a valid decimal amount", field, s)
+	}
+	sawDot := false
+	hasDigit := false
+	for i, r := range s {
+		switch r {
+		case '-':
+			if i != 0 {
+				return fmt.Errorf("%s: %q is not a valid decimal amount (minus sign must be leading)", field, s)
+			}
+		case '.':
+			if sawDot {
+				return fmt.Errorf("%s: %q is not a valid decimal amount (multiple decimal points)", field, s)
+			}
+			sawDot = true
+		case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
+			hasDigit = true
+		default:
+			return fmt.Errorf("%s: %q is not a valid decimal amount", field, s)
+		}
+	}
+	if !hasDigit {
+		return fmt.Errorf("%s: %q is not a valid decimal amount (no digits)", field, s)
+	}
+	// Length and format are validated above, so the input cannot trigger the
+	// malformed-string memory blowup described in CVE-2022-23772.
+	// #nosec G113
+	if _, ok := new(big.Rat).SetString(s); !ok {
+		return fmt.Errorf("%s: %q is not a valid decimal amount", field, s)
+	}
+	return nil
+}
+
 func validatePaymentPolicies(policies map[string]PaymentPolicy) error {
 	for name, policy := range policies {
 		if strings.TrimSpace(policy.Instrument) == "" {
@@ -56,13 +91,13 @@ func validatePaymentPolicies(policies map[string]PaymentPolicy) error {
 			return fmt.Errorf("paymentPolicies.%s.currency: required when max_amount limits are set", name)
 		}
 		if policy.MaxAmount.PerTransaction != "" {
-			if _, ok := new(big.Rat).SetString(policy.MaxAmount.PerTransaction); !ok {
-				return fmt.Errorf("paymentPolicies.%s.max_amount.per_transaction: %q is not a valid decimal amount", name, policy.MaxAmount.PerTransaction)
+			if err := validateDecimalString(policy.MaxAmount.PerTransaction, fmt.Sprintf("paymentPolicies.%s.max_amount.per_transaction", name)); err != nil {
+				return err
 			}
 		}
 		if policy.MaxAmount.PerDay != "" {
-			if _, ok := new(big.Rat).SetString(policy.MaxAmount.PerDay); !ok {
-				return fmt.Errorf("paymentPolicies.%s.max_amount.per_day: %q is not a valid decimal amount", name, policy.MaxAmount.PerDay)
+			if err := validateDecimalString(policy.MaxAmount.PerDay, fmt.Sprintf("paymentPolicies.%s.max_amount.per_day", name)); err != nil {
+				return err
 			}
 		}
 	}

--- a/internal/config/config_validate.go
+++ b/internal/config/config_validate.go
@@ -3,6 +3,7 @@ package config
 import (
 	"errors"
 	"fmt"
+	"math/big"
 	"path/filepath"
 	"strings"
 )
@@ -36,6 +37,46 @@ func validateAgents(agents map[string]AgentProfile) error {
 		case "", defaultPromptInjectionMode, "log-only", "wrap", approvalModeDeny:
 		default:
 			return fmt.Errorf("agent %q: invalid promptInjectionMode %q (valid: off, log-only, wrap, deny)", name, mode)
+		}
+	}
+	return nil
+}
+
+func validatePaymentPolicies(policies map[string]PaymentPolicy) error {
+	for name, policy := range policies {
+		if strings.TrimSpace(policy.Instrument) == "" {
+			return fmt.Errorf("paymentPolicies.%s.instrument: must not be empty", name)
+		}
+		hasAllowlist := len(policy.AllowedMerchants) > 0
+		hasLimits := policy.MaxAmount.PerTransaction != "" || policy.MaxAmount.PerDay != ""
+		if !hasAllowlist && !hasLimits {
+			return fmt.Errorf("paymentPolicies.%s: must have at least one allowed_merchant or max_amount limit", name)
+		}
+		if hasLimits && strings.TrimSpace(policy.Currency) == "" {
+			return fmt.Errorf("paymentPolicies.%s.currency: required when max_amount limits are set", name)
+		}
+		if policy.MaxAmount.PerTransaction != "" {
+			if _, ok := new(big.Rat).SetString(policy.MaxAmount.PerTransaction); !ok {
+				return fmt.Errorf("paymentPolicies.%s.max_amount.per_transaction: %q is not a valid decimal amount", name, policy.MaxAmount.PerTransaction)
+			}
+		}
+		if policy.MaxAmount.PerDay != "" {
+			if _, ok := new(big.Rat).SetString(policy.MaxAmount.PerDay); !ok {
+				return fmt.Errorf("paymentPolicies.%s.max_amount.per_day: %q is not a valid decimal amount", name, policy.MaxAmount.PerDay)
+			}
+		}
+	}
+	return nil
+}
+
+func validateAgentPaymentPolicies(agents map[string]AgentProfile, policies map[string]PaymentPolicy) error {
+	for name, profile := range agents {
+		policyName := profile.PaymentPolicyValue()
+		if policyName == "" {
+			continue
+		}
+		if _, ok := policies[policyName]; !ok {
+			return fmt.Errorf("agents.%s.paymentPolicy: policy %q not found in paymentPolicies", name, policyName)
 		}
 	}
 	return nil
@@ -103,6 +144,14 @@ func (c *Config) Validate() error {
 
 	if c.Clipboard != nil && c.Clipboard.AutoClearDuration < 0 {
 		errs = errors.Join(errs, errors.New("clipboard.autoClearDuration: must be non-negative (configure clipboard.autoClearDuration in config.yaml)"))
+	}
+
+	if err := validatePaymentPolicies(c.PaymentPolicies); err != nil {
+		errs = errors.Join(errs, err)
+	}
+
+	if err := validateAgentPaymentPolicies(c.Agents, c.PaymentPolicies); err != nil {
+		errs = errors.Join(errs, err)
 	}
 
 	return errs

--- a/internal/importer/bitwarden.go
+++ b/internal/importer/bitwarden.go
@@ -9,8 +9,8 @@ import (
 )
 
 const (
-	bitwardenLoginType   = 1
-	bitwardenCardType    = 2
+	bitwardenLoginType = 1
+	bitwardenCardType  = 2
 )
 
 type bitwardenImporter struct{}

--- a/internal/importer/bitwarden.go
+++ b/internal/importer/bitwarden.go
@@ -13,6 +13,16 @@ const (
 	bitwardenCardType  = 2
 )
 
+const (
+	bitwardenFieldUsername = "username"
+	bitwardenFieldPassword = "password"
+	bitwardenFieldURL      = "url"
+	bitwardenFieldURLs     = "urls"
+	bitwardenFieldNotes    = "notes"
+	bitwardenFieldTOTP     = "totp"
+	bitwardenFieldSecret   = "secret"
+)
+
 type bitwardenImporter struct{}
 
 type bitwardenExport struct {
@@ -119,11 +129,11 @@ func bitwardenPath(item bitwardenItem, folders map[string]string) string {
 
 func bitwardenParseLogin(item bitwardenItem, folders map[string]string) ImportedEntry {
 	data := map[string]any{
-		"username": item.Login.Username,
-		"password": item.Login.Password,
-		"url":      bitwardenPrimaryURI(item.Login.URIs),
-		"urls":     bitwardenURIs(item.Login.URIs),
-		"notes":    item.Notes,
+		bitwardenFieldUsername: item.Login.Username,
+		bitwardenFieldPassword: item.Login.Password,
+		bitwardenFieldURL:      bitwardenPrimaryURI(item.Login.URIs),
+		bitwardenFieldURLs:     bitwardenURIs(item.Login.URIs),
+		bitwardenFieldNotes:    item.Notes,
 	}
 
 	for _, field := range item.Fields {
@@ -134,7 +144,7 @@ func bitwardenParseLogin(item bitwardenItem, folders map[string]string) Imported
 	}
 
 	if item.Login.TOTP != "" {
-		data["totp"] = map[string]any{"secret": item.Login.TOTP}
+		data[bitwardenFieldTOTP] = map[string]any{bitwardenFieldSecret: item.Login.TOTP}
 	}
 
 	return ImportedEntry{
@@ -145,12 +155,12 @@ func bitwardenParseLogin(item bitwardenItem, folders map[string]string) Imported
 
 func bitwardenParseCard(item bitwardenItem, folders map[string]string) ImportedEntry {
 	data := map[string]any{
-		"card_number":  item.Card.Number,
-		"cardholder":   item.Card.CardholderName,
-		"expiry_month": item.Card.ExpMonth,
-		"expiry_year":  item.Card.ExpYear,
-		"cvc":          item.Card.Code,
-		"subtype":      string(vaultpkg.PaymentSubtypeCard),
+		vaultpkg.PaymentFieldCardNumber:  item.Card.Number,
+		vaultpkg.PaymentFieldCardholder:  item.Card.CardholderName,
+		vaultpkg.PaymentFieldExpiryMonth: item.Card.ExpMonth,
+		vaultpkg.PaymentFieldExpiryYear:  item.Card.ExpYear,
+		vaultpkg.PaymentFieldCVC:         item.Card.Code,
+		vaultpkg.PaymentFieldSubtype:     string(vaultpkg.PaymentSubtypeCard),
 	}
 
 	for _, field := range item.Fields {

--- a/internal/importer/bitwarden.go
+++ b/internal/importer/bitwarden.go
@@ -4,9 +4,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+
+	vaultpkg "github.com/danieljustus/symaira-vault/internal/vault"
 )
 
-const bitwardenLoginType = 1
+const (
+	bitwardenLoginType   = 1
+	bitwardenCardType    = 2
+)
 
 type bitwardenImporter struct{}
 
@@ -25,6 +30,7 @@ type bitwardenItem struct {
 	Name     string           `json:"name"`
 	FolderID string           `json:"folderId"`
 	Login    bitwardenLogin   `json:"login"`
+	Card     bitwardenCard    `json:"card"`
 	Notes    string           `json:"notes"`
 	Fields   []bitwardenField `json:"fields"`
 }
@@ -45,6 +51,15 @@ type bitwardenField struct {
 	Value string `json:"value"`
 }
 
+type bitwardenCard struct {
+	CardholderName string `json:"cardholderName"`
+	Brand          string `json:"brand"`
+	Number         string `json:"number"`
+	ExpMonth       string `json:"expMonth"`
+	ExpYear        string `json:"expYear"`
+	Code           string `json:"code"`
+}
+
 func (i *bitwardenImporter) Parse(r io.Reader) ([]ImportedEntry, error) {
 	var export bitwardenExport
 	if err := json.NewDecoder(r).Decode(&export); err != nil {
@@ -61,33 +76,16 @@ func (i *bitwardenImporter) Parse(r io.Reader) ([]ImportedEntry, error) {
 
 	entries := make([]ImportedEntry, 0, len(export.Items))
 	for _, item := range export.Items {
-		if item.Type != bitwardenLoginType {
+		switch item.Type {
+		case bitwardenLoginType:
+			entry := bitwardenParseLogin(item, folders)
+			entries = append(entries, entry)
+		case bitwardenCardType:
+			entry := bitwardenParseCard(item, folders)
+			entries = append(entries, entry)
+		default:
 			continue
 		}
-
-		data := map[string]any{
-			"username": item.Login.Username,
-			"password": item.Login.Password,
-			"url":      bitwardenPrimaryURI(item.Login.URIs),
-			"urls":     bitwardenURIs(item.Login.URIs),
-			"notes":    item.Notes,
-		}
-
-		for _, field := range item.Fields {
-			if field.Name == "" {
-				continue
-			}
-			data[field.Name] = field.Value
-		}
-
-		if item.Login.TOTP != "" {
-			data["totp"] = map[string]any{"secret": item.Login.TOTP}
-		}
-
-		entries = append(entries, ImportedEntry{
-			Path: bitwardenPath(item, folders),
-			Data: data,
-		})
 	}
 
 	return entries, nil
@@ -117,4 +115,57 @@ func bitwardenPath(item bitwardenItem, folders map[string]string) string {
 		path = ApplyPrefix(folderName, path)
 	}
 	return NormalizePath(path)
+}
+
+func bitwardenParseLogin(item bitwardenItem, folders map[string]string) ImportedEntry {
+	data := map[string]any{
+		"username": item.Login.Username,
+		"password": item.Login.Password,
+		"url":      bitwardenPrimaryURI(item.Login.URIs),
+		"urls":     bitwardenURIs(item.Login.URIs),
+		"notes":    item.Notes,
+	}
+
+	for _, field := range item.Fields {
+		if field.Name == "" {
+			continue
+		}
+		data[field.Name] = field.Value
+	}
+
+	if item.Login.TOTP != "" {
+		data["totp"] = map[string]any{"secret": item.Login.TOTP}
+	}
+
+	return ImportedEntry{
+		Path: bitwardenPath(item, folders),
+		Data: data,
+	}
+}
+
+func bitwardenParseCard(item bitwardenItem, folders map[string]string) ImportedEntry {
+	data := map[string]any{
+		"card_number":  item.Card.Number,
+		"cardholder":   item.Card.CardholderName,
+		"expiry_month": item.Card.ExpMonth,
+		"expiry_year":  item.Card.ExpYear,
+		"cvc":          item.Card.Code,
+		"subtype":      string(vaultpkg.PaymentSubtypeCard),
+	}
+
+	for _, field := range item.Fields {
+		if field.Name == "" {
+			continue
+		}
+		data[field.Name] = field.Value
+	}
+
+	return ImportedEntry{
+		Path: bitwardenPath(item, folders),
+		Data: data,
+		SecretMetadata: &vaultpkg.SecretMetadata{
+			Type:      vaultpkg.SecretTypePayment,
+			UsageHint: vaultpkg.UsageHintForType(vaultpkg.SecretTypePayment),
+		},
+	}
 }

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"io"
 	"strings"
+
+	vaultpkg "github.com/danieljustus/symaira-vault/internal/vault"
 )
 
 // ImportedEntry represents a single entry parsed from an external source.
@@ -14,6 +16,9 @@ type ImportedEntry struct {
 	Path string
 	// Data contains the entry fields (username, password, url, notes, totp, etc.).
 	Data map[string]any
+	// SecretMetadata carries the semantic type and hints set by the importer.
+	// When set, the import pipeline writes this metadata to the vault entry.
+	SecretMetadata *vaultpkg.SecretMetadata
 }
 
 // Importer parses a password export format and returns imported entries.

--- a/internal/importer/importer_test.go
+++ b/internal/importer/importer_test.go
@@ -221,6 +221,45 @@ func TestBitwardenImporterParse(t *testing.T) {
 	}
 }
 
+func TestBitwardenImporterParseCard(t *testing.T) {
+	cardJSON := strings.Join([]string{
+		`{"folders":[{"id":"f-pay","name":"Payment"}],`,
+		`"items":[{`,
+		`"type":2,"name":"Visa Personal","folderId":"f-pay",`,
+		`"card":{"cardholderName":"Jane Doe","brand":"Visa",`,
+		`"number":"4111111111111111","expMonth":"12","expYear":"2028","code":"123"},`,
+		`"fields":[{"name":"notes","value":"primary card"}]`,
+		`}]}`,
+	}, "")
+
+	entries, err := (&bitwardenImporter{}).Parse(strings.NewReader(cardJSON))
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("Parse() returned %d entries, want 1", len(entries))
+	}
+
+	entry := entries[0]
+	if entry.Path != "Payment/Visa-Personal" {
+		t.Errorf("path = %q, want Payment/Visa-Personal", entry.Path)
+	}
+	assertStringField(t, entry.Data, "card_number", "4111111111111111")
+	assertStringField(t, entry.Data, "cardholder", "Jane Doe")
+	assertStringField(t, entry.Data, "expiry_month", "12")
+	assertStringField(t, entry.Data, "expiry_year", "2028")
+	assertStringField(t, entry.Data, "cvc", "123")
+	assertStringField(t, entry.Data, "subtype", "card")
+	assertStringField(t, entry.Data, "notes", "primary card")
+
+	if entry.SecretMetadata == nil {
+		t.Fatal("card entry should have SecretMetadata set")
+	}
+	if entry.SecretMetadata.Type != "payment" {
+		t.Errorf("SecretMetadata.Type = %q, want payment", entry.SecretMetadata.Type)
+	}
+}
+
 func TestCSVImporterParseDefaultMapping(t *testing.T) {
 	f := openFixture(t, "../../testdata/importer/csv/sample.csv")
 	defer f.Close()

--- a/internal/mcp/server/server.go
+++ b/internal/mcp/server/server.go
@@ -6,6 +6,7 @@ package server
 import (
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -22,6 +23,7 @@ import (
 	"github.com/danieljustus/symaira-vault/internal/config"
 	transport "github.com/danieljustus/symaira-vault/internal/mcp/transport"
 	"github.com/danieljustus/symaira-vault/internal/notify"
+	"github.com/danieljustus/symaira-vault/internal/payment"
 	"github.com/danieljustus/symaira-vault/internal/policy"
 	"github.com/danieljustus/symaira-vault/internal/vault"
 )
@@ -93,6 +95,8 @@ type Server struct {
 	anomalyDetector *anomaly.AnomalyDetector
 
 	biometricChallenger *authguard.Challenger
+
+	paymentEnforcer *payment.Enforcer
 
 	clipboardCancel chan struct{}
 }
@@ -227,6 +231,17 @@ func New(v *vault.Vault, agentName string, transport string) (*Server, error) {
 	// Register hooks specified in the agent's config profile
 	srv.registerConfigHooks(cfg)
 
+	// Attach payment policy enforcer if the agent references one.
+	if policyName := agent.PaymentPolicyValue(); policyName != "" && cfg.PaymentPolicies != nil {
+		if pp, ok := cfg.PaymentPolicies[policyName]; ok {
+			statePath := paymentStatePath(v.Dir, policyName)
+			enforcer, enfErr := payment.NewEnforcerFromFile(pp, statePath)
+			if enfErr == nil {
+				srv.paymentEnforcer = enforcer
+			}
+		}
+	}
+
 	return srv, nil
 }
 
@@ -349,4 +364,14 @@ func (s *Server) getBiometricChallenger() *authguard.Challenger {
 		return s.biometricChallenger
 	}
 	return authguard.DefaultChallenger()
+}
+
+func paymentStatePath(vaultDir, policyName string) string {
+	h := sha256Short(vaultDir)
+	return filepath.Join(config.DefaultDataDir(), "payment-state", h, policyName, "daily-totals.json")
+}
+
+func sha256Short(s string) string {
+	h := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(h[:])[:12]
 }

--- a/internal/mcp/server/tool_registry.go
+++ b/internal/mcp/server/tool_registry.go
@@ -74,7 +74,7 @@ func objectSchema(required []string, properties map[string]schemaProperty) map[s
 // ARCHITECTURE.md § Tool Addition Review). The cap balances functionality
 // against the prompt injection attack surface — each additional tool is another
 // vector an attacker-controlled agent can exploit.
-const MaxToolDefinitions = 34
+const MaxToolDefinitions = 35
 
 var (
 	toolRegistry   []toolDefinition
@@ -130,6 +130,22 @@ func RegisterTools() {
 		}),
 		Handler:         (*Server).handleAutotype,
 		RiskLevel:       RiskLevelHigh,
+		DestructiveHint: true,
+	})
+
+	// -- tools_prepare_payment.go
+	RegisterTool(toolDefinition{
+		Name:        "prepare_payment",
+		Description: "Prepare a payment by validating a payment entry, showing a native approval prompt with merchant/amount/currency, and on approval autotyping card or bank account fields into the focused checkout window. Card values are never returned to the agent.",
+		InputSchema: objectSchema([]string{"entry_path", "merchant", "amount", "currency"}, map[string]schemaProperty{
+			"entry_path":  {Type: "string", Description: "Vault path of the payment entry"},
+			"merchant":    {Type: "string", Description: "Merchant name or origin (e.g. shop.example)"},
+			"amount":      {Type: "string", Description: "Payment amount (e.g. 75.00)"},
+			"currency":    {Type: "string", Description: "Currency code (e.g. EUR, USD)"},
+			"description": {Type: "string", Description: "Optional description shown in the approval prompt"},
+		}),
+		Handler:         (*Server).handlePreparePayment,
+		RiskLevel:       RiskLevelCritical,
 		DestructiveHint: true,
 	})
 
@@ -635,6 +651,7 @@ func checkToolBlockedByTier(agent *config.AgentProfile, toolName string) *errors
 			"request_credential":  true,
 			"copy_to_clipboard":   true,
 			"autotype":            true,
+			"prepare_payment":     true,
 		}
 		if blocked[toolName] {
 			return errors.ToolNotAllowed(toolName, "standard", upgradeCmdForAgent(agent))

--- a/internal/mcp/server/tools_get.go
+++ b/internal/mcp/server/tools_get.go
@@ -146,6 +146,9 @@ func (s *Server) handleGetValue(ctx context.Context, req mcp.CallToolRequest) (*
 	}
 
 	if s.agent != nil {
+		if entry.SecretMetadata.Type == vaultpkg.SecretTypePayment && !s.agent.ExposePaymentValuesValue() {
+			entry = redactEntry(entry, vaultpkg.AllPaymentSensitiveFields())
+		}
 		if patterns := s.agent.EffectiveRedactFields("get_entry_value"); len(patterns) > 0 {
 			entry = redactEntry(entry, patterns)
 		}

--- a/internal/mcp/server/tools_get_test.go
+++ b/internal/mcp/server/tools_get_test.go
@@ -976,3 +976,186 @@ func TestHandleGetValue_SealsAutoDetectedGitHubPAT(t *testing.T) {
 		t.Error("sealed response should not contain raw data field")
 	}
 }
+
+func TestHandleGetValue_PaymentRedactedByDefault(t *testing.T) {
+	vaultDir, identity := mockVault(t)
+
+	entry := &vault.Entry{
+		Data: map[string]any{
+			"card_number":  "4111111111111111",
+			"cardholder":   "Jane Doe",
+			"expiry_month": "12",
+			"expiry_year":  "2028",
+			"cvc":          "123",
+			"subtype":      "card",
+		},
+		SecretMetadata: vault.SecretMetadata{Type: vault.SecretTypePayment},
+	}
+	if err := vault.WriteEntry(vaultDir, "payment/visa", entry, identity); err != nil {
+		t.Fatalf("WriteEntry: %v", err)
+	}
+
+	srv := &Server{
+		vault: &vault.Vault{
+			Dir:      vaultDir,
+			Identity: identity,
+		},
+		vaultService: vault.NewVaultService(&vault.Vault{Dir: vaultDir, Identity: identity}, nil),
+		agent: &config.AgentProfile{
+			Name:          "test",
+			AllowedPaths:  []string{"*"},
+			CanReadValues: config.BoolPtr(true),
+			ApprovalMode:  config.StrPtr("none"),
+			AutoUnseal:    config.BoolPtr(true),
+		},
+		hookRegistry: NewHookRegistry(),
+	}
+
+	req := mcp.CallToolRequest{
+		Arguments: map[string]any{"path": "payment/visa"},
+	}
+
+	result, err := srv.handleGetValue(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleGetValue() error = %v", err)
+	}
+	if result == nil || result.IsError {
+		t.Fatalf("handleGetValue() returned error: %v", result)
+	}
+
+	var resp vault.Entry
+	if parseErr := json.Unmarshal([]byte(result.Text), &resp); parseErr != nil {
+		t.Fatalf("parse result: %v", parseErr)
+	}
+
+	cardNumber, _ := resp.Data["card_number"].(string)
+	if !strings.Contains(cardNumber, "[REDACTED]") {
+		t.Errorf("card_number should be redacted, got %q", cardNumber)
+	}
+	cvc, _ := resp.Data["cvc"].(string)
+	if !strings.Contains(cvc, "[REDACTED]") {
+		t.Errorf("cvc should be redacted, got %q", cvc)
+	}
+	cardholder, _ := resp.Data["cardholder"].(string)
+	if strings.Contains(cardholder, "[REDACTED]") {
+		t.Errorf("cardholder should NOT be redacted, got %q", cardholder)
+	}
+	expiryMonth, _ := resp.Data["expiry_month"].(string)
+	if strings.Contains(expiryMonth, "[REDACTED]") {
+		t.Errorf("expiry_month should NOT be redacted, got %q", expiryMonth)
+	}
+}
+
+func TestHandleGetValue_PaymentExposedWhenOptOut(t *testing.T) {
+	vaultDir, identity := mockVault(t)
+
+	entry := &vault.Entry{
+		Data: map[string]any{
+			"card_number":  "4111111111111111",
+			"cardholder":   "Jane Doe",
+			"expiry_month": "12",
+			"expiry_year":  "2028",
+			"cvc":          "123",
+			"subtype":      "card",
+		},
+		SecretMetadata: vault.SecretMetadata{Type: vault.SecretTypePayment},
+	}
+	if err := vault.WriteEntry(vaultDir, "payment/visa", entry, identity); err != nil {
+		t.Fatalf("WriteEntry: %v", err)
+	}
+
+	srv := &Server{
+		vault: &vault.Vault{
+			Dir:      vaultDir,
+			Identity: identity,
+		},
+		vaultService: vault.NewVaultService(&vault.Vault{Dir: vaultDir, Identity: identity}, nil),
+		agent: &config.AgentProfile{
+			Name:                "test",
+			AllowedPaths:        []string{"*"},
+			CanReadValues:       config.BoolPtr(true),
+			ApprovalMode:        config.StrPtr("none"),
+			AutoUnseal:          config.BoolPtr(true),
+			ExposePaymentValues: config.BoolPtr(true),
+		},
+		hookRegistry: NewHookRegistry(),
+	}
+
+	req := mcp.CallToolRequest{
+		Arguments: map[string]any{"path": "payment/visa"},
+	}
+
+	result, err := srv.handleGetValue(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleGetValue() error = %v", err)
+	}
+	if result == nil || result.IsError {
+		t.Fatalf("handleGetValue() returned error: %v", result)
+	}
+
+	var resp vault.Entry
+	if parseErr := json.Unmarshal([]byte(result.Text), &resp); parseErr != nil {
+		t.Fatalf("parse result: %v", parseErr)
+	}
+
+	cardNumber, _ := resp.Data["card_number"].(string)
+	if strings.Contains(cardNumber, "[REDACTED]") {
+		t.Errorf("card_number should NOT be redacted with exposePaymentValues, got %q", cardNumber)
+	}
+	cvc, _ := resp.Data["cvc"].(string)
+	if strings.Contains(cvc, "[REDACTED]") {
+		t.Errorf("cvc should NOT be redacted with exposePaymentValues, got %q", cvc)
+	}
+}
+
+func TestHandleGetValue_NonPaymentTypeNotRedacted(t *testing.T) {
+	vaultDir, identity := mockVault(t)
+
+	entry := &vault.Entry{
+		Data: map[string]any{
+			"password": "s3cr3t",
+			"username": "alice",
+		},
+	}
+	if err := vault.WriteEntry(vaultDir, "github", entry, identity); err != nil {
+		t.Fatalf("WriteEntry: %v", err)
+	}
+
+	srv := &Server{
+		vault: &vault.Vault{
+			Dir:      vaultDir,
+			Identity: identity,
+		},
+		vaultService: vault.NewVaultService(&vault.Vault{Dir: vaultDir, Identity: identity}, nil),
+		agent: &config.AgentProfile{
+			Name:          "test",
+			AllowedPaths:  []string{"*"},
+			CanReadValues: config.BoolPtr(true),
+			ApprovalMode:  config.StrPtr("none"),
+			AutoUnseal:    config.BoolPtr(true),
+		},
+		hookRegistry: NewHookRegistry(),
+	}
+
+	req := mcp.CallToolRequest{
+		Arguments: map[string]any{"path": "github"},
+	}
+
+	result, err := srv.handleGetValue(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleGetValue() error = %v", err)
+	}
+	if result == nil || result.IsError {
+		t.Fatalf("handleGetValue() returned error: %v", result)
+	}
+
+	var resp vault.Entry
+	if parseErr := json.Unmarshal([]byte(result.Text), &resp); parseErr != nil {
+		t.Fatalf("parse result: %v", parseErr)
+	}
+
+	password, _ := resp.Data["password"].(string)
+	if strings.Contains(password, "[REDACTED]") {
+		t.Errorf("password should NOT be redacted for non-payment entry, got %q", password)
+	}
+}

--- a/internal/mcp/server/tools_prepare_payment.go
+++ b/internal/mcp/server/tools_prepare_payment.go
@@ -1,0 +1,149 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/danieljustus/symaira-vault/internal/autotype"
+	mcp "github.com/danieljustus/symaira-vault/internal/mcp"
+	"github.com/danieljustus/symaira-vault/internal/metrics"
+	vaultpkg "github.com/danieljustus/symaira-vault/internal/vault"
+)
+
+// paymentAutotype is the function used to type payment fields.
+// Extracted for testability.
+var paymentAutotype = func(text string) error {
+	at := autotype.DefaultAutotype()
+	if at == nil {
+		return fmt.Errorf("autotype not available on this platform")
+	}
+	return at.Type(text)
+}
+
+// handlePreparePayment validates a payment entry, shows a native approval
+// prompt with merchant/amount/currency details, and on approval autotypes
+// the payment card or bank account fields into the focused checkout window.
+// Card number, CVC, and IBAN values are never returned in the tool response.
+func (s *Server) handlePreparePayment(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	path, err := req.RequireString("entry_path")
+	if err != nil {
+		s.logAudit(ctx, "payment.requested", "<invalid>", false)
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	merchant, err := req.RequireString("merchant")
+	if err != nil {
+		s.logAudit(ctx, "payment.requested", path, false)
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	amount, err := req.RequireString("amount")
+	if err != nil {
+		s.logAudit(ctx, "payment.requested", path, false)
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	currency, err := req.RequireString("currency")
+	if err != nil {
+		s.logAudit(ctx, "payment.requested", path, false)
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	description := req.GetString("description", "")
+
+	// --- Scope check ---
+	if !s.checkScope(path) {
+		s.logAudit(ctx, "payment.denied", path, false)
+		metrics.RecordAuthDenial("scope_denied", s.agent.Name)
+		return nil, fmt.Errorf("access denied: path %q outside allowed scope", path)
+	}
+
+	// --- Read entry and validate payment type ---
+	entry, err := vaultpkg.ReadEntry(s.vault.Dir, path, s.vault.Identity)
+	if err != nil {
+		s.logAudit(ctx, "payment.requested", path, false)
+		metrics.RecordVaultOperation("read", "error")
+		return vaultServiceErrorResult(err)
+	}
+
+	if entry.SecretMetadata.Type != vaultpkg.SecretTypePayment {
+		s.logAudit(ctx, "payment.denied", path, false)
+		return mcp.NewToolResultError(fmt.Sprintf("entry %s is not a payment entry (type: %s)", path, entry.SecretMetadata.Type)), nil
+	}
+
+	// --- Build approval summary ---
+	summary := buildPaymentSummary(merchant, amount, currency, description)
+
+	// --- Require user approval ---
+	if err := s.requireApproval(ctx, Intent{
+		Action:    "prepare_payment",
+		EntryPath: path,
+		Summary:   summary,
+	}); err != nil {
+		s.logAudit(ctx, "payment.denied", path, false)
+		return nil, fmt.Errorf("payment denied: %w", err)
+	}
+
+	s.logAudit(ctx, "payment.approved", path, true)
+
+	// --- Determine payment subtype and field order ---
+	subtype := vaultpkg.PaymentSubtypeCard
+	if st, ok := entry.Data[vaultpkg.PaymentFieldSubtype]; ok {
+		subtype = vaultpkg.PaymentSubtypeFromString(fmt.Sprintf("%v", st))
+	}
+
+	fields := paymentFieldOrder(subtype)
+
+	// --- Autotype each field ---
+	for _, field := range fields {
+		value, ok := entry.Data[field]
+		if !ok {
+			s.logAudit(ctx, "payment.denied", path, false)
+			return mcp.NewToolResultError(fmt.Sprintf("payment field %q not found in entry %s", field, path)), nil
+		}
+
+		strValue, ok := value.(string)
+		if !ok {
+			s.logAudit(ctx, "payment.denied", path, false)
+			return mcp.NewToolResultError(fmt.Sprintf("payment field %q is not a string", field)), nil
+		}
+
+		if err := paymentAutotype(strValue); err != nil {
+			s.logAudit(ctx, "payment.denied", path, false)
+			return mcp.NewToolResultError(fmt.Sprintf("autotype failed on field %q: %v", field, err)), nil
+		}
+	}
+
+	s.logAudit(ctx, "payment.typed", path, true)
+	metrics.RecordVaultOperation("autotype", "success")
+
+	return mcp.NewToolResultText(`{"success": true}`), nil
+}
+
+// paymentFieldOrder returns the fields to autotype in order for the given
+// payment subtype. Card entries use: card_number, expiry_month, expiry_year,
+// cvc. Bank account entries use: iban.
+func paymentFieldOrder(subtype vaultpkg.PaymentSubtype) []string {
+	switch subtype {
+	case vaultpkg.PaymentSubtypeBankAccount:
+		return []string{vaultpkg.PaymentFieldIBAN}
+	default:
+		return []string{
+			vaultpkg.PaymentFieldCardNumber,
+			vaultpkg.PaymentFieldExpiryMonth,
+			vaultpkg.PaymentFieldExpiryYear,
+			vaultpkg.PaymentFieldCVC,
+		}
+	}
+}
+
+// buildPaymentSummary produces a human-readable approval prompt for payment.
+func buildPaymentSummary(merchant, amount, currency, description string) string {
+	var parts []string
+	parts = append(parts, fmt.Sprintf("Allow payment of %s %s to %s?", currency, amount, merchant))
+	if description != "" {
+		parts = append(parts, fmt.Sprintf("Description: %s", description))
+	}
+	return strings.Join(parts, "\n")
+}

--- a/internal/mcp/server/tools_prepare_payment.go
+++ b/internal/mcp/server/tools_prepare_payment.go
@@ -3,11 +3,13 @@ package server
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"strings"
 
 	"github.com/danieljustus/symaira-vault/internal/autotype"
 	mcp "github.com/danieljustus/symaira-vault/internal/mcp"
 	"github.com/danieljustus/symaira-vault/internal/metrics"
+	"github.com/danieljustus/symaira-vault/internal/payment"
 	vaultpkg "github.com/danieljustus/symaira-vault/internal/vault"
 )
 
@@ -75,6 +77,20 @@ func (s *Server) handlePreparePayment(ctx context.Context, req mcp.CallToolReque
 	// --- Build approval summary ---
 	summary := buildPaymentSummary(merchant, amount, currency, description)
 
+	// --- Enforce payment policy ---
+	if s.paymentEnforcer != nil {
+		req := payment.PaymentRequest{
+			EntryPath: path,
+			Merchant:  merchant,
+			Amount:    amount,
+			Currency:  currency,
+		}
+		if err := s.paymentEnforcer.Check(req); err != nil {
+			s.logAudit(ctx, "payment.policy_denied", path, false)
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+	}
+
 	// --- Require user approval ---
 	if err := s.requireApproval(ctx, Intent{
 		Action:    "prepare_payment",
@@ -86,6 +102,17 @@ func (s *Server) handlePreparePayment(ctx context.Context, req mcp.CallToolReque
 	}
 
 	s.logAudit(ctx, "payment.approved", path, true)
+
+	if s.paymentEnforcer != nil {
+		if recErr := s.paymentEnforcer.RecordApproved(payment.PaymentRequest{
+			EntryPath: path,
+			Merchant:  merchant,
+			Amount:    amount,
+			Currency:  currency,
+		}); recErr != nil {
+			slog.Default().Warn("failed to record payment total", "err", recErr)
+		}
+	}
 
 	// --- Determine payment subtype and field order ---
 	subtype := vaultpkg.PaymentSubtypeCard

--- a/internal/mcp/server/tools_prepare_payment_test.go
+++ b/internal/mcp/server/tools_prepare_payment_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/danieljustus/symaira-vault/internal/autotype"
 	"github.com/danieljustus/symaira-vault/internal/config"
 	mcp "github.com/danieljustus/symaira-vault/internal/mcp"
+	"github.com/danieljustus/symaira-vault/internal/payment"
 	vaultpkg "github.com/danieljustus/symaira-vault/internal/vault"
 )
 
@@ -483,5 +484,298 @@ func TestBuildPaymentSummary(t *testing.T) {
 	withDesc := buildPaymentSummary("shop.example", "75.00", "EUR", "Gift for mom")
 	if !strings.Contains(withDesc, "Gift for mom") {
 		t.Errorf("summary = %q, want description", withDesc)
+	}
+}
+
+func TestHandlePreparePayment_Policy_DeniedMerchant(t *testing.T) {
+	vaultDir, identity := mockPaymentVault(t)
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:           "test",
+		AllowedPaths:   []string{"*"},
+		CanUseAutotype: config.BoolPtr(true),
+		ApprovalMode:   config.StrPtr("none"),
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+
+	origPaymentAutotype := paymentAutotype
+	paymentAutotype = func(text string) error { return nil }
+	defer func() { paymentAutotype = origPaymentAutotype }()
+
+	srv.paymentEnforcer = payment.NewEnforcer(
+		config.PaymentPolicy{
+			Instrument:      "payments/mycard",
+			AllowedMerchants: []string{"amazon.de"},
+			MaxAmount:       config.PaymentMaxAmount{PerTransaction: "100.00", PerDay: "200.00"},
+			Currency:        "EUR",
+		},
+		nil,
+	)
+
+	req := mcp.CallToolRequest{
+		Arguments: map[string]any{
+			"entry_path": "payments/mycard",
+			"merchant":   "evil.com",
+			"amount":     "50.00",
+			"currency":   "EUR",
+		},
+	}
+
+	result, err := srv.handlePreparePayment(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handlePreparePayment() error = %v", err)
+	}
+	if result == nil || !result.IsError {
+		t.Fatal("expected error result for denied merchant")
+	}
+	if !strings.Contains(result.Text, "merchant_not_allowed") {
+		t.Errorf("result = %q, want 'merchant_not_allowed'", result.Text)
+	}
+}
+
+func TestHandlePreparePayment_Policy_CurrencyMismatch(t *testing.T) {
+	vaultDir, identity := mockPaymentVault(t)
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:           "test",
+		AllowedPaths:   []string{"*"},
+		CanUseAutotype: config.BoolPtr(true),
+		ApprovalMode:   config.StrPtr("none"),
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+
+	origPaymentAutotype := paymentAutotype
+	paymentAutotype = func(text string) error { return nil }
+	defer func() { paymentAutotype = origPaymentAutotype }()
+
+	srv.paymentEnforcer = payment.NewEnforcer(
+		config.PaymentPolicy{
+			Instrument:      "payments/mycard",
+			AllowedMerchants: []string{"shop.example"},
+			MaxAmount:       config.PaymentMaxAmount{PerTransaction: "100.00"},
+			Currency:        "EUR",
+		},
+		nil,
+	)
+
+	req := mcp.CallToolRequest{
+		Arguments: map[string]any{
+			"entry_path": "payments/mycard",
+			"merchant":   "shop.example",
+			"amount":     "50.00",
+			"currency":   "USD",
+		},
+	}
+
+	result, err := srv.handlePreparePayment(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handlePreparePayment() error = %v", err)
+	}
+	if result == nil || !result.IsError {
+		t.Fatal("expected error result for currency mismatch")
+	}
+	if !strings.Contains(result.Text, "currency_mismatch") {
+		t.Errorf("result = %q, want 'currency_mismatch'", result.Text)
+	}
+}
+
+func TestHandlePreparePayment_Policy_OverPerTransaction(t *testing.T) {
+	vaultDir, identity := mockPaymentVault(t)
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:           "test",
+		AllowedPaths:   []string{"*"},
+		CanUseAutotype: config.BoolPtr(true),
+		ApprovalMode:   config.StrPtr("none"),
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+
+	origPaymentAutotype := paymentAutotype
+	paymentAutotype = func(text string) error { return nil }
+	defer func() { paymentAutotype = origPaymentAutotype }()
+
+	srv.paymentEnforcer = payment.NewEnforcer(
+		config.PaymentPolicy{
+			Instrument:      "payments/mycard",
+			AllowedMerchants: []string{"shop.example"},
+			MaxAmount:       config.PaymentMaxAmount{PerTransaction: "75.00"},
+			Currency:        "EUR",
+		},
+		nil,
+	)
+
+	req := mcp.CallToolRequest{
+		Arguments: map[string]any{
+			"entry_path": "payments/mycard",
+			"merchant":   "shop.example",
+			"amount":     "100.00",
+			"currency":   "EUR",
+		},
+	}
+
+	result, err := srv.handlePreparePayment(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handlePreparePayment() error = %v", err)
+	}
+	if result == nil || !result.IsError {
+		t.Fatal("expected error result for over per-transaction")
+	}
+	if !strings.Contains(result.Text, "over_per_transaction") {
+		t.Errorf("result = %q, want 'over_per_transaction'", result.Text)
+	}
+}
+
+func TestHandlePreparePayment_Policy_OverPerDay(t *testing.T) {
+	vaultDir, identity := mockPaymentVault(t)
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:           "test",
+		AllowedPaths:   []string{"*"},
+		CanUseAutotype: config.BoolPtr(true),
+		ApprovalMode:   config.StrPtr("none"),
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+
+	origPaymentAutotype := paymentAutotype
+	paymentAutotype = func(text string) error { return nil }
+	defer func() { paymentAutotype = origPaymentAutotype }()
+
+	// Pre-populate the tracker with a previous total
+	dir := t.TempDir()
+	tracker, err := payment.LoadDailyTotals(dir + "/test-totals.json")
+	if err != nil {
+		t.Fatalf("LoadDailyTotals() error = %v", err)
+	}
+	if err := tracker.AddToToday("payments/mycard", "150.00"); err != nil {
+		t.Fatalf("AddToToday() error = %v", err)
+	}
+
+	srv.paymentEnforcer = payment.NewEnforcer(
+		config.PaymentPolicy{
+			Instrument:      "payments/mycard",
+			AllowedMerchants: []string{"shop.example"},
+			MaxAmount:       config.PaymentMaxAmount{PerTransaction: "100.00", PerDay: "200.00"},
+			Currency:        "EUR",
+		},
+		tracker,
+	)
+
+	req := mcp.CallToolRequest{
+		Arguments: map[string]any{
+			"entry_path": "payments/mycard",
+			"merchant":   "shop.example",
+			"amount":     "60.00",
+			"currency":   "EUR",
+		},
+	}
+
+	result, err := srv.handlePreparePayment(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handlePreparePayment() error = %v", err)
+	}
+	if result == nil || !result.IsError {
+		t.Fatal("expected error result for over per-day")
+	}
+	if !strings.Contains(result.Text, "over_per_day") {
+		t.Errorf("result = %q, want 'over_per_day'", result.Text)
+	}
+}
+
+func TestHandlePreparePayment_Policy_PassesAndIncrements(t *testing.T) {
+	vaultDir, identity := mockPaymentVault(t)
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:           "test",
+		AllowedPaths:   []string{"*"},
+		CanUseAutotype: config.BoolPtr(true),
+		ApprovalMode:   config.StrPtr("none"),
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+
+	mockAT := &trackingAutotype{}
+	autotype.SetAutotype(mockAT)
+	defer autotype.SetAutotype(nil)
+	origPaymentAutotype := paymentAutotype
+	paymentAutotype = mockAT.Type
+	defer func() { paymentAutotype = origPaymentAutotype }()
+
+	dir := t.TempDir()
+	tracker, err := payment.LoadDailyTotals(dir + "/test-totals.json")
+	if err != nil {
+		t.Fatalf("LoadDailyTotals() error = %v", err)
+	}
+
+	srv.paymentEnforcer = payment.NewEnforcer(
+		config.PaymentPolicy{
+			Instrument:      "payments/mycard",
+			AllowedMerchants: []string{"shop.example"},
+			MaxAmount:       config.PaymentMaxAmount{PerTransaction: "75.00", PerDay: "200.00"},
+			Currency:        "EUR",
+		},
+		tracker,
+	)
+
+	req := mcp.CallToolRequest{
+		Arguments: map[string]any{
+			"entry_path": "payments/mycard",
+			"merchant":   "shop.example",
+			"amount":     "60.00",
+			"currency":   "EUR",
+		},
+	}
+
+	result, err := srv.handlePreparePayment(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handlePreparePayment() error = %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if result.IsError {
+		t.Fatalf("expected success, got error: %s", result.Text)
+	}
+
+	typed := mockAT.typedFields()
+	if len(typed) != 4 {
+		t.Fatalf("typed %d fields, want 4", len(typed))
+	}
+
+	if got := tracker.TodayTotal("payments/mycard"); got != "60" {
+		t.Errorf("TodayTotal() = %q, want \"60\"", got)
+	}
+}
+
+func TestHandlePreparePayment_NoPolicy_AllowsEverything(t *testing.T) {
+	vaultDir, identity := mockPaymentVault(t)
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:           "test",
+		AllowedPaths:   []string{"*"},
+		CanUseAutotype: config.BoolPtr(true),
+		ApprovalMode:   config.StrPtr("none"),
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+
+	mockAT := &trackingAutotype{}
+	autotype.SetAutotype(mockAT)
+	defer autotype.SetAutotype(nil)
+	origPaymentAutotype := paymentAutotype
+	paymentAutotype = mockAT.Type
+	defer func() { paymentAutotype = origPaymentAutotype }()
+
+	srv.paymentEnforcer = nil
+
+	req := mcp.CallToolRequest{
+		Arguments: map[string]any{
+			"entry_path": "payments/mycard",
+			"merchant":   "any-merchant",
+			"amount":     "99999.99",
+			"currency":   "USD",
+		},
+	}
+
+	result, err := srv.handlePreparePayment(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handlePreparePayment() error = %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if result.IsError {
+		t.Fatalf("expected success, got error: %s", result.Text)
 	}
 }

--- a/internal/mcp/server/tools_prepare_payment_test.go
+++ b/internal/mcp/server/tools_prepare_payment_test.go
@@ -1,0 +1,487 @@
+package server
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+
+	"filippo.io/age"
+
+	"github.com/danieljustus/symaira-vault/internal/autotype"
+	"github.com/danieljustus/symaira-vault/internal/config"
+	mcp "github.com/danieljustus/symaira-vault/internal/mcp"
+	vaultpkg "github.com/danieljustus/symaira-vault/internal/vault"
+)
+
+func mockPaymentVault(t *testing.T) (string, *age.X25519Identity) {
+	t.Helper()
+
+	dir := t.TempDir()
+	identity, err := age.GenerateX25519Identity()
+	if err != nil {
+		t.Fatalf("generate identity: %v", err)
+	}
+
+	entry := &vaultpkg.Entry{
+		SecretMetadata: vaultpkg.SecretMetadata{
+			Type: vaultpkg.SecretTypePayment,
+		},
+		Data: map[string]any{
+			vaultpkg.PaymentFieldCardNumber:  "4111111111111111",
+			vaultpkg.PaymentFieldExpiryMonth: "12",
+			vaultpkg.PaymentFieldExpiryYear:  "2028",
+			vaultpkg.PaymentFieldCVC:         "123",
+			vaultpkg.PaymentFieldCardholder:  "Jane Doe",
+			vaultpkg.PaymentFieldSubtype:     "card",
+		},
+	}
+	if err := vaultpkg.WriteEntry(dir, "payments/mycard", entry, identity); err != nil {
+		t.Fatalf("write payment entry: %v", err)
+	}
+
+	return dir, identity
+}
+
+func mockBankAccountVault(t *testing.T) (string, *age.X25519Identity) {
+	t.Helper()
+
+	dir := t.TempDir()
+	identity, err := age.GenerateX25519Identity()
+	if err != nil {
+		t.Fatalf("generate identity: %v", err)
+	}
+
+	entry := &vaultpkg.Entry{
+		SecretMetadata: vaultpkg.SecretMetadata{
+			Type: vaultpkg.SecretTypePayment,
+		},
+		Data: map[string]any{
+			vaultpkg.PaymentFieldIBAN:       "DE89370400440532013000",
+			vaultpkg.PaymentFieldBIC:        "COBADEFFXXX",
+			vaultpkg.PaymentFieldCardholder: "Jane Doe",
+			vaultpkg.PaymentFieldSubtype:    "bank_account",
+		},
+	}
+	if err := vaultpkg.WriteEntry(dir, "payments/mybank", entry, identity); err != nil {
+		t.Fatalf("write bank account entry: %v", err)
+	}
+
+	return dir, identity
+}
+
+func mockNonPaymentVault(t *testing.T) (string, *age.X25519Identity) {
+	t.Helper()
+
+	dir := t.TempDir()
+	identity, err := age.GenerateX25519Identity()
+	if err != nil {
+		t.Fatalf("generate identity: %v", err)
+	}
+
+	entry := &vaultpkg.Entry{
+		Data: map[string]any{
+			"password": "testpass123",
+			"username": "testuser",
+		},
+	}
+	if err := vaultpkg.WriteEntry(dir, "github", entry, identity); err != nil {
+		t.Fatalf("write entry: %v", err)
+	}
+
+	return dir, identity
+}
+
+type trackingAutotype struct {
+	mu     sync.Mutex
+	fields []string
+}
+
+func (a *trackingAutotype) Type(text string) error {
+	a.mu.Lock()
+	a.fields = append(a.fields, text)
+	a.mu.Unlock()
+	return nil
+}
+
+func (a *trackingAutotype) typedFields() []string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	result := make([]string, len(a.fields))
+	copy(result, a.fields)
+	return result
+}
+
+func TestHandlePreparePayment(t *testing.T) {
+	t.Run("success_card_entry", func(t *testing.T) {
+		vaultDir, identity := mockPaymentVault(t)
+		srv := newTestServerWithVault(t, config.AgentProfile{
+			Name:           "test",
+			AllowedPaths:   []string{"*"},
+			CanUseAutotype: config.BoolPtr(true),
+			ApprovalMode:   config.StrPtr("none"),
+		}, "stdio", vaultDir)
+		srv.vault.Identity = identity
+
+		mockAT := &trackingAutotype{}
+		autotype.SetAutotype(mockAT)
+		defer autotype.SetAutotype(nil)
+		origPaymentAutotype := paymentAutotype
+		paymentAutotype = mockAT.Type
+		defer func() { paymentAutotype = origPaymentAutotype }()
+
+		req := mcp.CallToolRequest{
+			Arguments: map[string]any{
+				"entry_path": "payments/mycard",
+				"merchant":   "shop.example",
+				"amount":     "75.00",
+				"currency":   "EUR",
+			},
+		}
+
+		result, err := srv.handlePreparePayment(context.Background(), req)
+		if err != nil {
+			t.Fatalf("handlePreparePayment() error = %v", err)
+		}
+		if result == nil {
+			t.Fatal("handlePreparePayment() returned nil result")
+		}
+		if result.IsError {
+			t.Fatalf("handlePreparePayment() returned error result: %s", result.Text)
+		}
+
+		typed := mockAT.typedFields()
+		expected := []string{
+			"4111111111111111",
+			"12",
+			"2028",
+			"123",
+		}
+		if len(typed) != len(expected) {
+			t.Fatalf("typed %d fields, want %d", len(typed), len(expected))
+		}
+		for i, got := range typed {
+			if got != expected[i] {
+				t.Errorf("typed field[%d] = %q, want %q", i, got, expected[i])
+			}
+		}
+
+		if strings.Contains(result.Text, "4111111111111111") {
+			t.Error("result contains card number — must not expose payment data")
+		}
+		if strings.Contains(result.Text, "123") {
+			t.Error("result contains CVC — must not expose payment data")
+		}
+	})
+
+	t.Run("success_bank_account_entry", func(t *testing.T) {
+		vaultDir, identity := mockBankAccountVault(t)
+		srv := newTestServerWithVault(t, config.AgentProfile{
+			Name:           "test",
+			AllowedPaths:   []string{"*"},
+			CanUseAutotype: config.BoolPtr(true),
+			ApprovalMode:   config.StrPtr("none"),
+		}, "stdio", vaultDir)
+		srv.vault.Identity = identity
+
+		mockAT := &trackingAutotype{}
+		autotype.SetAutotype(mockAT)
+		defer autotype.SetAutotype(nil)
+		origPaymentAutotype := paymentAutotype
+		paymentAutotype = mockAT.Type
+		defer func() { paymentAutotype = origPaymentAutotype }()
+
+		req := mcp.CallToolRequest{
+			Arguments: map[string]any{
+				"entry_path": "payments/mybank",
+				"merchant":   "rent.example",
+				"amount":     "1200.00",
+				"currency":   "EUR",
+			},
+		}
+
+		result, err := srv.handlePreparePayment(context.Background(), req)
+		if err != nil {
+			t.Fatalf("handlePreparePayment() error = %v", err)
+		}
+		if result == nil {
+			t.Fatal("handlePreparePayment() returned nil result")
+		}
+		if result.IsError {
+			t.Fatalf("handlePreparePayment() returned error result: %s", result.Text)
+		}
+
+		typed := mockAT.typedFields()
+		if len(typed) != 1 {
+			t.Fatalf("typed %d fields, want 1 (IBAN only)", len(typed))
+		}
+		if typed[0] != "DE89370400440532013000" {
+			t.Errorf("typed field = %q, want IBAN value", typed[0])
+		}
+
+		if strings.Contains(result.Text, "DE89370400440532013000") {
+			t.Error("result contains IBAN — must not expose payment data")
+		}
+	})
+
+	t.Run("denial_no_autotype", func(t *testing.T) {
+		vaultDir, identity := mockPaymentVault(t)
+		srv := newTestServerWithVault(t, config.AgentProfile{
+			Name:           "test",
+			AllowedPaths:   []string{"*"},
+			CanUseAutotype: config.BoolPtr(true),
+			ApprovalMode:   config.StrPtr("deny"),
+		}, "stdio", vaultDir)
+		srv.vault.Identity = identity
+
+		mockAT := &trackingAutotype{}
+		autotype.SetAutotype(mockAT)
+		defer autotype.SetAutotype(nil)
+		origPaymentAutotype := paymentAutotype
+		paymentAutotype = mockAT.Type
+		defer func() { paymentAutotype = origPaymentAutotype }()
+
+		req := mcp.CallToolRequest{
+			Arguments: map[string]any{
+				"entry_path": "payments/mycard",
+				"merchant":   "shop.example",
+				"amount":     "75.00",
+				"currency":   "EUR",
+			},
+		}
+
+		_, err := srv.handlePreparePayment(context.Background(), req)
+		if err == nil {
+			t.Fatal("handlePreparePayment() expected error for denied approval, got nil")
+		}
+		if !strings.Contains(err.Error(), "denied") {
+			t.Fatalf("handlePreparePayment() error = %v, want 'denied'", err)
+		}
+
+		typed := mockAT.typedFields()
+		if len(typed) != 0 {
+			t.Errorf("autotype called %d times after denial, want 0", len(typed))
+		}
+	})
+
+	t.Run("non_payment_entry_rejected", func(t *testing.T) {
+		vaultDir, identity := mockNonPaymentVault(t)
+		srv := newTestServerWithVault(t, config.AgentProfile{
+			Name:           "test",
+			AllowedPaths:   []string{"*"},
+			CanUseAutotype: config.BoolPtr(true),
+			ApprovalMode:   config.StrPtr("none"),
+		}, "stdio", vaultDir)
+		srv.vault.Identity = identity
+
+		req := mcp.CallToolRequest{
+			Arguments: map[string]any{
+				"entry_path": "github",
+				"merchant":   "shop.example",
+				"amount":     "10.00",
+				"currency":   "USD",
+			},
+		}
+
+		result, err := srv.handlePreparePayment(context.Background(), req)
+		if err != nil {
+			t.Fatalf("handlePreparePayment() error = %v", err)
+		}
+		if result == nil {
+			t.Fatal("handlePreparePayment() returned nil result")
+		}
+		if !result.IsError {
+			t.Fatal("handlePreparePayment() expected error result for non-payment entry")
+		}
+		if !strings.Contains(result.Text, "not a payment entry") {
+			t.Errorf("result = %q, want 'not a payment entry'", result.Text)
+		}
+	})
+
+	t.Run("missing_required_fields", func(t *testing.T) {
+		srv := newTestServerWithVault(t, config.AgentProfile{
+			Name:           "test",
+			AllowedPaths:   []string{"*"},
+			CanUseAutotype: config.BoolPtr(true),
+			ApprovalMode:   config.StrPtr("none"),
+		}, "stdio", "")
+
+		tests := []struct {
+			name string
+			args map[string]any
+		}{
+			{
+				name: "missing_entry_path",
+				args: map[string]any{"merchant": "x", "amount": "1", "currency": "USD"},
+			},
+			{
+				name: "missing_merchant",
+				args: map[string]any{"entry_path": "x", "amount": "1", "currency": "USD"},
+			},
+			{
+				name: "missing_amount",
+				args: map[string]any{"entry_path": "x", "merchant": "x", "currency": "USD"},
+			},
+			{
+				name: "missing_currency",
+				args: map[string]any{"entry_path": "x", "merchant": "x", "amount": "1"},
+			},
+			{
+				name: "empty_args",
+				args: map[string]any{},
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				req := mcp.CallToolRequest{Arguments: tt.args}
+				result, err := srv.handlePreparePayment(context.Background(), req)
+				if err != nil {
+					t.Fatalf("handlePreparePayment() error = %v", err)
+				}
+				if result == nil {
+					t.Fatal("handlePreparePayment() returned nil result")
+				}
+				if !result.IsError {
+					t.Fatalf("handlePreparePayment() expected error result for %s", tt.name)
+				}
+			})
+		}
+	})
+
+	t.Run("outside_scope", func(t *testing.T) {
+		vaultDir, identity := mockPaymentVault(t)
+		srv := newTestServerWithVault(t, config.AgentProfile{
+			Name:           "test",
+			AllowedPaths:   []string{"work/"},
+			CanUseAutotype: config.BoolPtr(true),
+			ApprovalMode:   config.StrPtr("none"),
+		}, "stdio", vaultDir)
+		srv.vault.Identity = identity
+
+		req := mcp.CallToolRequest{
+			Arguments: map[string]any{
+				"entry_path": "payments/mycard",
+				"merchant":   "shop.example",
+				"amount":     "75.00",
+				"currency":   "EUR",
+			},
+		}
+
+		_, err := srv.handlePreparePayment(context.Background(), req)
+		if err == nil {
+			t.Fatal("handlePreparePayment() expected error for out-of-scope path, got nil")
+		}
+		if !strings.Contains(err.Error(), "outside allowed scope") {
+			t.Fatalf("handlePreparePayment() error = %v, want 'outside allowed scope'", err)
+		}
+	})
+
+	t.Run("entry_not_found", func(t *testing.T) {
+		dir := t.TempDir()
+		identity, err := age.GenerateX25519Identity()
+		if err != nil {
+			t.Fatalf("generate identity: %v", err)
+		}
+		srv := newTestServerWithVault(t, config.AgentProfile{
+			Name:           "test",
+			AllowedPaths:   []string{"*"},
+			CanUseAutotype: config.BoolPtr(true),
+			ApprovalMode:   config.StrPtr("none"),
+		}, "stdio", dir)
+		srv.vault.Identity = identity
+
+		req := mcp.CallToolRequest{
+			Arguments: map[string]any{
+				"entry_path": "nonexistent",
+				"merchant":   "shop.example",
+				"amount":     "75.00",
+				"currency":   "EUR",
+			},
+		}
+
+		result, err := srv.handlePreparePayment(context.Background(), req)
+		if err != nil {
+			t.Fatalf("handlePreparePayment() error = %v", err)
+		}
+		if result == nil {
+			t.Fatal("handlePreparePayment() returned nil result")
+		}
+		if !result.IsError {
+			t.Fatal("handlePreparePayment() expected error result for not found")
+		}
+	})
+
+	t.Run("response_exposes_no_card_values", func(t *testing.T) {
+		vaultDir, identity := mockPaymentVault(t)
+		srv := newTestServerWithVault(t, config.AgentProfile{
+			Name:           "test",
+			AllowedPaths:   []string{"*"},
+			CanUseAutotype: config.BoolPtr(true),
+			ApprovalMode:   config.StrPtr("none"),
+		}, "stdio", vaultDir)
+		srv.vault.Identity = identity
+
+		origPaymentAutotype := paymentAutotype
+		paymentAutotype = func(text string) error { return nil }
+		defer func() { paymentAutotype = origPaymentAutotype }()
+
+		req := mcp.CallToolRequest{
+			Arguments: map[string]any{
+				"entry_path": "payments/mycard",
+				"merchant":   "shop.example",
+				"amount":     "75.00",
+				"currency":   "EUR",
+			},
+		}
+
+		result, err := srv.handlePreparePayment(context.Background(), req)
+		if err != nil {
+			t.Fatalf("handlePreparePayment() error = %v", err)
+		}
+		if result == nil {
+			t.Fatal("nil result")
+		}
+
+		sensitiveValues := []string{
+			"4111111111111111",
+			"123",
+			"Jane Doe",
+		}
+		for _, v := range sensitiveValues {
+			if strings.Contains(result.Text, v) {
+				t.Errorf("result contains sensitive value %q — must never be exposed", v)
+			}
+		}
+	})
+}
+
+func TestPaymentFieldOrder(t *testing.T) {
+	card := paymentFieldOrder(vaultpkg.PaymentSubtypeCard)
+	if len(card) != 4 {
+		t.Fatalf("card fields = %d, want 4", len(card))
+	}
+	if card[0] != vaultpkg.PaymentFieldCardNumber || card[3] != vaultpkg.PaymentFieldCVC {
+		t.Errorf("card order = %v, want [card_number, expiry_month, expiry_year, cvc]", card)
+	}
+
+	bank := paymentFieldOrder(vaultpkg.PaymentSubtypeBankAccount)
+	if len(bank) != 1 {
+		t.Fatalf("bank fields = %d, want 1", len(bank))
+	}
+	if bank[0] != vaultpkg.PaymentFieldIBAN {
+		t.Errorf("bank field[0] = %q, want %q", bank[0], vaultpkg.PaymentFieldIBAN)
+	}
+}
+
+func TestBuildPaymentSummary(t *testing.T) {
+	summary := buildPaymentSummary("shop.example", "75.00", "EUR", "")
+	if !strings.Contains(summary, "75.00") || !strings.Contains(summary, "shop.example") || !strings.Contains(summary, "EUR") {
+		t.Errorf("summary = %q, want merchant/amount/currency", summary)
+	}
+
+	withDesc := buildPaymentSummary("shop.example", "75.00", "EUR", "Gift for mom")
+	if !strings.Contains(withDesc, "Gift for mom") {
+		t.Errorf("summary = %q, want description", withDesc)
+	}
+}

--- a/internal/mcp/server/tools_prepare_payment_test.go
+++ b/internal/mcp/server/tools_prepare_payment_test.go
@@ -503,10 +503,10 @@ func TestHandlePreparePayment_Policy_DeniedMerchant(t *testing.T) {
 
 	srv.paymentEnforcer = payment.NewEnforcer(
 		config.PaymentPolicy{
-			Instrument:      "payments/mycard",
+			Instrument:       "payments/mycard",
 			AllowedMerchants: []string{"amazon.de"},
-			MaxAmount:       config.PaymentMaxAmount{PerTransaction: "100.00", PerDay: "200.00"},
-			Currency:        "EUR",
+			MaxAmount:        config.PaymentMaxAmount{PerTransaction: "100.00", PerDay: "200.00"},
+			Currency:         "EUR",
 		},
 		nil,
 	)
@@ -548,10 +548,10 @@ func TestHandlePreparePayment_Policy_CurrencyMismatch(t *testing.T) {
 
 	srv.paymentEnforcer = payment.NewEnforcer(
 		config.PaymentPolicy{
-			Instrument:      "payments/mycard",
+			Instrument:       "payments/mycard",
 			AllowedMerchants: []string{"shop.example"},
-			MaxAmount:       config.PaymentMaxAmount{PerTransaction: "100.00"},
-			Currency:        "EUR",
+			MaxAmount:        config.PaymentMaxAmount{PerTransaction: "100.00"},
+			Currency:         "EUR",
 		},
 		nil,
 	)
@@ -593,10 +593,10 @@ func TestHandlePreparePayment_Policy_OverPerTransaction(t *testing.T) {
 
 	srv.paymentEnforcer = payment.NewEnforcer(
 		config.PaymentPolicy{
-			Instrument:      "payments/mycard",
+			Instrument:       "payments/mycard",
 			AllowedMerchants: []string{"shop.example"},
-			MaxAmount:       config.PaymentMaxAmount{PerTransaction: "75.00"},
-			Currency:        "EUR",
+			MaxAmount:        config.PaymentMaxAmount{PerTransaction: "75.00"},
+			Currency:         "EUR",
 		},
 		nil,
 	)
@@ -648,10 +648,10 @@ func TestHandlePreparePayment_Policy_OverPerDay(t *testing.T) {
 
 	srv.paymentEnforcer = payment.NewEnforcer(
 		config.PaymentPolicy{
-			Instrument:      "payments/mycard",
+			Instrument:       "payments/mycard",
 			AllowedMerchants: []string{"shop.example"},
-			MaxAmount:       config.PaymentMaxAmount{PerTransaction: "100.00", PerDay: "200.00"},
-			Currency:        "EUR",
+			MaxAmount:        config.PaymentMaxAmount{PerTransaction: "100.00", PerDay: "200.00"},
+			Currency:         "EUR",
 		},
 		tracker,
 	)
@@ -702,10 +702,10 @@ func TestHandlePreparePayment_Policy_PassesAndIncrements(t *testing.T) {
 
 	srv.paymentEnforcer = payment.NewEnforcer(
 		config.PaymentPolicy{
-			Instrument:      "payments/mycard",
+			Instrument:       "payments/mycard",
 			AllowedMerchants: []string{"shop.example"},
-			MaxAmount:       config.PaymentMaxAmount{PerTransaction: "75.00", PerDay: "200.00"},
-			Currency:        "EUR",
+			MaxAmount:        config.PaymentMaxAmount{PerTransaction: "75.00", PerDay: "200.00"},
+			Currency:         "EUR",
 		},
 		tracker,
 	)

--- a/internal/payment/decimal.go
+++ b/internal/payment/decimal.go
@@ -1,0 +1,56 @@
+package payment
+
+import (
+	"fmt"
+	"math/big"
+)
+
+// maxDecimalLen caps the length of strings parsed by this package. It is
+// generous enough for typical currency values while preventing the
+// malformed-string memory blowup described in CVE-2022-23772.
+const maxDecimalLen = 30
+
+// parseAmount parses a decimal string (e.g. "75.00", "-10") or a rational
+// string produced by big.Rat.RatString() (e.g. "3/10", "-1/2"). It validates
+// length and format before invoking big.Rat.SetString.
+func parseAmount(s string) (*big.Rat, error) {
+	if len(s) == 0 || len(s) > maxDecimalLen {
+		return nil, fmt.Errorf("invalid amount %q", s)
+	}
+	sawDot := false
+	sawSlash := false
+	hasDigit := false
+	for i, r := range s {
+		switch r {
+		case '-':
+			if i != 0 {
+				return nil, fmt.Errorf("invalid amount %q", s)
+			}
+		case '.':
+			if sawSlash || sawDot {
+				return nil, fmt.Errorf("invalid amount %q", s)
+			}
+			sawDot = true
+		case '/':
+			if sawSlash || sawDot {
+				return nil, fmt.Errorf("invalid amount %q", s)
+			}
+			sawSlash = true
+		case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
+			hasDigit = true
+		default:
+			return nil, fmt.Errorf("invalid amount %q", s)
+		}
+	}
+	if !hasDigit {
+		return nil, fmt.Errorf("invalid amount %q", s)
+	}
+	// Length and format are validated above, so the input cannot trigger the
+	// malformed-string memory blowup described in CVE-2022-23772.
+	// #nosec G113
+	rat, ok := new(big.Rat).SetString(s)
+	if !ok {
+		return nil, fmt.Errorf("invalid amount %q", s)
+	}
+	return rat, nil
+}

--- a/internal/payment/enforcer.go
+++ b/internal/payment/enforcer.go
@@ -84,15 +84,15 @@ func (e *Enforcer) Check(req PaymentRequest) error {
 		}
 	}
 
-	reqAmount, ok := new(big.Rat).SetString(req.Amount)
-	if !ok {
-		return fmt.Errorf("invalid amount %q", req.Amount)
+	reqAmount, err := parseAmount(req.Amount)
+	if err != nil {
+		return fmt.Errorf("invalid amount: %w", err)
 	}
 
 	if e.policy.MaxAmount.PerTransaction != "" {
-		limit, ok := new(big.Rat).SetString(e.policy.MaxAmount.PerTransaction)
-		if !ok {
-			return fmt.Errorf("invalid per_transaction limit %q", e.policy.MaxAmount.PerTransaction)
+		limit, err := parseAmount(e.policy.MaxAmount.PerTransaction)
+		if err != nil {
+			return fmt.Errorf("invalid per_transaction limit: %w", err)
 		}
 		if reqAmount.Cmp(limit) > 0 {
 			return &DenialError{
@@ -103,17 +103,17 @@ func (e *Enforcer) Check(req PaymentRequest) error {
 	}
 
 	if e.policy.MaxAmount.PerDay != "" && e.tracker != nil {
-		dayLimit, ok := new(big.Rat).SetString(e.policy.MaxAmount.PerDay)
-		if !ok {
-			return fmt.Errorf("invalid per_day limit %q", e.policy.MaxAmount.PerDay)
+		dayLimit, err := parseAmount(e.policy.MaxAmount.PerDay)
+		if err != nil {
+			return fmt.Errorf("invalid per_day limit: %w", err)
 		}
 		todayTotal := e.tracker.TodayTotal(e.policy.Instrument)
 		if todayTotal == "" {
 			todayTotal = "0"
 		}
-		todayRat, ok := new(big.Rat).SetString(todayTotal)
-		if !ok {
-			todayRat = new(big.Rat)
+		todayRat, err := parseAmount(todayTotal)
+		if err != nil {
+			return fmt.Errorf("invalid today total: %w", err)
 		}
 		projected := new(big.Rat).Add(todayRat, reqAmount)
 		if projected.Cmp(dayLimit) > 0 {

--- a/internal/payment/enforcer.go
+++ b/internal/payment/enforcer.go
@@ -1,0 +1,138 @@
+package payment
+
+import (
+	"fmt"
+	"math/big"
+	"strings"
+
+	"github.com/danieljustus/symaira-vault/internal/config"
+)
+
+type DenialReason string
+
+const (
+	DenialMerchantNotAllowed DenialReason = "merchant_not_allowed"
+	DenialCurrencyMismatch   DenialReason = "currency_mismatch"
+	DenialOverPerTransaction DenialReason = "over_per_transaction"
+	DenialOverPerDay         DenialReason = "over_per_day"
+)
+
+type DenialError struct {
+	Reason DenialReason
+	Detail string
+}
+
+func (e *DenialError) Error() string {
+	return fmt.Sprintf("payment policy denied: %s — %s", e.Reason, e.Detail)
+}
+
+type Enforcer struct {
+	policy   config.PaymentPolicy
+	tracker  *DailyTotals
+	stateDir string
+}
+
+func NewEnforcer(policy config.PaymentPolicy, tracker *DailyTotals) *Enforcer {
+	return &Enforcer{
+		policy:  policy,
+		tracker: tracker,
+	}
+}
+
+func NewEnforcerFromFile(policy config.PaymentPolicy, statePath string) (*Enforcer, error) {
+	tracker, err := LoadDailyTotals(statePath)
+	if err != nil {
+		return nil, fmt.Errorf("load daily totals: %w", err)
+	}
+	return &Enforcer{
+		policy:   policy,
+		tracker:  tracker,
+		stateDir: statePath,
+	}, nil
+}
+
+type PaymentRequest struct {
+	EntryPath string
+	Merchant  string
+	Amount    string
+	Currency  string
+}
+
+func (e *Enforcer) Check(req PaymentRequest) error {
+	if len(e.policy.AllowedMerchants) > 0 {
+		allowed := false
+		reqMerchant := strings.ToLower(strings.TrimSpace(req.Merchant))
+		for _, m := range e.policy.AllowedMerchants {
+			if strings.ToLower(strings.TrimSpace(m)) == reqMerchant {
+				allowed = true
+				break
+			}
+		}
+		if !allowed {
+			return &DenialError{
+				Reason: DenialMerchantNotAllowed,
+				Detail: fmt.Sprintf("merchant %q not in allowed list", req.Merchant),
+			}
+		}
+	}
+
+	if e.policy.Currency != "" && strings.ToUpper(strings.TrimSpace(req.Currency)) != strings.ToUpper(strings.TrimSpace(e.policy.Currency)) {
+		return &DenialError{
+			Reason: DenialCurrencyMismatch,
+			Detail: fmt.Sprintf("requested currency %q does not match policy currency %q", req.Currency, e.policy.Currency),
+		}
+	}
+
+	reqAmount, ok := new(big.Rat).SetString(req.Amount)
+	if !ok {
+		return fmt.Errorf("invalid amount %q", req.Amount)
+	}
+
+	if e.policy.MaxAmount.PerTransaction != "" {
+		limit, ok := new(big.Rat).SetString(e.policy.MaxAmount.PerTransaction)
+		if !ok {
+			return fmt.Errorf("invalid per_transaction limit %q", e.policy.MaxAmount.PerTransaction)
+		}
+		if reqAmount.Cmp(limit) > 0 {
+			return &DenialError{
+				Reason: DenialOverPerTransaction,
+				Detail: fmt.Sprintf("amount %s exceeds per-transaction limit %s", req.Amount, e.policy.MaxAmount.PerTransaction),
+			}
+		}
+	}
+
+	if e.policy.MaxAmount.PerDay != "" && e.tracker != nil {
+		dayLimit, ok := new(big.Rat).SetString(e.policy.MaxAmount.PerDay)
+		if !ok {
+			return fmt.Errorf("invalid per_day limit %q", e.policy.MaxAmount.PerDay)
+		}
+		todayTotal := e.tracker.TodayTotal(e.policy.Instrument)
+		if todayTotal == "" {
+			todayTotal = "0"
+		}
+		todayRat, ok := new(big.Rat).SetString(todayTotal)
+		if !ok {
+			todayRat = new(big.Rat)
+		}
+		projected := new(big.Rat).Add(todayRat, reqAmount)
+		if projected.Cmp(dayLimit) > 0 {
+			return &DenialError{
+				Reason: DenialOverPerDay,
+				Detail: fmt.Sprintf("amount %s + today's total %s would exceed per-day limit %s", req.Amount, todayTotal, e.policy.MaxAmount.PerDay),
+			}
+		}
+	}
+
+	return nil
+}
+
+func (e *Enforcer) RecordApproved(req PaymentRequest) error {
+	if e.tracker == nil {
+		return nil
+	}
+	return e.tracker.AddToToday(e.policy.Instrument, req.Amount)
+}
+
+func (e *Enforcer) PolicyName() string {
+	return e.policy.Instrument
+}

--- a/internal/payment/enforcer.go
+++ b/internal/payment/enforcer.go
@@ -1,3 +1,4 @@
+// Package payment enforces payment policies for the Symaira Vault prepare_payment flow.
 package payment
 
 import (
@@ -76,7 +77,7 @@ func (e *Enforcer) Check(req PaymentRequest) error {
 		}
 	}
 
-	if e.policy.Currency != "" && strings.ToUpper(strings.TrimSpace(req.Currency)) != strings.ToUpper(strings.TrimSpace(e.policy.Currency)) {
+	if e.policy.Currency != "" && !strings.EqualFold(strings.TrimSpace(req.Currency), strings.TrimSpace(e.policy.Currency)) {
 		return &DenialError{
 			Reason: DenialCurrencyMismatch,
 			Detail: fmt.Sprintf("requested currency %q does not match policy currency %q", req.Currency, e.policy.Currency),

--- a/internal/payment/policy_test.go
+++ b/internal/payment/policy_test.go
@@ -1,0 +1,197 @@
+package payment
+
+import (
+	"testing"
+
+	"github.com/danieljustus/symaira-vault/internal/config"
+)
+
+func newTestEnforcer(t *testing.T, policy config.PaymentPolicy) *Enforcer {
+	t.Helper()
+	dir := t.TempDir()
+	tracker, err := LoadDailyTotals(dir + "/test-daily-totals.json")
+	if err != nil {
+		t.Fatalf("LoadDailyTotals() error = %v", err)
+	}
+	return NewEnforcer(policy, tracker)
+}
+
+func TestCheck_Allowlist_AllowedMerchant(t *testing.T) {
+	e := newTestEnforcer(t, config.PaymentPolicy{
+		Instrument:      "payments/visa",
+		AllowedMerchants: []string{"amazon.de", "otto.de"},
+		Currency:        "EUR",
+	})
+	err := e.Check(PaymentRequest{
+		EntryPath: "payments/visa",
+		Merchant:  "amazon.de",
+		Amount:    "50.00",
+		Currency:  "EUR",
+	})
+	if err != nil {
+		t.Errorf("Check() error = %v, want nil", err)
+	}
+}
+
+func TestCheck_Allowlist_DeniedMerchant(t *testing.T) {
+	e := newTestEnforcer(t, config.PaymentPolicy{
+		Instrument:      "payments/visa",
+		AllowedMerchants: []string{"amazon.de"},
+		Currency:        "EUR",
+	})
+	err := e.Check(PaymentRequest{
+		EntryPath: "payments/visa",
+		Merchant:  "evil.com",
+		Amount:    "10.00",
+		Currency:  "EUR",
+	})
+	if err == nil {
+		t.Error("Check() error = nil, want merchant_not_allowed")
+	}
+	var denial *DenialError
+	if ok := asDenialError(err, &denial); ok {
+		if denial.Reason != DenialMerchantNotAllowed {
+			t.Errorf("Reason = %q, want %q", denial.Reason, DenialMerchantNotAllowed)
+		}
+	}
+}
+
+func TestCheck_Allowlist_CaseInsensitive(t *testing.T) {
+	e := newTestEnforcer(t, config.PaymentPolicy{
+		Instrument:      "payments/visa",
+		AllowedMerchants: []string{"Amazon.de"},
+		Currency:        "EUR",
+	})
+	err := e.Check(PaymentRequest{
+		EntryPath: "payments/visa",
+		Merchant:  "amazon.de",
+		Amount:    "5.00",
+		Currency:  "EUR",
+	})
+	if err != nil {
+		t.Errorf("Check() error = %v, want nil (case-insensitive match)", err)
+	}
+}
+
+func TestCheck_CurrencyMismatch(t *testing.T) {
+	e := newTestEnforcer(t, config.PaymentPolicy{
+		Instrument:      "payments/visa",
+		AllowedMerchants: []string{"shop.com"},
+		MaxAmount:       config.PaymentMaxAmount{PerTransaction: "100.00"},
+		Currency:        "EUR",
+	})
+	err := e.Check(PaymentRequest{
+		EntryPath: "payments/visa",
+		Merchant:  "shop.com",
+		Amount:    "50.00",
+		Currency:  "USD",
+	})
+	if err == nil {
+		t.Error("Check() error = nil, want currency_mismatch")
+	}
+	var denial *DenialError
+	if ok := asDenialError(err, &denial); ok {
+		if denial.Reason != DenialCurrencyMismatch {
+			t.Errorf("Reason = %q, want %q", denial.Reason, DenialCurrencyMismatch)
+		}
+	}
+}
+
+func TestCheck_OverPerTransaction(t *testing.T) {
+	e := newTestEnforcer(t, config.PaymentPolicy{
+		Instrument:      "payments/visa",
+		AllowedMerchants: []string{"shop.com"},
+		MaxAmount:       config.PaymentMaxAmount{PerTransaction: "75.00"},
+		Currency:        "EUR",
+	})
+	err := e.Check(PaymentRequest{
+		EntryPath: "payments/visa",
+		Merchant:  "shop.com",
+		Amount:    "100.00",
+		Currency:  "EUR",
+	})
+	if err == nil {
+		t.Error("Check() error = nil, want over_per_transaction")
+	}
+	var denial *DenialError
+	if ok := asDenialError(err, &denial); ok {
+		if denial.Reason != DenialOverPerTransaction {
+			t.Errorf("Reason = %q, want %q", denial.Reason, DenialOverPerTransaction)
+		}
+	}
+}
+
+func TestCheck_OverPerDay(t *testing.T) {
+	e := newTestEnforcer(t, config.PaymentPolicy{
+		Instrument:      "payments/visa",
+		AllowedMerchants: []string{"shop.com"},
+		MaxAmount:       config.PaymentMaxAmount{PerDay: "200.00"},
+		Currency:        "EUR",
+	})
+	if err := e.tracker.AddToToday("payments/visa", "150.00"); err != nil {
+		t.Fatalf("AddToToday() error = %v", err)
+	}
+	err := e.Check(PaymentRequest{
+		EntryPath: "payments/visa",
+		Merchant:  "shop.com",
+		Amount:    "60.00",
+		Currency:  "EUR",
+	})
+	if err == nil {
+		t.Error("Check() error = nil, want over_per_day")
+	}
+	var denial *DenialError
+	if ok := asDenialError(err, &denial); ok {
+		if denial.Reason != DenialOverPerDay {
+			t.Errorf("Reason = %q, want %q", denial.Reason, DenialOverPerDay)
+		}
+	}
+}
+
+func TestCheck_UnderLimits(t *testing.T) {
+	e := newTestEnforcer(t, config.PaymentPolicy{
+		Instrument:      "payments/visa",
+		AllowedMerchants: []string{"shop.com"},
+		MaxAmount:       config.PaymentMaxAmount{PerTransaction: "75.00", PerDay: "200.00"},
+		Currency:        "EUR",
+	})
+	if err := e.tracker.AddToToday("payments/visa", "100.00"); err != nil {
+		t.Fatalf("AddToToday() error = %v", err)
+	}
+	err := e.Check(PaymentRequest{
+		EntryPath: "payments/visa",
+		Merchant:  "shop.com",
+		Amount:    "50.00",
+		Currency:  "EUR",
+	})
+	if err != nil {
+		t.Errorf("Check() error = %v, want nil", err)
+	}
+}
+
+func TestRecordApproved(t *testing.T) {
+	e := newTestEnforcer(t, config.PaymentPolicy{
+		Instrument: "payments/visa",
+		MaxAmount:  config.PaymentMaxAmount{PerDay: "200.00"},
+		Currency:   "EUR",
+	})
+	if err := e.RecordApproved(PaymentRequest{
+		EntryPath: "payments/visa",
+		Merchant:  "shop.com",
+		Amount:    "50.00",
+		Currency:  "EUR",
+	}); err != nil {
+		t.Fatalf("RecordApproved() error = %v", err)
+	}
+	if got := e.tracker.TodayTotal("payments/visa"); got != "50" {
+		t.Errorf("TodayTotal() = %q, want \"50\"", got)
+	}
+}
+
+func asDenialError(err error, target **DenialError) bool {
+	if de, ok := err.(*DenialError); ok {
+		*target = de
+		return true
+	}
+	return false
+}

--- a/internal/payment/policy_test.go
+++ b/internal/payment/policy_test.go
@@ -18,9 +18,9 @@ func newTestEnforcer(t *testing.T, policy config.PaymentPolicy) *Enforcer {
 
 func TestCheck_Allowlist_AllowedMerchant(t *testing.T) {
 	e := newTestEnforcer(t, config.PaymentPolicy{
-		Instrument:      "payments/visa",
+		Instrument:       "payments/visa",
 		AllowedMerchants: []string{"amazon.de", "otto.de"},
-		Currency:        "EUR",
+		Currency:         "EUR",
 	})
 	err := e.Check(PaymentRequest{
 		EntryPath: "payments/visa",
@@ -35,9 +35,9 @@ func TestCheck_Allowlist_AllowedMerchant(t *testing.T) {
 
 func TestCheck_Allowlist_DeniedMerchant(t *testing.T) {
 	e := newTestEnforcer(t, config.PaymentPolicy{
-		Instrument:      "payments/visa",
+		Instrument:       "payments/visa",
 		AllowedMerchants: []string{"amazon.de"},
-		Currency:        "EUR",
+		Currency:         "EUR",
 	})
 	err := e.Check(PaymentRequest{
 		EntryPath: "payments/visa",
@@ -58,9 +58,9 @@ func TestCheck_Allowlist_DeniedMerchant(t *testing.T) {
 
 func TestCheck_Allowlist_CaseInsensitive(t *testing.T) {
 	e := newTestEnforcer(t, config.PaymentPolicy{
-		Instrument:      "payments/visa",
+		Instrument:       "payments/visa",
 		AllowedMerchants: []string{"Amazon.de"},
-		Currency:        "EUR",
+		Currency:         "EUR",
 	})
 	err := e.Check(PaymentRequest{
 		EntryPath: "payments/visa",
@@ -75,10 +75,10 @@ func TestCheck_Allowlist_CaseInsensitive(t *testing.T) {
 
 func TestCheck_CurrencyMismatch(t *testing.T) {
 	e := newTestEnforcer(t, config.PaymentPolicy{
-		Instrument:      "payments/visa",
+		Instrument:       "payments/visa",
 		AllowedMerchants: []string{"shop.com"},
-		MaxAmount:       config.PaymentMaxAmount{PerTransaction: "100.00"},
-		Currency:        "EUR",
+		MaxAmount:        config.PaymentMaxAmount{PerTransaction: "100.00"},
+		Currency:         "EUR",
 	})
 	err := e.Check(PaymentRequest{
 		EntryPath: "payments/visa",
@@ -99,10 +99,10 @@ func TestCheck_CurrencyMismatch(t *testing.T) {
 
 func TestCheck_OverPerTransaction(t *testing.T) {
 	e := newTestEnforcer(t, config.PaymentPolicy{
-		Instrument:      "payments/visa",
+		Instrument:       "payments/visa",
 		AllowedMerchants: []string{"shop.com"},
-		MaxAmount:       config.PaymentMaxAmount{PerTransaction: "75.00"},
-		Currency:        "EUR",
+		MaxAmount:        config.PaymentMaxAmount{PerTransaction: "75.00"},
+		Currency:         "EUR",
 	})
 	err := e.Check(PaymentRequest{
 		EntryPath: "payments/visa",
@@ -123,10 +123,10 @@ func TestCheck_OverPerTransaction(t *testing.T) {
 
 func TestCheck_OverPerDay(t *testing.T) {
 	e := newTestEnforcer(t, config.PaymentPolicy{
-		Instrument:      "payments/visa",
+		Instrument:       "payments/visa",
 		AllowedMerchants: []string{"shop.com"},
-		MaxAmount:       config.PaymentMaxAmount{PerDay: "200.00"},
-		Currency:        "EUR",
+		MaxAmount:        config.PaymentMaxAmount{PerDay: "200.00"},
+		Currency:         "EUR",
 	})
 	if err := e.tracker.AddToToday("payments/visa", "150.00"); err != nil {
 		t.Fatalf("AddToToday() error = %v", err)
@@ -150,10 +150,10 @@ func TestCheck_OverPerDay(t *testing.T) {
 
 func TestCheck_UnderLimits(t *testing.T) {
 	e := newTestEnforcer(t, config.PaymentPolicy{
-		Instrument:      "payments/visa",
+		Instrument:       "payments/visa",
 		AllowedMerchants: []string{"shop.com"},
-		MaxAmount:       config.PaymentMaxAmount{PerTransaction: "75.00", PerDay: "200.00"},
-		Currency:        "EUR",
+		MaxAmount:        config.PaymentMaxAmount{PerTransaction: "75.00", PerDay: "200.00"},
+		Currency:         "EUR",
 	})
 	if err := e.tracker.AddToToday("payments/visa", "100.00"); err != nil {
 		t.Fatalf("AddToToday() error = %v", err)

--- a/internal/payment/tracker.go
+++ b/internal/payment/tracker.go
@@ -107,13 +107,13 @@ func (dt *DailyTotals) save() error {
 }
 
 func addRatStrings(a, b string) (string, error) {
-	ra, ok := new(big.Rat).SetString(a)
-	if !ok {
-		return "", fmt.Errorf("parse %q as decimal", a)
+	ra, err := parseAmount(a)
+	if err != nil {
+		return "", fmt.Errorf("parse %q as decimal: %w", a, err)
 	}
-	rb, ok := new(big.Rat).SetString(b)
-	if !ok {
-		return "", fmt.Errorf("parse %q as decimal", b)
+	rb, err := parseAmount(b)
+	if err != nil {
+		return "", fmt.Errorf("parse %q as decimal: %w", b, err)
 	}
 	sum := new(big.Rat).Add(ra, rb)
 	return sum.RatString(), nil

--- a/internal/payment/tracker.go
+++ b/internal/payment/tracker.go
@@ -25,7 +25,8 @@ func LoadDailyTotals(path string) (*DailyTotals, error) {
 		entries: make(map[string]map[string]string),
 		path:    path,
 	}
-	data, err := os.ReadFile(path)
+	// path is constructed from DefaultDataDir and a SHA-256 hash of the vault dir with a fixed filename.
+	data, err := os.ReadFile(path) // #nosec G304
 	if err != nil {
 		if os.IsNotExist(err) {
 			return dt, nil

--- a/internal/payment/tracker.go
+++ b/internal/payment/tracker.go
@@ -1,0 +1,119 @@
+package payment
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+type DailyTotals struct {
+	mu      sync.Mutex
+	entries map[string]map[string]string
+	path    string
+}
+
+type dailyTotalsFile struct {
+	Entries map[string]map[string]string `json:"entries"`
+}
+
+func LoadDailyTotals(path string) (*DailyTotals, error) {
+	dt := &DailyTotals{
+		entries: make(map[string]map[string]string),
+		path:    path,
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return dt, nil
+		}
+		return nil, fmt.Errorf("read daily totals: %w", err)
+	}
+	var file dailyTotalsFile
+	if err := json.Unmarshal(data, &file); err != nil {
+		return nil, fmt.Errorf("parse daily totals: %w", err)
+	}
+	if file.Entries != nil {
+		dt.entries = file.Entries
+	}
+	dt.expireOldEntries()
+	return dt, nil
+}
+
+func (dt *DailyTotals) expireOldEntries() {
+	today := time.Now().UTC().Format("2006-01-02")
+	for policy, dates := range dt.entries {
+		for dateKey := range dates {
+			if dateKey < today {
+				delete(dates, dateKey)
+			}
+		}
+		if len(dates) == 0 {
+			delete(dt.entries, policy)
+		}
+	}
+}
+
+func (dt *DailyTotals) TodayTotal(policyName string) string {
+	dt.mu.Lock()
+	defer dt.mu.Unlock()
+	today := time.Now().UTC().Format("2006-01-02")
+	if dates, ok := dt.entries[policyName]; ok {
+		if total, ok := dates[today]; ok {
+			return total
+		}
+	}
+	return "0"
+}
+
+func (dt *DailyTotals) AddToToday(policyName, amount string) error {
+	dt.mu.Lock()
+	defer dt.mu.Unlock()
+	today := time.Now().UTC().Format("2006-01-02")
+	if dt.entries[policyName] == nil {
+		dt.entries[policyName] = make(map[string]string)
+	}
+	current := dt.entries[policyName][today]
+	if current == "" {
+		current = "0"
+	}
+	sum, err := addRatStrings(current, amount)
+	if err != nil {
+		return fmt.Errorf("add amounts: %w", err)
+	}
+	dt.entries[policyName][today] = sum
+	return dt.save()
+}
+
+func (dt *DailyTotals) save() error {
+	dt.expireOldEntries()
+	file := dailyTotalsFile{Entries: dt.entries}
+	data, err := json.MarshalIndent(file, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal daily totals: %w", err)
+	}
+	dir := filepath.Dir(dt.path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("create payment state dir: %w", err)
+	}
+	if err := os.WriteFile(dt.path, data, 0o600); err != nil {
+		return fmt.Errorf("write daily totals: %w", err)
+	}
+	return nil
+}
+
+func addRatStrings(a, b string) (string, error) {
+	ra, ok := new(big.Rat).SetString(a)
+	if !ok {
+		return "", fmt.Errorf("parse %q as decimal", a)
+	}
+	rb, ok := new(big.Rat).SetString(b)
+	if !ok {
+		return "", fmt.Errorf("parse %q as decimal", b)
+	}
+	sum := new(big.Rat).Add(ra, rb)
+	return sum.RatString(), nil
+}

--- a/internal/payment/tracker_test.go
+++ b/internal/payment/tracker_test.go
@@ -1,0 +1,135 @@
+package payment
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestLoadDailyTotals_EmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "daily-totals.json")
+	dt, err := LoadDailyTotals(path)
+	if err != nil {
+		t.Fatalf("LoadDailyTotals() error = %v", err)
+	}
+	if dt == nil {
+		t.Fatal("LoadDailyTotals() returned nil")
+	}
+	if got := dt.TodayTotal("policy-a"); got != "0" {
+		t.Errorf("TodayTotal() = %q, want \"0\"", got)
+	}
+}
+
+func TestLoadDailyTotals_ExistingFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "daily-totals.json")
+	today := time.Now().UTC().Format("2006-01-02")
+	file := dailyTotalsFile{
+		Entries: map[string]map[string]string{
+			"policy-a": {today: "50.00"},
+		},
+	}
+	data, err := json.Marshal(file)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	dt, err := LoadDailyTotals(path)
+	if err != nil {
+		t.Fatalf("LoadDailyTotals() error = %v", err)
+	}
+	if got := dt.TodayTotal("policy-a"); got != "50.00" {
+		t.Errorf("TodayTotal() = %q, want \"50.00\"", got)
+	}
+}
+
+func TestAddToToday(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "daily-totals.json")
+	dt, err := LoadDailyTotals(path)
+	if err != nil {
+		t.Fatalf("LoadDailyTotals() error = %v", err)
+	}
+
+	if err := dt.AddToToday("policy-a", "25.50"); err != nil {
+		t.Fatalf("AddToToday() error = %v", err)
+	}
+	if got := dt.TodayTotal("policy-a"); got != "51/2" {
+		t.Errorf("TodayTotal() after first add = %q, want \"51/2\"", got)
+	}
+
+	if err := dt.AddToToday("policy-a", "10.25"); err != nil {
+		t.Fatalf("AddToToday() error = %v", err)
+	}
+	if got := dt.TodayTotal("policy-a"); got != "143/4" {
+		t.Errorf("TodayTotal() after second add = %q, want \"143/4\"", got)
+	}
+}
+
+func TestAddToToday_PersistsToDisk(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "daily-totals.json")
+	dt, err := LoadDailyTotals(path)
+	if err != nil {
+		t.Fatalf("LoadDailyTotals() error = %v", err)
+	}
+	if err := dt.AddToToday("policy-a", "30.00"); err != nil {
+		t.Fatalf("AddToToday() error = %v", err)
+	}
+
+	dt2, err := LoadDailyTotals(path)
+	if err != nil {
+		t.Fatalf("LoadDailyTotals() error = %v", err)
+	}
+	if got := dt2.TodayTotal("policy-a"); got != "30" {
+		t.Errorf("TodayTotal() after reload = %q, want \"30\"", got)
+	}
+}
+
+func TestExpireOldEntries(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "daily-totals.json")
+	yesterday := time.Now().UTC().AddDate(0, 0, -1).Format("2006-01-02")
+	file := dailyTotalsFile{
+		Entries: map[string]map[string]string{
+			"policy-a": {yesterday: "100.00"},
+		},
+	}
+	data, err := json.Marshal(file)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	dt, err := LoadDailyTotals(path)
+	if err != nil {
+		t.Fatalf("LoadDailyTotals() error = %v", err)
+	}
+
+	if got := dt.TodayTotal("policy-a"); got != "0" {
+		t.Errorf("TodayTotal() = %q, want \"0\" (yesterday expired)", got)
+	}
+}
+
+func TestCreateDir(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sub", "dir", "daily-totals.json")
+	dt, err := LoadDailyTotals(path)
+	if err != nil {
+		t.Fatalf("LoadDailyTotals() error = %v", err)
+	}
+	if err := dt.AddToToday("policy-a", "10.00"); err != nil {
+		t.Fatalf("AddToToday() error = %v", err)
+	}
+	if _, err := os.Stat(filepath.Dir(path)); os.IsNotExist(err) {
+		t.Error("expected directory to be created")
+	}
+}

--- a/internal/vault/payment.go
+++ b/internal/vault/payment.go
@@ -1,5 +1,17 @@
 package vault
 
+// Payment field names used across the vault and MCP layers.
+const (
+	PaymentFieldCardNumber  = "card_number"
+	PaymentFieldExpiryMonth = "expiry_month"
+	PaymentFieldExpiryYear  = "expiry_year"
+	PaymentFieldCVC         = "cvc"
+	PaymentFieldCardholder  = "cardholder"
+	PaymentFieldIBAN        = "iban"
+	PaymentFieldBIC         = "bic"
+	PaymentFieldSubtype     = "subtype"
+)
+
 // PaymentSubtype represents the subtype of a payment entry.
 type PaymentSubtype string
 
@@ -48,18 +60,18 @@ type paymentField struct {
 // agent responses.
 var PaymentFields = map[PaymentSubtype][]paymentField{
 	PaymentSubtypeCard: {
-		{Name: "card_number", Sensitive: true},
-		{Name: "expiry_month", Sensitive: false},
-		{Name: "expiry_year", Sensitive: false},
-		{Name: "cvc", Sensitive: true},
-		{Name: "cardholder", Sensitive: false},
-		{Name: "subtype", Sensitive: false},
+		{Name: PaymentFieldCardNumber, Sensitive: true},
+		{Name: PaymentFieldExpiryMonth, Sensitive: false},
+		{Name: PaymentFieldExpiryYear, Sensitive: false},
+		{Name: PaymentFieldCVC, Sensitive: true},
+		{Name: PaymentFieldCardholder, Sensitive: false},
+		{Name: PaymentFieldSubtype, Sensitive: false},
 	},
 	PaymentSubtypeBankAccount: {
-		{Name: "iban", Sensitive: true},
-		{Name: "bic", Sensitive: false},
-		{Name: "cardholder", Sensitive: false},
-		{Name: "subtype", Sensitive: false},
+		{Name: PaymentFieldIBAN, Sensitive: true},
+		{Name: PaymentFieldBIC, Sensitive: false},
+		{Name: PaymentFieldCardholder, Sensitive: false},
+		{Name: PaymentFieldSubtype, Sensitive: false},
 	},
 }
 
@@ -83,5 +95,5 @@ func PaymentSensitiveFields(subtype PaymentSubtype) []string {
 // AllPaymentSensitiveFields returns the union of sensitive field names across
 // all payment subtypes. Use this when the subtype is not yet known.
 func AllPaymentSensitiveFields() []string {
-	return []string{"card_number", "cvc", "iban"}
+	return []string{PaymentFieldCardNumber, PaymentFieldCVC, PaymentFieldIBAN}
 }

--- a/internal/vault/payment.go
+++ b/internal/vault/payment.go
@@ -1,0 +1,87 @@
+package vault
+
+// PaymentSubtype represents the subtype of a payment entry.
+type PaymentSubtype string
+
+const (
+	// PaymentSubtypeCard represents a credit or debit card.
+	PaymentSubtypeCard PaymentSubtype = "card"
+	// PaymentSubtypeBankAccount represents a bank account (IBAN/BIC).
+	PaymentSubtypeBankAccount PaymentSubtype = "bank_account"
+)
+
+// AllPaymentSubtypes returns all valid payment subtypes.
+func AllPaymentSubtypes() []PaymentSubtype {
+	return []PaymentSubtype{PaymentSubtypeCard, PaymentSubtypeBankAccount}
+}
+
+// IsValidPaymentSubtype checks if the given string is a valid payment subtype.
+func IsValidPaymentSubtype(s string) bool {
+	switch PaymentSubtype(s) {
+	case PaymentSubtypeCard, PaymentSubtypeBankAccount:
+		return true
+	}
+	return false
+}
+
+// PaymentSubtypeFromString parses a payment subtype from string, defaulting
+// to card when the input is empty or unrecognized.
+func PaymentSubtypeFromString(s string) PaymentSubtype {
+	switch PaymentSubtype(s) {
+	case PaymentSubtypeCard:
+		return PaymentSubtypeCard
+	case PaymentSubtypeBankAccount:
+		return PaymentSubtypeBankAccount
+	default:
+		return PaymentSubtypeCard
+	}
+}
+
+// paymentField describes a single field in the payment schema.
+type paymentField struct {
+	Name      string
+	Sensitive bool
+}
+
+// PaymentFields defines the allowed data fields for payment entries,
+// partitioned by subtype. Sensitive fields are redacted by default in
+// agent responses.
+var PaymentFields = map[PaymentSubtype][]paymentField{
+	PaymentSubtypeCard: {
+		{Name: "card_number", Sensitive: true},
+		{Name: "expiry_month", Sensitive: false},
+		{Name: "expiry_year", Sensitive: false},
+		{Name: "cvc", Sensitive: true},
+		{Name: "cardholder", Sensitive: false},
+		{Name: "subtype", Sensitive: false},
+	},
+	PaymentSubtypeBankAccount: {
+		{Name: "iban", Sensitive: true},
+		{Name: "bic", Sensitive: false},
+		{Name: "cardholder", Sensitive: false},
+		{Name: "subtype", Sensitive: false},
+	},
+}
+
+// PaymentSensitiveFields returns the field names that are automatically
+// redacted for the given payment subtype. These are redacted independently
+// of per-profile redactFields configuration.
+func PaymentSensitiveFields(subtype PaymentSubtype) []string {
+	fields, ok := PaymentFields[subtype]
+	if !ok {
+		return nil
+	}
+	var result []string
+	for _, f := range fields {
+		if f.Sensitive {
+			result = append(result, f.Name)
+		}
+	}
+	return result
+}
+
+// AllPaymentSensitiveFields returns the union of sensitive field names across
+// all payment subtypes. Use this when the subtype is not yet known.
+func AllPaymentSensitiveFields() []string {
+	return []string{"card_number", "cvc", "iban"}
+}

--- a/internal/vault/types.go
+++ b/internal/vault/types.go
@@ -259,7 +259,7 @@ func PrimaryFieldForType(t SecretType) string {
 	case SecretTypeTOTPSeed:
 		return "seed"
 	case SecretTypePayment:
-		return "card_number"
+		return PaymentFieldCardNumber
 	case SecretTypeBasicAuth:
 		return string(SecretTypeBasicAuth)
 	default:

--- a/internal/vault/types.go
+++ b/internal/vault/types.go
@@ -17,6 +17,7 @@ const (
 	SecretTypeCertificate SecretType = "certificate"
 	SecretTypeDatabaseURL SecretType = "database_url"
 	SecretTypeTOTPSeed    SecretType = "totp_seed"
+	SecretTypePayment     SecretType = "payment"
 	SecretTypeCustom      SecretType = "custom"
 )
 
@@ -31,6 +32,7 @@ func AllSecretTypes() []SecretType {
 		SecretTypeCertificate,
 		SecretTypeDatabaseURL,
 		SecretTypeTOTPSeed,
+		SecretTypePayment,
 		SecretTypeCustom,
 	}
 }
@@ -54,6 +56,8 @@ func SecretTypeFromString(s string) SecretType {
 		return SecretTypeDatabaseURL
 	case string(SecretTypeTOTPSeed):
 		return SecretTypeTOTPSeed
+	case string(SecretTypePayment):
+		return SecretTypePayment
 	case string(SecretTypeCustom):
 		return SecretTypeCustom
 	default:
@@ -65,7 +69,8 @@ func SecretTypeFromString(s string) SecretType {
 func IsValidSecretType(s string) bool {
 	switch strings.ToLower(s) {
 	case string(SecretTypeAPIKey), string(SecretTypeBearerToken), string(SecretTypeBasicAuth), string(SecretTypeSSHKey),
-		string(SecretTypePassword), string(SecretTypeCertificate), string(SecretTypeDatabaseURL), string(SecretTypeTOTPSeed), string(SecretTypeCustom):
+		string(SecretTypePassword), string(SecretTypeCertificate), string(SecretTypeDatabaseURL), string(SecretTypeTOTPSeed),
+		string(SecretTypePayment), string(SecretTypeCustom):
 		return true
 	}
 	return false
@@ -253,6 +258,8 @@ func PrimaryFieldForType(t SecretType) string {
 		return "cert_pem"
 	case SecretTypeTOTPSeed:
 		return "seed"
+	case SecretTypePayment:
+		return "card_number"
 	case SecretTypeBasicAuth:
 		return string(SecretTypeBasicAuth)
 	default:
@@ -279,6 +286,8 @@ func UsageHintForType(t SecretType) string {
 		return "Use as connection string. Ensure credentials are not logged."
 	case SecretTypeTOTPSeed:
 		return "Use with TOTP generator. Never share the seed - only share generated codes."
+	case SecretTypePayment:
+		return "Payment card or bank account details. Sensitive fields (card_number, cvc, iban) are redacted by default."
 	case SecretTypeCustom:
 		return "Follow the specific integration instructions for this secret."
 	default:
@@ -305,6 +314,8 @@ func SecretTypeIcon(t SecretType) string {
 		return "🗄️"
 	case SecretTypeTOTPSeed:
 		return "⏱️"
+	case SecretTypePayment:
+		return "💳"
 	case SecretTypeCustom:
 		return "📦"
 	default:

--- a/internal/vault/types_test.go
+++ b/internal/vault/types_test.go
@@ -7,8 +7,8 @@ import (
 
 func TestAllSecretTypes(t *testing.T) {
 	types := AllSecretTypes()
-	if len(types) != 9 {
-		t.Errorf("AllSecretTypes() returned %d types, want 9", len(types))
+	if len(types) != 10 {
+		t.Errorf("AllSecretTypes() returned %d types, want 10", len(types))
 	}
 	// Should include all known types
 	seen := make(map[SecretType]bool)
@@ -18,7 +18,8 @@ func TestAllSecretTypes(t *testing.T) {
 	for _, st := range []SecretType{
 		SecretTypeAPIKey, SecretTypeBearerToken, SecretTypeBasicAuth,
 		SecretTypeSSHKey, SecretTypePassword, SecretTypeCertificate,
-		SecretTypeDatabaseURL, SecretTypeTOTPSeed, SecretTypeCustom,
+		SecretTypeDatabaseURL, SecretTypeTOTPSeed, SecretTypePayment,
+		SecretTypeCustom,
 	} {
 		if !seen[st] {
 			t.Errorf("AllSecretTypes() missing %q", st)
@@ -42,6 +43,8 @@ func TestSecretTypeFromString(t *testing.T) {
 		{"certificate", SecretTypeCertificate},
 		{"database_url", SecretTypeDatabaseURL},
 		{"totp_seed", SecretTypeTOTPSeed},
+		{"payment", SecretTypePayment},
+		{"PAYMENT", SecretTypePayment},
 		{"custom", SecretTypeCustom},
 		{"unknown", SecretTypeCustom},
 		{"", SecretTypeCustom},
@@ -57,7 +60,7 @@ func TestSecretTypeFromString(t *testing.T) {
 func TestIsValidSecretType(t *testing.T) {
 	valid := []string{
 		"api_key", "bearer_token", "basic_auth", "ssh_key",
-		"password", "certificate", "database_url", "totp_seed", "custom",
+		"password", "certificate", "database_url", "totp_seed", "payment", "custom",
 		"API_KEY", "PASSWORD",
 	}
 	for _, s := range valid {
@@ -214,6 +217,7 @@ func TestPrimaryFieldForType(t *testing.T) {
 		{SecretTypeDatabaseURL, "connection_string"},
 		{SecretTypeCertificate, "cert_pem"},
 		{SecretTypeTOTPSeed, "seed"},
+		{SecretTypePayment, "card_number"},
 		{SecretTypeBasicAuth, "basic_auth"},
 		{SecretTypePassword, "password"},
 		{SecretTypeCustom, "password"},
@@ -239,6 +243,7 @@ func TestUsageHintForType(t *testing.T) {
 		{SecretTypeCertificate, "TLS/SSL"},
 		{SecretTypeDatabaseURL, "connection string"},
 		{SecretTypeTOTPSeed, "TOTP generator"},
+		{SecretTypePayment, "Payment card"},
 		{SecretTypeCustom, "specific integration"},
 	}
 	for _, tt := range tests {
@@ -259,5 +264,81 @@ func TestSecretTypeIcon(t *testing.T) {
 	}
 	if icon := SecretTypeIcon("unknown_type"); icon == "" {
 		t.Error("SecretTypeIcon(unknown) returned empty, want default")
+	}
+}
+
+func TestPaymentSubtypeRoundTrip(t *testing.T) {
+	tests := []struct {
+		input string
+		want  PaymentSubtype
+	}{
+		{"card", PaymentSubtypeCard},
+		{"bank_account", PaymentSubtypeBankAccount},
+		{"", PaymentSubtypeCard},
+		{"unknown", PaymentSubtypeCard},
+	}
+	for _, tt := range tests {
+		got := PaymentSubtypeFromString(tt.input)
+		if got != tt.want {
+			t.Errorf("PaymentSubtypeFromString(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestIsValidPaymentSubtype(t *testing.T) {
+	valid := []string{"card", "bank_account"}
+	for _, s := range valid {
+		if !IsValidPaymentSubtype(s) {
+			t.Errorf("IsValidPaymentSubtype(%q) = false, want true", s)
+		}
+	}
+	invalid := []string{"", "credit", "debit", "payment"}
+	for _, s := range invalid {
+		if IsValidPaymentSubtype(s) {
+			t.Errorf("IsValidPaymentSubtype(%q) = true, want false", s)
+		}
+	}
+}
+
+func TestPaymentSensitiveFields(t *testing.T) {
+	cardSensitive := PaymentSensitiveFields(PaymentSubtypeCard)
+	if len(cardSensitive) != 2 {
+		t.Errorf("PaymentSensitiveFields(card) returned %d fields, want 2", len(cardSensitive))
+	}
+	seen := make(map[string]bool)
+	for _, f := range cardSensitive {
+		seen[f] = true
+	}
+	if !seen["card_number"] || !seen["cvc"] {
+		t.Errorf("PaymentSensitiveFields(card) = %v, want card_number and cvc", cardSensitive)
+	}
+
+	bankSensitive := PaymentSensitiveFields(PaymentSubtypeBankAccount)
+	if len(bankSensitive) != 1 {
+		t.Errorf("PaymentSensitiveFields(bank_account) returned %d fields, want 1", len(bankSensitive))
+	}
+	if bankSensitive[0] != "iban" {
+		t.Errorf("PaymentSensitiveFields(bank_account) = %v, want [iban]", bankSensitive)
+	}
+
+	unknownSensitive := PaymentSensitiveFields("unknown")
+	if unknownSensitive != nil {
+		t.Errorf("PaymentSensitiveFields(unknown) = %v, want nil", unknownSensitive)
+	}
+}
+
+func TestAllPaymentSensitiveFields(t *testing.T) {
+	fields := AllPaymentSensitiveFields()
+	if len(fields) != 3 {
+		t.Errorf("AllPaymentSensitiveFields() returned %d fields, want 3", len(fields))
+	}
+	seen := make(map[string]bool)
+	for _, f := range fields {
+		seen[f] = true
+	}
+	for _, want := range []string{"card_number", "cvc", "iban"} {
+		if !seen[want] {
+			t.Errorf("AllPaymentSensitiveFields() missing %q", want)
+		}
 	}
 }


### PR DESCRIPTION
This session PR addresses a cohesive unit of open issues.

<!-- closes-list-start -->
- Closes #641 Add a dedicated payment entry type with strong default redaction
- Closes #642 Native payment-approval flow: prepare_payment MCP tool with user confirmation
- Closes #643 Declarative paymentPolicies config section with merchant allowlist, per-transaction/day limits, and currency enforcement
<!-- closes-list-end -->