### PR TITLE
export: harden plaintext export output permissions and error propagation (+4 more)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -117,6 +117,10 @@ linters:
       - path: 'cmd/.+\.go'
         linters:
           - goconst
+      # Domain field names — vault path key and attachment chunking keys
+      - path: 'internal/exporter/.+\.go'
+        linters:
+          - goconst
       - path: 'internal/daemon/.+\.go'
         linters:
           - goconst

--- a/cmd/admin/audit_export.go
+++ b/cmd/admin/audit_export.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/danieljustus/symaira-vault/internal/audit"
 	cli "github.com/danieljustus/symaira-vault/internal/cli"
+	"github.com/danieljustus/symaira-vault/internal/fsutil"
 )
 
 var (
@@ -47,7 +48,7 @@ Optionally verify HMAC integrity and redact vault paths.`,
 	Annotations: map[string]string{
 		cli.RequiresVaultAnnotation: "false",
 	},
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(cmd *cobra.Command, args []string) (retErr error) {
 		vaultDir, _ := cli.VaultPath()
 
 		opts := audit.ExportOptions{
@@ -79,13 +80,17 @@ Optionally verify HMAC integrity and redact vault paths.`,
 				return fmt.Errorf("create output directory: %w", err)
 			}
 
-			f, err := os.OpenFile(cleanPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600) // #nosec G304 -- output path is user-provided CLI argument
+			out, err := fsutil.CreateSensitiveOutput(cleanPath)
 			if err != nil {
 				return fmt.Errorf("create output file: %w", err)
 			}
-			defer func() { _ = f.Close() }()
+			defer func() {
+				if closeErr := out.Close(); closeErr != nil && retErr == nil {
+					retErr = fmt.Errorf("close output file: %w", closeErr)
+				}
+			}()
 
-			result, err := audit.ExportAuditLog(opts, f, auditExportFormat)
+			result, err := audit.ExportAuditLog(opts, out, auditExportFormat)
 			if err != nil {
 				return err
 			}

--- a/cmd/admin/backup.go
+++ b/cmd/admin/backup.go
@@ -65,18 +65,22 @@ Use --exclude-git to omit the .git/ directory from the backup.`,
 	},
 }
 
-func CreateBackup(vaultDir, archivePath string, excludeGit bool) error {
+func CreateBackup(vaultDir, archivePath string, excludeGit bool) (retErr error) {
 	if err := os.MkdirAll(filepath.Dir(archivePath), 0o700); err != nil {
 		return fmt.Errorf("create backup directory: %w", err)
 	}
 
-	f, err := os.OpenFile(archivePath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600) // #nosec // archivePath is user-provided output path
+	out, err := fsutil.CreateSensitiveOutput(archivePath)
 	if err != nil {
 		return fmt.Errorf("create archive: %w", err)
 	}
-	defer func() { _ = f.Close() }()
+	defer func() {
+		if closeErr := out.Close(); closeErr != nil && retErr == nil {
+			retErr = fmt.Errorf("close archive: %w", closeErr)
+		}
+	}()
 
-	gw := gzip.NewWriter(f)
+	gw := gzip.NewWriter(out)
 	defer func() { _ = gw.Close() }()
 
 	tw := tar.NewWriter(gw)

--- a/cmd/admin/export.go
+++ b/cmd/admin/export.go
@@ -44,7 +44,7 @@ var exportCmd = &cobra.Command{
 			return errorspkg.NewCLIError(errorspkg.ExitGeneralError, "invalid mapping", err)
 		}
 
-		return cli.WithVault(func(v *vaultpkg.Vault, vs *cli.VaultService) error {
+		return cli.WithVault(func(v *vaultpkg.Vault, vs *cli.VaultService) (retErr error) {
 			entries, err := vs.ListEntries("")
 			if err != nil {
 				return fmt.Errorf("list entries: %w", err)
@@ -76,11 +76,15 @@ var exportCmd = &cobra.Command{
 			// Determine output destination
 			var w io.Writer
 			if ExportOutput != "" {
-				f, createErr := os.Create(ExportOutput) // #nosec G304 -- output path is user-provided CLI argument
+				f, createErr := createOutputFile(ExportOutput)
 				if createErr != nil {
 					return errorspkg.NewCLIError(errorspkg.ExitGeneralError, "create output file", createErr)
 				}
-				defer func() { _ = f.Close() }()
+				defer func() {
+					if closeErr := f.Close(); closeErr != nil && retErr == nil {
+						retErr = errorspkg.NewCLIError(errorspkg.ExitGeneralError, "close output file", closeErr)
+					}
+				}()
 				w = f
 			} else {
 				w = os.Stdout
@@ -129,4 +133,8 @@ func newExporter(format exporter.Format) (exporter.Exporter, error) {
 	default:
 		return nil, fmt.Errorf("unsupported export format: %s", format)
 	}
+}
+
+func createOutputFile(path string) (*os.File, error) {
+	return os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600) // #nosec G304 -- output path is user-provided CLI argument
 }

--- a/cmd/admin/export.go
+++ b/cmd/admin/export.go
@@ -2,7 +2,6 @@ package admin
 
 import (
 	"fmt"
-	"io"
 	"os"
 	"time"
 
@@ -13,6 +12,7 @@ import (
 	"github.com/danieljustus/symaira-vault/internal/audit"
 	errorspkg "github.com/danieljustus/symaira-vault/internal/errors"
 	"github.com/danieljustus/symaira-vault/internal/exporter"
+	"github.com/danieljustus/symaira-vault/internal/fsutil"
 	"github.com/danieljustus/symaira-vault/internal/importer"
 	"github.com/danieljustus/symaira-vault/internal/ui/cliout"
 	vaultpkg "github.com/danieljustus/symaira-vault/internal/vault"
@@ -49,7 +49,8 @@ var exportCmd = &cobra.Command{
 			return errorspkg.NewCLIError(errorspkg.ExitGeneralError, fmt.Sprintf("unsupported export format: %s", ExportFormat), nil)
 		}
 
-		if _, err := importer.ParseMapping(ExportMapping); err != nil {
+		mapping, err := importer.ParseMapping(ExportMapping)
+		if err != nil {
 			return errorspkg.NewCLIError(errorspkg.ExitGeneralError, "invalid mapping", err)
 		}
 
@@ -101,30 +102,18 @@ var exportCmd = &cobra.Command{
 			}
 
 			// Determine output destination
-			var w io.Writer
-			if ExportOutput != "" {
-				f, createErr := createOutputFile(ExportOutput)
-				if createErr != nil {
-					return errorspkg.NewCLIError(errorspkg.ExitGeneralError, "create output file", createErr)
+			out, createErr := fsutil.CreateSensitiveOutput(ExportOutput)
+			if createErr != nil {
+				return errorspkg.NewCLIError(errorspkg.ExitGeneralError, "create output file", createErr)
+			}
+			defer func() {
+				if closeErr := out.Close(); closeErr != nil && retErr == nil {
+					retErr = errorspkg.NewCLIError(errorspkg.ExitGeneralError, "close output file", closeErr)
 				}
-				defer func() {
-					if closeErr := f.Close(); closeErr != nil && retErr == nil {
-						retErr = errorspkg.NewCLIError(errorspkg.ExitGeneralError, "close output file", closeErr)
-					}
-				}()
-				w = f
-			} else {
-				w = os.Stdout
-			}
-
-			// Parse mapping
-			mapping, err := importer.ParseMapping(ExportMapping)
-			if err != nil {
-				return errorspkg.NewCLIError(errorspkg.ExitGeneralError, "parse mapping", err)
-			}
+			}()
 
 			// Export
-			if err := exp.Export(w, exportEntries, mapping); err != nil {
+			if err := exp.Export(out, exportEntries, mapping); err != nil {
 				return errorspkg.NewCLIError(errorspkg.ExitGeneralError, "export entries", err)
 			}
 
@@ -175,8 +164,4 @@ func newExporter(format exporter.Format) (exporter.Exporter, error) {
 	default:
 		return nil, fmt.Errorf("unsupported export format: %s", format)
 	}
-}
-
-func createOutputFile(path string) (*os.File, error) {
-	return os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600) // #nosec G304 -- output path is user-provided CLI argument
 }

--- a/cmd/admin/export.go
+++ b/cmd/admin/export.go
@@ -169,7 +169,7 @@ func isSupportedExportFormat(format exporter.Format) bool {
 func newExporter(format exporter.Format) (exporter.Exporter, error) {
 	switch format {
 	case exporter.FormatCSV:
-		return &exporter.CSVExporter{}, nil
+		return &exporter.CSVExporter{NoticeWriter: os.Stderr}, nil
 	case exporter.FormatJSON:
 		return &exporter.JSONExporter{}, nil
 	default:

--- a/cmd/admin/export.go
+++ b/cmd/admin/export.go
@@ -2,7 +2,9 @@ package admin
 
 import (
 	"fmt"
+	"io"
 	"os"
+	"sync"
 	"time"
 
 	cli "github.com/danieljustus/symaira-vault/internal/cli"
@@ -83,25 +85,6 @@ var exportCmd = &cobra.Command{
 				return nil
 			}
 
-			exp, err := newExporter(format)
-			if err != nil {
-				return errorspkg.NewCLIError(errorspkg.ExitGeneralError, "create exporter", err)
-			}
-
-			// Read all entries
-			var exportEntries []exporter.ExportEntry
-			for _, entryPath := range entries {
-				entry, readErr := vs.GetEntry(entryPath)
-				if readErr != nil {
-					return fmt.Errorf("read entry %s: %w", entryPath, readErr)
-				}
-				exportEntries = append(exportEntries, exporter.ExportEntry{
-					Path: entryPath,
-					Data: entry.Data,
-				})
-			}
-
-			// Determine output destination
 			out, createErr := fsutil.CreateSensitiveOutput(ExportOutput)
 			if createErr != nil {
 				return errorspkg.NewCLIError(errorspkg.ExitGeneralError, "create output file", createErr)
@@ -112,12 +95,94 @@ var exportCmd = &cobra.Command{
 				}
 			}()
 
-			// Export
-			if err := exp.Export(out, exportEntries, mapping); err != nil {
-				return errorspkg.NewCLIError(errorspkg.ExitGeneralError, "export entries", err)
+			workers := 0
+			if v.Config != nil && v.Config.Vault != nil {
+				workers = v.Config.Vault.SearchWorkers
+			}
+			maxWorkers := vaultpkg.SearchWorkerCount(workers)
+
+			entryChan := make(chan struct {
+				index int
+				path  string
+			}, len(entries))
+			resultChan := make(chan exportResult, len(entries))
+
+			done := make(chan struct{})
+			var cancelOnce sync.Once
+			cancel := func() { cancelOnce.Do(func() { close(done) }) }
+
+			var wg sync.WaitGroup
+			for i := 0; i < maxWorkers; i++ {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					for item := range entryChan {
+						select {
+						case <-done:
+							return
+						default:
+						}
+						entry, readErr := vs.GetEntry(item.path)
+						if readErr != nil {
+							resultChan <- exportResult{
+								index: item.index,
+								err:   fmt.Errorf("read entry %s: %w", item.path, readErr),
+							}
+							cancel()
+							return
+						}
+						resultChan <- exportResult{
+							index: item.index,
+							entry: exporter.ExportEntry{
+								Path: item.path,
+								Data: entry.Data,
+							},
+						}
+					}
+				}()
 			}
 
-			// Best-effort audit log — do not fail the export on audit errors.
+			go func() {
+				defer close(entryChan)
+				for i, path := range entries {
+					select {
+					case <-done:
+						return
+					case entryChan <- struct {
+						index int
+						path  string
+					}{index: i, path: path}:
+					}
+				}
+			}()
+
+			go func() {
+				wg.Wait()
+				close(resultChan)
+			}()
+
+			if format == exporter.FormatJSON {
+				if err := exportJSONStreaming(out, resultChan, mapping); err != nil {
+					return errorspkg.NewCLIError(errorspkg.ExitGeneralError, "export entries", err)
+				}
+			} else {
+				exportEntries := make([]exporter.ExportEntry, len(entries))
+				for result := range resultChan {
+					if result.err != nil {
+						return result.err
+					}
+					exportEntries[result.index] = result.entry
+				}
+
+				exp, expErr := newExporter(format)
+				if expErr != nil {
+					return errorspkg.NewCLIError(errorspkg.ExitGeneralError, "create exporter", expErr)
+				}
+				if err := exp.Export(out, exportEntries, mapping); err != nil {
+					return errorspkg.NewCLIError(errorspkg.ExitGeneralError, "export entries", err)
+				}
+			}
+
 			if auditLog, auditErr := audit.New("symvault", v.Dir, v.Identity); auditErr == nil {
 				if logErr := auditLog.LogEntry(audit.LogEntry{
 					Action:    "export",
@@ -131,7 +196,7 @@ var exportCmd = &cobra.Command{
 				}
 			}
 
-			cli.PrintQuietAware("Exported %d entries\n", len(exportEntries))
+			cli.PrintQuietAware("Exported %d entries\n", len(entries))
 			return nil
 		})
 	},
@@ -164,4 +229,44 @@ func newExporter(format exporter.Format) (exporter.Exporter, error) {
 	default:
 		return nil, fmt.Errorf("unsupported export format: %s", format)
 	}
+}
+
+type exportResult struct {
+	index int
+	entry exporter.ExportEntry
+	err   error
+}
+
+func exportJSONStreaming(out io.Writer, resultChan <-chan exportResult, mapping map[string]string) error {
+	stream := exporter.NewJSONStream(out, mapping)
+
+	pending := make(map[int]exporter.ExportEntry)
+	nextIdx := 0
+
+	for result := range resultChan {
+		if result.err != nil {
+			return result.err
+		}
+		if result.index == nextIdx {
+			if err := stream.WriteEntry(result.entry); err != nil {
+				return err
+			}
+			nextIdx++
+			for {
+				if entry, ok := pending[nextIdx]; ok {
+					delete(pending, nextIdx)
+					if err := stream.WriteEntry(entry); err != nil {
+						return err
+					}
+					nextIdx++
+				} else {
+					break
+				}
+			}
+		} else {
+			pending[result.index] = result.entry
+		}
+	}
+
+	return stream.Close()
 }

--- a/cmd/admin/export.go
+++ b/cmd/admin/export.go
@@ -4,14 +4,17 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"time"
 
 	cli "github.com/danieljustus/symaira-vault/internal/cli"
 
 	"github.com/spf13/cobra"
 
+	"github.com/danieljustus/symaira-vault/internal/audit"
 	errorspkg "github.com/danieljustus/symaira-vault/internal/errors"
 	"github.com/danieljustus/symaira-vault/internal/exporter"
 	"github.com/danieljustus/symaira-vault/internal/importer"
+	"github.com/danieljustus/symaira-vault/internal/ui/cliout"
 	vaultpkg "github.com/danieljustus/symaira-vault/internal/vault"
 )
 
@@ -19,7 +22,13 @@ var (
 	ExportFormat  string
 	ExportMapping string
 	ExportOutput  string
+	ExportYes     bool
 )
+
+// confirmExport prompts the user for confirmation before exporting vault entries.
+// Tests may replace this to control stdin behavior without modifying
+// cli.ConfirmInteractive's shared implementation.
+var confirmExport = cli.ConfirmInteractive
 
 var exportCmd = &cobra.Command{
 	Use:   "export",
@@ -42,6 +51,24 @@ var exportCmd = &cobra.Command{
 
 		if _, err := importer.ParseMapping(ExportMapping); err != nil {
 			return errorspkg.NewCLIError(errorspkg.ExitGeneralError, "invalid mapping", err)
+		}
+
+		const warningMsg = "WARNING: Vault export produces unencrypted output. All secrets will be in plaintext."
+		if ExportYes {
+			// Scripting mode: respect --quiet suppression via cliout.
+			cliout.Warnf(warningMsg)
+		} else {
+			// Interactive mode: always show, even in quiet — user must see before confirming.
+			fmt.Fprintln(os.Stderr, warningMsg)
+		}
+
+		confirmed, err := confirmExport("Export all vault entries as plaintext?", ExportYes)
+		if err != nil {
+			return errorspkg.NewCLIError(errorspkg.ExitGeneralError, "export confirmation failed", err)
+		}
+		if !confirmed {
+			fmt.Fprintln(os.Stderr, "Export canceled.")
+			return nil
 		}
 
 		return cli.WithVault(func(v *vaultpkg.Vault, vs *cli.VaultService) (retErr error) {
@@ -101,6 +128,20 @@ var exportCmd = &cobra.Command{
 				return errorspkg.NewCLIError(errorspkg.ExitGeneralError, "export entries", err)
 			}
 
+			// Best-effort audit log — do not fail the export on audit errors.
+			if auditLog, auditErr := audit.New("symvault", v.Dir, v.Identity); auditErr == nil {
+				if logErr := auditLog.LogEntry(audit.LogEntry{
+					Action:    "export",
+					OK:        true,
+					Timestamp: time.Now().UTC().Format(time.RFC3339),
+				}); logErr != nil {
+					cliout.Warnf("Warning: audit log write failed: %v", logErr)
+				}
+				if closeErr := auditLog.Close(); closeErr != nil {
+					cliout.Warnf("Warning: audit log close failed: %v", closeErr)
+				}
+			}
+
 			cli.PrintQuietAware("Exported %d entries\n", len(exportEntries))
 			return nil
 		})
@@ -111,6 +152,7 @@ func init() {
 	exportCmd.Flags().StringVar(&ExportFormat, "format", "", "Export format: csv or json (required)")
 	exportCmd.Flags().StringVar(&ExportMapping, "mapping", "", "Column mapping (format: vault_field=output_header,...)")
 	exportCmd.Flags().StringVar(&ExportOutput, "output", "", "Output file path (default: stdout)")
+	exportCmd.Flags().BoolVarP(&ExportYes, "yes", "y", false, "Skip confirmation prompt")
 	_ = exportCmd.MarkFlagRequired("format") //nolint:errcheck
 	cli.RootCmd.AddCommand(exportCmd)
 }

--- a/cmd/admin/export_test.go
+++ b/cmd/admin/export_test.go
@@ -1,9 +1,15 @@
 package admin
 
 import (
+	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	cli "github.com/danieljustus/symaira-vault/internal/cli"
+	"github.com/danieljustus/symaira-vault/internal/config"
+	vaultpkg "github.com/danieljustus/symaira-vault/internal/vault"
 )
 
 func TestCreateOutputFile_Mode0600(t *testing.T) {
@@ -52,5 +58,137 @@ func TestCreateOutputFile_OverwritesExisting(t *testing.T) {
 	}
 	if string(data) != "new" {
 		t.Errorf("content = %q, want %q", string(data), "new")
+	}
+}
+
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	origStderr := os.Stderr
+	os.Stderr = w
+	t.Cleanup(func() { os.Stderr = origStderr })
+	fn()
+	w.Close()
+	os.Stderr = origStderr
+	var buf strings.Builder
+	if _, copyErr := io.Copy(&buf, r); copyErr != nil {
+		t.Fatalf("copy stderr: %v", copyErr)
+	}
+	return buf.String()
+}
+
+func TestExport_ConfirmDecline_NoOutput(t *testing.T) {
+	outputPath := filepath.Join(t.TempDir(), "should-not-exist.csv")
+
+	origConfirm := confirmExport
+	confirmExport = func(_ string, _ bool) (bool, error) { return false, nil }
+	t.Cleanup(func() { confirmExport = origConfirm })
+
+	stderr := captureStderr(t, func() {
+		cmd := cli.RootCmd
+		cmd.SetArgs([]string{"export", "--format", "csv", "--output", outputPath})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("export: %v", err)
+		}
+	})
+
+	if _, err := os.Stat(outputPath); err == nil {
+		t.Error("output file should not exist after decline")
+	}
+	if !strings.Contains(stderr, "Export canceled.") {
+		t.Errorf("stderr missing cancel message, got: %q", stderr)
+	}
+}
+
+func TestExport_ConfirmAccept_WithEntries(t *testing.T) {
+	vaultDir := t.TempDir()
+	passphrase := "test-passphrase"
+	if _, err := vaultpkg.InitWithPassphrase(vaultDir, []byte(passphrase), config.Default()); err != nil {
+		t.Fatalf("init vault: %v", err)
+	}
+	origVault := cli.Vault
+	cli.Vault = vaultDir
+	t.Cleanup(func() { cli.Vault = origVault })
+	t.Setenv("SYMVAULT_PASSPHRASE", passphrase)
+
+	v, err := cli.UnlockVault(vaultDir, true)
+	if err != nil {
+		t.Fatalf("unlock vault: %v", err)
+	}
+	vs := cli.NewVaultService(v, nil)
+	if setErr := vs.SetFields("test/entry", map[string]any{"password": "secret123"}); setErr != nil {
+		t.Fatalf("set entry: %v", setErr)
+	}
+
+	origConfirm := confirmExport
+	confirmExport = func(_ string, _ bool) (bool, error) { return true, nil }
+	t.Cleanup(func() { confirmExport = origConfirm })
+
+	outputPath := filepath.Join(t.TempDir(), "export.csv")
+
+	cmd := cli.RootCmd
+	cmd.SetArgs([]string{"export", "--format", "csv", "--output", outputPath})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("export: %v", err)
+	}
+
+	data, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	if len(data) == 0 {
+		t.Error("export produced empty output")
+	}
+}
+
+func TestExport_YesFlag_SkipsPrompt(t *testing.T) {
+	vaultDir := t.TempDir()
+	passphrase := "test-passphrase"
+	if _, err := vaultpkg.InitWithPassphrase(vaultDir, []byte(passphrase), config.Default()); err != nil {
+		t.Fatalf("init vault: %v", err)
+	}
+	origVault := cli.Vault
+	cli.Vault = vaultDir
+	t.Cleanup(func() { cli.Vault = origVault })
+	t.Setenv("SYMVAULT_PASSPHRASE", passphrase)
+
+	v, err := cli.UnlockVault(vaultDir, true)
+	if err != nil {
+		t.Fatalf("unlock vault: %v", err)
+	}
+	vs := cli.NewVaultService(v, nil)
+	if setErr := vs.SetFields("test/entry", map[string]any{"password": "secret123"}); setErr != nil {
+		t.Fatalf("set entry: %v", setErr)
+	}
+
+	var capturedForce bool
+	origConfirm := confirmExport
+	confirmExport = func(_ string, force bool) (bool, error) {
+		capturedForce = force
+		return true, nil
+	}
+	t.Cleanup(func() { confirmExport = origConfirm })
+
+	outputPath := filepath.Join(t.TempDir(), "export.json")
+
+	cmd := cli.RootCmd
+	cmd.SetArgs([]string{"export", "--format", "json", "--output", outputPath, "--yes"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("export: %v", err)
+	}
+
+	if !capturedForce {
+		t.Error("confirmExport should receive force=true when --yes is set")
+	}
+
+	data, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	if len(data) == 0 {
+		t.Error("export produced empty output")
 	}
 }

--- a/cmd/admin/export_test.go
+++ b/cmd/admin/export_test.go
@@ -1,6 +1,8 @@
 package admin
 
 import (
+	"bytes"
+	"encoding/json"
 	"io"
 	"os"
 	"path/filepath"
@@ -9,6 +11,7 @@ import (
 
 	cli "github.com/danieljustus/symaira-vault/internal/cli"
 	"github.com/danieljustus/symaira-vault/internal/config"
+	"github.com/danieljustus/symaira-vault/internal/exporter"
 	vaultpkg "github.com/danieljustus/symaira-vault/internal/vault"
 )
 
@@ -141,5 +144,185 @@ func TestExport_YesFlag_SkipsPrompt(t *testing.T) {
 	}
 	if len(data) == 0 {
 		t.Error("export produced empty output")
+	}
+}
+
+func setupTestVault(t *testing.T, searchWorkers int) *cli.VaultService {
+	t.Helper()
+	vaultDir := t.TempDir()
+	passphrase := "test-passphrase"
+	cfg := config.Default()
+	if cfg.Vault == nil {
+		cfg.Vault = &config.VaultConfig{}
+	}
+	cfg.Vault.SearchWorkers = searchWorkers
+	if _, err := vaultpkg.InitWithPassphrase(vaultDir, []byte(passphrase), cfg); err != nil {
+		t.Fatalf("init vault: %v", err)
+	}
+	origVault := cli.Vault
+	cli.Vault = vaultDir
+	t.Cleanup(func() { cli.Vault = origVault })
+	t.Setenv("SYMVAULT_PASSPHRASE", passphrase)
+
+	v, err := cli.UnlockVault(vaultDir, true)
+	if err != nil {
+		t.Fatalf("unlock vault: %v", err)
+	}
+	return cli.NewVaultService(v, nil)
+}
+
+func seedVaultEntries(t *testing.T, vs *cli.VaultService) {
+	t.Helper()
+	entries := map[string]map[string]any{
+		"aaa/first":  {"password": "pass1", "username": "user1"},
+		"bbb/second": {"token": "tok2", "host": "host2"},
+		"ccc/third":  {"password": "pass3", "extra": "data3", "note": "note3"},
+	}
+	for path, data := range entries {
+		if err := vs.SetFields(path, data); err != nil {
+			t.Fatalf("set entry %s: %v", path, err)
+		}
+	}
+}
+
+func runExport(t *testing.T, format, outputPath string) []byte {
+	t.Helper()
+	origConfirm := confirmExport
+	confirmExport = func(_ string, _ bool) (bool, error) { return true, nil }
+	t.Cleanup(func() { confirmExport = origConfirm })
+
+	cmd := cli.RootCmd
+	cmd.SetArgs([]string{"export", "--format", format, "--output", outputPath})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("export: %v", err)
+	}
+	data, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	return data
+}
+
+func buildExpectedJSON(t *testing.T, vs *cli.VaultService) []byte {
+	t.Helper()
+	listEntries, err := vs.ListEntries("")
+	if err != nil {
+		t.Fatalf("list entries: %v", err)
+	}
+	var exportEntries []exporter.ExportEntry
+	for _, path := range listEntries {
+		entry, readErr := vs.GetEntry(path)
+		if readErr != nil {
+			t.Fatalf("get entry %s: %v", path, readErr)
+		}
+		exportEntries = append(exportEntries, exporter.ExportEntry{
+			Path: path,
+			Data: entry.Data,
+		})
+	}
+	var buf bytes.Buffer
+	exp := &exporter.JSONExporter{}
+	if err := exp.Export(&buf, exportEntries, nil); err != nil {
+		t.Fatalf("batch export: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func buildExpectedCSV(t *testing.T, vs *cli.VaultService) []byte {
+	t.Helper()
+	listEntries, err := vs.ListEntries("")
+	if err != nil {
+		t.Fatalf("list entries: %v", err)
+	}
+	var exportEntries []exporter.ExportEntry
+	for _, path := range listEntries {
+		entry, readErr := vs.GetEntry(path)
+		if readErr != nil {
+			t.Fatalf("get entry %s: %v", path, readErr)
+		}
+		exportEntries = append(exportEntries, exporter.ExportEntry{
+			Path: path,
+			Data: entry.Data,
+		})
+	}
+	var buf bytes.Buffer
+	exp := &exporter.CSVExporter{}
+	if err := exp.Export(&buf, exportEntries, nil); err != nil {
+		t.Fatalf("batch export: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func TestExport_Parallel_JSON_ByteIdentical(t *testing.T) {
+	vs := setupTestVault(t, 4)
+	seedVaultEntries(t, vs)
+
+	expected := buildExpectedJSON(t, vs)
+	outputPath := filepath.Join(t.TempDir(), "export.json")
+	actual := runExport(t, "json", outputPath)
+
+	if !bytes.Equal(actual, expected) {
+		t.Errorf("JSON output not byte-identical.\nexpected:\n%s\nactual:\n%s", expected, actual)
+	}
+}
+
+func TestExport_Parallel_CSV_ByteIdentical(t *testing.T) {
+	vs := setupTestVault(t, 4)
+	seedVaultEntries(t, vs)
+
+	expected := buildExpectedCSV(t, vs)
+	outputPath := filepath.Join(t.TempDir(), "export.csv")
+	actual := runExport(t, "csv", outputPath)
+
+	if !bytes.Equal(actual, expected) {
+		t.Errorf("CSV output not byte-identical.\nexpected:\n%s\nactual:\n%s", expected, actual)
+	}
+}
+
+func TestExport_Parallel_JSON_OrderingPreserved(t *testing.T) {
+	vs := setupTestVault(t, 2)
+	seedVaultEntries(t, vs)
+
+	outputPath := filepath.Join(t.TempDir(), "export.json")
+	actual := runExport(t, "json", outputPath)
+
+	var result []map[string]any
+	if err := json.Unmarshal(actual, &result); err != nil {
+		t.Fatalf("unmarshal JSON: %v", err)
+	}
+
+	listEntries, err := vs.ListEntries("")
+	if err != nil {
+		t.Fatalf("list entries: %v", err)
+	}
+
+	if len(result) != len(listEntries) {
+		t.Fatalf("got %d entries, want %d", len(result), len(listEntries))
+	}
+
+	for i, want := range listEntries {
+		if got := result[i]["path"].(string); got != want {
+			t.Errorf("entry %d path = %q, want %q", i, got, want)
+		}
+	}
+}
+
+func TestExport_Parallel_SearchWorkersConfig(t *testing.T) {
+	vs := setupTestVault(t, 8)
+	seedVaultEntries(t, vs)
+
+	outputPath := filepath.Join(t.TempDir(), "export.json")
+	actual := runExport(t, "json", outputPath)
+
+	if len(actual) == 0 {
+		t.Error("export produced empty output")
+	}
+
+	var result []map[string]any
+	if err := json.Unmarshal(actual, &result); err != nil {
+		t.Fatalf("unmarshal JSON: %v", err)
+	}
+	if len(result) != 3 {
+		t.Errorf("got %d entries, want 3", len(result))
 	}
 }

--- a/cmd/admin/export_test.go
+++ b/cmd/admin/export_test.go
@@ -1,0 +1,56 @@
+package admin
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCreateOutputFile_Mode0600(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "export.txt")
+
+	f, err := createOutputFile(path)
+	if err != nil {
+		t.Fatalf("createOutputFile: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("file mode = %o, want 0o600", perm)
+	}
+}
+
+func TestCreateOutputFile_OverwritesExisting(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "existing.txt")
+
+	if err := os.WriteFile(path, []byte("old content"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	f, err := createOutputFile(path)
+	if err != nil {
+		t.Fatalf("createOutputFile: %v", err)
+	}
+	if _, err := f.WriteString("new"); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(data) != "new" {
+		t.Errorf("content = %q, want %q", string(data), "new")
+	}
+}

--- a/cmd/admin/export_test.go
+++ b/cmd/admin/export_test.go
@@ -4,7 +4,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 
@@ -12,59 +11,6 @@ import (
 	"github.com/danieljustus/symaira-vault/internal/config"
 	vaultpkg "github.com/danieljustus/symaira-vault/internal/vault"
 )
-
-func TestCreateOutputFile_Mode0600(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("permission bits are not honored on Windows")
-	}
-
-	path := filepath.Join(t.TempDir(), "export.txt")
-
-	f, err := createOutputFile(path)
-	if err != nil {
-		t.Fatalf("createOutputFile: %v", err)
-	}
-	if err := f.Close(); err != nil {
-		t.Fatalf("close: %v", err)
-	}
-
-	info, err := os.Stat(path)
-	if err != nil {
-		t.Fatalf("stat: %v", err)
-	}
-
-	if perm := info.Mode().Perm(); perm != 0o600 {
-		t.Errorf("file mode = %o, want 0o600", perm)
-	}
-}
-
-func TestCreateOutputFile_OverwritesExisting(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "existing.txt")
-
-	if err := os.WriteFile(path, []byte("old content"), 0o644); err != nil {
-		t.Fatalf("WriteFile: %v", err)
-	}
-
-	f, err := createOutputFile(path)
-	if err != nil {
-		t.Fatalf("createOutputFile: %v", err)
-	}
-	if _, err := f.WriteString("new"); err != nil {
-		t.Fatalf("write: %v", err)
-	}
-	if err := f.Close(); err != nil {
-		t.Fatalf("close: %v", err)
-	}
-
-	data, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("ReadFile: %v", err)
-	}
-	if string(data) != "new" {
-		t.Errorf("content = %q, want %q", string(data), "new")
-	}
-}
 
 func captureStderr(t *testing.T, fn func()) string {
 	t.Helper()

--- a/cmd/admin/export_test.go
+++ b/cmd/admin/export_test.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -13,6 +14,10 @@ import (
 )
 
 func TestCreateOutputFile_Mode0600(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission bits are not honored on Windows")
+	}
+
 	path := filepath.Join(t.TempDir(), "export.txt")
 
 	f, err := createOutputFile(path)

--- a/internal/exporter/csv.go
+++ b/internal/exporter/csv.go
@@ -5,10 +5,15 @@ import (
 	"fmt"
 	"io"
 	"sort"
+	"strings"
 )
 
 // CSVExporter writes vault entries in CSV format.
-type CSVExporter struct{}
+type CSVExporter struct {
+	// NoticeWriter receives per-entry notices when attachment fields are
+	// omitted from the CSV output. When nil, no notices are emitted.
+	NoticeWriter io.Writer
+}
 
 // Export writes entries as CSV with headers derived from entry data keys.
 // If mapping is provided, it renames the output headers:
@@ -19,24 +24,24 @@ func (e *CSVExporter) Export(w io.Writer, entries []ExportEntry, mapping map[str
 		return nil
 	}
 
-	// Collect all unique data keys across all entries
 	keySet := make(map[string]struct{})
 	for _, entry := range entries {
 		for key := range entry.Data {
+			if isAttachmentField(key) {
+				continue
+			}
 			keySet[key] = struct{}{}
 		}
 	}
 
-	// Sort keys for consistent output
 	keys := make([]string, 0, len(keySet))
 	for key := range keySet {
 		keys = append(keys, key)
 	}
 	sort.Strings(keys)
 
-	// Build header row with optional mapping
 	headers := make([]string, 0, len(keys)+1)
-	headers = append(headers, "path") // path is always the first column
+	headers = append(headers, "path")
 	fieldOrder := []string{"__path__"}
 
 	for _, key := range keys {
@@ -48,7 +53,6 @@ func (e *CSVExporter) Export(w io.Writer, entries []ExportEntry, mapping map[str
 		fieldOrder = append(fieldOrder, key)
 	}
 
-	// Write CSV
 	writer := csv.NewWriter(w)
 
 	if err := writer.Write(headers); err != nil {
@@ -57,6 +61,7 @@ func (e *CSVExporter) Export(w io.Writer, entries []ExportEntry, mapping map[str
 
 	for _, entry := range entries {
 		row := make([]string, 0, len(fieldOrder))
+		hasAttachment := false
 		for _, field := range fieldOrder {
 			if field == "__path__" {
 				row = append(row, entry.Path)
@@ -68,8 +73,16 @@ func (e *CSVExporter) Export(w io.Writer, entries []ExportEntry, mapping map[str
 			}
 			row = append(row, value)
 		}
+		if e.hasAttachmentFields(entry.Data) {
+			hasAttachment = true
+		}
 		if err := writer.Write(row); err != nil {
 			return fmt.Errorf("write CSV row: %w", err)
+		}
+		if hasAttachment && e.NoticeWriter != nil {
+			if _, writeErr := fmt.Fprintf(e.NoticeWriter, "attachment data omitted for entry %s; use --format json for a lossless export\n", entry.Path); writeErr != nil {
+				return fmt.Errorf("write attachment notice: %w", writeErr)
+			}
 		}
 	}
 
@@ -78,4 +91,17 @@ func (e *CSVExporter) Export(w io.Writer, entries []ExportEntry, mapping map[str
 		return fmt.Errorf("flush csv writer: %w", err)
 	}
 	return nil
+}
+
+func (e *CSVExporter) hasAttachmentFields(data map[string]any) bool {
+	for key := range data {
+		if isAttachmentField(key) {
+			return true
+		}
+	}
+	return false
+}
+
+func isAttachmentField(key string) bool {
+	return strings.HasPrefix(key, "file_b64_") || key == "chunk_count" || key == "chunk_size"
 }

--- a/internal/exporter/csv.go
+++ b/internal/exporter/csv.go
@@ -50,7 +50,6 @@ func (e *CSVExporter) Export(w io.Writer, entries []ExportEntry, mapping map[str
 
 	// Write CSV
 	writer := csv.NewWriter(w)
-	defer writer.Flush()
 
 	if err := writer.Write(headers); err != nil {
 		return fmt.Errorf("write CSV header: %w", err)
@@ -74,5 +73,9 @@ func (e *CSVExporter) Export(w io.Writer, entries []ExportEntry, mapping map[str
 		}
 	}
 
+	writer.Flush()
+	if err := writer.Error(); err != nil {
+		return fmt.Errorf("flush csv writer: %w", err)
+	}
 	return nil
 }

--- a/internal/exporter/csv_test.go
+++ b/internal/exporter/csv_test.go
@@ -3,6 +3,7 @@ package exporter
 import (
 	"bytes"
 	"encoding/csv"
+	"encoding/json"
 	"io"
 	"strings"
 	"testing"
@@ -141,4 +142,215 @@ type failFlushWriter struct {
 
 func (w *failFlushWriter) Write(p []byte) (int, error) {
 	return 0, w.err
+}
+
+func TestCSVExporter_AttachmentFieldsExcluded(t *testing.T) {
+	entries := []ExportEntry{
+		{
+			Path: "github.com/user",
+			Data: map[string]any{
+				"username":      "alice",
+				"password":      "s3cret",
+				"file_b64_0001": "dGhpcyBpcyBhIHRlc3Q=",
+				"file_b64_0002": "YW5vdGhlciBjaHVuaw==",
+				"chunk_count":   "2",
+				"chunk_size":    "4096",
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	exp := &CSVExporter{}
+
+	if err := exp.Export(&buf, entries, nil); err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+
+	reader := csv.NewReader(&buf)
+	records, err := reader.ReadAll()
+	if err != nil {
+		t.Fatalf("read CSV: %v", err)
+	}
+
+	if len(records) != 2 {
+		t.Fatalf("got %d rows, want 2 (header + 1 data)", len(records))
+	}
+
+	header := records[0]
+	for _, h := range header[1:] {
+		if strings.HasPrefix(h, "file_b64_") || h == "chunk_count" || h == "chunk_size" {
+			t.Errorf("attachment field %q should not appear in headers", h)
+		}
+	}
+
+	wantHeaders := []string{"path", "password", "username"}
+	if len(header) != len(wantHeaders) {
+		t.Fatalf("header count = %d, want %d: got %v", len(header), len(wantHeaders), header)
+	}
+	for i, want := range wantHeaders {
+		if header[i] != want {
+			t.Errorf("header[%d] = %q, want %q", i, header[i], want)
+		}
+	}
+
+	dataRow := records[1]
+	if dataRow[0] != "github.com/user" {
+		t.Errorf("row path = %q, want %q", dataRow[0], "github.com/user")
+	}
+	if dataRow[1] != "s3cret" {
+		t.Errorf("row password = %q, want %q", dataRow[1], "s3cret")
+	}
+	if dataRow[2] != "alice" {
+		t.Errorf("row username = %q, want %q", dataRow[2], "alice")
+	}
+}
+
+func TestCSVExporter_AttachmentFieldsOnly_EntryStillValid(t *testing.T) {
+	entries := []ExportEntry{
+		{
+			Path: "work/attachment-only",
+			Data: map[string]any{
+				"file_b64_0001": "dGVzdA==",
+				"chunk_count":   "1",
+				"chunk_size":    "1024",
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	exp := &CSVExporter{}
+
+	if err := exp.Export(&buf, entries, nil); err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+
+	reader := csv.NewReader(&buf)
+	records, err := reader.ReadAll()
+	if err != nil {
+		t.Fatalf("read CSV: %v", err)
+	}
+
+	if len(records) != 2 {
+		t.Fatalf("got %d rows, want 2 (header + 1 data)", len(records))
+	}
+
+	header := records[0]
+	if len(header) != 1 || header[0] != "path" {
+		t.Errorf("header = %v, want [path] only", header)
+	}
+
+	dataRow := records[1]
+	if len(dataRow) != 1 || dataRow[0] != "work/attachment-only" {
+		t.Errorf("data row = %v, want [work/attachment-only]", dataRow)
+	}
+}
+
+func TestCSVExporter_AttachNoticeEmitted(t *testing.T) {
+	entries := []ExportEntry{
+		{
+			Path: "github.com/user",
+			Data: map[string]any{"username": "alice", "file_b64_0001": "dGVzdA==", "chunk_count": "1"},
+		},
+		{
+			Path: "work/aws",
+			Data: map[string]any{"access_key": "AKIAIOSFODNN7"},
+		},
+	}
+
+	var csvBuf bytes.Buffer
+	var noticeBuf bytes.Buffer
+	exp := &CSVExporter{NoticeWriter: &noticeBuf}
+
+	if err := exp.Export(&csvBuf, entries, nil); err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+
+	notices := noticeBuf.String()
+	if !strings.Contains(notices, "github.com/user") {
+		t.Errorf("notice missing affected path, got: %q", notices)
+	}
+	if strings.Contains(notices, "work/aws") {
+		t.Errorf("notice should not mention unaffected entry, got: %q", notices)
+	}
+	if !strings.Contains(notices, "lossless") {
+		t.Errorf("notice should mention lossless JSON export, got: %q", notices)
+	}
+	if !strings.Contains(notices, "--format json") {
+		t.Errorf("notice should mention --format json, got: %q", notices)
+	}
+
+	lines := strings.Split(strings.TrimSpace(notices), "\n")
+	if len(lines) != 1 {
+		t.Errorf("expected 1 notice line, got %d: %q", len(lines), notices)
+	}
+}
+
+func TestCSVExporter_NoNoticeWhenNoAttachments(t *testing.T) {
+	entries := []ExportEntry{
+		{Path: "test", Data: map[string]any{"username": "alice"}},
+	}
+
+	var csvBuf bytes.Buffer
+	var noticeBuf bytes.Buffer
+	exp := &CSVExporter{NoticeWriter: &noticeBuf}
+
+	if err := exp.Export(&csvBuf, entries, nil); err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+
+	if noticeBuf.Len() != 0 {
+		t.Errorf("expected no notices, got: %q", noticeBuf.String())
+	}
+}
+
+func TestCSVExporter_NoNoticeWhenNoticeWriterNil(t *testing.T) {
+	entries := []ExportEntry{
+		{Path: "test", Data: map[string]any{"file_b64_0001": "dGVzdA=="}},
+	}
+
+	var csvBuf bytes.Buffer
+	exp := &CSVExporter{}
+
+	if err := exp.Export(&csvBuf, entries, nil); err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+}
+
+func TestJSONExporter_AttachmentFieldsPreserved(t *testing.T) {
+	entries := []ExportEntry{
+		{
+			Path: "github.com/user",
+			Data: map[string]any{
+				"username":      "alice",
+				"password":      "s3cret",
+				"file_b64_0001": "dGhpcyBpcyBhIHRlc3Q=",
+				"chunk_count":   "2",
+				"chunk_size":    "4096",
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	exp := &JSONExporter{}
+
+	if err := exp.Export(&buf, entries, nil); err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+
+	var result []map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("unmarshal JSON: %v", err)
+	}
+
+	if len(result) != 1 {
+		t.Fatalf("got %d entries, want 1", len(result))
+	}
+
+	data := result[0]["data"].(map[string]any)
+	wantKeys := []string{"username", "password", "file_b64_0001", "chunk_count", "chunk_size"}
+	for _, key := range wantKeys {
+		if _, ok := data[key]; !ok {
+			t.Errorf("JSON output missing key %q", key)
+		}
+	}
 }

--- a/internal/exporter/csv_test.go
+++ b/internal/exporter/csv_test.go
@@ -1,0 +1,144 @@
+package exporter
+
+import (
+	"bytes"
+	"encoding/csv"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestCSVExporter_RoundTrip(t *testing.T) {
+	entries := []ExportEntry{
+		{Path: "github.com/user", Data: map[string]any{"username": "alice", "password": "s3cret"}},
+		{Path: "work/aws", Data: map[string]any{"access_key": "AKIAIOSFODNN7", "username": "bob"}},
+	}
+
+	var buf bytes.Buffer
+	exp := &CSVExporter{}
+
+	if err := exp.Export(&buf, entries, nil); err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+
+	reader := csv.NewReader(&buf)
+	records, err := reader.ReadAll()
+	if err != nil {
+		t.Fatalf("read CSV: %v", err)
+	}
+
+	if len(records) != 3 {
+		t.Fatalf("got %d rows, want 3 (header + 2 data rows)", len(records))
+	}
+
+	// Header row: path, access_key, password, username (sorted)
+	header := records[0]
+	if header[0] != "path" {
+		t.Errorf("first column = %q, want %q", header[0], "path")
+	}
+
+	// First data row
+	if records[1][0] != "github.com/user" {
+		t.Errorf("row 1 path = %q, want %q", records[1][0], "github.com/user")
+	}
+
+	// Second data row
+	if records[2][0] != "work/aws" {
+		t.Errorf("row 2 path = %q, want %q", records[2][0], "work/aws")
+	}
+}
+
+func TestCSVExporter_RoundTripWithMapping(t *testing.T) {
+	entries := []ExportEntry{
+		{Path: "test", Data: map[string]any{"username": "alice", "password": "s3cret"}},
+	}
+
+	mapping := map[string]string{"username": "user", "password": "secret"}
+
+	var buf bytes.Buffer
+	exp := &CSVExporter{}
+
+	if err := exp.Export(&buf, entries, mapping); err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+
+	reader := csv.NewReader(&buf)
+	records, err := reader.ReadAll()
+	if err != nil {
+		t.Fatalf("read CSV: %v", err)
+	}
+
+	header := records[0]
+	for _, h := range header[1:] {
+		if h == "username" || h == "password" {
+			t.Errorf("unmapped header %q should have been renamed by mapping", h)
+		}
+	}
+}
+
+func TestCSVExporter_EmptyEntries(t *testing.T) {
+	var buf bytes.Buffer
+	exp := &CSVExporter{}
+
+	if err := exp.Export(&buf, nil, nil); err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+
+	if buf.Len() != 0 {
+		t.Errorf("expected empty output, got %d bytes", buf.Len())
+	}
+}
+
+func TestCSVExporter_WriteErrorPropagation(t *testing.T) {
+	w := &failWriter{errAfter: 0}
+	exp := &CSVExporter{}
+	entries := []ExportEntry{
+		{Path: "test", Data: map[string]any{"key": "value"}},
+	}
+
+	err := exp.Export(w, entries, nil)
+	if err == nil {
+		t.Fatal("expected error from failing writer, got nil")
+	}
+}
+
+func TestCSVExporter_FlushErrorPropagation(t *testing.T) {
+	w := &failFlushWriter{err: io.ErrShortWrite}
+	exp := &CSVExporter{}
+	entries := []ExportEntry{
+		{Path: "test", Data: map[string]any{"key": "value"}},
+	}
+
+	err := exp.Export(w, entries, nil)
+	if err == nil {
+		t.Fatal("expected error from failing flush, got nil")
+	}
+	if !strings.Contains(err.Error(), "flush csv writer") {
+		t.Errorf("error = %q, want it to contain %q", err.Error(), "flush csv writer")
+	}
+}
+
+// failWriter returns errAfter successful Write calls, then returns err on
+// subsequent calls. This simulates a write failure after the CSV data has been
+// buffered.
+type failWriter struct {
+	n        int
+	errAfter int
+	err      error
+}
+
+func (f *failWriter) Write(p []byte) (int, error) {
+	f.n++
+	if f.n > f.errAfter {
+		return 0, io.ErrShortWrite
+	}
+	return len(p), nil
+}
+
+type failFlushWriter struct {
+	err error
+}
+
+func (w *failFlushWriter) Write(p []byte) (int, error) {
+	return 0, w.err
+}

--- a/internal/exporter/json.go
+++ b/internal/exporter/json.go
@@ -43,3 +43,73 @@ func (e *JSONExporter) Export(w io.Writer, entries []ExportEntry, mapping map[st
 	}
 	return nil
 }
+
+// JSONStream writes JSON entries one at a time to reduce peak memory.
+// Create with NewJSONStream, call WriteEntry for each entry in order,
+// then call Close. The output is byte-identical to JSONExporter.Export
+// for the same input.
+type JSONStream struct {
+	w       io.Writer
+	mapping map[string]string
+	count   int
+}
+
+// NewJSONStream returns a streaming JSON writer. The mapping renames output
+// keys in each entry's data object (same semantics as JSONExporter.Export).
+func NewJSONStream(w io.Writer, mapping map[string]string) *JSONStream {
+	return &JSONStream{w: w, mapping: mapping}
+}
+
+// WriteEntry appends one entry to the JSON array. Entries MUST be written
+// in index order (0, 1, 2, …). The method is not safe for concurrent use.
+func (s *JSONStream) WriteEntry(entry ExportEntry) error {
+	if s.count == 0 {
+		if _, err := fmt.Fprint(s.w, "[\n"); err != nil {
+			return err
+		}
+	} else {
+		if _, err := fmt.Fprint(s.w, ",\n"); err != nil {
+			return err
+		}
+	}
+
+	row := map[string]any{
+		"path": entry.Path,
+	}
+	data := make(map[string]any, len(entry.Data))
+	for k, v := range entry.Data {
+		key := k
+		if mappedKey, ok := s.mapping[k]; ok {
+			key = mappedKey
+		}
+		data[key] = v
+	}
+	row["data"] = data
+
+	b, err := json.MarshalIndent(row, "  ", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal JSON: %w", err)
+	}
+	// MarshalIndent omits the prefix on the first line; prepend one level
+	// of array indentation to match json.Encoder output.
+	if _, err := s.w.Write([]byte("  ")); err != nil {
+		return err
+	}
+	if _, err := s.w.Write(b); err != nil {
+		return err
+	}
+
+	s.count++
+	return nil
+}
+
+// Close finalizes the JSON array. It writes the closing bracket and trailing
+// newline (matching json.Encoder.Encode behavior) or "[]" for zero entries.
+func (s *JSONStream) Close() error {
+	if s.count == 0 {
+		_, err := fmt.Fprint(s.w, "[]")
+		return err
+	}
+	_, err := fmt.Fprint(s.w, "\n]\n")
+	return err
+}

--- a/internal/exporter/json_test.go
+++ b/internal/exporter/json_test.go
@@ -1,0 +1,253 @@
+package exporter
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+func TestJSONStream_SingleEntry(t *testing.T) {
+	entry := ExportEntry{
+		Path: "test/path",
+		Data: map[string]any{"password": "s3cret", "user": "alice"},
+	}
+
+	var buf bytes.Buffer
+	stream := NewJSONStream(&buf, nil)
+	if err := stream.WriteEntry(entry); err != nil {
+		t.Fatalf("WriteEntry: %v", err)
+	}
+	if err := stream.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	var result []map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("unmarshal JSON: %v", err)
+	}
+	if len(result) != 1 {
+		t.Fatalf("got %d entries, want 1", len(result))
+	}
+	if result[0]["path"] != "test/path" {
+		t.Errorf("path = %q, want %q", result[0]["path"], "test/path")
+	}
+	data := result[0]["data"].(map[string]any)
+	if data["password"] != "s3cret" {
+		t.Errorf("password = %q, want %q", data["password"], "s3cret")
+	}
+}
+
+func TestJSONStream_MultipleEntries(t *testing.T) {
+	entries := []ExportEntry{
+		{Path: "a/b", Data: map[string]any{"k1": "v1"}},
+		{Path: "c/d", Data: map[string]any{"k2": "v2"}},
+		{Path: "e/f", Data: map[string]any{"k3": "v3"}},
+	}
+
+	var buf bytes.Buffer
+	stream := NewJSONStream(&buf, nil)
+	for _, entry := range entries {
+		if err := stream.WriteEntry(entry); err != nil {
+			t.Fatalf("WriteEntry %s: %v", entry.Path, err)
+		}
+	}
+	if err := stream.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	var result []map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("unmarshal JSON: %v", err)
+	}
+	if len(result) != 3 {
+		t.Fatalf("got %d entries, want 3", len(result))
+	}
+	for i, want := range []string{"a/b", "c/d", "e/f"} {
+		if result[i]["path"] != want {
+			t.Errorf("entry %d path = %q, want %q", i, result[i]["path"], want)
+		}
+	}
+}
+
+func TestJSONStream_Empty(t *testing.T) {
+	var buf bytes.Buffer
+	stream := NewJSONStream(&buf, nil)
+	if err := stream.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if buf.String() != "[]" {
+		t.Errorf("empty output = %q, want %q", buf.String(), "[]")
+	}
+}
+
+func TestJSONStream_MappingApplied(t *testing.T) {
+	entry := ExportEntry{
+		Path: "test",
+		Data: map[string]any{"username": "alice", "password": "s3cret"},
+	}
+	mapping := map[string]string{"username": "user", "password": "secret"}
+
+	var buf bytes.Buffer
+	stream := NewJSONStream(&buf, mapping)
+	if err := stream.WriteEntry(entry); err != nil {
+		t.Fatalf("WriteEntry: %v", err)
+	}
+	if err := stream.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	var result []map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("unmarshal JSON: %v", err)
+	}
+	data := result[0]["data"].(map[string]any)
+	if _, ok := data["username"]; ok {
+		t.Error("original key 'username' should have been mapped")
+	}
+	if data["user"] != "alice" {
+		t.Errorf("mapped key 'user' = %q, want %q", data["user"], "alice")
+	}
+	if _, ok := data["password"]; ok {
+		t.Error("original key 'password' should have been mapped")
+	}
+	if data["secret"] != "s3cret" {
+		t.Errorf("mapped key 'secret' = %q, want %q", data["secret"], "s3cret")
+	}
+}
+
+func TestJSONStream_ByteIdenticalToExport(t *testing.T) {
+	entries := []ExportEntry{
+		{Path: "a/b", Data: map[string]any{"password": "s3cret", "user": "alice"}},
+		{Path: "c/d", Data: map[string]any{"token": "abc123", "host": "example.com"}},
+	}
+	mapping := map[string]string{"user": "username"}
+
+	var batchBuf bytes.Buffer
+	batchExp := &JSONExporter{}
+	if err := batchExp.Export(&batchBuf, entries, mapping); err != nil {
+		t.Fatalf("batch Export: %v", err)
+	}
+
+	var streamBuf bytes.Buffer
+	stream := NewJSONStream(&streamBuf, mapping)
+	for _, entry := range entries {
+		if err := stream.WriteEntry(entry); err != nil {
+			t.Fatalf("WriteEntry: %v", err)
+		}
+	}
+	if err := stream.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	if !bytes.Equal(batchBuf.Bytes(), streamBuf.Bytes()) {
+		t.Errorf("output mismatch.\nbatch:  %q\nstream: %q", batchBuf.String(), streamBuf.String())
+	}
+}
+
+func TestJSONStream_ByteIdenticalToExport_NilMapping(t *testing.T) {
+	entries := []ExportEntry{
+		{Path: "x", Data: map[string]any{"a": "1", "b": "2"}},
+		{Path: "y", Data: map[string]any{"c": "3"}},
+	}
+
+	var batchBuf bytes.Buffer
+	batchExp := &JSONExporter{}
+	if err := batchExp.Export(&batchBuf, entries, nil); err != nil {
+		t.Fatalf("batch Export: %v", err)
+	}
+
+	var streamBuf bytes.Buffer
+	stream := NewJSONStream(&streamBuf, nil)
+	for _, entry := range entries {
+		if err := stream.WriteEntry(entry); err != nil {
+			t.Fatalf("WriteEntry: %v", err)
+		}
+	}
+	if err := stream.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	if !bytes.Equal(batchBuf.Bytes(), streamBuf.Bytes()) {
+		t.Errorf("output mismatch (nil mapping).\nbatch:  %q\nstream: %q", batchBuf.String(), streamBuf.String())
+	}
+}
+
+func TestJSONStream_ByteIdenticalToExport_EmptyMapping(t *testing.T) {
+	entries := []ExportEntry{
+		{Path: "only", Data: map[string]any{"file_b64_0001": "dGVzdA==", "chunk_count": "1"}},
+	}
+
+	var batchBuf bytes.Buffer
+	batchExp := &JSONExporter{}
+	if err := batchExp.Export(&batchBuf, entries, map[string]string{}); err != nil {
+		t.Fatalf("batch Export: %v", err)
+	}
+
+	var streamBuf bytes.Buffer
+	stream := NewJSONStream(&streamBuf, map[string]string{})
+	for _, entry := range entries {
+		if err := stream.WriteEntry(entry); err != nil {
+			t.Fatalf("WriteEntry: %v", err)
+		}
+	}
+	if err := stream.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	if !bytes.Equal(batchBuf.Bytes(), streamBuf.Bytes()) {
+		t.Errorf("output mismatch (empty mapping).\nbatch:  %q\nstream: %q", batchBuf.String(), streamBuf.String())
+	}
+}
+
+func TestJSONStream_ByteIdenticalToExport_LargerDataMaps(t *testing.T) {
+	entries := []ExportEntry{
+		{
+			Path: "work/prod/db",
+			Data: map[string]any{
+				"host":     "db.example.com",
+				"port":     "5432",
+				"user":     "admin",
+				"password": "supersecret",
+				"name":     "production",
+				"sslmode":  "require",
+			},
+		},
+		{
+			Path: "work/prod/api",
+			Data: map[string]any{
+				"base_url":   "https://api.example.com",
+				"api_key":    "ak_test_12345",
+				"timeout_ms": "30000",
+			},
+		},
+		{
+			Path: "personal/email",
+			Data: map[string]any{
+				"email":    "user@example.com",
+				"password": "emailpass",
+				"server":   "imap.example.com",
+			},
+		},
+	}
+
+	var batchBuf bytes.Buffer
+	batchExp := &JSONExporter{}
+	if err := batchExp.Export(&batchBuf, entries, nil); err != nil {
+		t.Fatalf("batch Export: %v", err)
+	}
+
+	var streamBuf bytes.Buffer
+	stream := NewJSONStream(&streamBuf, nil)
+	for _, entry := range entries {
+		if err := stream.WriteEntry(entry); err != nil {
+			t.Fatalf("WriteEntry: %v", err)
+		}
+	}
+	if err := stream.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	if !bytes.Equal(batchBuf.Bytes(), streamBuf.Bytes()) {
+		t.Errorf("output mismatch (larger data maps).\nbatch:  %q\nstream: %q", batchBuf.String(), streamBuf.String())
+	}
+}

--- a/internal/fsutil/createsensitiveoutput.go
+++ b/internal/fsutil/createsensitiveoutput.go
@@ -1,0 +1,31 @@
+package fsutil
+
+import (
+	"io"
+	"os"
+)
+
+// noopWriteCloser wraps a Writer with a no-op Close so callers can defer
+// Close without risking closing stdout or other shared file descriptors.
+type noopWriteCloser struct {
+	io.Writer
+}
+
+// Close is a no-op — it never returns an error.
+func (noopWriteCloser) Close() error { return nil }
+
+// CreateSensitiveOutput returns an io.WriteCloser for writing sensitive output.
+// When path is empty it writes to os.Stdout with a no-op Close so that stdout
+// is never closed. When path is non-empty it creates (or truncates) the file at
+// path with mode 0600 so that only the file owner can read or write the
+// contents.
+func CreateSensitiveOutput(path string) (io.WriteCloser, error) {
+	if path == "" {
+		return noopWriteCloser{Writer: os.Stdout}, nil
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600) // #nosec G304 -- output path is user-provided CLI argument
+	if err != nil {
+		return nil, err
+	}
+	return f, nil
+}

--- a/internal/fsutil/createsensitiveoutput_test.go
+++ b/internal/fsutil/createsensitiveoutput_test.go
@@ -1,0 +1,79 @@
+package fsutil
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestCreateSensitiveOutput_FilePermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission bits are not honored on Windows")
+	}
+
+	path := filepath.Join(t.TempDir(), "sensitive.txt")
+	wc, err := CreateSensitiveOutput(path)
+	if err != nil {
+		t.Fatalf("CreateSensitiveOutput: %v", err)
+	}
+	if err := wc.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("file mode = %o, want 0o600", perm)
+	}
+}
+
+func TestCreateSensitiveOutput_OverwritesExisting(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "existing.txt")
+
+	if err := os.WriteFile(path, []byte("old content"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	wc, err := CreateSensitiveOutput(path)
+	if err != nil {
+		t.Fatalf("CreateSensitiveOutput: %v", err)
+	}
+	if _, err := io.WriteString(wc, "new"); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := wc.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(data) != "new" {
+		t.Errorf("content = %q, want %q", string(data), "new")
+	}
+}
+
+func TestCreateSensitiveOutput_StdoutPassthrough(t *testing.T) {
+	wc, err := CreateSensitiveOutput("")
+	if err != nil {
+		t.Fatalf("CreateSensitiveOutput: %v", err)
+	}
+	// Close must be a no-op and never return an error.
+	if err := wc.Close(); err != nil {
+		t.Errorf("stdout Close should not return error, got: %v", err)
+	}
+}
+
+func TestCreateSensitiveOutput_InvalidPath(t *testing.T) {
+	_, err := CreateSensitiveOutput("/nonexistent/dir/file.txt")
+	if err == nil {
+		t.Fatal("expected error for invalid path")
+	}
+}


### PR DESCRIPTION
Bundles fixes for multiple open issues. The list below grows as commits land; every linked issue will close automatically on merge.

<!-- closes-list-start -->
- Closes #650 Harden plaintext export output: 0600 perms and close/flush error propagation
- Closes #651 Require confirmation and warn before plaintext vault export
- Closes #652 Exclude chunked attachment fields from CSV export
- Closes #653 Unify sensitive output-file creation across export, audit export and backup
- Closes #654 Parallelize entry decryption and reduce memory footprint in export
<!-- closes-list-end -->