### PR TITLE
release: name GitHub releases after the tag, not "<project> <version>"

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -124,7 +124,7 @@ release:
     name: "symaira-vault"
   draft: false
   prerelease: auto
-  name_template: "{{ .ProjectName }} {{ .Version }}"
+  name_template: "{{ .Tag }}"
   header: |
     ## Symaira Vault {{ .Version }}
     


### PR DESCRIPTION
Releases were titled "symaira-vault 0.10.0" via GoReleaser's default
name_template ("{{ .ProjectName }} {{ .Version }}"). Use the tag
itself (e.g. "v0.10.1") as the release name going forward.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
