### PR TITLE
nix: refresh vendorHash and add CI drift check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -397,10 +397,44 @@ jobs:
           
           echo "All smoke tests passed!"
 
+  flake-vendorhash:
+    name: Flake vendorHash
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+
+      - name: Verify flake.nix vendorHash matches go.mod/go.sum
+        run: |
+          EXPECTED=$(grep -oP 'vendorHash\s*=\s*"\K[^"]+' flake.nix)
+          if [ -z "$EXPECTED" ]; then
+            echo "FAIL: could not find vendorHash in flake.nix"
+            exit 1
+          fi
+          go mod vendor
+          ACTUAL=$(nix --extra-experimental-features 'nix-command flakes' hash path --sri vendor/)
+          rm -rf vendor
+          echo "flake.nix vendorHash: $EXPECTED"
+          echo "computed vendorHash:  $ACTUAL"
+          if [ "$EXPECTED" != "$ACTUAL" ]; then
+            echo "FAIL: flake.nix vendorHash is stale — update it to $ACTUAL"
+            exit 1
+          fi
+          echo "PASS: flake.nix vendorHash matches the current go.mod/go.sum tree"
+
   ci-gate:
     name: CI Success
     runs-on: ubuntu-latest
-    needs: [govulncheck, dependency-scan, lint, test, fuzz, build, integration-test, smoke-test]
+    needs: [govulncheck, dependency-scan, lint, test, fuzz, build, integration-test, smoke-test, flake-vendorhash]
     steps:
       - name: Confirm Success
         run: echo "All checks passed successfully!"

--- a/flake.nix
+++ b/flake.nix
@@ -21,11 +21,11 @@
           src = ./.;
 
           # Resolved via `go mod vendor; nix hash path --sri vendor/`
-          vendorHash = "sha256-mFck88bFcrdG4eO+IDdGsG6gQLx8SlOGLyit6A68uL4=";
+          vendorHash = "sha256-jOhrizaIOhavkAQnF1mpDZWwjGG25Tn8N3L4z5F0ujg=";
 
           # Disable CGO for Linux — reduces distributability and is not needed
           # (keyring integration requires CGO only on darwin).
-          CGO_ENABLED = 0;
+          env.CGO_ENABLED = "0";
 
           ldflags = [
             "-s"


### PR DESCRIPTION
Recomputes `flake.nix`'s `vendorHash` against the current `go.mod`/`go.sum` tree, which had drifted stale since the dependency bump in #649 and broken the documented `nix run` install channel. Also fixes an unrelated `CGO_ENABLED`/`env` attribute collision surfaced while verifying the build against current nixpkgs.

Adds a CI job that independently re-derives the vendorHash from `go.mod`/`go.sum` on every push and pull request and fails when it no longer matches `flake.nix`, so future dependency bumps can't drift the flake silently again.

Known limitation: a full `nix build` currently still fails in this environment because nixpkgs' packaged Go (1.26.4) lags behind this repo's `go.mod` requirement (1.26.5) — an upstream packaging gap outside this repo's control. The new CI check validates vendorHash correctness independently of that gap by vendoring with the real Go toolchain from `actions/setup-go` rather than nixpkgs' bundled compiler.

<!-- closes-list-start -->
- Closes #657 flake.nix vendorHash stale after dependency bump — Nix install channel broken
<!-- closes-list-end -->

Milestone: v0.10.1