### PR TITLE
feat: ephemeral file injection for run_command (files map)

### DIFF
--- a/docs/mcp-api.md
+++ b/docs/mcp-api.md
@@ -1158,12 +1158,37 @@ Execute a command on the host with secrets injected as environment variables.
 }
 ```
 
+Some consumers need a **file path**, not an environment variable — e.g. a
+certificate a tool opens by path. `files` materializes each referenced secret
+into an ephemeral, `0600`, owner-only file for the lifetime of the command,
+exposed as `$SYMVAULT_FILE_<name>`; the file is shredded and removed once the
+command finishes, whether it succeeds, fails, or times out. A plain string
+value is treated as raw text (same convention as `env`); use the
+`{"ref": ..., "encoding": "base64"}` form to decode base64-encoded binary
+content (e.g. a PKCS#12 certificate) before it is written to disk:
+
+```json
+{
+  "tool": "run_command",
+  "arguments": {
+    "command": ["ericctl", "send", "--cert", "$SYMVAULT_FILE_CERT"],
+    "files": {
+      "CERT": {"ref": "elster/org-zertifikat.pfx", "encoding": "base64"}
+    },
+    "env": {
+      "ELSTER_PIN": "elster/org-zertifikat.pin"
+    }
+  }
+}
+```
+
 **Parameters**:
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | `command` | array | Yes | - | Command and arguments as strings |
 | `env` | object | No | `{}` | Map of env var names to secret refs (e.g. `{"API_KEY": "github.api_key"}`) |
+| `files` | object | No | `{}` | Map of names to secret refs (string) or `{"ref", "encoding"}` objects, materialized as ephemeral `$SYMVAULT_FILE_<name>` files |
 | `working_dir` | string | No | current dir | Working directory for the command |
 | `timeout` | number | No | 30 | Timeout in seconds |
 
@@ -1180,10 +1205,10 @@ Execute a command on the host with secrets injected as environment variables.
 
 **Notes**:
 - Requires `canRunCommands: true` in agent profile (separate from `canWrite`)
-- Each secret ref is scope-checked individually
-- Secret values are never exposed in the MCP response or audit logs
+- Each secret ref (`env` and `files`) is scope-checked individually
+- Secret values are never exposed in the MCP response or audit logs — audit logs record `files` refs, never their content
 - Output is capped at 100KB per stream to prevent context bloat
-- Timeout kills the process with exit code `-1`
+- Timeout kills the process with exit code `-1`, and any `files` are still removed
 
 **Errors**:
 - `run_denied`: Agent profile has `canRunCommands: false`

--- a/internal/mcp/server/tools_run.go
+++ b/internal/mcp/server/tools_run.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"sort"
@@ -83,6 +84,14 @@ func (s *Server) handleRunCommand(ctx context.Context, req mcp.CallToolRequest) 
 		return mcp.NewToolResultError(fmt.Sprintf("env contains denied keys: %s", strings.Join(denied, ", "))), nil
 	}
 
+	resolvedFiles, fileAudit, filesToolErr, filesErr := s.resolveRunCommandFiles(ctx, req.Arguments["files"])
+	if filesErr != nil {
+		return nil, filesErr
+	}
+	if filesToolErr != nil {
+		return filesToolErr, nil
+	}
+
 	if s.requiresApproval() {
 		s.logAudit(ctx, "approval_denied", "run_command", false)
 		metrics.RecordApproval(s.agent.Name, "denied")
@@ -95,10 +104,25 @@ func (s *Server) handleRunCommand(ctx context.Context, req mcp.CallToolRequest) 
 	if len(envNames) > 0 {
 		auditPath += ", env=[" + strings.Join(envNames, ", ") + "]"
 	}
+	if len(fileAudit) > 0 {
+		auditPath += ", files=[" + strings.Join(fileAudit, ", ") + "]"
+	}
+
+	// knownSecrets is the union of resolved env and file values, used only to
+	// redact known secret content out of command output/errors — RunOptions.Env
+	// and RunOptions.Files stay separate so files are never set as env vars.
+	knownSecrets := make(map[string]string, len(resolvedEnv)+len(resolvedFiles))
+	for k, v := range resolvedEnv {
+		knownSecrets[k] = v
+	}
+	for k, v := range resolvedFiles {
+		knownSecrets[k] = v
+	}
 
 	result, err := secrets.RunCommand(secrets.RunOptions{
 		Command:    command,
 		Env:        resolvedEnv,
+		Files:      resolvedFiles,
 		WorkingDir: workingDir,
 		Timeout:    time.Duration(timeoutSeconds) * time.Second,
 	})
@@ -106,17 +130,17 @@ func (s *Server) handleRunCommand(ctx context.Context, req mcp.CallToolRequest) 
 	if err != nil {
 		s.logAudit(ctx, "run_command", auditPath, false)
 		if result != nil {
-			sanitizedStdout, sanitizedStderr := s.sanitizeRunOutput(result.Stdout, result.Stderr, resolvedEnv)
-			sanitizedErr := s.sanitizeKnownSecretValues(err.Error(), resolvedEnv)
+			sanitizedStdout, sanitizedStderr := s.sanitizeRunOutput(result.Stdout, result.Stderr, knownSecrets)
+			sanitizedErr := s.sanitizeKnownSecretValues(err.Error(), knownSecrets)
 			return mcp.NewToolResultError(fmt.Sprintf("%s\nExit code: %d\nStdout: %s\nStderr: %s",
 				sanitizedErr, result.ExitCode, EmbedAsData("command_output", sanitizedStdout), EmbedAsData("command_output", sanitizedStderr))), nil
 		}
-		return mcp.NewToolResultError(s.sanitizeKnownSecretValues(err.Error(), resolvedEnv)), nil
+		return mcp.NewToolResultError(s.sanitizeKnownSecretValues(err.Error(), knownSecrets)), nil
 	}
 
 	s.logAudit(ctx, "run_command", auditPath, true)
 
-	sanitizedStdout, sanitizedStderr := s.sanitizeRunOutput(result.Stdout, result.Stderr, resolvedEnv)
+	sanitizedStdout, sanitizedStderr := s.sanitizeRunOutput(result.Stdout, result.Stderr, knownSecrets)
 
 	resultJSON, err := json.Marshal(map[string]any{
 		"exit_code":   result.ExitCode,
@@ -130,6 +154,67 @@ func (s *Server) handleRunCommand(ctx context.Context, req mcp.CallToolRequest) 
 	return mcp.NewToolResultText(string(resultJSON)), nil
 }
 
+// resolveRunCommandFiles parses and resolves handleRunCommand's "files"
+// argument into plaintext content ready for ephemeral materialization,
+// mirroring the "env" map's per-ref scope check and resolution. resolvedFiles
+// holds plaintext (post-decode) content keyed by the name the caller chose —
+// it is only ever handed to secrets.RunCommand for ephemeral 0600
+// materialization and to the output sanitizer, never returned to the agent or
+// logged. fileAudit records "name:ref" pairs (never content) for the caller's
+// audit log.
+//
+// The two error-shaped return values mirror handleRunCommand's own
+// convention: toolErr is a user-facing tool-result error (bad input,
+// unresolvable ref) the caller should return as-is; err is a hard access
+// denial the caller should propagate as a JSON-RPC error, matching how the
+// rest of handleRunCommand distinguishes the two.
+func (s *Server) resolveRunCommandFiles(ctx context.Context, filesRaw any) (resolvedFiles map[string]string, fileAudit []string, toolErr *mcp.CallToolResult, err error) {
+	resolvedFiles = make(map[string]string)
+	if filesRaw == nil {
+		return resolvedFiles, nil, nil, nil
+	}
+
+	filesMap, ok := filesRaw.(map[string]any)
+	if !ok {
+		s.logAudit(ctx, "run_command", "<invalid>", false)
+		return nil, nil, mcp.NewToolResultError("argument \"files\" must be an object"), nil
+	}
+
+	for name, specRaw := range filesMap {
+		ref, encoding, specErr := parseFileSpec(specRaw)
+		if specErr != nil {
+			return nil, nil, mcp.NewToolResultError(fmt.Sprintf("files.%s: %v", name, specErr)), nil
+		}
+
+		path := extractPathFromRef(ref)
+		if !s.checkScope(path) {
+			s.logAudit(ctx, "run_command", path, false)
+			metrics.RecordAuthDenial("scope_denied", s.agent.Name)
+			return nil, nil, nil, fmt.Errorf("access denied: secret ref path %q outside allowed scope", path)
+		}
+
+		value, resolveErr := secrets.ResolveSecretRef(s.vault, ref)
+		if resolveErr != nil {
+			return nil, nil, mcp.NewToolResultError(fmt.Sprintf("cannot resolve secret ref %q: %v", ref, resolveErr)), nil
+		}
+
+		content := value
+		if encoding == "base64" {
+			decoded, decErr := base64.StdEncoding.DecodeString(value)
+			if decErr != nil {
+				return nil, nil, mcp.NewToolResultError(fmt.Sprintf("files.%s: cannot base64-decode resolved value", name)), nil
+			}
+			content = string(decoded)
+		}
+
+		resolvedFiles[name] = content
+		fileAudit = append(fileAudit, name+":"+ref)
+	}
+	sort.Strings(fileAudit)
+
+	return resolvedFiles, fileAudit, nil, nil
+}
+
 // extractPathFromRef returns the entry path portion of a secret reference.
 // For "work/aws.password", returns "work/aws".
 // For "github", returns "github".
@@ -138,4 +223,34 @@ func extractPathFromRef(ref string) string {
 		return ref[:idx]
 	}
 	return ref
+}
+
+// parseFileSpec parses one "files" map entry for run_command. It accepts
+// either a bare secret reference string (materialized as raw text, same
+// convention as the "env" map) or an object {"ref": "...", "encoding":
+// "base64"} for binary content — e.g. a PKCS#12 certificate stored as base64
+// — that must be decoded before being written to the ephemeral file.
+func parseFileSpec(raw any) (ref, encoding string, err error) {
+	switch v := raw.(type) {
+	case string:
+		return v, "", nil
+	case map[string]any:
+		refRaw, ok := v["ref"].(string)
+		if !ok || refRaw == "" {
+			return "", "", fmt.Errorf("missing required \"ref\" string")
+		}
+		if encRaw, ok := v["encoding"]; ok && encRaw != nil {
+			encStr, ok := encRaw.(string)
+			if !ok {
+				return "", "", fmt.Errorf("\"encoding\" must be a string")
+			}
+			if encStr != "" && encStr != "base64" {
+				return "", "", fmt.Errorf("unsupported encoding %q (supported: base64)", encStr)
+			}
+			encoding = encStr
+		}
+		return refRaw, encoding, nil
+	default:
+		return "", "", fmt.Errorf("must be a string secret reference or {\"ref\":...,\"encoding\":...} object")
+	}
 }

--- a/internal/mcp/server/tools_run_test.go
+++ b/internal/mcp/server/tools_run_test.go
@@ -2,7 +2,9 @@ package server
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"runtime"
 	"strings"
 	"testing"
@@ -770,5 +772,296 @@ func TestHandleRunCommand_ExecutableAllowlist_EmptyAllowsAll(t *testing.T) {
 	}
 	if result.IsError {
 		t.Fatalf("handleRunCommand() returned error: %s", result.Text)
+	}
+}
+
+// --- files map (ephemeral file injection, issue #671) ---
+
+func TestHandleRunCommand_FileInjection(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows: relies on sh")
+	}
+	vaultDir, identity := mockVaultWithEntry(t, "elster/org-zertifikat", map[string]any{
+		"pin": "1234-secret-pin",
+	})
+
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:           "test",
+		AllowedPaths:   []string{"*"},
+		CanRunCommands: config.BoolPtr(true),
+		ApprovalMode:   config.StrPtr("none"),
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+
+	req := mcp.CallToolRequest{
+		Arguments: map[string]any{
+			"command": []any{"sh", "-c", `cat "$SYMVAULT_FILE_PIN"`},
+			"files": map[string]any{
+				"PIN": "elster/org-zertifikat.pin",
+			},
+		},
+	}
+
+	result, err := srv.handleRunCommand(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleRunCommand() error = %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handleRunCommand() returned error: %s", result.Text)
+	}
+
+	var output map[string]any
+	if err := json.Unmarshal([]byte(result.Text), &output); err != nil {
+		t.Fatalf("parse result: %v", err)
+	}
+	stdout, _ := output["stdout"].(string)
+	if strings.Contains(stdout, "1234-secret-pin") {
+		t.Errorf("stdout = %q, should not contain plaintext secret", stdout)
+	}
+	if !strings.Contains(stdout, "***") {
+		t.Errorf("stdout = %q, want masked file content ('***') echoed back through the command output", stdout)
+	}
+}
+
+func TestHandleRunCommand_FileInjection_Base64Encoding(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows: relies on sh")
+	}
+	binaryContent := []byte{0x50, 0x4b, 0x03, 0x04, 0x00, 0xff, 0x10} // fake PKCS#12-ish bytes
+	vaultDir, identity := mockVaultWithEntry(t, "elster/org-zertifikat", map[string]any{
+		"pfx": base64.StdEncoding.EncodeToString(binaryContent),
+	})
+
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:           "test",
+		AllowedPaths:   []string{"*"},
+		CanRunCommands: config.BoolPtr(true),
+		ApprovalMode:   config.StrPtr("none"),
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+
+	req := mcp.CallToolRequest{
+		Arguments: map[string]any{
+			"command": []any{"sh", "-c", `wc -c < "$SYMVAULT_FILE_CERT"`},
+			"files": map[string]any{
+				"CERT": map[string]any{
+					"ref":      "elster/org-zertifikat.pfx",
+					"encoding": "base64",
+				},
+			},
+		},
+	}
+
+	result, err := srv.handleRunCommand(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleRunCommand() error = %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handleRunCommand() returned error: %s", result.Text)
+	}
+
+	var output map[string]any
+	if err := json.Unmarshal([]byte(result.Text), &output); err != nil {
+		t.Fatalf("parse result: %v", err)
+	}
+	stdout, _ := output["stdout"].(string)
+	if !strings.Contains(stdout, fmt.Sprintf("%d", len(binaryContent))) {
+		t.Errorf("stdout = %q, want decoded byte count %d (proves base64 was decoded before materialization, not written as base64 text)", stdout, len(binaryContent))
+	}
+}
+
+func TestHandleRunCommand_FileInjection_BadBase64(t *testing.T) {
+	vaultDir, identity := mockVaultWithEntry(t, "elster/org-zertifikat", map[string]any{
+		"pfx": "not-valid-base64!!!",
+	})
+
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:           "test",
+		AllowedPaths:   []string{"*"},
+		CanRunCommands: config.BoolPtr(true),
+		ApprovalMode:   config.StrPtr("none"),
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+
+	req := mcp.CallToolRequest{
+		Arguments: map[string]any{
+			"command": []any{"echo", "test"},
+			"files": map[string]any{
+				"CERT": map[string]any{
+					"ref":      "elster/org-zertifikat.pfx",
+					"encoding": "base64",
+				},
+			},
+		},
+	}
+
+	result, err := srv.handleRunCommand(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleRunCommand() error = %v", err)
+	}
+	if !result.IsError {
+		t.Fatal("handleRunCommand() expected error result for invalid base64 content")
+	}
+	if !strings.Contains(result.Text, "cannot base64-decode") {
+		t.Fatalf("result text = %q, want 'cannot base64-decode'", result.Text)
+	}
+}
+
+func TestHandleRunCommand_FileInjection_UnsupportedEncoding(t *testing.T) {
+	vaultDir, identity := mockVaultWithEntry(t, "elster/org-zertifikat", map[string]any{
+		"pfx": "value",
+	})
+
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:           "test",
+		AllowedPaths:   []string{"*"},
+		CanRunCommands: config.BoolPtr(true),
+		ApprovalMode:   config.StrPtr("none"),
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+
+	req := mcp.CallToolRequest{
+		Arguments: map[string]any{
+			"command": []any{"echo", "test"},
+			"files": map[string]any{
+				"CERT": map[string]any{
+					"ref":      "elster/org-zertifikat.pfx",
+					"encoding": "rot13",
+				},
+			},
+		},
+	}
+
+	result, err := srv.handleRunCommand(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleRunCommand() error = %v", err)
+	}
+	if !result.IsError {
+		t.Fatal("handleRunCommand() expected error result for unsupported encoding")
+	}
+	if !strings.Contains(result.Text, "unsupported encoding") {
+		t.Fatalf("result text = %q, want 'unsupported encoding'", result.Text)
+	}
+}
+
+func TestHandleRunCommand_FileInjection_ScopeCheck(t *testing.T) {
+	vaultDir, identity := mockVaultWithEntry(t, "work/cert", map[string]any{
+		"pfx": "secret-bytes",
+	})
+
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:           "test",
+		AllowedPaths:   []string{"personal/"},
+		CanRunCommands: config.BoolPtr(true),
+		ApprovalMode:   config.StrPtr("none"),
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+
+	req := mcp.CallToolRequest{
+		Arguments: map[string]any{
+			"command": []any{"echo", "test"},
+			"files": map[string]any{
+				"CERT": "work/cert.pfx",
+			},
+		},
+	}
+
+	_, err := srv.handleRunCommand(context.Background(), req)
+	if err == nil {
+		t.Fatal("handleRunCommand() expected error for out-of-scope file ref, got nil")
+	}
+	if !strings.Contains(err.Error(), "outside allowed scope") {
+		t.Fatalf("error = %v, want 'outside allowed scope'", err)
+	}
+}
+
+func TestHandleRunCommand_FileInjection_MissingRef(t *testing.T) {
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:           "test",
+		AllowedPaths:   []string{"*"},
+		CanRunCommands: config.BoolPtr(true),
+		ApprovalMode:   config.StrPtr("none"),
+	}, "stdio", t.TempDir())
+
+	req := mcp.CallToolRequest{
+		Arguments: map[string]any{
+			"command": []any{"echo", "test"},
+			"files": map[string]any{
+				"CERT": "nonexistent/entry.pfx",
+			},
+		},
+	}
+
+	result, err := srv.handleRunCommand(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleRunCommand() error = %v", err)
+	}
+	if !result.IsError {
+		t.Fatal("handleRunCommand() expected error result for missing file ref")
+	}
+	if !strings.Contains(result.Text, "cannot resolve secret ref") {
+		t.Fatalf("result text = %q, want 'cannot resolve secret ref'", result.Text)
+	}
+}
+
+func TestHandleRunCommand_FileInjection_ExecutableDenied(t *testing.T) {
+	// A denied executable must block the whole call before any file ref is
+	// ever resolved or materialized — files share the same allowlist gate
+	// as env refs, checked earlier in handleRunCommand.
+	vaultDir, identity := mockVaultWithEntry(t, "elster/org-zertifikat", map[string]any{
+		"pfx": "secret-bytes",
+	})
+
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:               "test",
+		AllowedPaths:       []string{"*"},
+		CanRunCommands:     config.BoolPtr(true),
+		ApprovalMode:       config.StrPtr("none"),
+		AllowedExecutables: []string{"echo"},
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+
+	req := mcp.CallToolRequest{
+		Arguments: map[string]any{
+			"command": []any{"sh", "-c", `cat "$SYMVAULT_FILE_CERT"`},
+			"files": map[string]any{
+				"CERT": "elster/org-zertifikat.pfx",
+			},
+		},
+	}
+
+	_, err := srv.handleRunCommand(context.Background(), req)
+	if err == nil {
+		t.Fatal("handleRunCommand() expected error for disallowed executable, got nil")
+	}
+	if !strings.Contains(err.Error(), "not in agent allowlist") {
+		t.Fatalf("error = %v, want 'not in agent allowlist'", err)
+	}
+}
+
+func TestHandleRunCommand_FileInjection_FilesNotObject(t *testing.T) {
+	srv := newTestServer(t, config.AgentProfile{
+		Name:           "test",
+		AllowedPaths:   []string{"*"},
+		CanRunCommands: config.BoolPtr(true),
+		ApprovalMode:   config.StrPtr("none"),
+	}, "stdio")
+
+	req := mcp.CallToolRequest{
+		Arguments: map[string]any{
+			"command": []any{"echo", "test"},
+			"files":   "not-an-object",
+		},
+	}
+
+	result, err := srv.handleRunCommand(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleRunCommand() error = %v", err)
+	}
+	if !result.IsError {
+		t.Fatal("handleRunCommand() expected error result for files not an object")
+	}
+	if !strings.Contains(result.Text, "must be an object") {
+		t.Fatalf("result text = %q, want 'must be an object'", result.Text)
 	}
 }

--- a/internal/secrets/runner.go
+++ b/internal/secrets/runner.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"sort"
 	"time"
 )
 
@@ -32,6 +34,14 @@ type RunOptions struct {
 	WorkingDir string
 	// Timeout is the maximum duration. Zero means no timeout.
 	Timeout time.Duration
+	// Files maps a name to plaintext content that must be materialized into an
+	// ephemeral 0600 file for the lifetime of the child process, exposed to it
+	// as $SYMVAULT_FILE_<name>. Content is never logged. Every file (and its
+	// private directory) is best-effort shredded and removed once the command
+	// finishes, regardless of how it finishes — success, non-zero exit, or a
+	// timeout kill. Keys must be safe identifiers ([A-Za-z0-9_]+): they become
+	// both an env var suffix and a filename.
+	Files map[string]string
 }
 
 // boundedBuffer captures up to max bytes of written data while still reporting
@@ -74,6 +84,12 @@ func RunCommand(opts RunOptions) (*RunResult, error) {
 		return nil, fmt.Errorf("command must have at least one element")
 	}
 
+	fileEnv, cleanupFiles, err := materializeFiles(opts.Files)
+	if err != nil {
+		return nil, err
+	}
+	defer cleanupFiles()
+
 	ctx := context.Background()
 	var cancel context.CancelFunc
 	if opts.Timeout > 0 {
@@ -100,6 +116,9 @@ func RunCommand(opts RunOptions) (*RunResult, error) {
 	}
 	cmd.Env = FilterEnv(whitelist)
 	for k, v := range opts.Env {
+		cmd.Env = append(cmd.Env, k+"="+v)
+	}
+	for k, v := range fileEnv {
 		cmd.Env = append(cmd.Env, k+"="+v)
 	}
 
@@ -136,4 +155,92 @@ func RunCommand(opts RunOptions) (*RunResult, error) {
 	}
 
 	return result, nil
+}
+
+// isSafeFileName reports whether name is safe to use both as an environment
+// variable suffix and as a filename component — no path separators, no "..",
+// no empty string.
+func isSafeFileName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for _, r := range name {
+		switch {
+		case r >= 'A' && r <= 'Z', r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '_':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// materializeFiles writes each named secret to a private, 0600 ephemeral file
+// and returns the SYMVAULT_FILE_<name> environment assignments plus a cleanup
+// function that best-effort shreds and removes every file it created (and the
+// private directory holding them). The returned cleanup is always safe to
+// call, even after a partial failure — callers should defer it immediately
+// after a nil error so cleanup runs no matter how the caller's command
+// finishes (success, non-zero exit, or a timeout kill).
+func materializeFiles(files map[string]string) (map[string]string, func(), error) {
+	noop := func() {}
+	if len(files) == 0 {
+		return nil, noop, nil
+	}
+
+	names := make([]string, 0, len(files))
+	for name := range files {
+		if !isSafeFileName(name) {
+			return nil, noop, fmt.Errorf("invalid file name %q: must match [A-Za-z0-9_]+", name)
+		}
+		names = append(names, name)
+	}
+	sort.Strings(names) // deterministic materialization order
+
+	dir, err := os.MkdirTemp("", "symvault-file-*")
+	if err != nil {
+		return nil, noop, fmt.Errorf("create ephemeral file directory: %w", err)
+	}
+	// #nosec G302 -- 0700 is correct for a private directory; 0600 would remove the execute bit needed to enter it
+	if err := os.Chmod(dir, 0o700); err != nil {
+		_ = os.RemoveAll(dir)
+		return nil, noop, fmt.Errorf("secure ephemeral file directory: %w", err)
+	}
+
+	var written []string
+	cleanup := func() {
+		for _, p := range written {
+			shredFile(p)
+		}
+		_ = os.RemoveAll(dir)
+	}
+
+	env := make(map[string]string, len(files))
+	for _, name := range names {
+		path := filepath.Join(dir, name)
+		// #nosec G304 -- path is built from filepath.Join(dir, name) where dir is our own MkdirTemp result and name was already validated by isSafeFileName
+		if err := os.WriteFile(path, []byte(files[name]), 0o600); err != nil {
+			cleanup()
+			return nil, noop, fmt.Errorf("materialize file %q: %w", name, err)
+		}
+		written = append(written, path)
+		env["SYMVAULT_FILE_"+name] = path
+	}
+
+	return env, cleanup, nil
+}
+
+// shredFile best-effort overwrites a file's content with zeros before
+// removing it, so the plaintext does not linger in free disk blocks after
+// cleanup. Errors are intentionally swallowed — cleanup must never fail the
+// caller, and a failed overwrite still leaves the subsequent remove to try.
+func shredFile(path string) {
+	if info, statErr := os.Stat(path); statErr == nil && info.Size() > 0 {
+		// #nosec G304 -- path is one of the paths this package just wrote in materializeFiles, reopened only to overwrite it with zeros before removal
+		if f, openErr := os.OpenFile(path, os.O_WRONLY, 0o600); openErr == nil {
+			_, _ = f.Write(make([]byte, info.Size()))
+			_ = f.Sync()
+			_ = f.Close()
+		}
+	}
+	_ = os.Remove(path)
 }

--- a/internal/secrets/runner_test.go
+++ b/internal/secrets/runner_test.go
@@ -318,3 +318,165 @@ func TestRunCommand_NonExitError(t *testing.T) {
 		t.Errorf("expected 'failed to run command' in error, got: %q", err.Error())
 	}
 }
+
+// --- Files (ephemeral file injection, issue #671) ---
+
+func TestRunCommand_FileInjection(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows: relies on sh")
+	}
+	result, err := RunCommand(RunOptions{
+		Command: []string{"sh", "-c", `cat "$SYMVAULT_FILE_CERT"`},
+		Files:   map[string]string{"CERT": "certificate-bytes"},
+	})
+	if err != nil {
+		t.Fatalf("RunCommand() unexpected error: %v", err)
+	}
+	if !strings.Contains(result.Stdout, "certificate-bytes") {
+		t.Fatalf("Stdout = %q, want file content 'certificate-bytes'", result.Stdout)
+	}
+}
+
+func TestRunCommand_FileInjection_RemovedAfterSuccess(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows: relies on sh")
+	}
+	result, err := RunCommand(RunOptions{
+		Command: []string{"sh", "-c", `echo "$SYMVAULT_FILE_CERT"`},
+		Files:   map[string]string{"CERT": "x"},
+	})
+	if err != nil {
+		t.Fatalf("RunCommand() unexpected error: %v", err)
+	}
+	path := strings.TrimSpace(result.Stdout)
+	if path == "" {
+		t.Fatal("SYMVAULT_FILE_CERT was empty")
+	}
+	if !filepath.IsAbs(path) {
+		t.Fatalf("SYMVAULT_FILE_CERT = %q, want absolute path", path)
+	}
+	if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+		t.Fatalf("expected ephemeral file %q removed after RunCommand returns, stat err = %v", path, statErr)
+	}
+}
+
+func TestRunCommand_FileInjection_RemovedAfterNonZeroExit(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows: relies on sh")
+	}
+	result, err := RunCommand(RunOptions{
+		Command: []string{"sh", "-c", `echo "$SYMVAULT_FILE_CERT"; exit 7`},
+		Files:   map[string]string{"CERT": "x"},
+	})
+	if err != nil {
+		t.Fatalf("RunCommand() unexpected error: %v", err)
+	}
+	if result.ExitCode != 7 {
+		t.Fatalf("ExitCode = %d, want 7", result.ExitCode)
+	}
+	path := strings.TrimSpace(result.Stdout)
+	if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+		t.Fatalf("expected ephemeral file removed after non-zero exit, stat err = %v", statErr)
+	}
+}
+
+func TestRunCommand_FileInjection_RemovedAfterTimeout(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows: relies on sh")
+	}
+	result, err := RunCommand(RunOptions{
+		// exec replaces the shell with sleep in-place (no forked grandchild),
+		// so the context-timeout kill lands on the actual sleeping process and
+		// its stdout/stderr pipes close immediately instead of staying open
+		// until a forked "sh -c '...; sleep 10'" grandchild exits on its own.
+		Command: []string{"sh", "-c", `echo "$SYMVAULT_FILE_CERT"; exec sleep 10`},
+		Files:   map[string]string{"CERT": "x"},
+		Timeout: 200 * time.Millisecond,
+	})
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+	if !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("error message does not mention timeout: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result on timeout")
+	}
+	path := strings.TrimSpace(result.Stdout)
+	if path == "" {
+		t.Fatal("expected the child to have printed the file path before being killed")
+	}
+	if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+		t.Fatalf("expected ephemeral file removed after timeout kill, stat err = %v", statErr)
+	}
+}
+
+func TestMaterializeFiles_Empty(t *testing.T) {
+	env, cleanup, err := materializeFiles(nil)
+	if err != nil {
+		t.Fatalf("materializeFiles(nil) error = %v", err)
+	}
+	if len(env) != 0 {
+		t.Fatalf("env = %v, want empty", env)
+	}
+	cleanup() // must not panic on a no-op cleanup
+}
+
+func TestMaterializeFiles_InvalidName(t *testing.T) {
+	for _, name := range []string{"", "../etc/passwd", "a/b", "a b", "a.b", "a$b"} {
+		if _, _, err := materializeFiles(map[string]string{name: "x"}); err == nil {
+			t.Errorf("materializeFiles(%q) expected error, got nil", name)
+		}
+	}
+}
+
+func TestMaterializeFiles_WritesAndCleansUp(t *testing.T) {
+	env, cleanup, err := materializeFiles(map[string]string{"CERT": "hello"})
+	if err != nil {
+		t.Fatalf("materializeFiles() error = %v", err)
+	}
+	path := env["SYMVAULT_FILE_CERT"]
+	if path == "" {
+		t.Fatal("env[SYMVAULT_FILE_CERT] is empty")
+	}
+
+	data, readErr := os.ReadFile(path)
+	if readErr != nil {
+		t.Fatalf("ReadFile(%q): %v", path, readErr)
+	}
+	if string(data) != "hello" {
+		t.Fatalf("content = %q, want %q", data, "hello")
+	}
+
+	if runtime.GOOS != "windows" {
+		info, statErr := os.Stat(path)
+		if statErr != nil {
+			t.Fatalf("Stat(%q): %v", path, statErr)
+		}
+		if info.Mode().Perm() != 0o600 {
+			t.Errorf("mode = %v, want 0600", info.Mode().Perm())
+		}
+	}
+
+	cleanup()
+	if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+		t.Fatalf("expected file removed after cleanup, stat err = %v", statErr)
+	}
+}
+
+func TestMaterializeFiles_BinaryContentPreserved(t *testing.T) {
+	content := string([]byte{0x00, 0xFF, 0x10, 0x89, 0x50, 0x4E, 0x47})
+	env, cleanup, err := materializeFiles(map[string]string{"BIN": content})
+	if err != nil {
+		t.Fatalf("materializeFiles() error = %v", err)
+	}
+	defer cleanup()
+
+	data, readErr := os.ReadFile(env["SYMVAULT_FILE_BIN"])
+	if readErr != nil {
+		t.Fatalf("ReadFile: %v", readErr)
+	}
+	if string(data) != content {
+		t.Fatalf("content mismatch: got %d bytes, want %d bytes", len(data), len(content))
+	}
+}


### PR DESCRIPTION
Adds a files map to run_command, analogous to the existing env map,
so secrets that must be consumed as a seekable file path (e.g. a
PKCS#12 certificate for tax-software APIs) no longer have to live
permanently unencrypted on disk or be decoded by a caller-managed
wrapper script.

- secrets.RunOptions gains a Files field. RunCommand materializes each
  entry into a private 0700 tempdir as a 0600 file, exposes the path as
  $SYMVAULT_FILE_<name>, and shreds-then-removes every file via a defer
  that runs regardless of how the command finishes: success, non-zero
  exit, or a context-timeout kill.
- run_command's files map accepts a bare secret ref (raw text) or an
  {"ref":..., "encoding":"base64"} object for binary content, decoded
  before materialization. Each ref is scope-checked individually, same
  as env; the executable allowlist and approval gate already cover the
  whole call. Audit logs record "name:ref" pairs, never content;
  command output/error sanitization now also redacts known file
  content, not just env values.
- docs/mcp-api.md documents the files parameter alongside env.

Scope note: execute_with_secret does not get files support here (its
env/secret_refs shape is more involved) - can reuse this same
secrets.RunOptions.Files plumbing as a fast follow. The CLI ergonomics
(symvault file add/get/use) and the full ELSTER walkthrough are
tracked separately in #672, which depends on this issue.

Closes #671

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
