### PR TITLE
Reject sensitive-named env vars even when explicitly requested

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,9 @@ jobs:
         shell: bash
         env:
           CGO_ENABLED: ${{ matrix.os == 'ubuntu-latest' && '1' || '0' }}
+          # Command tests exercise non-interactive vault unlocks with synthetic
+          # passphrases; production remains default-deny outside the test job.
+          SYMVAULT_ALLOW_ENV_PASSPHRASE: "1"
         run: |
           if [ "${{ matrix.os }}" == "ubuntu-latest" ]; then
             go test -v -race -timeout=30m -coverprofile=coverage.out -skip 'TestFlow|TestBinaryE2E|Integration' ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -364,6 +364,7 @@ jobs:
           BIN="./bin/symvault-linux-amd64"
           VAULT_DIR=$(mktemp -d)
           PASSPHRASE="test-passphrase-123"
+          export SYMVAULT_ALLOW_ENV_PASSPHRASE=1
           
           echo "Testing vault initialization..."
           SYMVAULT_PASSPHRASE="$PASSPHRASE" $BIN init "$VAULT_DIR"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Autobuild
         if: matrix.build-mode == 'autobuild'
-        uses: github/codeql-action/autobuild@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
+        uses: github/codeql-action/autobuild@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -339,7 +339,7 @@ jobs:
       - name: Smoke test - init vault
         run: |
           TMPDIR=$(mktemp -d)
-          SYMVAULT_PASSPHRASE="test-passphrase-123" SYMVAULT_VAULT="$TMPDIR/test-vault" symvault init
+          SYMVAULT_ALLOW_ENV_PASSPHRASE=1 SYMVAULT_PASSPHRASE="test-passphrase-123" SYMVAULT_VAULT="$TMPDIR/test-vault" symvault init
           rm -rf "$TMPDIR"
 
   smoke-test-deb:
@@ -376,7 +376,7 @@ jobs:
       - name: Smoke test - init vault
         run: |
           TMPDIR=$(mktemp -d)
-          SYMVAULT_PASSPHRASE="test-passphrase-123" SYMVAULT_VAULT="$TMPDIR/test-vault" symvault init
+          SYMVAULT_ALLOW_ENV_PASSPHRASE=1 SYMVAULT_PASSPHRASE="test-passphrase-123" SYMVAULT_VAULT="$TMPDIR/test-vault" symvault init
           rm -rf "$TMPDIR"
 
   smoke-test-macos:
@@ -413,7 +413,7 @@ jobs:
       - name: Smoke test - init vault
         run: |
           TMPDIR=$(mktemp -d)
-          SYMVAULT_PASSPHRASE="test-passphrase-123" SYMVAULT_VAULT="$TMPDIR/test-vault" symvault init
+          SYMVAULT_ALLOW_ENV_PASSPHRASE=1 SYMVAULT_PASSPHRASE="test-passphrase-123" SYMVAULT_VAULT="$TMPDIR/test-vault" symvault init
           rm -rf "$TMPDIR"
 
   smoke-test-windows:
@@ -474,8 +474,10 @@ jobs:
             exit 1
           }
           $env:SYMVAULT_PASSPHRASE = "test-passphrase-123"
+          $env:SYMVAULT_ALLOW_ENV_PASSPHRASE = "1"
           & $exe init --vault "$tmpdir"
           Remove-Item Env:SYMVAULT_PASSPHRASE
+          Remove-Item Env:SYMVAULT_ALLOW_ENV_PASSPHRASE
           Remove-Item -Path $tmpdir -Recurse -Force -ErrorAction SilentlyContinue
 
   smoke-test-homebrew:

--- a/beta_smoke_test.go
+++ b/beta_smoke_test.go
@@ -33,6 +33,9 @@ func TestBetaSmokeFlow(t *testing.T) {
 	initCmd.Dir = repoRoot(t)
 	initCmd.Env = append(os.Environ(),
 		"GOWORK=off",
+		// The smoke flow intentionally runs non-interactive subprocesses with a
+		// synthetic passphrase. Production stays default-deny without this opt-in.
+		"SYMVAULT_ALLOW_ENV_PASSPHRASE=1",
 		"SYMVAULT_PASSPHRASE="+passphrase,
 	)
 	if output, err := initCmd.CombinedOutput(); err != nil {
@@ -46,6 +49,7 @@ func TestBetaSmokeFlow(t *testing.T) {
 		cmd.Dir = repoRoot(t)
 		cmd.Env = append(os.Environ(),
 			"GOWORK=off",
+			"SYMVAULT_ALLOW_ENV_PASSPHRASE=1",
 			"SYMVAULT_PASSPHRASE="+passphrase,
 		)
 		output, err := cmd.Output()

--- a/cmd/test_helpers_test.go
+++ b/cmd/test_helpers_test.go
@@ -69,12 +69,12 @@ func initVault(t *testing.T) (string, []byte) {
 
 func setPassEnv(t *testing.T, passphrase string) {
 	t.Helper()
-	_ = os.Setenv("SYMVAULT_PASSPHRASE", passphrase)
-	_ = os.Setenv("OPENPASS_PASSPHRASE", passphrase)
-	t.Cleanup(func() {
-		_ = os.Unsetenv("SYMVAULT_PASSPHRASE")
-		_ = os.Unsetenv("OPENPASS_PASSPHRASE")
-	})
+	// Environment passphrase use is deliberately default-deny in production.
+	// Command tests use it as their non-interactive unlock fixture, so opt in
+	// explicitly rather than weakening the production default.
+	t.Setenv("SYMVAULT_ALLOW_ENV_PASSPHRASE", "1")
+	t.Setenv("SYMVAULT_PASSPHRASE", passphrase)
+	t.Setenv("OPENPASS_PASSPHRASE", passphrase)
 }
 
 func fakeEditorWithContent(t *testing.T, content string) string {

--- a/cmd/test_state_test.go
+++ b/cmd/test_state_test.go
@@ -27,6 +27,9 @@ import (
 
 func TestMain(m *testing.M) {
 	_ = os.Unsetenv("OPENPASS_MCP_TOKEN")
+	// Command fixtures use synthetic passphrases non-interactively. This is
+	// test-process only; production remains default-deny.
+	_ = os.Setenv("SYMVAULT_ALLOW_ENV_PASSPHRASE", "1")
 	restoreScryptWorkFactor := vaultcrypto.SetTestScryptWorkFactor(12)
 	if runtime.GOOS == "windows" {
 		return // skip cmd tests on Windows: LockFileEx access violation in AcquireWriteLock

--- a/internal/health/doctor_session.go
+++ b/internal/health/doctor_session.go
@@ -262,6 +262,7 @@ func inspectPassphraseSourceFiles(candidates []string) (foundPath string, perm o
 		if err != nil || info.IsDir() {
 			continue
 		}
+		// #nosec G304 -- production candidates are fixed local shell/config paths; caller-supplied candidates exist only for unit tests.
 		f, err := os.Open(p)
 		if err != nil {
 			continue

--- a/internal/health/doctor_test.go
+++ b/internal/health/doctor_test.go
@@ -1194,6 +1194,9 @@ func TestRunChecks_EnvPassphrase_Present(t *testing.T) {
 }
 
 func TestRunChecks_EnvPassphrase_UnsafeSourceFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows does not preserve the requested Unix permission bits")
+	}
 	t.Setenv("SYMVAULT_PASSPHRASE", "")
 	t.Setenv("OPENPASS_PASSPHRASE", "")
 
@@ -1216,6 +1219,9 @@ func TestRunChecks_EnvPassphrase_UnsafeSourceFile(t *testing.T) {
 }
 
 func TestRunChecks_EnvPassphrase_SafeSourceFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows does not preserve the requested Unix permission bits")
+	}
 	t.Setenv("SYMVAULT_PASSPHRASE", "")
 	t.Setenv("OPENPASS_PASSPHRASE", "")
 

--- a/internal/secrets/filter.go
+++ b/internal/secrets/filter.go
@@ -129,3 +129,75 @@ func RejectDenied(env map[string]string) []string {
 	sort.Strings(rejected)
 	return rejected
 }
+
+// sensitiveNameTokens are the naming conventions that mark an environment
+// variable as likely holding a secret value (passphrase, password, token,
+// API key, credential). Matched as a whole underscore-delimited token so
+// "PASSWORD" flags "DB_PASSWORD" and "PASSWORD" but not "PASSWORDLESS_MODE".
+var sensitiveNameTokens = []string{
+	"PASSPHRASE",
+	"PASSWORD",
+	"PASSWD",
+	"SECRET",
+	"TOKEN",
+	"APIKEY",
+	"CREDENTIAL",
+	"CREDENTIALS",
+	"PRIVATEKEY",
+}
+
+// IsSensitiveName reports whether an environment variable name looks like it
+// holds a secret value, based on common naming conventions (passphrase,
+// password, secret, token, API key, credential). This is independent of who
+// supplied the name: it applies even when a caller explicitly requests the
+// variable via RunOptions.Env or RunOptions.Passthrough, so an accidental or
+// malicious request to forward e.g. VAULT_PASSPHRASE to a child process is
+// rejected rather than honored.
+func IsSensitiveName(name string) bool {
+	upper := strings.ToUpper(name)
+	// Strip non-alphanumeric separators so "API_KEY" and "APIKEY" both match
+	// the "APIKEY" token, and "-" / "." separators are treated the same as "_".
+	normalized := strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+			return r
+		default:
+			return '_'
+		}
+	}, upper)
+	for _, sep := range []string{"-", "."} {
+		normalized = strings.ReplaceAll(normalized, sep, "_")
+	}
+	tokens := strings.Split(strings.Trim(normalized, "_"), "_")
+	// Also check tokens with adjacent underscore-free runs collapsed, so
+	// "API_KEY" (two tokens) matches the single "APIKEY" sensitive token.
+	joined := strings.ReplaceAll(strings.Trim(normalized, "_"), "_", "")
+	for _, sensitive := range sensitiveNameTokens {
+		if strings.Contains(joined, sensitive) {
+			return true
+		}
+		for _, t := range tokens {
+			if t == sensitive {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// RejectSensitiveNames splits names into safe (not sensitive-looking) and
+// rejected (sensitive-looking, sorted) based on IsSensitiveName. Unlike
+// RejectDenied (which targets interpreter/loader injection vectors like
+// LD_PRELOAD), this targets names that likely hold a secret value regardless
+// of injection risk.
+func RejectSensitiveNames(names []string) (safe []string, rejected []string) {
+	for _, n := range names {
+		if IsSensitiveName(n) {
+			rejected = append(rejected, n)
+			continue
+		}
+		safe = append(safe, n)
+	}
+	sort.Strings(rejected)
+	return safe, rejected
+}

--- a/internal/secrets/filter.go
+++ b/internal/secrets/filter.go
@@ -150,9 +150,10 @@ var sensitiveNameTokens = []string{
 // holds a secret value, based on common naming conventions (passphrase,
 // password, secret, token, API key, credential). This is independent of who
 // supplied the name: it applies even when a caller explicitly requests the
-// variable via RunOptions.Env or RunOptions.Passthrough, so an accidental or
-// malicious request to forward e.g. VAULT_PASSPHRASE to a child process is
-// rejected rather than honored.
+// variable via RunOptions.Passthrough, so an accidental or malicious request
+// to forward e.g. VAULT_PASSPHRASE from the parent process to a child is
+// rejected rather than honored. Callers must not apply it to RunOptions.Env:
+// that map contains intentional, already-resolved vault-secret injection.
 func IsSensitiveName(name string) bool {
 	upper := strings.ToUpper(name)
 	// Strip non-alphanumeric separators so "API_KEY" and "APIKEY" both match

--- a/internal/secrets/filter_test.go
+++ b/internal/secrets/filter_test.go
@@ -398,3 +398,59 @@ func TestPrepareCmd_NoSymvaultEnvLeak(t *testing.T) {
 		t.Error("PrepareCmd leaked SYMVAULT_TEST_SECRET to child process env")
 	}
 }
+
+func TestIsSensitiveName_KnownPatterns(t *testing.T) {
+	cases := []string{
+		"PASSPHRASE", "VAULT_PASSPHRASE", "OPENPASS_VAULT_PASSPHRASE",
+		"PASSWORD", "DB_PASSWORD", "PASSWD",
+		"SECRET", "AWS_SECRET_ACCESS_KEY", "APP_SECRET",
+		"TOKEN", "SYMVAULT_MCP_TOKEN", "AUTH_TOKEN",
+		"API_KEY", "APIKEY", "STRIPE_API_KEY",
+		"CREDENTIAL", "CREDENTIALS", "GOOGLE_CREDENTIALS",
+		"PRIVATE_KEY", "SSH_PRIVATE_KEY",
+	}
+	for _, name := range cases {
+		if !IsSensitiveName(name) {
+			t.Errorf("IsSensitiveName(%q) = false, want true", name)
+		}
+	}
+}
+
+func TestIsSensitiveName_BenignNames(t *testing.T) {
+	cases := []string{
+		"PATH", "HOME", "TERM", "LANG", "CUSTOM_VAR", "MY_API_BASE",
+		"GIT_SSH_COMMAND", "DISPLAY", "TMPDIR", "COLORTERM",
+	}
+	for _, name := range cases {
+		if IsSensitiveName(name) {
+			t.Errorf("IsSensitiveName(%q) = true, want false", name)
+		}
+	}
+}
+
+func TestRejectSensitiveNames_SplitsCorrectly(t *testing.T) {
+	safe, rejected := RejectSensitiveNames([]string{"CUSTOM_VAR", "VAULT_PASSPHRASE", "PATH", "API_KEY"})
+
+	if !contains(safe, "CUSTOM_VAR") || !contains(safe, "PATH") {
+		t.Errorf("RejectSensitiveNames safe = %v, want CUSTOM_VAR and PATH present", safe)
+	}
+	if contains(safe, "VAULT_PASSPHRASE") || contains(safe, "API_KEY") {
+		t.Errorf("RejectSensitiveNames safe = %v, should not contain sensitive names", safe)
+	}
+	expected := []string{"API_KEY", "VAULT_PASSPHRASE"}
+	if len(rejected) != len(expected) {
+		t.Fatalf("RejectSensitiveNames rejected = %v, want %v", rejected, expected)
+	}
+	for i, v := range expected {
+		if rejected[i] != v {
+			t.Errorf("rejected[%d] = %s, want %s", i, rejected[i], v)
+		}
+	}
+}
+
+func TestRejectSensitiveNames_Empty(t *testing.T) {
+	safe, rejected := RejectSensitiveNames(nil)
+	if len(safe) != 0 || len(rejected) != 0 {
+		t.Errorf("RejectSensitiveNames(nil) = (%v, %v), want ([], [])", safe, rejected)
+	}
+}

--- a/internal/secrets/runner.go
+++ b/internal/secrets/runner.go
@@ -19,6 +19,12 @@ type RunResult struct {
 	Duration        time.Duration
 	StdoutTruncated bool
 	StderrTruncated bool
+	// RejectedEnvVars lists the names (never values) of environment
+	// variables that were requested via RunOptions.Env or
+	// RunOptions.Passthrough but withheld from the child process because
+	// their name looks sensitive (see IsSensitiveName). Sorted, nil when
+	// nothing was rejected.
+	RejectedEnvVars []string
 }
 
 // RunOptions configures a command execution.
@@ -110,17 +116,31 @@ func RunCommand(opts RunOptions) (*RunResult, error) {
 	// This prevents leaking sensitive process env vars (API keys, OPENPASS_*, AWS_*,
 	// etc.) to child processes. Only the DefaultWhitelist vars (plus any passthrough)
 	// are passed through. Later entries override earlier ones for the same key.
+	//
+	// Passthrough and Env are caller-requested additions on top of the
+	// whitelist, so a sensitive-looking name is rejected here even though the
+	// caller asked for it explicitly — fail closed rather than trust intent.
+	safePassthrough, rejectedPassthrough := RejectSensitiveNames(opts.Passthrough)
 	whitelist := DefaultWhitelist()
-	if len(opts.Passthrough) > 0 {
-		whitelist = MergeWhitelist(whitelist, opts.Passthrough)
+	if len(safePassthrough) > 0 {
+		whitelist = MergeWhitelist(whitelist, safePassthrough)
 	}
 	cmd.Env = FilterEnv(whitelist)
-	for k, v := range opts.Env {
-		cmd.Env = append(cmd.Env, k+"="+v)
+
+	envKeys := make([]string, 0, len(opts.Env))
+	for k := range opts.Env {
+		envKeys = append(envKeys, k)
+	}
+	safeEnvKeys, rejectedEnv := RejectSensitiveNames(envKeys)
+	for _, k := range safeEnvKeys {
+		cmd.Env = append(cmd.Env, k+"="+opts.Env[k])
 	}
 	for k, v := range fileEnv {
 		cmd.Env = append(cmd.Env, k+"="+v)
 	}
+
+	rejected := MergeWhitelist(rejectedPassthrough, rejectedEnv)
+	sort.Strings(rejected)
 
 	const maxOutput = 100 * 1024
 	stdout := newBoundedBuffer(maxOutput)
@@ -139,6 +159,7 @@ func RunCommand(opts RunOptions) (*RunResult, error) {
 		Stderr:          string(stderr.data),
 		StdoutTruncated: stdout.truncated,
 		StderrTruncated: stderr.truncated,
+		RejectedEnvVars: rejected,
 	}
 
 	if runErr != nil {

--- a/internal/secrets/runner.go
+++ b/internal/secrets/runner.go
@@ -19,11 +19,12 @@ type RunResult struct {
 	Duration        time.Duration
 	StdoutTruncated bool
 	StderrTruncated bool
-	// RejectedEnvVars lists the names (never values) of environment
-	// variables that were requested via RunOptions.Env or
-	// RunOptions.Passthrough but withheld from the child process because
-	// their name looks sensitive (see IsSensitiveName). Sorted, nil when
-	// nothing was rejected.
+	// RejectedEnvVars lists the names (never values) of ambient parent-process
+	// environment variables that were requested via RunOptions.Passthrough but
+	// withheld from the child process because their name looks sensitive (see
+	// IsSensitiveName). Does not apply to RunOptions.Env, which is caller-
+	// supplied and already-resolved (see RunCommand). Sorted, nil when nothing
+	// was rejected.
 	RejectedEnvVars []string
 }
 
@@ -117,9 +118,18 @@ func RunCommand(opts RunOptions) (*RunResult, error) {
 	// etc.) to child processes. Only the DefaultWhitelist vars (plus any passthrough)
 	// are passed through. Later entries override earlier ones for the same key.
 	//
-	// Passthrough and Env are caller-requested additions on top of the
-	// whitelist, so a sensitive-looking name is rejected here even though the
-	// caller asked for it explicitly — fail closed rather than trust intent.
+	// Passthrough forwards an *ambient* parent-process variable to the child by
+	// name only — the caller never sees or chooses its value, so a
+	// sensitive-looking name (VAULT_PASSPHRASE, AWS_SECRET_ACCESS_KEY, ...) is
+	// rejected even though the caller asked for it explicitly: fail closed
+	// rather than trust that the name was requested with full knowledge of its
+	// value. opts.Env is different — it is the caller handing RunCommand an
+	// already-resolved value it explicitly chose to inject (e.g. a vault secret
+	// the agent asked to inject by name via execute_with_secret); rejecting
+	// those by name would break that feature outright, since resolved secret
+	// env var names routinely contain KEY/SECRET/TOKEN/PASSWORD. opts.Env still
+	// goes through RejectDenied (interpreter/loader injection names) at the
+	// call site.
 	safePassthrough, rejectedPassthrough := RejectSensitiveNames(opts.Passthrough)
 	whitelist := DefaultWhitelist()
 	if len(safePassthrough) > 0 {
@@ -127,19 +137,14 @@ func RunCommand(opts RunOptions) (*RunResult, error) {
 	}
 	cmd.Env = FilterEnv(whitelist)
 
-	envKeys := make([]string, 0, len(opts.Env))
-	for k := range opts.Env {
-		envKeys = append(envKeys, k)
-	}
-	safeEnvKeys, rejectedEnv := RejectSensitiveNames(envKeys)
-	for _, k := range safeEnvKeys {
-		cmd.Env = append(cmd.Env, k+"="+opts.Env[k])
+	for k, v := range opts.Env {
+		cmd.Env = append(cmd.Env, k+"="+v)
 	}
 	for k, v := range fileEnv {
 		cmd.Env = append(cmd.Env, k+"="+v)
 	}
 
-	rejected := MergeWhitelist(rejectedPassthrough, rejectedEnv)
+	rejected := append([]string(nil), rejectedPassthrough...)
 	sort.Strings(rejected)
 
 	const maxOutput = 100 * 1024

--- a/internal/secrets/runner_test.go
+++ b/internal/secrets/runner_test.go
@@ -480,3 +480,71 @@ func TestMaterializeFiles_BinaryContentPreserved(t *testing.T) {
 		t.Fatalf("content mismatch: got %d bytes, want %d bytes", len(data), len(content))
 	}
 }
+
+func TestRunCommand_RejectsSensitivePassthrough(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows: relies on sh")
+	}
+	t.Setenv("MY_APP_PASSPHRASE", "should_never_reach_child")
+
+	result, err := RunCommand(RunOptions{
+		Command:     []string{"sh", "-c", "echo VAL=[$MY_APP_PASSPHRASE]"},
+		Passthrough: []string{"MY_APP_PASSPHRASE"},
+	})
+	if err != nil {
+		t.Fatalf("RunCommand() unexpected error: %v", err)
+	}
+	if strings.Contains(result.Stdout, "should_never_reach_child") {
+		t.Fatalf("sensitive passthrough var leaked to child: %q", result.Stdout)
+	}
+	if !strings.Contains(result.Stdout, "VAL=[]") {
+		t.Fatalf("expected empty var in child, got: %q", result.Stdout)
+	}
+	if !contains(result.RejectedEnvVars, "MY_APP_PASSPHRASE") {
+		t.Errorf("RejectedEnvVars = %v, want MY_APP_PASSPHRASE", result.RejectedEnvVars)
+	}
+}
+
+func TestRunCommand_RejectsSensitiveOptsEnv(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows: relies on sh")
+	}
+	result, err := RunCommand(RunOptions{
+		Command: []string{"sh", "-c", "echo VAL=[$API_TOKEN]"},
+		Env:     map[string]string{"API_TOKEN": "should_never_reach_child"},
+	})
+	if err != nil {
+		t.Fatalf("RunCommand() unexpected error: %v", err)
+	}
+	if strings.Contains(result.Stdout, "should_never_reach_child") {
+		t.Fatalf("sensitive opts.Env var leaked to child: %q", result.Stdout)
+	}
+	if !contains(result.RejectedEnvVars, "API_TOKEN") {
+		t.Errorf("RejectedEnvVars = %v, want API_TOKEN", result.RejectedEnvVars)
+	}
+}
+
+func TestRunCommand_NonSensitiveEnvAndPassthroughStillWork(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows: relies on sh")
+	}
+	t.Setenv("MY_CUSTOM_FLAG", "on")
+
+	result, err := RunCommand(RunOptions{
+		Command:     []string{"sh", "-c", "echo A=[$MY_CUSTOM_FLAG] B=[$OTHER_VAR]"},
+		Passthrough: []string{"MY_CUSTOM_FLAG"},
+		Env:         map[string]string{"OTHER_VAR": "plain_value"},
+	})
+	if err != nil {
+		t.Fatalf("RunCommand() unexpected error: %v", err)
+	}
+	if !strings.Contains(result.Stdout, "A=[on]") {
+		t.Errorf("expected MY_CUSTOM_FLAG to pass through, got: %q", result.Stdout)
+	}
+	if !strings.Contains(result.Stdout, "B=[plain_value]") {
+		t.Errorf("expected OTHER_VAR to pass through, got: %q", result.Stdout)
+	}
+	if len(result.RejectedEnvVars) != 0 {
+		t.Errorf("RejectedEnvVars = %v, want none", result.RejectedEnvVars)
+	}
+}

--- a/internal/secrets/runner_test.go
+++ b/internal/secrets/runner_test.go
@@ -505,22 +505,29 @@ func TestRunCommand_RejectsSensitivePassthrough(t *testing.T) {
 	}
 }
 
-func TestRunCommand_RejectsSensitiveOptsEnv(t *testing.T) {
+// TestRunCommand_OptsEnvSensitiveNamesStillDelivered proves opts.Env is
+// never subject to the sensitive-name reject: it is caller-supplied,
+// already-resolved data (e.g. a vault secret execute_with_secret injects
+// under a name like AWS_SECRET_ACCESS_KEY), not an ambient parent-env
+// forward. Rejecting it by name would silently break that feature for any
+// secret whose generated env var name contains KEY/SECRET/TOKEN/PASSWORD —
+// which is the common case.
+func TestRunCommand_OptsEnvSensitiveNamesStillDelivered(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("skipping on windows: relies on sh")
 	}
 	result, err := RunCommand(RunOptions{
 		Command: []string{"sh", "-c", "echo VAL=[$API_TOKEN]"},
-		Env:     map[string]string{"API_TOKEN": "should_never_reach_child"},
+		Env:     map[string]string{"API_TOKEN": "resolved_secret_value"},
 	})
 	if err != nil {
 		t.Fatalf("RunCommand() unexpected error: %v", err)
 	}
-	if strings.Contains(result.Stdout, "should_never_reach_child") {
-		t.Fatalf("sensitive opts.Env var leaked to child: %q", result.Stdout)
+	if !strings.Contains(result.Stdout, "VAL=[resolved_secret_value]") {
+		t.Fatalf("expected opts.Env value to reach child regardless of sensitive-looking name, got: %q", result.Stdout)
 	}
-	if !contains(result.RejectedEnvVars, "API_TOKEN") {
-		t.Errorf("RejectedEnvVars = %v, want API_TOKEN", result.RejectedEnvVars)
+	if len(result.RejectedEnvVars) != 0 {
+		t.Errorf("RejectedEnvVars = %v, want none (opts.Env is never rejected by name)", result.RejectedEnvVars)
 	}
 }
 


### PR DESCRIPTION
Bundles fixes for multiple open issues (group: leak-detection). The list below grows as commits land; every linked issue will close automatically on merge.

<!-- closes-list-start -->
- Closes #694 Harden child-process environment passphrase whitelist boundary
<!-- closes-list-end -->
