### PR TITLE
feat: symvault file add/get/use CLI commands for certificate/key attachments

### DIFF
--- a/cmd/file/add.go
+++ b/cmd/file/add.go
@@ -1,0 +1,133 @@
+package file
+
+import (
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	cli "github.com/danieljustus/symaira-vault/internal/cli"
+	errorspkg "github.com/danieljustus/symaira-vault/internal/errors"
+	"github.com/danieljustus/symaira-vault/internal/secrets"
+	"github.com/danieljustus/symaira-vault/internal/ui/cliout"
+	vaultpkg "github.com/danieljustus/symaira-vault/internal/vault"
+)
+
+// DefaultMaxAttachmentSize caps a stored attachment's original (pre-base64)
+// size, keeping vault entries and git history sane by default.
+const DefaultMaxAttachmentSize int64 = 1 << 20 // 1 MiB
+
+var (
+	AddField   string
+	AddFrom    string
+	AddType    = string(vaultpkg.SecretTypeCertificate)
+	AddMaxSize = DefaultMaxAttachmentSize
+	AddShred   bool
+)
+
+var addCmd = &cobra.Command{
+	Use:   "add <path>",
+	Short: "Attach a certificate/key file to a vault entry",
+	Long: `Reads a file from disk, base64-encodes it, and stores it in the named
+vault entry's field, recording sha256, original filename and size as
+attachment metadata. Creates the entry if it does not exist, or merges the
+field into an existing entry.`,
+	Example: `  symvault file add elster/cert --field cert_p12 --from ~/Downloads/elster.pfx --shred`,
+	Args:    cobra.ExactArgs(1),
+	RunE:    runFileAdd,
+}
+
+func runFileAdd(cmd *cobra.Command, args []string) error {
+	path := args[0]
+	if AddField == "" {
+		return errorspkg.NewCLIError(errorspkg.ExitInvalidInput, "--field is required", nil)
+	}
+	if AddFrom == "" {
+		return errorspkg.NewCLIError(errorspkg.ExitInvalidInput, "--from is required", nil)
+	}
+
+	info, statErr := os.Stat(AddFrom)
+	if statErr != nil {
+		return errorspkg.ReadFailed(statErr, "cannot stat source file")
+	}
+	if info.Size() > AddMaxSize {
+		return errorspkg.NewCLIError(errorspkg.ExitInvalidInput,
+			fmt.Sprintf("source file is %d bytes, exceeds the %d byte limit (override with --max-size)", info.Size(), AddMaxSize), nil)
+	}
+
+	content, readErr := os.ReadFile(AddFrom) // #nosec G304 -- user-provided CLI argument, size already bounded above
+	if readErr != nil {
+		return errorspkg.ReadFailed(readErr, "cannot read source file")
+	}
+
+	sha := vaultpkg.HashAttachmentSHA256(content)
+	encoded := base64.StdEncoding.EncodeToString(content)
+
+	return cli.WithVaultRaw(func(v *vaultpkg.Vault, vs *cli.VaultService) error {
+		// Attachment content (base64) routinely exceeds the generic
+		// vs.SetFields/UpsertEntry field-length cap (4096 chars, meant for
+		// pasted secrets, not files) — read-or-create and vs.WriteEntry
+		// directly instead, so --max-size is the only size gate that applies.
+		entry, err := vs.GetEntry(path)
+		if err != nil {
+			var cliErr *errorspkg.CLIError
+			if errors.As(err, &cliErr) && cliErr.Code == errorspkg.ExitNotFound {
+				entry = &vaultpkg.Entry{Data: map[string]any{}}
+			} else {
+				return errorspkg.ReadFailed(err, "cannot read entry")
+			}
+		}
+		if entry.Data == nil {
+			entry.Data = map[string]any{}
+		}
+		entry.Data[AddField] = encoded
+
+		if entry.SecretMetadata.Attachments == nil {
+			entry.SecretMetadata.Attachments = map[string]vaultpkg.AttachmentInfo{}
+		}
+		entry.SecretMetadata.Attachments[AddField] = vaultpkg.AttachmentInfo{
+			Filename: filepath.Base(AddFrom),
+			Size:     int64(len(content)),
+			SHA256:   sha,
+		}
+		if entry.SecretMetadata.Type == "" {
+			entry.SecretMetadata.Type = vaultpkg.SecretTypeFromString(AddType)
+		}
+
+		now := time.Now().UTC()
+		if entry.Metadata.Created.IsZero() {
+			entry.Metadata.Created = now
+		}
+		entry.Metadata.Updated = now
+		entry.Metadata.Version++
+
+		if err := vs.WriteEntry(path, entry); err != nil {
+			return errorspkg.WriteFailed(err, "cannot write attachment")
+		}
+
+		if commitErr := v.AutoCommitEntry(fmt.Sprintf("Attach %s to %s", filepath.Base(AddFrom), path), path); commitErr != nil {
+			cliout.Warnf("Warning: auto-commit failed: %v", commitErr)
+		}
+
+		cli.PrintQuietAware("Attached %s to %s#%s (%d bytes, sha256:%s)\n", filepath.Base(AddFrom), path, AddField, len(content), sha)
+
+		if AddShred {
+			secrets.ShredFile(AddFrom)
+			cli.PrintQuietAware("Shredded source file: %s\n", AddFrom)
+		}
+		return nil
+	})
+}
+
+func init() {
+	addCmd.Flags().StringVar(&AddField, "field", "", "Data field name to store the attachment under (required)")
+	addCmd.Flags().StringVar(&AddFrom, "from", "", "Path to the source file to attach (required)")
+	addCmd.Flags().StringVar(&AddType, "type", string(vaultpkg.SecretTypeCertificate), "Secret type to set on the entry if not already set")
+	addCmd.Flags().Int64Var(&AddMaxSize, "max-size", DefaultMaxAttachmentSize, "Maximum source file size in bytes")
+	addCmd.Flags().BoolVar(&AddShred, "shred", false, "Best-effort overwrite and remove the source file after a successful attach")
+	fileCmd.AddCommand(addCmd)
+}

--- a/cmd/file/field.go
+++ b/cmd/file/field.go
@@ -1,0 +1,51 @@
+package file
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	errorspkg "github.com/danieljustus/symaira-vault/internal/errors"
+	vaultpkg "github.com/danieljustus/symaira-vault/internal/vault"
+)
+
+// splitPathField splits "path#field" into its two parts. field is empty
+// when arg has no "#" separator.
+func splitPathField(arg string) (path, field string) {
+	if idx := strings.LastIndex(arg, "#"); idx > 0 {
+		return arg[:idx], arg[idx+1:]
+	}
+	return arg, ""
+}
+
+// resolveAttachmentField picks the attachment field to act on: explicitField
+// when given (attachment metadata is looked up but its absence is not an
+// error, since --field may point at a field added outside `file add`),
+// or the entry's only recorded attachment when there is exactly one,
+// otherwise an error listing the available fields.
+func resolveAttachmentField(entry *vaultpkg.Entry, explicitField string) (field string, info *vaultpkg.AttachmentInfo, err error) {
+	if explicitField != "" {
+		if got, ok := entry.SecretMetadata.Attachments[explicitField]; ok {
+			return explicitField, &got, nil
+		}
+		return explicitField, nil, nil
+	}
+
+	switch len(entry.SecretMetadata.Attachments) {
+	case 0:
+		return "", nil, errorspkg.NewCLIError(errorspkg.ExitInvalidInput, "entry has no recorded attachment fields; specify --field", nil)
+	case 1:
+		for name, got := range entry.SecretMetadata.Attachments {
+			gotCopy := got
+			return name, &gotCopy, nil
+		}
+	}
+
+	names := make([]string, 0, len(entry.SecretMetadata.Attachments))
+	for name := range entry.SecretMetadata.Attachments {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return "", nil, errorspkg.NewCLIError(errorspkg.ExitInvalidInput,
+		fmt.Sprintf("entry has multiple attachment fields (%s); specify --field", strings.Join(names, ", ")), nil)
+}

--- a/cmd/file/file.go
+++ b/cmd/file/file.go
@@ -1,0 +1,24 @@
+// Package file provides CLI commands for storing, exporting, and consuming
+// binary file attachments (e.g. a PKCS#12 certificate) through vault entries.
+package file
+
+import (
+	"github.com/spf13/cobra"
+
+	cli "github.com/danieljustus/symaira-vault/internal/cli"
+)
+
+var fileCmd = &cobra.Command{
+	Use:   "file",
+	Short: "Store, export, and consume file attachments in the vault",
+	Long: `Store, export, and consume binary file attachments (e.g. a PKCS#12
+certificate) through vault entries. Content is base64-encoded at rest, with
+sha256, original filename and size recorded as attachment metadata.`,
+	Example: `  symvault file add elster/cert --field cert_p12 --from ~/elster.pfx --shred
+  symvault file get elster/cert#cert_p12 --out ~/elster.pfx
+  symvault file use elster/cert -- java -jar elstertool.jar --cert $SYMVAULT_FILE_CERT_P12`,
+}
+
+func init() {
+	cli.RootCmd.AddCommand(fileCmd)
+}

--- a/cmd/file/get.go
+++ b/cmd/file/get.go
@@ -1,0 +1,85 @@
+package file
+
+import (
+	"encoding/base64"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	cli "github.com/danieljustus/symaira-vault/internal/cli"
+	errorspkg "github.com/danieljustus/symaira-vault/internal/errors"
+	"github.com/danieljustus/symaira-vault/internal/ui/cliout"
+	vaultpkg "github.com/danieljustus/symaira-vault/internal/vault"
+)
+
+var (
+	GetField string
+	GetOut   string
+)
+
+var getCmd = &cobra.Command{
+	Use:   "get <path>[#field]",
+	Short: "Export a stored file attachment to disk",
+	Long: `Decodes a vault entry's attachment field back to its original binary
+content and writes it to the given output path. Use path#field, or --field,
+to select the field when an entry has more than one attachment.`,
+	Example: `  symvault file get elster/cert#cert_p12 --out ~/elster.pfx`,
+	Args:    cobra.ExactArgs(1),
+	RunE:    runFileGet,
+}
+
+func runFileGet(cmd *cobra.Command, args []string) error {
+	path, field := splitPathField(args[0])
+	if field == "" {
+		field = GetField
+	}
+	if GetOut == "" {
+		return errorspkg.NewCLIError(errorspkg.ExitInvalidInput, "--out is required", nil)
+	}
+
+	return cli.WithVaultRaw(func(v *vaultpkg.Vault, vs *cli.VaultService) error {
+		entry, err := vs.GetEntry(path)
+		if err != nil {
+			return errorspkg.ReadFailed(err, "cannot read entry")
+		}
+
+		resolvedField, attachment, resolveErr := resolveAttachmentField(entry, field)
+		if resolveErr != nil {
+			return resolveErr
+		}
+
+		raw, ok := entry.Data[resolvedField]
+		if !ok {
+			return errorspkg.NewCLIError(errorspkg.ExitNotFound, fmt.Sprintf("field %q not found in entry %q", resolvedField, path), nil)
+		}
+		encoded, ok := raw.(string)
+		if !ok {
+			return errorspkg.NewCLIError(errorspkg.ExitGeneralError, fmt.Sprintf("field %q is not string-encoded content", resolvedField), nil)
+		}
+
+		content, decErr := base64.StdEncoding.DecodeString(encoded)
+		if decErr != nil {
+			return errorspkg.Wrap(errorspkg.ExitGeneralError, errorspkg.ErrKindNone, decErr, "decode attachment content")
+		}
+
+		if attachment != nil {
+			if got := vaultpkg.HashAttachmentSHA256(content); got != attachment.SHA256 {
+				cliout.Warnf("Warning: sha256 mismatch for %s#%s (expected %s, got %s)", path, resolvedField, attachment.SHA256, got)
+			}
+		}
+
+		if err := os.WriteFile(GetOut, content, 0o600); err != nil {
+			return errorspkg.WriteFailed(err, "cannot write output file")
+		}
+
+		cli.PrintQuietAware("Exported %s#%s to %s (%d bytes)\n", path, resolvedField, GetOut, len(content))
+		return nil
+	})
+}
+
+func init() {
+	getCmd.Flags().StringVar(&GetField, "field", "", "Data field to export (auto-detected when the entry has exactly one attachment)")
+	getCmd.Flags().StringVar(&GetOut, "out", "", "Output file path (required)")
+	fileCmd.AddCommand(getCmd)
+}

--- a/cmd/file/use.go
+++ b/cmd/file/use.go
@@ -1,0 +1,100 @@
+package file
+
+import (
+	"encoding/base64"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	cli "github.com/danieljustus/symaira-vault/internal/cli"
+	errorspkg "github.com/danieljustus/symaira-vault/internal/errors"
+	"github.com/danieljustus/symaira-vault/internal/secrets"
+	vaultpkg "github.com/danieljustus/symaira-vault/internal/vault"
+)
+
+var (
+	UseField   string
+	UseAs      string
+	UseTimeout time.Duration
+)
+
+var useCmd = &cobra.Command{
+	Use:   "use <path>[#field] -- <command> [args...]",
+	Short: "Run a command with a stored file attachment materialized to an ephemeral path",
+	Long: `Decodes a vault entry's attachment field back to its original binary
+content, writes it to a private ephemeral file for the lifetime of the given
+command, exposes it as $SYMVAULT_FILE_<NAME>, and shreds it afterward — the
+CLI twin of the MCP run_command "files" map.`,
+	Example: `  symvault file use elster/cert -- java -jar elstertool.jar --cert $SYMVAULT_FILE_CERT_P12`,
+	Args:    cobra.MinimumNArgs(2),
+	RunE:    runFileUse,
+}
+
+func runFileUse(cmd *cobra.Command, args []string) error {
+	path, field := splitPathField(args[0])
+	if field == "" {
+		field = UseField
+	}
+	command := args[1:]
+
+	return cli.WithVaultRaw(func(v *vaultpkg.Vault, vs *cli.VaultService) error {
+		entry, err := vs.GetEntry(path)
+		if err != nil {
+			return errorspkg.ReadFailed(err, "cannot read entry")
+		}
+
+		resolvedField, _, resolveErr := resolveAttachmentField(entry, field)
+		if resolveErr != nil {
+			return resolveErr
+		}
+
+		raw, ok := entry.Data[resolvedField]
+		if !ok {
+			return errorspkg.NewCLIError(errorspkg.ExitNotFound, fmt.Sprintf("field %q not found in entry %q", resolvedField, path), nil)
+		}
+		encoded, ok := raw.(string)
+		if !ok {
+			return errorspkg.NewCLIError(errorspkg.ExitGeneralError, fmt.Sprintf("field %q is not string-encoded content", resolvedField), nil)
+		}
+
+		content, decErr := base64.StdEncoding.DecodeString(encoded)
+		if decErr != nil {
+			return errorspkg.Wrap(errorspkg.ExitGeneralError, errorspkg.ErrKindNone, decErr, "decode attachment content")
+		}
+
+		name := UseAs
+		if name == "" {
+			name = strings.ToUpper(resolvedField)
+		}
+
+		result, runErr := secrets.RunCommand(secrets.RunOptions{
+			Command: command,
+			Files:   map[string]string{name: string(content)},
+			Timeout: UseTimeout,
+		})
+		if runErr != nil {
+			return runErr
+		}
+
+		if result.Stdout != "" {
+			_, _ = fmt.Print(result.Stdout)
+		}
+		if result.Stderr != "" {
+			_, _ = fmt.Fprint(os.Stderr, result.Stderr)
+		}
+		if result.ExitCode != 0 {
+			return errorspkg.NewCLIError(errorspkg.ExitGeneralError, fmt.Sprintf("command exited with code %d", result.ExitCode), nil)
+		}
+		return nil
+	})
+}
+
+func init() {
+	useCmd.Flags().StringVar(&UseField, "field", "", "Data field to materialize (auto-detected when the entry has exactly one attachment)")
+	useCmd.Flags().StringVar(&UseAs, "as", "", "Name exposed as $SYMVAULT_FILE_<NAME> (defaults to the uppercased field name)")
+	useCmd.Flags().DurationVarP(&UseTimeout, "timeout", "t", 0, "Timeout for the command (e.g., 30s)")
+	fileCmd.AddCommand(useCmd)
+}

--- a/cmd/file_test.go
+++ b/cmd/file_test.go
@@ -1,0 +1,185 @@
+package cmd
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeTestAttachment(t *testing.T, content []byte) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "cert.pfx")
+	if err := os.WriteFile(path, content, 0o600); err != nil {
+		t.Fatalf("write test attachment: %v", err)
+	}
+	return path
+}
+
+func TestCmdFile_AddGetRoundTrip(t *testing.T) {
+	vaultDir, passphrase := initVault(t)
+	setPassEnv(t, string(passphrase))
+	defer setupVaultFlag(t, vaultDir)()
+
+	content := []byte("fake-pkcs12-certificate-bytes-1234567890")
+	src := writeTestAttachment(t, content)
+
+	out := execWithStdout("--vault", vaultDir, "file", "add", "elster/cert", "--field", "cert_p12", "--from", src)
+	if !strings.Contains(out, "Attached") {
+		t.Fatalf("expected 'Attached' in output, got: %q", out)
+	}
+	sum := sha256.Sum256(content)
+	wantSHA := hex.EncodeToString(sum[:])
+	if !strings.Contains(out, wantSHA) {
+		t.Errorf("expected sha256 %s in add output, got: %q", wantSHA, out)
+	}
+
+	outPath := filepath.Join(t.TempDir(), "roundtrip.pfx")
+	getOut := execWithStdout("--vault", vaultDir, "file", "get", "elster/cert#cert_p12", "--out", outPath)
+	if !strings.Contains(getOut, "Exported") {
+		t.Fatalf("expected 'Exported' in output, got: %q", getOut)
+	}
+
+	got, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("read exported file: %v", err)
+	}
+	if string(got) != string(content) {
+		t.Errorf("round-trip content mismatch: got %q, want %q", got, content)
+	}
+}
+
+func TestCmdFile_GetAutoDetectsSoleAttachment(t *testing.T) {
+	vaultDir, passphrase := initVault(t)
+	setPassEnv(t, string(passphrase))
+	defer setupVaultFlag(t, vaultDir)()
+
+	content := []byte("sole-attachment-content")
+	src := writeTestAttachment(t, content)
+
+	execWithStdout("--vault", vaultDir, "file", "add", "svc/cert", "--field", "cert_p12", "--from", src)
+
+	outPath := filepath.Join(t.TempDir(), "out.pfx")
+	// No "#field" and no --field: must auto-detect the entry's only attachment.
+	getOut := execWithStdout("--vault", vaultDir, "file", "get", "svc/cert", "--out", outPath)
+	if !strings.Contains(getOut, "Exported") {
+		t.Fatalf("expected 'Exported' in output, got: %q", getOut)
+	}
+	got, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("read exported file: %v", err)
+	}
+	if string(got) != string(content) {
+		t.Errorf("content mismatch: got %q, want %q", got, content)
+	}
+}
+
+func TestCmdFile_AddSizeLimitRejected(t *testing.T) {
+	vaultDir, passphrase := initVault(t)
+	setPassEnv(t, string(passphrase))
+	defer setupVaultFlag(t, vaultDir)()
+
+	src := writeTestAttachment(t, make([]byte, 200))
+
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "file", "add", "toobig/cert",
+		"--field", "cert_p12", "--from", src, "--max-size", "100"})
+	defer rootCmd.SetArgs(nil)
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected size-limit error, got nil")
+	}
+	if !strings.Contains(err.Error(), "exceeds the 100 byte limit") {
+		t.Errorf("expected size-limit message, got: %q", err.Error())
+	}
+
+	// Nothing should have been written to the vault.
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "file", "get", "toobig/cert", "--out", filepath.Join(t.TempDir(), "x")})
+	getErr := rootCmd.Execute()
+	rootCmd.SetArgs(nil)
+	if getErr == nil {
+		t.Error("expected entry to not exist after rejected add, but get succeeded")
+	}
+}
+
+func TestCmdFile_AddMissingRequiredFlags(t *testing.T) {
+	vaultDir, passphrase := initVault(t)
+	setPassEnv(t, string(passphrase))
+	defer setupVaultFlag(t, vaultDir)()
+
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "file", "add", "svc/cert", "--from", "/nonexistent"})
+	defer rootCmd.SetArgs(nil)
+	if err := rootCmd.Execute(); err == nil || !strings.Contains(err.Error(), "--field is required") {
+		t.Errorf("expected '--field is required' error, got: %v", err)
+	}
+}
+
+func TestCmdFile_UseInvokesCommandWithMaterializedPath(t *testing.T) {
+	if os.Getenv("SYMVAULT_SKIP_SUBPROCESS_TESTS") != "" {
+		t.Skip("subprocess execution disabled in this environment")
+	}
+	vaultDir, passphrase := initVault(t)
+	setPassEnv(t, string(passphrase))
+	defer setupVaultFlag(t, vaultDir)()
+
+	content := []byte("materialize-me-please")
+	src := writeTestAttachment(t, content)
+	execWithStdout("--vault", vaultDir, "file", "add", "elster/cert", "--field", "cert_p12", "--from", src)
+
+	out := execWithStdout("--vault", vaultDir, "file", "use", "elster/cert", "--",
+		"sh", "-c", "cat \"$SYMVAULT_FILE_CERT_P12\"")
+	if !strings.Contains(out, string(content)) {
+		t.Errorf("expected materialized file content %q in stdout, got: %q", content, out)
+	}
+}
+
+func TestCmdFile_UseCustomAsName(t *testing.T) {
+	if os.Getenv("SYMVAULT_SKIP_SUBPROCESS_TESTS") != "" {
+		t.Skip("subprocess execution disabled in this environment")
+	}
+	vaultDir, passphrase := initVault(t)
+	setPassEnv(t, string(passphrase))
+	defer setupVaultFlag(t, vaultDir)()
+
+	content := []byte("custom-name-content")
+	src := writeTestAttachment(t, content)
+	execWithStdout("--vault", vaultDir, "file", "add", "elster/cert", "--field", "cert_p12", "--from", src)
+
+	out := execWithStdout("--vault", vaultDir, "file", "use", "elster/cert", "--as", "MYCERT", "--",
+		"sh", "-c", "cat \"$SYMVAULT_FILE_MYCERT\"")
+	if !strings.Contains(out, string(content)) {
+		t.Errorf("expected materialized file content %q in stdout, got: %q", content, out)
+	}
+}
+
+func TestCmdFile_UseMissingCommandArg(t *testing.T) {
+	vaultDir, passphrase := initVault(t)
+	setPassEnv(t, string(passphrase))
+	defer setupVaultFlag(t, vaultDir)()
+
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "file", "use", "elster/cert"})
+	defer rootCmd.SetArgs(nil)
+	if err := rootCmd.Execute(); err == nil {
+		t.Error("expected error when no command is given after path, got nil")
+	}
+}
+
+func TestCmdFile_GetAmbiguousAttachmentsRequiresField(t *testing.T) {
+	vaultDir, passphrase := initVault(t)
+	setPassEnv(t, string(passphrase))
+	defer setupVaultFlag(t, vaultDir)()
+
+	src1 := writeTestAttachment(t, []byte("first"))
+	src2 := writeTestAttachment(t, []byte("second"))
+	execWithStdout("--vault", vaultDir, "file", "add", "multi/certs", "--field", "cert_a", "--from", src1)
+	execWithStdout("--vault", vaultDir, "file", "add", "multi/certs", "--field", "cert_b", "--from", src2)
+
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "file", "get", "multi/certs", "--out", filepath.Join(t.TempDir(), "x")})
+	defer rootCmd.SetArgs(nil)
+	err := rootCmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "multiple attachment fields") {
+		t.Errorf("expected 'multiple attachment fields' error, got: %v", err)
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,6 +10,7 @@ import (
 	_ "github.com/danieljustus/symaira-vault/cmd/admin"
 	_ "github.com/danieljustus/symaira-vault/cmd/auth"
 	_ "github.com/danieljustus/symaira-vault/cmd/crud"
+	_ "github.com/danieljustus/symaira-vault/cmd/file"
 	_ "github.com/danieljustus/symaira-vault/cmd/mcp"
 	cli "github.com/danieljustus/symaira-vault/internal/cli"
 )

--- a/docs/agent-integration.md
+++ b/docs/agent-integration.md
@@ -164,6 +164,77 @@ See [`docs/hermes-safe-adoption.md`](hermes-safe-adoption.md) § "Separate
 runner profile after masking review" for the full runner-profile rules
 (narrow `allowedPaths`, tight `allowed_tools`, session/rate caps).
 
+## File Attachments: An ELSTER `.pfx` Walkthrough
+
+Some integrations need a secret to arrive on disk as a real file, not an
+environment variable — for example, ELSTER (the German tax authority's
+e-filing API) authenticates with a PKCS#12 certificate (`.pfx`) plus a PIN.
+Symaira Vault stores the certificate as a base64-encoded attachment field and
+materializes it back to an ephemeral, private file only for the lifetime of
+the command that needs it — the plaintext certificate never lives
+permanently unencrypted on disk.
+
+### 1. Store the certificate and PIN
+
+```bash
+# Store the PKCS#12 certificate as an attachment field, with sha256,
+# filename and size recorded as metadata. --shred best-effort wipes the
+# source file afterward once it is safely in the vault.
+symvault file add elster/cert --field cert_p12 --from ~/Downloads/elster.pfx --shred
+
+# Store the PIN as a regular field on the same entry
+symvault set elster/cert.pin --stdin-value
+```
+
+### 2. Consume it from an MCP agent
+
+An agent with `canRunCommands: true` invokes `run_command` with both `env`
+(for the PIN) and `files` (for the certificate) in one call:
+
+```json
+{
+  "tool": "run_command",
+  "arguments": {
+    "command": ["java", "-jar", "elstertool.jar", "--cert", "$SYMVAULT_FILE_CERT", "--pin-env", "ELSTER_PIN"],
+    "env": {"ELSTER_PIN": "elster/cert.pin"},
+    "files": {"CERT": {"ref": "elster/cert.cert_p12", "encoding": "base64"}}
+  }
+}
+```
+
+SymVault decodes `cert_p12` (base64) into a private 0600 file exposed to the
+child process as `$SYMVAULT_FILE_CERT`, and injects `ELSTER_PIN` into its
+environment — the agent never sees either value. Both are shredded and
+removed once the command exits, regardless of success, non-zero exit, or a
+timeout kill. See [`docs/mcp-api.md`](mcp-api.md) for the full `files`
+parameter reference.
+
+### 3. Consume it from the CLI directly
+
+For a human or script running outside an MCP agent, `symvault file use` is
+the CLI twin of the same mechanism — no manual `base64 -d` or temp-file
+bookkeeping required:
+
+```bash
+ELSTER_PIN=$(symvault get elster/cert.pin --print) \
+  symvault file use elster/cert -- java -jar elstertool.jar --cert "$SYMVAULT_FILE_CERT_P12"
+```
+
+`file use` auto-detects the field when the entry has exactly one recorded
+attachment (add `--field cert_p12` explicitly if it has more than one), and
+the materialized path is exposed as `$SYMVAULT_FILE_<NAME>` where `<NAME>`
+defaults to the uppercased field name (override with `--as`). To export the
+certificate to a real path instead of materializing it just-in-time (e.g. to
+hand it to a tool that cannot read an ephemeral path from an env var), use:
+
+```bash
+symvault file get elster/cert#cert_p12 --out ~/elster.pfx
+```
+
+`file get` re-checks the exported bytes against the sha256 recorded at
+`file add` time and warns on a mismatch, so silent corruption between add and
+export does not go unnoticed.
+
 ## OpenClaw and Other Local Agents
 
 For agents that support stdio MCP, use:

--- a/internal/secrets/runner.go
+++ b/internal/secrets/runner.go
@@ -209,7 +209,7 @@ func materializeFiles(files map[string]string) (map[string]string, func(), error
 	var written []string
 	cleanup := func() {
 		for _, p := range written {
-			shredFile(p)
+			ShredFile(p)
 		}
 		_ = os.RemoveAll(dir)
 	}
@@ -229,11 +229,11 @@ func materializeFiles(files map[string]string) (map[string]string, func(), error
 	return env, cleanup, nil
 }
 
-// shredFile best-effort overwrites a file's content with zeros before
+// ShredFile best-effort overwrites a file's content with zeros before
 // removing it, so the plaintext does not linger in free disk blocks after
 // cleanup. Errors are intentionally swallowed — cleanup must never fail the
 // caller, and a failed overwrite still leaves the subsequent remove to try.
-func shredFile(path string) {
+func ShredFile(path string) {
 	if info, statErr := os.Stat(path); statErr == nil && info.Size() > 0 {
 		// #nosec G304 -- path is one of the paths this package just wrote in materializeFiles, reopened only to overwrite it with zeros before removal
 		if f, openErr := os.OpenFile(path, os.O_WRONLY, 0o600); openErr == nil {

--- a/internal/vault/entry.go
+++ b/internal/vault/entry.go
@@ -1,6 +1,8 @@
 package vault
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -39,10 +41,21 @@ type EntryMetadata struct {
 
 // SecretMetadata contains semantic metadata about a secret for AI agent usage.
 type SecretMetadata struct {
-	Type       SecretType `json:"type,omitempty"`
-	UsageHint  string     `json:"usage_hint,omitempty"`
-	AutoRotate bool       `json:"auto_rotate,omitempty"`
-	ExpiresAt  *time.Time `json:"expires_at,omitempty"`
+	Type        SecretType                `json:"type,omitempty"`
+	UsageHint   string                    `json:"usage_hint,omitempty"`
+	AutoRotate  bool                      `json:"auto_rotate,omitempty"`
+	ExpiresAt   *time.Time                `json:"expires_at,omitempty"`
+	Attachments map[string]AttachmentInfo `json:"attachments,omitempty"`
+}
+
+// AttachmentInfo records provenance for a Data field holding base64-encoded
+// binary file content added via `symvault file add`, so `file get`/`file use`
+// can detect silent corruption and report the original filename/size without
+// having to guess whether a field is text or a file attachment.
+type AttachmentInfo struct {
+	Filename string `json:"filename,omitempty"`
+	Size     int64  `json:"size"`
+	SHA256   string `json:"sha256"`
 }
 
 // MarshalJSON implements custom JSON marshaling for Entry
@@ -208,4 +221,12 @@ func (e *Entry) HasField(name string) bool {
 	}
 	_, ok := e.Data[name]
 	return ok
+}
+
+// HashAttachmentSHA256 returns the lowercase hex-encoded SHA-256 digest of
+// file content, recorded in AttachmentInfo at add time and re-checked at
+// get/use time to detect silent corruption of the stored base64 content.
+func HashAttachmentSHA256(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
 }


### PR DESCRIPTION
Adds CLI ergonomics for storing and consuming certificate/key file
attachments (e.g. an ELSTER .pfx), building on the run_command files map
injection mechanism from #671/#673.

- New `cmd/file` package: `symvault file add <path> --field --from` reads
  a file, base64-encodes it, and records sha256/filename/size as
  attachment metadata (internal/vault: new AttachmentInfo type on
  SecretMetadata). Content is written via vs.WriteEntry directly rather
  than vs.SetFields/UpsertEntry, since the generic 4096-char field-length
  cap (meant for pasted secrets) does not fit file attachments; the new
  --max-size flag (default 1 MiB) is the size gate instead.
- `symvault file get <path>#field --out <file>` decodes and exports an
  attachment, re-checking sha256 against the recorded metadata.
- `symvault file use <path> -- <cmd> [args...]` is the CLI twin of the
  MCP run_command files map: it decodes the attachment and calls the
  same secrets.RunCommand/materializeFiles ephemeral-file mechanism,
  exposing it as $SYMVAULT_FILE_<NAME>. internal/secrets: exported
  shredFile -> ShredFile so `file add --shred` can reuse the same
  best-effort wipe instead of duplicating it.
- docs/agent-integration.md: full ELSTER .pfx walkthrough covering
  storage, MCP consumption (run_command env + files), and the CLI-only
  `file use`/`file get` paths.
- Regression tests: add+get round-trip (byte-identical, sha256
  verified), auto-detection of a sole attachment field, size-limit
  rejection, `file use` invoking a command with the materialized path
  (default and custom --as name), and multi-attachment ambiguity
  requiring an explicit --field.

Closes #672

Co-authored-by: Claude Sonnet 5 <noreply@anthropic.com>
