### PR TITLE
git: classify push/pull auth errors by precise status patterns

### DIFF
--- a/internal/git/git_pull.go
+++ b/internal/git/git_pull.go
@@ -90,7 +90,7 @@ func PullWithResult(vaultDir string) PullResult {
 
 	errStr := pullErr.Error()
 	if strings.Contains(errStr, "authentication") || strings.Contains(errStr, "credentials") ||
-		strings.Contains(errStr, "401") || strings.Contains(errStr, "403") {
+		strings.Contains(errStr, "error: 401") || strings.Contains(errStr, "error: 403") {
 		result.Error = &PushError{
 			Message: "authentication failed - please check your credentials",
 			Cause:   pullErr,

--- a/internal/git/git_push.go
+++ b/internal/git/git_push.go
@@ -154,8 +154,8 @@ func classifyPushError(err error) *PushError {
 		}
 	case strings.Contains(errStr, "authentication"),
 		strings.Contains(errStr, "credentials"),
-		strings.Contains(errStr, "401"),
-		strings.Contains(errStr, "403"):
+		strings.Contains(errStr, "error: 401"),
+		strings.Contains(errStr, "error: 403"):
 		return &PushError{
 			Message: "authentication failed - please check your credentials",
 			Cause:   err,


### PR DESCRIPTION
## Problem

CI on main failed after merging #655: `TestPushWithResultSSHAuthError` expected a network-error classification for an ssh `Connection refused` push failure, but got `authentication failed`.

Root cause: the push and pull error classifiers matched the bare substrings `"401"` / `"403"` for auth detection. The test's random local port (`40329`) contains `403`, so a connection-refused error was misclassified as an authentication failure. Any error text containing those digit sequences (ports, PIDs) could trigger the wrong branch — a latent misclassification, not just a flaky test.

## Fix

Match git's canonical HTTPS status messages (`error: 401`, `error: 403`) instead of the bare digits in both classifiers (`internal/git/git_push.go`, `internal/git/git_pull.go`).

## Verified

- `go test ./internal/git/... -count=10 -run 'TestPushWithResult|TestAutoCommitAndPush|TestPull'` — pass
- `go test ./internal/git/...` — pass
- build / vet / fmt clean; no new lint findings