### PR TITLE
feat: make secret consumption discoverable for agents that only see a reference

### DIFF
--- a/docs/agent-integration.md
+++ b/docs/agent-integration.md
@@ -103,6 +103,67 @@ Symaira Vault exposes the following MCP tools for agent integration:
 - `get_auth_status` — Check unlock authentication status
 - `set_auth_method` — Change unlock method (passphrase / touchid)
 
+## Consuming a Secret Without Seeing It
+
+A metadata-first profile (like `hermes-metadata` above) never returns plaintext
+values. `get_entry` and `get_entry_value` instead return a **reference** — a
+`handle` such as `op://github/token/token` — plus a per-field `usage` hint
+describing how to act on it. Do not try to resolve that reference yourself;
+you are not meant to see the value. The pattern is:
+
+1. Call `get_entry` (or `get_entry_metadata`) to discover the field(s) and their
+   `handle`/`usage` hint.
+2. Pass the secret to a consuming tool by **reference**, not by value:
+   - `run_command` / `execute_with_secret` — put `"path.field"` in the `env`
+     map (not the `op://` handle — the resolver expects dot notation):
+     ```json
+     {"tool": "run_command",
+      "arguments": {"command": ["gh", "api", "user"],
+                    "env": {"GH_TOKEN": "github/token.token"}}}
+     ```
+     SymVault resolves the reference and injects the value into the child
+     process's environment only. It is never returned to you.
+   - `copy_to_clipboard` / `autotype` — for interactive, human-facing use.
+   - `request_credential` — ask the user to supply or confirm a credential
+     directly when no vault entry exists yet.
+
+If a consuming tool call is denied (`run_denied`, or "not in the agent's
+allowed tools"), the error names the exact profile fix — read it before giving
+up. For example, `run_command` denied by `canRunCommands: false` explains which
+config key to set and suggests the fallback tools above.
+
+### Escalating to a runner profile
+
+Metadata-first profiles deliberately omit `run_command`/`execute_with_secret`.
+When a task genuinely needs to consume a secret (not just discover it exists),
+use a separate, narrowly-scoped runner profile instead of widening the
+metadata profile:
+
+```yaml
+agents:
+  hermes-runner-provider-smoke:
+    allowedPaths:
+      - agents/providers/example-provider/
+    canWrite: false
+    canRunCommands: true
+    canManageConfig: false
+    canUseClipboard: false
+    canUseAutotype: false
+    approvalMode: deny
+    allowed_tools:
+      - health
+      - get_entry_metadata
+      - run_command
+      - execute_with_secret
+    max_reads_per_hour: 5
+    max_reads_per_day: 20
+    max_secrets_in_session: 1
+```
+
+See [`docs/hermes-safe-adoption.md`](hermes-safe-adoption.md) § "Separate
+runner profile after masking review" for the full runner-profile rules
+(narrow `allowedPaths`, tight `allowed_tools`, session/rate caps).
+
 ## OpenClaw and Other Local Agents
 
 For agents that support stdio MCP, use:

--- a/internal/mcp/server/hooks_builtin.go
+++ b/internal/mcp/server/hooks_builtin.go
@@ -85,7 +85,14 @@ func NewScopeCheckPreHook() PreCallHook {
 			}
 		}
 		server.logAudit(ctx, "tool_scope_denied", toolName, false)
-		return ctx, fmt.Errorf("tool %q is not in the agent's allowed tools", toolName)
+		name := server.agent.Name
+		if name == "" || name == "default" {
+			name = "<name>"
+		}
+		return ctx, fmt.Errorf(
+			"tool %q is not in the agent's allowed tools: add it to agents.%s.allowed_tools in the profile "+
+				"(symvault config set agents.%s.allowed_tools '[...]'), or remove the allowed_tools restriction "+
+				"to allow every registered tool", toolName, name, name)
 	}
 }
 

--- a/internal/mcp/server/hooks_test.go
+++ b/internal/mcp/server/hooks_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -572,6 +573,10 @@ func TestScopeCheckHook_DeniesDisallowedTool(t *testing.T) {
 	_, err := srv.executeTool(context.Background(), "generate_password", nil)
 	if err == nil {
 		t.Fatal("executeTool() expected scope error, got nil")
+	}
+	// The denial must name the concrete profile remedy, not just refuse. Issue #667.
+	if !strings.Contains(err.Error(), "agents.test.allowed_tools") {
+		t.Fatalf("error = %v, want it to name the allowed_tools profile remedy", err)
 	}
 }
 

--- a/internal/mcp/server/protocol.go
+++ b/internal/mcp/server/protocol.go
@@ -39,7 +39,28 @@ type InitializeResult struct {
 	Capabilities    *ServerCapabilities `json:"capabilities"`
 	ServerInfo      *ServerInfo         `json:"serverInfo"`
 	ProtocolVersion string              `json:"protocolVersion"`
+	Instructions    string              `json:"instructions,omitempty"`
 }
+
+// serverInstructions is surfaced to every client in the initialize response so
+// agents can self-discover the "consume a secret without seeing it" pattern
+// instead of dead-ending on a redacted reference (issue #667). It intentionally
+// does not vary per agent/profile — it describes the pattern, not this agent's
+// specific permissions, which the agent learns from tool availability and from
+// the per-field "usage" hints in get_entry/get_entry_value responses.
+const serverInstructions = `SymVault redacts secret values by default: get_entry and get_entry_value ` +
+	`return a reference (a "handle", e.g. op://path/field) instead of the plaintext, plus a per-field ` +
+	`"usage" hint. Do not try to resolve that reference yourself — you are not meant to see the value.
+
+To consume a secret without seeing it:
+  - run_command / execute_with_secret: pass "path.field" (not the op:// handle) as an env map value, ` +
+	`e.g. {"env": {"GH_TOKEN": "github.token"}}. SymVault resolves and injects it; only the child ` +
+	`process sees the value.
+  - copy_to_clipboard / autotype: for interactive, human-facing use.
+  - request_credential: ask the user to supply or confirm a credential directly.
+
+If a tool call is denied (run_denied / not in allowed_tools), the error names the exact profile fix — ` +
+	`read it before giving up. See docs/agent-integration.md for the full recipe and a runner-profile example.`
 
 // ServerCapabilities represents the capabilities of the MCP server
 type ServerCapabilities struct {
@@ -143,6 +164,7 @@ func (h *ProtocolHandler) handleInitialize(_ context.Context, msg *transport.Mes
 			Name:    h.serverName,
 			Version: h.serverVersion,
 		},
+		Instructions: serverInstructions,
 	}
 
 	h.mu.Lock()

--- a/internal/mcp/server/protocol_test.go
+++ b/internal/mcp/server/protocol_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/danieljustus/symaira-vault/internal/config"
@@ -46,6 +47,14 @@ func TestProtocolHandler_Initialize(t *testing.T) {
 	}
 	if result.ServerInfo.Name != "Symaira Vault" {
 		t.Errorf("ServerInfo.Name = %q, want Symaira Vault", result.ServerInfo.Name)
+	}
+	// Instructions must teach agents the "consume without seeing" pattern up
+	// front instead of leaving them to dead-end on a redacted reference. Issue #667.
+	if !strings.Contains(result.Instructions, "run_command") {
+		t.Errorf("Instructions = %q, want it to mention run_command", result.Instructions)
+	}
+	if !strings.Contains(result.Instructions, "path.field") {
+		t.Errorf("Instructions = %q, want it to mention the path.field env-ref syntax", result.Instructions)
 	}
 }
 

--- a/internal/mcp/server/server_authorize.go
+++ b/internal/mcp/server/server_authorize.go
@@ -198,6 +198,22 @@ func (s *Server) canRunCommands() bool {
 	return s != nil && s.agent != nil && s.agent.CanRunCommands != nil && *s.agent.CanRunCommands
 }
 
+// runCommandDeniedError builds an actionable denial message for tools gated
+// by canRunCommands, naming the exact profile remedy instead of a bare
+// refusal — mirrors upgradeCmdForAgent's "<name>" placeholder for an unknown
+// or generic agent name.
+func runCommandDeniedError(agentName, tool string) error {
+	name := agentName
+	if name == "" || name == "default" {
+		name = "<name>"
+	}
+	return fmt.Errorf(
+		"command execution not permitted for this agent: set \"canRunCommands: true\" in its profile "+
+			"(symvault config set agents.%s.canRunCommands true), or add %q to allowed_tools if tier-based "+
+			"scoping applies. For interactive use without running commands, use copy_to_clipboard, autotype, "+
+			"or request_credential instead", name, tool)
+}
+
 func (s *Server) canManageConfig() bool {
 	return s != nil && s.agent != nil && s.agent.CanManageConfig != nil && *s.agent.CanManageConfig
 }

--- a/internal/mcp/server/tools_execute_api_request.go
+++ b/internal/mcp/server/tools_execute_api_request.go
@@ -38,7 +38,7 @@ func (s *Server) handleExecuteAPIRequest(ctx context.Context, req mcp.CallToolRe
 	if !s.canRunCommands() {
 		s.logAudit(ctx, "execute_api_request", "<run-denied>", false)
 		metrics.RecordAuthDenial("run_denied", s.agent.Name)
-		return nil, fmt.Errorf("command execution not permitted for this agent")
+		return nil, runCommandDeniedError(s.agent.Name, "execute_api_request")
 	}
 
 	templateName, err := req.RequireString("template")

--- a/internal/mcp/server/tools_execute_api_request_test.go
+++ b/internal/mcp/server/tools_execute_api_request_test.go
@@ -605,6 +605,10 @@ func TestHandleExecuteAPIRequest_RunDenied(t *testing.T) {
 	if !strings.Contains(err.Error(), "command execution not permitted") {
 		t.Fatalf("error = %v, want 'command execution not permitted'", err)
 	}
+	// The denial must name the concrete profile remedy, not just refuse. Issue #667.
+	if !strings.Contains(err.Error(), "canRunCommands: true") || !strings.Contains(err.Error(), "agents.readonly.canRunCommands") {
+		t.Fatalf("error = %v, want it to name the canRunCommands profile remedy", err)
+	}
 }
 
 func TestHandleExecuteAPIRequest_Sanitization(t *testing.T) {

--- a/internal/mcp/server/tools_execute_with_secret.go
+++ b/internal/mcp/server/tools_execute_with_secret.go
@@ -23,7 +23,7 @@ func (s *Server) handleExecuteWithSecret(ctx context.Context, req mcp.CallToolRe
 	if !s.canRunCommands() {
 		s.logAudit(ctx, "execute_with_secret", "<run-denied>", false)
 		metrics.RecordAuthDenial("run_denied", s.agent.Name)
-		return nil, fmt.Errorf("command execution not permitted for this agent")
+		return nil, runCommandDeniedError(s.agent.Name, "execute_with_secret")
 	}
 
 	cmdRaw, ok := req.Arguments["command"]

--- a/internal/mcp/server/tools_execute_with_secret_test.go
+++ b/internal/mcp/server/tools_execute_with_secret_test.go
@@ -274,6 +274,10 @@ func TestHandleExecuteWithSecret_RunDenied(t *testing.T) {
 	if !strings.Contains(err.Error(), "command execution not permitted") {
 		t.Fatalf("error = %v, want 'command execution not permitted'", err)
 	}
+	// The denial must name the concrete profile remedy, not just refuse. Issue #667.
+	if !strings.Contains(err.Error(), "canRunCommands: true") || !strings.Contains(err.Error(), "agents.readonly.canRunCommands") {
+		t.Fatalf("error = %v, want it to name the canRunCommands profile remedy", err)
+	}
 }
 
 func TestHandleExecuteWithSecret_ApprovalDeny(t *testing.T) {

--- a/internal/mcp/server/tools_get.go
+++ b/internal/mcp/server/tools_get.go
@@ -39,6 +39,7 @@ func buildSecretMetadataResponse(entry *vaultpkg.Entry, path string) map[string]
 			"name":   k,
 			"handle": (taint.SecretHandle{Path: path, Field: k}).String(),
 			"kind":   inferFieldKind(v),
+			"usage":  consumptionUsageHint(path, k),
 		})
 	}
 
@@ -224,12 +225,35 @@ func (s *Server) sealEntryResponse(_ context.Context, entry *vaultpkg.Entry, pat
 		"handle":         handle,
 		"classification": entry.Classification.String(),
 		"note":           "Use secret_unseal tool to reveal the value",
+		"usage":          consumptionUsageHint(path, fieldName),
 	}
 	result, err := json.Marshal(resp)
 	if err != nil {
 		return mcp.NewToolResultError("failed to marshal sealed response")
 	}
 	return mcp.NewToolResultText(string(result))
+}
+
+// consumptionUsageHint tells an agent how to consume a redacted/sealed field
+// without ever seeing its plaintext value. run_command's env map (and the
+// equivalent CLI/config secret-ref syntax) takes a "path.field" reference —
+// not the "op://path/field" handle used elsewhere — so the hint spells that
+// out explicitly rather than pointing the agent at the handle string, which
+// run_command's resolver does not accept.
+func consumptionUsageHint(path, field string) map[string]any {
+	ref := path
+	if field != "" {
+		ref = path + "." + field
+	}
+	return map[string]any{
+		"run_command": map[string]any{
+			"env": map[string]string{"<VAR_NAME>": ref},
+		},
+		"note": "The raw value is never returned to agents. Pass \"" + ref + "\" as a run_command " +
+			"env reference (SymVault resolves and injects it; the command sees the value, you don't), " +
+			"or use copy_to_clipboard/autotype for interactive use, or request_credential to ask the " +
+			"user directly. Consuming it this way does not require unsealing first.",
+	}
 }
 
 func (s *Server) handleGetMetadata(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/internal/mcp/server/tools_get_test.go
+++ b/internal/mcp/server/tools_get_test.go
@@ -118,6 +118,68 @@ func TestHandleGet_WithValue(t *testing.T) {
 	}
 }
 
+// TestHandleGet_FieldUsageHint verifies that each field in a get_entry
+// response carries a machine-readable "usage" hint so an agent that only
+// ever sees a reference (never the plaintext value) knows how to consume it
+// — e.g. via run_command's env map — instead of dead-ending. Issue #667.
+func TestHandleGet_FieldUsageHint(t *testing.T) {
+	vaultDir, identity := mockVault(t)
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:         "test",
+		AllowedPaths: []string{"*"},
+		CanWrite:     config.BoolPtr(false),
+		ApprovalMode: config.StrPtr("none"),
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+
+	req := mcp.CallToolRequest{Arguments: map[string]any{"path": "github"}}
+
+	result, err := srv.handleGet(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleGet() error = %v", err)
+	}
+
+	var response map[string]any
+	if err := json.Unmarshal([]byte(result.Text), &response); err != nil {
+		t.Fatalf("parse result: %v", err)
+	}
+
+	fields, _ := response["fields"].([]any)
+	var passwordField map[string]any
+	for _, f := range fields {
+		fm := f.(map[string]any)
+		if fm["name"] == "password" {
+			passwordField = fm
+		}
+	}
+	if passwordField == nil {
+		t.Fatal(`fields should contain field "password"`)
+	}
+
+	usage, ok := passwordField["usage"].(map[string]any)
+	if !ok {
+		t.Fatal(`field "password" should have a "usage" hint`)
+	}
+	runCommand, ok := usage["run_command"].(map[string]any)
+	if !ok {
+		t.Fatal(`usage should have a "run_command" example`)
+	}
+	env, ok := runCommand["env"].(map[string]any)
+	if !ok || len(env) == 0 {
+		t.Fatal(`usage.run_command should have a non-empty "env" example`)
+	}
+	// run_command's resolver takes "path.field", not the "op://path/field"
+	// handle — the hint must use the syntax that actually works.
+	for _, ref := range env {
+		if ref != "github.password" {
+			t.Errorf(`usage.run_command.env ref = %q, want "github.password"`, ref)
+		}
+	}
+	if note, _ := usage["note"].(string); note == "" {
+		t.Error(`usage should have a non-empty "note"`)
+	}
+}
+
 // TestHandleGet_WithoutMetadata tests without the include_value flag.
 // This is the default behavior — always returns metadata.
 
@@ -468,6 +530,59 @@ func TestHandleGetValue_SealsSecretClassification(t *testing.T) {
 	}
 	if note == "" {
 		t.Error("expected non-empty note")
+	}
+}
+
+// TestHandleGetValue_SealedResponseHasUsageHint verifies a sealed response
+// tells the agent it can consume the secret via run_command without ever
+// unsealing it — secret_unseal is only needed to see the plaintext directly.
+// Issue #667.
+func TestHandleGetValue_SealedResponseHasUsageHint(t *testing.T) {
+	vaultDir, identity := mockVault(t)
+	secretEntry := &vault.Entry{
+		Data:           map[string]any{"pin": "1234"},
+		Classification: taint.Secret,
+	}
+	if err := vault.WriteEntry(vaultDir, "sealed-entry", secretEntry, identity); err != nil {
+		t.Fatalf("write secret entry: %v", err)
+	}
+
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:         "test",
+		AllowedPaths: []string{"*"},
+		CanWrite:     config.BoolPtr(false),
+		ApprovalMode: config.StrPtr("none"),
+		AutoUnseal:   config.BoolPtr(false),
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+
+	req := mcp.CallToolRequest{Arguments: map[string]any{"path": "sealed-entry"}}
+	result, err := srv.handleGetValue(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleGetValue() error = %v", err)
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal([]byte(result.Text), &resp); err != nil {
+		t.Fatalf("parse result: %v", err)
+	}
+
+	usage, ok := resp["usage"].(map[string]any)
+	if !ok {
+		t.Fatal(`sealed response should have a "usage" hint`)
+	}
+	runCommand, ok := usage["run_command"].(map[string]any)
+	if !ok {
+		t.Fatal(`usage should have a "run_command" example`)
+	}
+	env, _ := runCommand["env"].(map[string]any)
+	for _, ref := range env {
+		if ref != "sealed-entry.pin" {
+			t.Errorf(`usage.run_command.env ref = %q, want "sealed-entry.pin"`, ref)
+		}
+	}
+	if len(env) == 0 {
+		t.Error("usage.run_command.env should not be empty")
 	}
 }
 

--- a/internal/mcp/server/tools_run.go
+++ b/internal/mcp/server/tools_run.go
@@ -17,7 +17,7 @@ func (s *Server) handleRunCommand(ctx context.Context, req mcp.CallToolRequest) 
 	if !s.canRunCommands() {
 		s.logAudit(ctx, "run_command", "<run-denied>", false)
 		metrics.RecordAuthDenial("run_denied", s.agent.Name)
-		return nil, fmt.Errorf("command execution not permitted for this agent")
+		return nil, runCommandDeniedError(s.agent.Name, "run_command")
 	}
 
 	cmdRaw, ok := req.Arguments["command"]

--- a/internal/mcp/server/tools_run_test.go
+++ b/internal/mcp/server/tools_run_test.go
@@ -256,6 +256,10 @@ func TestHandleRunCommand_RunDenied(t *testing.T) {
 	if !strings.Contains(err.Error(), "command execution not permitted") {
 		t.Fatalf("error = %v, want 'command execution not permitted'", err)
 	}
+	// The denial must name the concrete profile remedy, not just refuse. Issue #667.
+	if !strings.Contains(err.Error(), "canRunCommands: true") || !strings.Contains(err.Error(), "agents.readonly.canRunCommands") {
+		t.Fatalf("error = %v, want it to name the canRunCommands profile remedy", err)
+	}
 }
 
 func TestHandleRunCommand_Timeout(t *testing.T) {


### PR DESCRIPTION
Bundles fixes for multiple open issues. The list below grows as commits land; every linked issue will close automatically on merge.

<!-- closes-list-start -->
- Closes #667 feat: make secret consumption discoverable for agents that only see a reference
<!-- closes-list-end -->
