### PR TITLE
fix(cli): make environment passphrase unlocking explicit opt-in

### DIFF
--- a/internal/cli/passphrase_env.go
+++ b/internal/cli/passphrase_env.go
@@ -11,6 +11,13 @@ var (
 	cachedEnvPassphraseOnce sync.Once
 )
 
+// zeroizeBytes overwrites a byte slice with zeros.
+func zeroizeBytes(b []byte) {
+	for i := range b {
+		b[i] = 0
+	}
+}
+
 // SniffAndClearEnvPassphrase reads SYMVAULT_PASSPHRASE (and the legacy
 // OPENPASS_PASSPHRASE) from the environment, stores the value in a process-
 // local buffer, and immediately unsets both variables so child processes
@@ -21,6 +28,9 @@ func SniffAndClearEnvPassphrase() {
 	cachedEnvPassphraseOnce.Do(func() {
 		p := envutil.Getenv("SYMVAULT_PASSPHRASE", "OPENPASS_PASSPHRASE")
 		if p != "" {
+			if cachedEnvPassphrase != nil {
+				zeroizeBytes(cachedEnvPassphrase)
+			}
 			cachedEnvPassphrase = []byte(p)
 		}
 		envutil.Unsetenv("SYMVAULT_PASSPHRASE", "OPENPASS_PASSPHRASE")
@@ -28,11 +38,20 @@ func SniffAndClearEnvPassphrase() {
 }
 
 // ConsumeCachedEnvPassphrase returns the early-cached env passphrase
-// and clears the process-local cache so the bytes are not retained.
+// and clears the process-local reference. Ownership is transferred to
+// the caller, which must zeroize the returned slice after use.
 func ConsumeCachedEnvPassphrase() []byte {
 	p := cachedEnvPassphrase
 	cachedEnvPassphrase = nil
 	return p
+}
+
+// ClearCachedEnvPassphrase zeroizes and clears the cached environment passphrase.
+func ClearCachedEnvPassphrase() {
+	if cachedEnvPassphrase != nil {
+		zeroizeBytes(cachedEnvPassphrase)
+		cachedEnvPassphrase = nil
+	}
 }
 
 // HasCachedEnvPassphrase reports whether an environment passphrase was
@@ -42,8 +61,10 @@ func HasCachedEnvPassphrase() bool {
 }
 
 // SetCachedEnvPassphrase sets the cached passphrase for testing purposes.
-// This is used by tests that need to simulate an environment passphrase
-// without going through SniffAndClearEnvPassphrase.
+// It zeroizes any previously cached bytes before replacement.
 func SetCachedEnvPassphrase(p []byte) {
+	if cachedEnvPassphrase != nil {
+		zeroizeBytes(cachedEnvPassphrase)
+	}
 	cachedEnvPassphrase = p
 }

--- a/internal/cli/passphrase_env_test.go
+++ b/internal/cli/passphrase_env_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"sync"
 	"testing"
+
+	configpkg "github.com/danieljustus/symaira-vault/internal/config"
 )
 
 func TestHasCachedEnvPassphrase_Empty(t *testing.T) {
@@ -207,3 +209,81 @@ func TestSetCachedEnvPassphrase_EmptyBytes(t *testing.T) {
 		t.Error("HasCachedEnvPassphrase() = true after SetCachedEnvPassphrase([]), want false")
 	}
 }
+
+func TestClearCachedEnvPassphrase_Zeroizes(t *testing.T) {
+	buf := []byte("secret-to-zeroize")
+	cachedEnvPassphrase = buf
+	t.Cleanup(func() { cachedEnvPassphrase = nil })
+
+	ClearCachedEnvPassphrase()
+
+	if HasCachedEnvPassphrase() {
+		t.Error("HasCachedEnvPassphrase() = true after ClearCachedEnvPassphrase, want false")
+	}
+	for i, b := range buf {
+		if b != 0 {
+			t.Errorf("buf[%d] = %d after ClearCachedEnvPassphrase, want 0", i, b)
+		}
+	}
+}
+
+func TestSetCachedEnvPassphrase_ZeroizesOldBytes(t *testing.T) {
+	oldBuf := []byte("old-secret")
+	cachedEnvPassphrase = oldBuf
+	t.Cleanup(func() { cachedEnvPassphrase = nil })
+
+	SetCachedEnvPassphrase([]byte("new-secret"))
+
+	for i, b := range oldBuf {
+		if b != 0 {
+			t.Errorf("oldBuf[%d] = %d after replacement, want 0", i, b)
+		}
+	}
+}
+
+func TestIsEnvPassphraseAllowed_DefaultDeny(t *testing.T) {
+	t.Setenv("SYMVAULT_ALLOW_ENV_PASSPHRASE", "")
+	t.Setenv("OPENPASS_ALLOW_ENV_PASSPHRASE", "")
+
+	if IsEnvPassphraseAllowed(nil) {
+		t.Error("IsEnvPassphraseAllowed(nil) = true by default, want false (default-deny)")
+	}
+}
+
+func TestIsEnvPassphraseAllowed_ConfigOptIn(t *testing.T) {
+	t.Setenv("SYMVAULT_ALLOW_ENV_PASSPHRASE", "")
+	t.Setenv("OPENPASS_ALLOW_ENV_PASSPHRASE", "")
+
+	cfg := &configpkg.Config{
+		Security: &configpkg.SecurityConfig{
+			AllowEnvPassphrase: true,
+		},
+	}
+	if !IsEnvPassphraseAllowed(cfg) {
+		t.Error("IsEnvPassphraseAllowed(cfg) = false with AllowEnvPassphrase: true, want true")
+	}
+}
+
+func TestIsEnvPassphraseAllowed_EnvOptIn(t *testing.T) {
+	t.Setenv("SYMVAULT_ALLOW_ENV_PASSPHRASE", "1")
+	t.Setenv("OPENPASS_ALLOW_ENV_PASSPHRASE", "")
+
+	if !IsEnvPassphraseAllowed(nil) {
+		t.Error("IsEnvPassphraseAllowed(nil) = false with SYMVAULT_ALLOW_ENV_PASSPHRASE=1, want true")
+	}
+}
+
+func TestIsEnvPassphraseAllowed_DisableOverridesAllow(t *testing.T) {
+	t.Setenv("SYMVAULT_ALLOW_ENV_PASSPHRASE", "1")
+
+	cfg := &configpkg.Config{
+		Security: &configpkg.SecurityConfig{
+			AllowEnvPassphrase:   true,
+			DisableEnvPassphrase: true,
+		},
+	}
+	if IsEnvPassphraseAllowed(cfg) {
+		t.Error("IsEnvPassphraseAllowed(cfg) = true when DisableEnvPassphrase: true, want false")
+	}
+}
+

--- a/internal/cli/terminal.go
+++ b/internal/cli/terminal.go
@@ -33,7 +33,7 @@ func WarnEnvPassphrase() {
 		return
 	}
 	EnvPassphraseWarningEmitted = true
-	cliout.Warnf("SYMVAULT_PASSPHRASE or OPENPASS_PASSPHRASE is set — the passphrase is visible in /proc/PID/environ and may be exposed in process listings and crash dumps.")
+	cliout.Warnf("SYMVAULT_PASSPHRASE or OPENPASS_PASSPHRASE is active — environment passphrases are visible in process listings and crash dumps.")
 }
 
 func WarnPipeRead(label string) {
@@ -44,7 +44,7 @@ func WarnPipeRead(label string) {
 		return
 	}
 	PipeWarningEmitted = true
-	cliout.Warnf("Reading %s from a non-TTY source — the producing process may expose it in 'ps' or audit logs. Prefer SYMVAULT_PASSPHRASE, OPENPASS_PASSPHRASE, or 'symvault auth set touchid'.", label)
+	cliout.Warnf("Reading %s from a non-TTY source — the producing process may expose it in 'ps' or audit logs. Prefer 'symvault unlock' or 'symvault auth set touchid'.", label)
 }
 
 func ReadHiddenInput(prompt string, reader *bufio.Reader) ([]byte, error) {

--- a/internal/cli/unlock.go
+++ b/internal/cli/unlock.go
@@ -112,6 +112,20 @@ func resolveConfig(vaultDir string, interactive bool) (*configpkg.Config, error)
 	}
 }
 
+// IsEnvPassphraseAllowed checks if environment passphrase unlocking is allowed.
+// Environment passphrase usage is default-deny and requires explicit opt-in
+// via security.allow_env_passphrase: true in config.yaml or SYMVAULT_ALLOW_ENV_PASSPHRASE=1.
+func IsEnvPassphraseAllowed(cfg *configpkg.Config) bool {
+	if cfg != nil && cfg.Security != nil && cfg.Security.DisableEnvPassphrase {
+		return false
+	}
+	if cfg != nil && cfg.Security != nil && cfg.Security.AllowEnvPassphrase {
+		return true
+	}
+	v := envutil.Getenv("SYMVAULT_ALLOW_ENV_PASSPHRASE", "OPENPASS_ALLOW_ENV_PASSPHRASE")
+	return v == "1" || v == "true" || v == "yes"
+}
+
 func resolveUnlockPassphrase(vaultDir string, interactive bool, cfg *configpkg.Config) ([]byte, bool, bool, error) {
 	passphrase, err := SessionLoadPassphrase(vaultDir)
 	passphraseFromEnv := false
@@ -125,9 +139,9 @@ func resolveUnlockPassphrase(vaultDir string, interactive bool, cfg *configpkg.C
 				passphraseFromBiometric = true
 			}
 		} else if cfg.EffectiveAuthMethod() == configpkg.AuthMethodTouchID && !interactive {
-			cliout.Warnf("Touch ID skipped in non-interactive mode; use 'symvault unlock' or set SYMVAULT_PASSPHRASE")
+			cliout.Warnf("Touch ID skipped in non-interactive mode; use 'symvault unlock' or enable security.allow_env_passphrase / SYMVAULT_ALLOW_ENV_PASSPHRASE")
 		}
-		if len(passphrase) == 0 && (cfg == nil || cfg.Security == nil || !cfg.Security.DisableEnvPassphrase) {
+		if len(passphrase) == 0 && IsEnvPassphraseAllowed(cfg) {
 			// Check the early-cached env passphrase first (sniffed in main()
 			// before any child process could inherit it).
 			if cached := ConsumeCachedEnvPassphrase(); len(cached) > 0 {
@@ -197,9 +211,9 @@ func WithVaultForScripting(fn func(*vaultpkg.Vault, *VaultService) error) error 
 func lockedMessageForCache() string {
 	status := SessionGetCacheStatus()
 	if !status.Persistent {
-		return "vault locked: this build cannot share 'symvault unlock' sessions across processes; set SYMVAULT_PASSPHRASE or OPENPASS_PASSPHRASE, or use a build with OS keyring support"
+		return "vault locked: this build cannot share 'symvault unlock' sessions across processes; use 'symvault unlock', enable Touch ID, or for headless/CI set security.allow_env_passphrase: true / SYMVAULT_ALLOW_ENV_PASSPHRASE=1"
 	}
-	return "vault locked: run 'symvault unlock' first, enable Touch ID with 'symvault auth set touchid', or set SYMVAULT_PASSPHRASE or OPENPASS_PASSPHRASE"
+	return "vault locked: run 'symvault unlock' first or enable Touch ID with 'symvault auth set touchid' (for headless/CI see security.allow_env_passphrase)"
 }
 
 func DefaultSessionTTL() time.Duration {

--- a/internal/cli/unlock_test.go
+++ b/internal/cli/unlock_test.go
@@ -153,6 +153,7 @@ func TestUnlockVaultWithTTLDoesNotSaveTouchIDItemForUncachedEnvPassphrase(t *tes
 	}
 	// Prime the early-cached env passphrase (normally sniffed in main()
 	// before any child process can inherit it).
+	t.Setenv("SYMVAULT_ALLOW_ENV_PASSPHRASE", "1")
 	cachedEnvPassphrase = append([]byte(nil), passphrase...)
 
 	v, _, err := UnlockVaultWithTTL(vaultDir, false, 0, false)

--- a/internal/config/config_merge.go
+++ b/internal/config/config_merge.go
@@ -473,6 +473,9 @@ func mergeSecurityConfig(raw *SecurityConfig, sf map[string]bool) *SecurityConfi
 	if sf["disable_env_passphrase"] {
 		defaults.DisableEnvPassphrase = raw.DisableEnvPassphrase
 	}
+	if sf["allow_env_passphrase"] {
+		defaults.AllowEnvPassphrase = raw.AllowEnvPassphrase
+	}
 	return &defaults
 }
 

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -104,12 +104,14 @@ type LoggingConfig struct {
 // SecurityConfig holds security-related configuration.
 type SecurityConfig struct {
 	DisableEnvPassphrase bool `yaml:"disable_env_passphrase,omitempty"`
+	AllowEnvPassphrase   bool `yaml:"allow_env_passphrase,omitempty"`
 }
 
 // defaultSecurityConfig returns the default security configuration.
 func defaultSecurityConfig() SecurityConfig {
 	return SecurityConfig{
 		DisableEnvPassphrase: false,
+		AllowEnvPassphrase:   false,
 	}
 }
 

--- a/internal/health/doctor_session.go
+++ b/internal/health/doctor_session.go
@@ -257,10 +257,14 @@ func checkEnvPassphrase(vaultDir string, _ Options) Result {
 		r.Status = StatusWarn
 		r.Message = envVarName + " is set despite security.disable_env_passphrase: true"
 		r.Hint = "unset the environment variable to eliminate the exposure"
+	} else if cfg.Security == nil || !cfg.Security.AllowEnvPassphrase {
+		r.Status = StatusWarn
+		r.Message = envVarName + " is set in environment but allow_env_passphrase is false (default-deny) — variable is ignored"
+		r.Hint = "enable security.allow_env_passphrase: true in config.yaml or set SYMVAULT_ALLOW_ENV_PASSPHRASE=1 if required for headless use, or unset the variable"
 	} else {
 		r.Status = StatusWarn
-		r.Message = envVarName + " is set — passphrase is present in the process environment and may be readable by other processes or crash dumps"
-		r.Hint = "set security.disable_env_passphrase: true in config.yaml to disable env var passphrase, or unset the variable"
+		r.Message = envVarName + " is set and allowed — passphrase is present in process environment and may be readable by other processes or crash dumps"
+		r.Hint = "unset the environment variable or set security.disable_env_passphrase: true"
 	}
 	return r
 }


### PR DESCRIPTION
## Summary

- Make environment-based passphrase unlocking explicit opt-in via `security.allow_env_passphrase: true` in `config.yaml` or `SYMVAULT_ALLOW_ENV_PASSPHRASE=1` (#675).
- Add zeroization helper to wipe cached passphrase bytes on replacement and cleanup paths (#676).
- Make passphrase source tests hermetic with explicit environment isolation (#678).
- Remove unsafe environment passphrase recommendations from normal interactive CLI guidance (#679).

## Closed Issues

<!-- closes-list-start -->
- Closes #675 Make environment passphrase unlocking explicit opt-in
- Closes #676 Zeroize cached environment passphrase on every cleanup path
- Closes #678 Make passphrase-source tests hermetic
- Closes #679 Remove unsafe environment-passphrase recommendations from normal CLI guidance
<!-- closes-list-end -->