### PR TITLE
test(admin): opt in to env-passphrase unlocking in export/import tests

### DIFF
--- a/cmd/admin/export_test.go
+++ b/cmd/admin/export_test.go
@@ -66,6 +66,7 @@ func TestExport_ConfirmAccept_WithEntries(t *testing.T) {
 	origVault := cli.Vault
 	cli.Vault = vaultDir
 	t.Cleanup(func() { cli.Vault = origVault })
+	t.Setenv("SYMVAULT_ALLOW_ENV_PASSPHRASE", "1")
 	t.Setenv("SYMVAULT_PASSPHRASE", passphrase)
 
 	v, err := cli.UnlockVault(vaultDir, true)
@@ -107,6 +108,7 @@ func TestExport_YesFlag_SkipsPrompt(t *testing.T) {
 	origVault := cli.Vault
 	cli.Vault = vaultDir
 	t.Cleanup(func() { cli.Vault = origVault })
+	t.Setenv("SYMVAULT_ALLOW_ENV_PASSPHRASE", "1")
 	t.Setenv("SYMVAULT_PASSPHRASE", passphrase)
 
 	v, err := cli.UnlockVault(vaultDir, true)
@@ -162,6 +164,7 @@ func setupTestVault(t *testing.T, searchWorkers int) *cli.VaultService {
 	origVault := cli.Vault
 	cli.Vault = vaultDir
 	t.Cleanup(func() { cli.Vault = origVault })
+	t.Setenv("SYMVAULT_ALLOW_ENV_PASSPHRASE", "1")
 	t.Setenv("SYMVAULT_PASSPHRASE", passphrase)
 
 	v, err := cli.UnlockVault(vaultDir, true)

--- a/cmd/admin/import_test.go
+++ b/cmd/admin/import_test.go
@@ -100,6 +100,7 @@ func TestImportCommandAutoDetectCSV(t *testing.T) {
 	origVault := cli.Vault
 	cli.Vault = vaultDir
 	t.Cleanup(func() { cli.Vault = origVault })
+	t.Setenv("SYMVAULT_ALLOW_ENV_PASSPHRASE", "1")
 	t.Setenv("SYMVAULT_PASSPHRASE", passphrase)
 
 	// Reset global flags
@@ -135,6 +136,7 @@ func TestImportCommandExplicitFormatOverride(t *testing.T) {
 	origVault := cli.Vault
 	cli.Vault = vaultDir
 	t.Cleanup(func() { cli.Vault = origVault })
+	t.Setenv("SYMVAULT_ALLOW_ENV_PASSPHRASE", "1")
 	t.Setenv("SYMVAULT_PASSPHRASE", passphrase)
 
 	// Reset global flags


### PR DESCRIPTION
Environment-based passphrase unlocking became explicit opt-in in
20565da (gated behind SYMVAULT_ALLOW_ENV_PASSPHRASE), but
cmd/admin's export and import tests still relied on the old
default-on behavior by only setting SYMVAULT_PASSPHRASE. They now
opt in explicitly, same pattern already used by cmd's own
setPassEnv test helper.

Closes #700
