### PR TITLE
chore: bump version to v0.10.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,7 +13,7 @@ body:
     attributes:
       label: Symaira Vault version
       description: Run `symvault version` or provide the commit SHA.
-      placeholder: "v0.4.1"
+      placeholder: "v0.10.0"
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/installation_problem.yml
+++ b/.github/ISSUE_TEMPLATE/installation_problem.yml
@@ -29,7 +29,7 @@ body:
     attributes:
       label: Symaira Vault version
       description: If known. Run `symvault version` after installation, or provide the release tag you tried.
-      placeholder: "v0.4.1"
+      placeholder: "v0.10.0"
   - type: input
     id: os
     attributes:

--- a/docs/commercial-boundary.md
+++ b/docs/commercial-boundary.md
@@ -26,7 +26,7 @@ cloud deployment automation, compliance operations, and monitoring.
 The current Symaira Vault release line is `v0.x`. Historical OpenPass releases
 such as `v4.0.0` remain part of the old release history and must not be treated
 as the current Symaira Vault release target. The next planned core milestone is
-`v0.4.1`.
+`v0.10.0`.
 
 ## Related
 


### PR DESCRIPTION
Update version placeholders in issue templates (v0.4.1 → v0.10.0) and commercial-boundary.md to match the upcoming v0.10.0 release.