### PR TITLE
Add proactive local secret-leak detection at process and output boundaries (+4 more)

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ For the full configuration reference, see [docs/configuration.md](docs/configura
 - [MCP API](docs/mcp-api.md)
 - [Audit event schema](docs/audit-schema.md)
 - [Audit retention & integrity](docs/audit-retention.md)
+- [Local secret-leak detection](docs/leak-detection.md)
 - [Distribution channels](docs/distribution.md)
 - [Troubleshooting](docs/troubleshooting.md)
 - [Architecture](ARCHITECTURE.md)

--- a/docs/leak-detection.md
+++ b/docs/leak-detection.md
@@ -1,0 +1,147 @@
+# Local Secret-Leak Detection
+
+> **Scope:** Output-scanning redaction applied to command output
+> (`run_command`, `execute_with_secret`) and MCP tool response payloads
+> before they leave the Symaira Vault process — implemented in
+> `internal/redact`. This is a separate, narrower mechanism from the
+> prompt-injection defenses covered in [threat-model.md](threat-model.md);
+> see that document for the broader trust-boundary picture.
+
+## What this protects against
+
+Symaira Vault scans text it is about to hand back across the MCP process
+boundary — subprocess stdout/stderr from `run_command` and
+`execute_with_secret`, and other MCP tool response payloads — for secret
+material, and rewrites any match before the text can be displayed to an
+agent or persisted (e.g. to the audit log). Three independent detectors run
+in a fixed pipeline, each tagged with a confidence tier:
+
+| Tier | Detector | What it catches |
+|---|---|---|
+| **Exact match** (high confidence) | known-value matching | Literal occurrences of a currently-unlocked vault secret value that the caller resolved for this call (e.g. an `env`/`files` reference on `run_command`) |
+| **Pattern match** (high confidence) | credential-shaped patterns | Explicit, well-known secret formats — AWS access keys, GitHub/Slack/Stripe/OpenAI tokens, PEM private keys, bearer tokens, JWTs, and similar (see `internal/mcp/masking.DefaultPatterns`) |
+| **Entropy heuristic** (low confidence) | conservative last resort | Long (20+ character), high-Shannon-entropy token-shaped substrings that don't match a known value or an explicit pattern, but look randomly generated |
+
+Every match — regardless of tier — is replaced with a single fixed marker,
+`[REDACTED]`. The marker never contains any substring, prefix, length hint,
+or hash of the original value: knowing the marker tells you nothing about
+what was removed.
+
+Detection **fails closed**: if a detector itself errors while scanning, the
+affected output is withheld entirely (replaced with a fixed
+`[REDACTED: output withheld]` marker) rather than returned unscanned. A
+scanner bug can cause you to see less output than expected; it cannot cause
+an unscanned value to slip through.
+
+## What this explicitly does not protect against
+
+This is a **process-boundary output filter**, not a general secrets-leak
+prevention system. In particular, it does **not**:
+
+- Protect against a secret being visible in a **screenshot** or captured by
+  screen recording — the redaction happens on the data flowing through this
+  process, not on anything rendered by other applications.
+- Protect against secrets already visible in an **external application** —
+  a terminal emulator, editor, or browser that independently displays the
+  same command output outside of Symaira Vault's control.
+- Redact secrets from **already-persisted third-party chat history** — if a
+  secret reached an MCP host's own logs or a chat transcript before this
+  feature was enabled (or through a path this feature doesn't cover), this
+  feature cannot retroactively scrub it.
+- Transmit anything it detects **anywhere remote** — all scanning happens
+  in-process, synchronously, with no network calls. Detected values are
+  never sent off-host for classification or analysis.
+- **Log or persist the matched value itself**, in any form — not the raw
+  value, not a prefix, not a hash, not a length. Audit events (below)
+  record only that a detection occurred, never what was detected.
+- Guarantee it catches **every** possible secret shape. The pattern
+  detector only knows the formats it's been given; the entropy heuristic is
+  deliberately tuned to avoid flagging ordinary long identifiers (temp
+  paths, UUIDs, test/run IDs), which means it also misses some real
+  secrets — see [Detection limits](#detection-limits-and-known-false-positivenegative-classes)
+  below.
+
+## Redact vs. block: what strict mode changes
+
+By default, a detection is **redacted**: the matched text is replaced with
+`[REDACTED]` in place, and the rest of the output (with the match removed)
+is still delivered. This is the "detect and warn" behavior.
+
+An opt-in **strict mode** changes this for high-confidence detections only:
+when a **high-confidence** match (exact-value or pattern-match tier) fires
+in strict mode, the entire affected output stream (e.g. all of stdout, or
+all of stderr) is withheld and replaced with a fixed
+`[REDACTED: output withheld]` marker instead of being redacted in place.
+This is the "detect and block" behavior — it exists for deployments that
+want a harder guarantee that a high-confidence secret never reaches the
+agent, even partially.
+
+Low-confidence (entropy heuristic) detections are **never** blocked, even
+in strict mode — they are always redacted in place. This keeps the
+last-resort heuristic's inherent false-positive risk from being able to
+silently withhold legitimate output; only findings from the two
+high-precision detectors can trigger a block.
+
+### Enabling / disabling strict mode
+
+Strict mode is opt-in and disabled by default. Set the environment variable
+`SYMVAULT_REDACT_STRICT_MODE` to a truthy value (`1`, `true`, `yes`, `on`;
+case-insensitive) for the `symvault` process (MCP server or CLI) to enable
+it:
+
+```bash
+export SYMVAULT_REDACT_STRICT_MODE=true
+```
+
+Unset the variable, or set it to anything else (e.g. `0`, `false`, or leave
+it empty), to return to the default redact-and-continue behavior.
+
+## Inspecting audit events
+
+Every detection — whether redacted or blocked — emits one audit event to
+Symaira Vault's normal audit log (action `leak_detection`), containing
+**metadata only**:
+
+- which detector fired (`exact_value`, `credential_pattern`, or
+  `entropy_heuristic`)
+- the channel it fired on (e.g. `stdout`, `stderr`)
+- its confidence tier (`high` or `low`)
+- how many matches were redacted
+- whether the finding caused a block (`blocked=true`/`false`)
+- a correlation ID tying the event back to the specific `run_command` /
+  `execute_with_secret` call that produced it (the same correlation ID is
+  shared by an stdout and stderr scan from the same call)
+
+The event **never** contains the matched value, a prefix of it, or a hash
+of it. Inspect these events the same way you inspect any other Symaira
+Vault audit entry — see [Audit event schema](audit-schema.md) and
+[Audit retention & integrity](audit-retention.md) for the log format and
+verification tooling.
+
+## Detection limits and known false-positive/negative classes
+
+The entropy heuristic is deliberately tuned so that false-positive
+resistance wins over recall — see `internal/redact/entropy_test.go`'s
+`TestEntropyDetector_DocumentedFalsePositiveClasses` for the authoritative,
+executable record of these trade-offs. As of this writing:
+
+| Shape | Flagged? | Why |
+|---|---|---|
+| Mixed-case/digit/symbol random secret (32+ chars) | Yes | High empirical entropy across a large alphabet |
+| Base64-encoded payload (secret or not) | Yes | High entropy by construction — a known false-positive source for *non-secret* base64 blobs |
+| Hex-encoded hash (e.g. SHA-256 digest) | No | Only a 16-symbol alphabet keeps empirical entropy below the floor — a known false-negative for hex-only secrets |
+| UUID (hyphenated) | No | Split into short hex runs at each `-`, each below the minimum token length |
+| Long purely-numeric identifier | No | Small 10-symbol alphabet keeps entropy below the floor |
+| Filesystem paths, temp-dir names, test/run identifiers | No | Split at each `/`, and the entropy floor is calibrated above typical identifier entropy |
+
+These are accepted, documented limitations of a conservative last-resort
+layer — they are not "bugs" to be silently tuned away, since loosening the
+thresholds to catch more of the false-negative classes above would
+reintroduce false positives on ordinary tool output (paths, identifiers,
+hashes) that are far more common than the secrets being missed.
+
+The exact-value and pattern-match tiers do not have this trade-off in the
+same way: they only match a bounded, explicit set of values/formats, so
+they carry effectively no false-positive risk, but also cannot catch a
+secret whose value isn't currently resolved for the call, or whose format
+isn't in the known pattern list.

--- a/internal/mcp/server/prompt_injection_e2e_test.go
+++ b/internal/mcp/server/prompt_injection_e2e_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"strings"
 	"testing"
@@ -183,7 +184,7 @@ func TestE2E_PromptInjection_SubprocessOutput(t *testing.T) {
 
 	for _, p := range promptInjectionCorpus() {
 		t.Run(p.name, func(t *testing.T) {
-			stdout, stderr := srv.sanitizeRunOutput("prefix "+p.value+" suffix",
+			stdout, stderr := srv.sanitizeRunOutput(context.Background(), "prefix "+p.value+" suffix",
 				p.value, nil)
 			// Build the same JSON envelope tools_run.go would.
 			envelope, _ := json.Marshal(map[string]any{

--- a/internal/mcp/server/tools_execute_with_secret.go
+++ b/internal/mcp/server/tools_execute_with_secret.go
@@ -176,7 +176,7 @@ func (s *Server) handleExecuteWithSecret(ctx context.Context, req mcp.CallToolRe
 
 	if runErr != nil {
 		if result != nil {
-			sanitizedStdout, sanitizedStderr := s.sanitizeRunOutput(result.Stdout, result.Stderr, secretEnv)
+			sanitizedStdout, sanitizedStderr := s.sanitizeRunOutput(ctx, result.Stdout, result.Stderr, secretEnv)
 			sanitizedErr := s.sanitizeKnownSecretValues(runErr.Error(), secretEnv)
 			return mcp.NewToolResultError(fmt.Sprintf("%s\nExit code: %d\nStdout: %s\nStderr: %s",
 				sanitizedErr, result.ExitCode, EmbedAsData("command_output", sanitizedStdout), EmbedAsData("command_output", sanitizedStderr))), nil
@@ -184,7 +184,7 @@ func (s *Server) handleExecuteWithSecret(ctx context.Context, req mcp.CallToolRe
 		return mcp.NewToolResultError(s.sanitizeKnownSecretValues(runErr.Error(), secretEnv)), nil
 	}
 
-	sanitizedStdout, sanitizedStderr := s.sanitizeRunOutput(result.Stdout, result.Stderr, secretEnv)
+	sanitizedStdout, sanitizedStderr := s.sanitizeRunOutput(ctx, result.Stdout, result.Stderr, secretEnv)
 	resultJSON, err := json.Marshal(map[string]any{
 		"exit_code":   result.ExitCode,
 		"stdout":      EmbedAsData("command_output", sanitizedStdout),

--- a/internal/mcp/server/tools_execute_with_secret_test.go
+++ b/internal/mcp/server/tools_execute_with_secret_test.go
@@ -94,8 +94,13 @@ func TestHandleExecuteWithSecret_SecretInjection(t *testing.T) {
 	if strings.Contains(stdout, "AKIAIO...MPLE") {
 		t.Errorf("stdout = %q, should not contain plaintext secret", stdout)
 	}
-	if !strings.Contains(stdout, "***") {
-		t.Errorf("stdout = %q, want to contain masked value '***'", stdout)
+	// The AWS-shaped key is caught by the credential-pattern detector
+	// (internal/redact) inside secrets.RunCommand itself, before the
+	// MCP-layer known-value masking even sees it, so the marker here may
+	// be either layer's: "***" (known-value mask) or "[REDACTED]"
+	// (pattern detector marker).
+	if !strings.Contains(stdout, "***") && !strings.Contains(stdout, "[REDACTED]") {
+		t.Errorf("stdout = %q, want to contain a masked/redacted value", stdout)
 	}
 }
 

--- a/internal/mcp/server/tools_run.go
+++ b/internal/mcp/server/tools_run.go
@@ -130,7 +130,7 @@ func (s *Server) handleRunCommand(ctx context.Context, req mcp.CallToolRequest) 
 	if err != nil {
 		s.logAudit(ctx, "run_command", auditPath, false)
 		if result != nil {
-			sanitizedStdout, sanitizedStderr := s.sanitizeRunOutput(result.Stdout, result.Stderr, knownSecrets)
+			sanitizedStdout, sanitizedStderr := s.sanitizeRunOutput(ctx, result.Stdout, result.Stderr, knownSecrets)
 			sanitizedErr := s.sanitizeKnownSecretValues(err.Error(), knownSecrets)
 			return mcp.NewToolResultError(fmt.Sprintf("%s\nExit code: %d\nStdout: %s\nStderr: %s",
 				sanitizedErr, result.ExitCode, EmbedAsData("command_output", sanitizedStdout), EmbedAsData("command_output", sanitizedStderr))), nil
@@ -140,7 +140,7 @@ func (s *Server) handleRunCommand(ctx context.Context, req mcp.CallToolRequest) 
 
 	s.logAudit(ctx, "run_command", auditPath, true)
 
-	sanitizedStdout, sanitizedStderr := s.sanitizeRunOutput(result.Stdout, result.Stderr, knownSecrets)
+	sanitizedStdout, sanitizedStderr := s.sanitizeRunOutput(ctx, result.Stdout, result.Stderr, knownSecrets)
 
 	resultJSON, err := json.Marshal(map[string]any{
 		"exit_code":   result.ExitCode,

--- a/internal/mcp/server/tools_sanitize.go
+++ b/internal/mcp/server/tools_sanitize.go
@@ -91,7 +91,14 @@ func (s *Server) sanitizeKnownSecretValues(text string, resolvedEnv map[string]s
 // name, channel, confidence, redaction count, and correlationID only;
 // never the matched value or any excerpt of it.
 func (s *Server) scanOutputPatterns(ctx context.Context, channel, correlationID, text string) string {
-	scanner := redact.NewScanner(redact.NewPatternDetector())
+	// Detector order matters for Scanner.Scan's audit/strict-mode
+	// bookkeeping only in that later detectors see earlier ones' already-
+	// redacted text; ConfidenceHigh patterns run first, followed by the
+	// conservative ConfidenceLow entropy heuristic (#697) as the last
+	// resort for secret-shaped strings the explicit patterns miss. Strict
+	// mode (#696) only ever blocks on a ConfidenceHigh finding, so an
+	// entropy-only match is always redacted in place, never blocked.
+	scanner := redact.NewScanner(redact.NewPatternDetector(), redact.NewEntropyDetector())
 	scanner.Channel = channel
 	scanner.Audit = func(e redact.AuditEvent) {
 		s.logAudit(ctx, redactAuditAction, redactAuditPath(e), true)

--- a/internal/mcp/server/tools_sanitize.go
+++ b/internal/mcp/server/tools_sanitize.go
@@ -11,12 +11,10 @@ import (
 	"github.com/danieljustus/symaira-vault/internal/redact"
 )
 
-// outputScanner is the output-scanning redaction core (#695) applied to
-// every MCP/tool response payload that carries subprocess or externally
-// sourced text, as a defense-in-depth layer alongside the known-secret
-// masking already performed by sanitizeKnownSecretValues. It is a package
-// var (not per-call) since it is stateless and safe for concurrent use.
-var outputScanner = redact.NewScanner(redact.NewPatternDetector())
+// redactAuditAction is the audit log action name used for metadata-only
+// leak-detection events (#696). It is distinct from the tool-call action
+// (e.g. "run_command") so audit consumers can filter on it independently.
+const redactAuditAction = "leak_detection"
 
 func (s *Server) handleSanitizeOutput(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	text, err := req.RequireString("text")
@@ -45,21 +43,28 @@ func (s *Server) handleSanitizeOutput(ctx context.Context, req mcp.CallToolReque
 	return mcp.NewToolResultText(string(resultJSON)), nil
 }
 
-// sanitizeRunOutput applies two passes to subprocess output before it
+// sanitizeRunOutput applies three passes to subprocess output before it
 // reaches the LLM:
 //  1. Mask any known secret values from resolvedEnv with "***".
-//  2. Strip prompt-injection vectors (ANSI escapes, XML closing tags,
+//  2. Run the output-scanning redaction core's credential-pattern detector
+//     (#695), which — when strict mode is opted into (#696) — blocks the
+//     affected stream instead of only redacting it, and always emits a
+//     metadata-only audit event.
+//  3. Strip prompt-injection vectors (ANSI escapes, XML closing tags,
 //     bidi overrides, zero-width chars) via the MCP chokepoint.
 //
-// Pass (2) is defense-in-depth: the final callToolResultPayload step
+// Pass (3) is defense-in-depth: the final callToolResultPayload step
 // also runs the chokepoint, but applying it here means stdout and
 // stderr can be embedded into structured responses (e.g. JSON fields)
 // without depending on the outer pipeline's order.
-func (s *Server) sanitizeRunOutput(stdout, stderr string, resolvedEnv map[string]string) (string, string) {
+func (s *Server) sanitizeRunOutput(ctx context.Context, stdout, stderr string, resolvedEnv map[string]string) (string, string) {
 	stdout = s.sanitizeKnownSecretValues(stdout, resolvedEnv)
 	stderr = s.sanitizeKnownSecretValues(stderr, resolvedEnv)
-	stdout = scanOutputPatterns(stdout)
-	stderr = scanOutputPatterns(stderr)
+
+	corrID := redact.NewCorrelationID()
+	stdout = s.scanOutputPatterns(ctx, "stdout", corrID, stdout)
+	stderr = s.scanOutputPatterns(ctx, "stderr", corrID, stderr)
+
 	stdout = globalChokepoint.SanitizeForMCP(stdout)
 	stderr = globalChokepoint.SanitizeForMCP(stderr)
 	return stdout, stderr
@@ -78,7 +83,31 @@ func (s *Server) sanitizeKnownSecretValues(text string, resolvedEnv map[string]s
 // in an MCP tool response payload. It fails closed: if scanning itself
 // errors, text is withheld (replaced with a fixed marker) rather than
 // returned unredacted.
-func scanOutputPatterns(text string) string {
-	res, _ := outputScanner.Scan(text, redact.ScanOptions{})
+//
+// Strict mode (#696) is an opt-in, process-wide setting (EnvStrictMode):
+// when enabled, a high-confidence match causes the affected channel to be
+// withheld entirely rather than redacted in place. Every detection — redacted
+// or blocked — emits one audit event via s.logAudit containing detector
+// name, channel, confidence, redaction count, and correlationID only;
+// never the matched value or any excerpt of it.
+func (s *Server) scanOutputPatterns(ctx context.Context, channel, correlationID, text string) string {
+	scanner := redact.NewScanner(redact.NewPatternDetector())
+	scanner.Channel = channel
+	scanner.Audit = func(e redact.AuditEvent) {
+		s.logAudit(ctx, redactAuditAction, redactAuditPath(e), true)
+	}
+
+	res, _ := scanner.Scan(text, redact.ScanOptions{
+		Strict:        redact.StrictModeEnabled(),
+		CorrelationID: correlationID,
+	})
 	return res.Text
+}
+
+// redactAuditPath renders an AuditEvent as the free-text "path" field
+// logAudit expects, using metadata only (detector, channel, confidence,
+// count, blocked, correlation ID) — never the matched value.
+func redactAuditPath(e redact.AuditEvent) string {
+	return fmt.Sprintf("detector=%s, channel=%s, confidence=%s, count=%d, blocked=%t, correlation_id=%s",
+		e.Detector, e.Channel, e.Confidence, e.RedactedCount, e.Blocked, e.CorrelationID)
 }

--- a/internal/mcp/server/tools_sanitize.go
+++ b/internal/mcp/server/tools_sanitize.go
@@ -8,7 +8,15 @@ import (
 	mcp "github.com/danieljustus/symaira-vault/internal/mcp"
 	"github.com/danieljustus/symaira-vault/internal/mcp/masking"
 	"github.com/danieljustus/symaira-vault/internal/metrics"
+	"github.com/danieljustus/symaira-vault/internal/redact"
 )
+
+// outputScanner is the output-scanning redaction core (#695) applied to
+// every MCP/tool response payload that carries subprocess or externally
+// sourced text, as a defense-in-depth layer alongside the known-secret
+// masking already performed by sanitizeKnownSecretValues. It is a package
+// var (not per-call) since it is stateless and safe for concurrent use.
+var outputScanner = redact.NewScanner(redact.NewPatternDetector())
 
 func (s *Server) handleSanitizeOutput(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	text, err := req.RequireString("text")
@@ -50,6 +58,8 @@ func (s *Server) handleSanitizeOutput(ctx context.Context, req mcp.CallToolReque
 func (s *Server) sanitizeRunOutput(stdout, stderr string, resolvedEnv map[string]string) (string, string) {
 	stdout = s.sanitizeKnownSecretValues(stdout, resolvedEnv)
 	stderr = s.sanitizeKnownSecretValues(stderr, resolvedEnv)
+	stdout = scanOutputPatterns(stdout)
+	stderr = scanOutputPatterns(stderr)
 	stdout = globalChokepoint.SanitizeForMCP(stdout)
 	stderr = globalChokepoint.SanitizeForMCP(stderr)
 	return stdout, stderr
@@ -61,4 +71,14 @@ func (s *Server) sanitizeKnownSecretValues(text string, resolvedEnv map[string]s
 	}
 
 	return masking.SanitizeWithKnownSecrets(text, resolvedEnv, "***")
+}
+
+// scanOutputPatterns applies the output-scanning redaction core's
+// credential-shaped pattern detector (#695) to text before it is embedded
+// in an MCP tool response payload. It fails closed: if scanning itself
+// errors, text is withheld (replaced with a fixed marker) rather than
+// returned unredacted.
+func scanOutputPatterns(text string) string {
+	res, _ := outputScanner.Scan(text, redact.ScanOptions{})
+	return res.Text
 }

--- a/internal/mcp/server/tools_sanitize_test.go
+++ b/internal/mcp/server/tools_sanitize_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -105,7 +106,7 @@ func TestSanitizeRunOutput(t *testing.T) {
 		"SECRET": "my-secret-value",
 	}
 
-	sanitizedStdout, sanitizedStderr := server.sanitizeRunOutput(stdout, stderr, resolvedEnv)
+	sanitizedStdout, sanitizedStderr := server.sanitizeRunOutput(context.Background(), stdout, stderr, resolvedEnv)
 
 	if sanitizedStdout != "The secret is ***" {
 		t.Errorf("stdout = %q, want %q", sanitizedStdout, "The secret is ***")
@@ -121,7 +122,7 @@ func TestSanitizeRunOutputNoSecrets(t *testing.T) {
 	stdout := "Normal output without secrets"
 	stderr := ""
 
-	sanitizedStdout, sanitizedStderr := server.sanitizeRunOutput(stdout, stderr, nil)
+	sanitizedStdout, sanitizedStderr := server.sanitizeRunOutput(context.Background(), stdout, stderr, nil)
 
 	if sanitizedStdout != stdout {
 		t.Errorf("stdout = %q, want %q", sanitizedStdout, stdout)
@@ -143,7 +144,7 @@ func TestSanitizeRunOutput_StripsPromptInjectionVectors(t *testing.T) {
 	stdout := "normal\x1b[31mred</data>injection"
 	stderr := "warn‮RTL"
 
-	sanitizedStdout, sanitizedStderr := server.sanitizeRunOutput(stdout, stderr, nil)
+	sanitizedStdout, sanitizedStderr := server.sanitizeRunOutput(context.Background(), stdout, stderr, nil)
 
 	if strings.ContainsRune(sanitizedStdout, 0x1b) {
 		t.Errorf("stdout still contains ANSI escape: %q", sanitizedStdout)
@@ -161,9 +162,43 @@ func TestSanitizeRunOutput_AppliesChokepointWithoutEnv(t *testing.T) {
 	server := &Server{}
 
 	stdout := "hello\x1b[31mworld"
-	out, _ := server.sanitizeRunOutput(stdout, "", nil)
+	out, _ := server.sanitizeRunOutput(context.Background(), stdout, "", nil)
 
 	if strings.ContainsRune(out, 0x1b) {
 		t.Errorf("ANSI escape leaked through when env is empty: %q", out)
+	}
+}
+
+func TestSanitizeRunOutput_StrictModeBlocksHighConfidencePattern(t *testing.T) {
+	server := setupTestServer(t)
+
+	t.Setenv("SYMVAULT_REDACT_STRICT_MODE", "true")
+
+	// A GitHub-PAT-shaped synthetic token (not a real credential) triggers
+	// the credential-pattern detector at ConfidenceHigh.
+	stdout := "token=ghp_" + strings.Repeat("B", 36)
+	sanitizedStdout, _ := server.sanitizeRunOutput(context.Background(), stdout, "", nil)
+
+	if strings.Contains(sanitizedStdout, strings.Repeat("B", 36)) {
+		t.Fatalf("strict mode leaked the secret: %q", sanitizedStdout)
+	}
+	if strings.Contains(sanitizedStdout, "token=") {
+		t.Fatalf("strict mode should withhold the whole stream, not just redact in place: %q", sanitizedStdout)
+	}
+}
+
+func TestSanitizeRunOutput_NonStrictModeRedactsInPlace(t *testing.T) {
+	server := setupTestServer(t)
+
+	t.Setenv("SYMVAULT_REDACT_STRICT_MODE", "")
+
+	stdout := "prefix token=ghp_" + strings.Repeat("C", 36) + " suffix"
+	sanitizedStdout, _ := server.sanitizeRunOutput(context.Background(), stdout, "", nil)
+
+	if strings.Contains(sanitizedStdout, strings.Repeat("C", 36)) {
+		t.Fatalf("secret leaked: %q", sanitizedStdout)
+	}
+	if !strings.Contains(sanitizedStdout, "prefix") || !strings.Contains(sanitizedStdout, "suffix") {
+		t.Fatalf("non-strict mode should redact in place and keep surrounding output: %q", sanitizedStdout)
 	}
 }

--- a/internal/redact/detectors.go
+++ b/internal/redact/detectors.go
@@ -1,0 +1,86 @@
+package redact
+
+import (
+	"github.com/danieljustus/symaira-vault/internal/mcp/masking"
+)
+
+// minExactValueLen is the shortest value the exact-value detector will
+// treat as a secret. Values shorter than this are far too likely to
+// produce false-positive matches against ordinary output (e.g. "ab") and
+// carry little value as a secret in the first place.
+const minExactValueLen = 4
+
+// exactValueDetector matches literal occurrences of a fixed set of known
+// values (e.g. currently-unlocked vault secret values) and replaces them
+// with Marker. It never logs or returns the values themselves.
+type exactValueDetector struct {
+	values []string
+}
+
+// NewExactValueDetector returns a ConfidenceHigh Detector that redacts every
+// literal occurrence of any value in values. Empty values and values
+// shorter than minExactValueLen are ignored (never treated as matchable)
+// to avoid mass false positives.
+func NewExactValueDetector(values []string) Detector {
+	filtered := make([]string, 0, len(values))
+	for _, v := range values {
+		if len(v) >= minExactValueLen {
+			filtered = append(filtered, v)
+		}
+	}
+	return &exactValueDetector{values: filtered}
+}
+
+func (d *exactValueDetector) Name() string           { return "exact_value" }
+func (d *exactValueDetector) Confidence() Confidence { return ConfidenceHigh }
+
+func (d *exactValueDetector) Redact(text string) (string, int, error) {
+	total := 0
+	for _, v := range d.values {
+		var n int
+		text, n = replaceAllValue(text, v)
+		total += n
+	}
+	return text, total, nil
+}
+
+// patternDetector matches explicit credential-shaped patterns (API key
+// formats, tokens, private keys, ...) using the existing pattern registry
+// from internal/mcp/masking, so this package composes with — rather than
+// duplicates — that detection logic.
+type patternDetector struct {
+	registry *masking.PatternRegistry
+}
+
+// NewPatternDetector returns a ConfidenceHigh Detector for explicit
+// variable-name/credential-shaped patterns (AWS keys, GitHub tokens,
+// Slack tokens, private keys, etc.), backed by masking.DefaultPatterns.
+func NewPatternDetector() Detector {
+	return &patternDetector{registry: masking.NewPatternRegistry()}
+}
+
+// NewPatternDetectorWithRegistry allows callers to supply a custom pattern
+// registry (e.g. with additional org-specific patterns registered).
+func NewPatternDetectorWithRegistry(r *masking.PatternRegistry) Detector {
+	return &patternDetector{registry: r}
+}
+
+func (d *patternDetector) Name() string           { return "credential_pattern" }
+func (d *patternDetector) Confidence() Confidence { return ConfidenceHigh }
+
+func (d *patternDetector) Redact(text string) (string, int, error) {
+	matches := d.registry.FindMatches(text)
+	if len(matches) == 0 {
+		return text, 0, nil
+	}
+
+	var out []byte
+	lastEnd := 0
+	for _, m := range matches {
+		out = append(out, text[lastEnd:m.Start]...)
+		out = append(out, Marker...)
+		lastEnd = m.End
+	}
+	out = append(out, text[lastEnd:]...)
+	return string(out), len(matches), nil
+}

--- a/internal/redact/entropy.go
+++ b/internal/redact/entropy.go
@@ -1,0 +1,156 @@
+package redact
+
+import (
+	"math"
+	"strings"
+)
+
+// Tuning constants for the entropy heuristic. These are deliberately
+// conservative (see package doc and #697): false-positive resistance
+// matters more than recall for this last-resort layer, so both the
+// minimum token length and the entropy floor are set high enough that
+// ordinary prose and short identifiers never match, at the cost of also
+// missing some real secrets shorter than minTokenLen. This trade-off is
+// intentional and documented, not a bug to "fix" by loosening the
+// thresholds — see entropy_test.go's TestEntropyDetector_
+// DocumentedFalsePositiveClasses for the classes this knowingly still
+// misses or over-matches.
+const (
+	// minTokenLen is the shortest candidate token the detector considers.
+	// Below this length, entropy measurements are too noisy to be
+	// reliable, and short strings are unlikely to be secrets worth this
+	// last-resort layer's attention (exact-value and pattern detectors
+	// already cover the common short-secret formats).
+	minTokenLen = 20
+	// minEntropyBitsPerChar is the empirical Shannon-entropy floor a
+	// candidate token's characters must clear to be flagged. Deliberately
+	// set high (~4.85 bits/char): this is calibrated to sit above common
+	// non-secret long tokens seen in real tool output — hex digests
+	// (~3.7 bits/char, 16-symbol alphabet), alphanumeric identifiers such
+	// as temp-dir names or generated test-run identifiers (~3.8-4.7
+	// bits/char, verified against Go's own t.TempDir()/test-name shapes)
+	// — while still catching mixed-case/digit/symbol secrets and
+	// base64-encoded payloads (~5+ bits/char). The trade-off this buys is
+	// fewer false positives at the cost of missing hex-only secrets and
+	// some shorter random tokens; see entropy_test.go's
+	// TestEntropyDetector_DocumentedFalsePositiveClasses.
+	minEntropyBitsPerChar = 4.85
+)
+
+// entropyTokenChars is the set of characters treated as part of a
+// candidate token. It intentionally excludes common separators — space,
+// hyphen, colon, comma, and '/' — so that, e.g., a hyphen-delimited UUID
+// is split into several short hex runs (each below minTokenLen) rather
+// than analyzed as one long low-entropy string, and a filesystem path
+// (e.g. a working directory echoed by a command) is split at each '/'
+// instead of being treated as one long high-entropy token. '-' and '/'
+// are excluded for the same reason even though both appear in some
+// secret formats (base32, base64); this is a known, deliberate trade-off
+// for a conservative last-resort detector — it costs some recall on
+// slash- or hyphen-heavy encoded secrets in exchange for not flagging
+// ordinary paths and identifiers.
+func isEntropyTokenChar(r rune) bool {
+	switch {
+	case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+		return true
+	case strings.ContainsRune("+=_.~!@#$%^&*", r):
+		return true
+	default:
+		return false
+	}
+}
+
+// entropyDetector is the conservative, last-resort heuristic layer
+// (#697): it flags long token-shaped substrings whose empirical character
+// distribution is high enough in entropy to plausibly be a randomly
+// generated secret, tagged at ConfidenceLow so strict-mode blocking
+// (#696) treats it differently from exact-value/pattern matches.
+type entropyDetector struct{}
+
+// NewEntropyDetector returns a ConfidenceLow Detector implementing the
+// conservative entropy/pattern heuristic described in #697. It is meant
+// to run last in a Scanner's detector chain, after the ConfidenceHigh
+// exact-value and pattern detectors.
+func NewEntropyDetector() Detector {
+	return entropyDetector{}
+}
+
+func (entropyDetector) Name() string           { return "entropy_heuristic" }
+func (entropyDetector) Confidence() Confidence { return ConfidenceLow }
+
+func (d entropyDetector) Redact(text string) (string, int, error) {
+	tokens := tokenize(text)
+	if len(tokens) == 0 {
+		return text, 0, nil
+	}
+
+	var out strings.Builder
+	out.Grow(len(text))
+	lastEnd := 0
+	count := 0
+	for _, tok := range tokens {
+		if tok.end-tok.start < minTokenLen {
+			continue
+		}
+		if shannonEntropy(text[tok.start:tok.end]) < minEntropyBitsPerChar {
+			continue
+		}
+		out.WriteString(text[lastEnd:tok.start])
+		out.WriteString(Marker)
+		lastEnd = tok.end
+		count++
+	}
+	out.WriteString(text[lastEnd:])
+
+	if count == 0 {
+		return text, 0, nil
+	}
+	return out.String(), count, nil
+}
+
+type tokenSpan struct{ start, end int }
+
+// tokenize splits text into maximal runs of isEntropyTokenChar runes,
+// returning their byte offsets.
+func tokenize(text string) []tokenSpan {
+	var spans []tokenSpan
+	start := -1
+	for i, r := range text {
+		if isEntropyTokenChar(r) {
+			if start == -1 {
+				start = i
+			}
+			continue
+		}
+		if start != -1 {
+			spans = append(spans, tokenSpan{start, i})
+			start = -1
+		}
+	}
+	if start != -1 {
+		spans = append(spans, tokenSpan{start, len(text)})
+	}
+	return spans
+}
+
+// shannonEntropy returns the empirical Shannon entropy, in bits per
+// character, of s's byte distribution.
+func shannonEntropy(s string) float64 {
+	if len(s) == 0 {
+		return 0
+	}
+	var counts [256]int
+	for i := 0; i < len(s); i++ {
+		counts[s[i]]++
+	}
+	total := float64(len(s))
+	var entropy float64
+	for _, c := range counts {
+		if c == 0 {
+			continue
+		}
+		p := float64(c) / total
+		entropy -= p * math.Log2(p)
+	}
+	return entropy
+}

--- a/internal/redact/entropy_test.go
+++ b/internal/redact/entropy_test.go
@@ -1,0 +1,139 @@
+package redact
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestEntropyDetector_ConfidenceIsLow(t *testing.T) {
+	d := NewEntropyDetector()
+	if d.Confidence() != ConfidenceLow {
+		t.Fatalf("entropy detector must be ConfidenceLow, got %v", d.Confidence())
+	}
+}
+
+func TestEntropyDetector_FlagsHighEntropyToken(t *testing.T) {
+	d := NewEntropyDetector()
+	// Synthetic, obviously-fake high-entropy token (mixed case, digits,
+	// symbols, no real-world credential format) — not a real secret.
+	secret := "kQ7#zM2$pL9@rT4!vX8&wY6^bN3*cJ1~"
+	text := "config value: " + secret + " end"
+
+	got, n, err := d.Redact(text)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n == 0 {
+		t.Fatalf("expected the high-entropy token to be flagged")
+	}
+	if strings.Contains(got, secret) {
+		t.Fatalf("high-entropy secret leaked into output: %q", got)
+	}
+}
+
+func TestEntropyDetector_IgnoresOrdinaryProse(t *testing.T) {
+	d := NewEntropyDetector()
+	text := "This is a perfectly ordinary sentence about deploying the release pipeline on Friday afternoon."
+	got, n, err := d.Redact(text)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("expected no matches on ordinary prose, got %d: %q", n, got)
+	}
+}
+
+func TestEntropyDetector_IgnoresShortTokens(t *testing.T) {
+	d := NewEntropyDetector()
+	got, n, err := d.Redact("short=aB3$kZ9")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("expected short tokens below the length floor to be ignored, got %d: %q", n, got)
+	}
+}
+
+// TestEntropyDetector_DocumentedFalsePositiveClasses measures — and pins
+// via this test, rather than "fixing" by silently weakening the detector
+// — the detector's behavior on shapes that are known to sometimes look
+// like high-entropy secrets: UUIDs, hex hashes, base64-encoded non-secret
+// payloads, and long opaque identifiers. False-positive resistance matters
+// more than recall for this last-resort layer (#697), so several of these
+// are expected to NOT match; where one does match, that is a documented,
+// accepted limitation of a conservative last-resort heuristic, not a bug.
+func TestEntropyDetector_DocumentedFalsePositiveClasses(t *testing.T) {
+	d := NewEntropyDetector()
+
+	cases := []struct {
+		name        string
+		text        string
+		wantMatched bool
+		note        string
+	}{
+		{
+			name:        "uuid_v4",
+			text:        "request_id=f47ac10b-58cc-4372-a567-0e02b2c3d479",
+			wantMatched: false,
+			note:        "hyphenated hex runs are short between separators and low-entropy per byte (hex alphabet); the tokenizer's separator set treats '-' as a boundary",
+		},
+		{
+			name:        "sha256_hash_of_content",
+			text:        "checksum=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+			wantMatched: false,
+			note:        "hex digests use only a 16-symbol alphabet, so their empirical entropy (~3.7 bits/char) stays under the floor tuned to avoid flagging ordinary long identifiers; documented as a known miss (false negative), not a false positive, for this heuristic",
+		},
+		{
+			name:        "base64_non_secret_payload",
+			text:        "payload=" + "VGhpcyBpcyBqdXN0IGEgcGxhaW4gRW5nbGlzaCBzZW50ZW5jZSBlbmNvZGVkIGFzIGJhc2U2NA==",
+			wantMatched: true,
+			note:        "known limitation: base64-encoded text (even of non-secret content) is high-entropy by construction and is a documented false-positive class for this heuristic",
+		},
+		{
+			name:        "long_numeric_identifier",
+			text:        "order_id=12345678901234567890123456789012",
+			wantMatched: false,
+			note:        "digits-only runs have low charset diversity (10 symbols) and stay well under the entropy floor",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, n, err := d.Redact(tc.text)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			matched := n > 0
+			if matched != tc.wantMatched {
+				t.Fatalf("%s: matched=%v, want=%v (%s)", tc.name, matched, tc.wantMatched, tc.note)
+			}
+		})
+	}
+}
+
+func TestEntropyDetector_ComposesAsLowerConfidenceLayerInScanner(t *testing.T) {
+	sc := NewScanner(NewPatternDetector(), NewEntropyDetector())
+	secret := "kQ7#zM2$pL9@rT4!vX8&wY6^bN3*cJ1~"
+
+	res, err := sc.Scan("value: "+secret, ScanOptions{Strict: true})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Only ConfidenceLow findings occurred, so strict mode must NOT block —
+	// strict blocking is reserved for ConfidenceHigh matches (#696).
+	if res.Blocked {
+		t.Fatalf("strict mode should not block on a ConfidenceLow-only finding")
+	}
+	if strings.Contains(res.Text, secret) {
+		t.Fatalf("secret leaked: %q", res.Text)
+	}
+	found := false
+	for _, f := range res.Findings {
+		if f.Detector == NewEntropyDetector().Name() && f.Confidence == ConfidenceLow {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected a ConfidenceLow entropy finding, got %+v", res.Findings)
+	}
+}

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -1,0 +1,221 @@
+// Package redact provides the output-scanning redaction core: a small set of
+// composable detectors (exact known-value matches, credential-shaped
+// patterns, and — see entropy.go — a conservative entropy heuristic) plus a
+// Scanner that runs them over captured command output and MCP/tool response
+// payloads before that content leaves the process boundary.
+//
+// Design principles (see #695/#696/#697):
+//   - Redaction markers are a fixed, stable string. They never contain any
+//     substring, prefix, length hint, or hash of the matched value.
+//   - Detectors operate on plain strings and replace matched spans in place,
+//     so callers can run the scanner over JSON payloads: only the substrings
+//     inside string values are rewritten, and surrounding structural
+//     characters (quotes, braces, commas) are left untouched.
+//   - Fail-closed: if any detector errors, the Scanner does not return the
+//     original (possibly-secret-bearing) text. It reports the failure via
+//     Result.Blocked and a non-nil error, and Result.Text is always safe to
+//     display.
+package redact
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Marker is the stable, non-reversible string substituted for every
+// detected secret. It intentionally carries no information about the
+// original value (no prefix, no length hint, no hash).
+const Marker = "[REDACTED]"
+
+// blockedText is returned in place of the original text whenever the
+// Scanner cannot guarantee the text is safe (detector failure, or a
+// strict-mode block). It is a fixed marker, never derived from the input.
+const blockedText = "[REDACTED: output withheld]"
+
+// Confidence classifies how certain a detector is about its matches.
+// Downstream consumers (e.g. strict-mode blocking in #696) use this to
+// decide whether a match is trusted enough to block delivery outright.
+type Confidence int
+
+const (
+	// ConfidenceHigh identifies detectors with very low false-positive
+	// rates: exact known-value matches and explicit credential-shaped
+	// patterns (e.g. "ghp_...", "AKIA...").
+	ConfidenceHigh Confidence = iota
+	// ConfidenceLow identifies last-resort heuristics (e.g. entropy-based
+	// detection, see #697) that trade recall for precision and are more
+	// prone to false positives.
+	ConfidenceLow
+)
+
+// String returns a human-readable label for the confidence level.
+func (c Confidence) String() string {
+	switch c {
+	case ConfidenceHigh:
+		return "high"
+	case ConfidenceLow:
+		return "low"
+	default:
+		return "unknown"
+	}
+}
+
+// Detector scans text for one class of secret and redacts matches in place.
+// Implementations must never return the matched value, a prefix of it, a
+// hash of it, or any other information that could reconstruct it — Redact's
+// returned string is the only thing callers are allowed to surface.
+type Detector interface {
+	// Name identifies the detector for audit/metadata purposes.
+	Name() string
+	// Confidence reports this detector's confidence tier.
+	Confidence() Confidence
+	// Redact returns text with every match replaced by Marker, the number
+	// of matches found, and an error if scanning failed. On error the
+	// returned string MUST NOT be used by the caller (see Scanner, which
+	// fails closed).
+	Redact(text string) (redacted string, count int, err error)
+}
+
+// Finding summarizes one detector's contribution to a Scan call. It
+// carries metadata only — never the matched value or any excerpt of it —
+// so it is safe to log or emit as an audit event.
+type Finding struct {
+	Detector   string
+	Confidence Confidence
+	Count      int
+}
+
+// ScanOptions configures a single Scan call.
+type ScanOptions struct {
+	// Strict, when true, causes the Scanner to block (withhold) the text
+	// entirely instead of redacting it in place, whenever a
+	// ConfidenceHigh detector reports at least one match. Lower-confidence
+	// findings are still redacted (not blocked) even in strict mode; see
+	// #696/#697 for the rationale.
+	Strict bool
+	// CorrelationID, if set, is echoed back on emitted AuditEvents so a
+	// caller can tie a block/redaction back to the call that produced it.
+	CorrelationID string
+}
+
+// Result is the outcome of a Scan call.
+type Result struct {
+	// Text is always safe to display: either the original text (no
+	// findings), the redacted text, or a fixed block marker. It never
+	// contains a matched secret value.
+	Text string
+	// Findings lists metadata about what was detected, in detector order.
+	Findings []Finding
+	// Blocked is true when Text was withheld/replaced entirely rather than
+	// redacted in place — either because strict mode fired on a
+	// high-confidence match, or because a detector failed (fail-closed).
+	Blocked bool
+}
+
+// AuditFunc receives one AuditEvent per Scan call that produced at least one
+// finding (whether redacted or blocked). Implementations must not derive
+// secret material from the event; the event type itself carries metadata
+// only, so any correctly-typed AuditFunc is safe.
+type AuditFunc func(AuditEvent)
+
+// AuditEvent is a metadata-only record of a detection. It never contains
+// the matched value, a prefix of it, or a hash of it.
+type AuditEvent struct {
+	Detector      string
+	Channel       string
+	Confidence    Confidence
+	RedactedCount int
+	Blocked       bool
+	CorrelationID string
+}
+
+// Scanner runs a fixed set of detectors over text.
+type Scanner struct {
+	detectors []Detector
+	// Channel labels emitted audit events (e.g. "run_command.stdout").
+	// Optional; defaults to "" if unset.
+	Channel string
+	// Audit, if set, is invoked once per detector that produced a finding
+	// during a Scan call.
+	Audit AuditFunc
+}
+
+// NewScanner builds a Scanner from the given detectors, applied in order.
+func NewScanner(detectors ...Detector) *Scanner {
+	return &Scanner{detectors: detectors}
+}
+
+// Scan runs every configured detector over text and returns a Result that
+// is always safe to surface to a caller, per the fail-closed contract
+// described on Result.Text.
+func (s *Scanner) Scan(text string, opts ScanOptions) (Result, error) {
+	if len(s.detectors) == 0 {
+		return Result{Text: text}, nil
+	}
+
+	current := text
+	var findings []Finding
+	highConfidenceHit := false
+
+	for _, d := range s.detectors {
+		redacted, count, err := d.Redact(current)
+		if err != nil {
+			// Fail closed: never return text derived from a run where a
+			// detector errored, even partially redacted text from prior
+			// detectors in this loop.
+			s.emitAudit(AuditEvent{
+				Detector:      d.Name(),
+				Channel:       s.Channel,
+				Confidence:    d.Confidence(),
+				Blocked:       true,
+				CorrelationID: opts.CorrelationID,
+			})
+			return Result{Text: blockedText, Blocked: true}, fmt.Errorf("redact: detector %q failed: %w", d.Name(), err)
+		}
+		if count > 0 {
+			findings = append(findings, Finding{Detector: d.Name(), Confidence: d.Confidence(), Count: count})
+			if d.Confidence() == ConfidenceHigh {
+				highConfidenceHit = true
+			}
+		}
+		current = redacted
+	}
+
+	blocked := opts.Strict && highConfidenceHit
+	for _, f := range findings {
+		s.emitAudit(AuditEvent{
+			Detector:      f.Detector,
+			Channel:       s.Channel,
+			Confidence:    f.Confidence,
+			RedactedCount: f.Count,
+			Blocked:       blocked,
+			CorrelationID: opts.CorrelationID,
+		})
+	}
+
+	if blocked {
+		return Result{Text: blockedText, Findings: findings, Blocked: true}, nil
+	}
+	return Result{Text: current, Findings: findings}, nil
+}
+
+func (s *Scanner) emitAudit(e AuditEvent) {
+	if s.Audit != nil {
+		s.Audit(e)
+	}
+}
+
+// replaceAllValue replaces every non-overlapping occurrence of value in text
+// with Marker and returns the result plus the number of replacements. It is
+// a thin wrapper over strings.Count/Replace kept here so every detector in
+// this package redacts consistently.
+func replaceAllValue(text, value string) (string, int) {
+	if value == "" {
+		return text, 0
+	}
+	n := strings.Count(text, value)
+	if n == 0 {
+		return text, 0
+	}
+	return strings.ReplaceAll(text, value, Marker), n
+}

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -1,0 +1,150 @@
+package redact
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestExactValueDetector_RedactsKnownSecret(t *testing.T) {
+	d := NewExactValueDetector([]string{"sup3r-s3cret-value-xyz"})
+	got, n, err := d.Redact("the password is sup3r-s3cret-value-xyz and that's it")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("want 1 match, got %d", n)
+	}
+	if strings.Contains(got, "sup3r-s3cret-value-xyz") {
+		t.Fatalf("secret leaked into output: %q", got)
+	}
+	if !strings.Contains(got, Marker) {
+		t.Fatalf("expected marker in output: %q", got)
+	}
+}
+
+func TestExactValueDetector_NoPartialLeak(t *testing.T) {
+	d := NewExactValueDetector([]string{"abcdefghijklmnop"})
+	got, _, _ := d.Redact("value=abcdefghijklmnop end")
+	// Marker must not contain any substring (len >= 3) of the secret.
+	secret := "abcdefghijklmnop"
+	for i := 0; i+3 <= len(secret); i++ {
+		sub := secret[i : i+3]
+		if strings.Contains(got, sub) {
+			t.Fatalf("output contains secret substring %q: %q", sub, got)
+		}
+	}
+}
+
+func TestExactValueDetector_IgnoresEmptyAndShortValues(t *testing.T) {
+	d := NewExactValueDetector([]string{"", "ab"})
+	got, n, err := d.Redact("ab is short and empty is nothing")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("expected no matches for empty/too-short values, got %d", n)
+	}
+	if got != "ab is short and empty is nothing" {
+		t.Fatalf("text should be unchanged, got %q", got)
+	}
+}
+
+func TestPatternDetector_DetectsCredentialShapedValues(t *testing.T) {
+	d := NewPatternDetector()
+	// Synthetic, obviously-fake GitHub-PAT-shaped token (not a real credential).
+	text := "token=ghp_" + strings.Repeat("A", 36)
+	got, n, err := d.Redact(text)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n == 0 {
+		t.Fatalf("expected pattern match, got none")
+	}
+	if strings.Contains(got, strings.Repeat("A", 36)) {
+		t.Fatalf("pattern-matched secret leaked: %q", got)
+	}
+}
+
+func TestPatternDetector_FalsePositiveResistance(t *testing.T) {
+	d := NewPatternDetector()
+	got, n, err := d.Redact("just a normal sentence about deployment pipelines and version 1.2.3")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("expected no matches on benign text, got %d: %q", n, got)
+	}
+}
+
+func TestScanner_JSONStructurePreserved(t *testing.T) {
+	sc := NewScanner(NewExactValueDetector([]string{"topsecretvalue1"}))
+	payload := `{"stdout":"login ok, token=topsecretvalue1","exit_code":0}`
+	res, err := sc.Scan(payload, ScanOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(res.Text, "topsecretvalue1") {
+		t.Fatalf("secret leaked in JSON output: %q", res.Text)
+	}
+	if !strings.HasPrefix(res.Text, `{"stdout":"login ok, token=`) {
+		t.Fatalf("JSON structure was corrupted: %q", res.Text)
+	}
+	if !strings.HasSuffix(res.Text, `,"exit_code":0}`) {
+		t.Fatalf("JSON structure was corrupted: %q", res.Text)
+	}
+}
+
+func TestScanner_MultilineAndTruncatedOutput(t *testing.T) {
+	sc := NewScanner(NewExactValueDetector([]string{"multilinesecretval"}))
+	text := "line one\nline two multilinesecretval\nline three (truncat"
+	res, err := sc.Scan(text, ScanOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(res.Text, "multilinesecretval") {
+		t.Fatalf("secret leaked: %q", res.Text)
+	}
+	if !strings.HasPrefix(res.Text, "line one\nline two ") {
+		t.Fatalf("multiline structure corrupted: %q", res.Text)
+	}
+	if !strings.HasSuffix(res.Text, "line three (truncat") {
+		t.Fatalf("truncated tail corrupted: %q", res.Text)
+	}
+}
+
+type erroringDetector struct{}
+
+func (erroringDetector) Name() string           { return "erroring" }
+func (erroringDetector) Confidence() Confidence { return ConfidenceHigh }
+func (erroringDetector) Redact(string) (string, int, error) {
+	return "", 0, errors.New("boom")
+}
+
+func TestScanner_FailClosedOnDetectorError(t *testing.T) {
+	sc := NewScanner(erroringDetector{})
+	res, err := sc.Scan("some very sensitive output that must never leak", ScanOptions{})
+	if err == nil {
+		t.Fatalf("expected error to be surfaced")
+	}
+	if strings.Contains(res.Text, "sensitive output") {
+		t.Fatalf("fail-closed violated: original text leaked through: %q", res.Text)
+	}
+	if !res.Blocked {
+		t.Fatalf("expected Blocked=true on detector failure")
+	}
+}
+
+func TestScanner_NoDetectors_ReturnsTextUnchanged(t *testing.T) {
+	sc := NewScanner()
+	res, err := sc.Scan("hello world", ScanOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Text != "hello world" {
+		t.Fatalf("expected unchanged text, got %q", res.Text)
+	}
+	if res.Blocked {
+		t.Fatalf("should not be blocked")
+	}
+}

--- a/internal/redact/strict.go
+++ b/internal/redact/strict.go
@@ -1,0 +1,48 @@
+package redact
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"os"
+)
+
+// EnvStrictMode is the opt-in environment variable that enables strict
+// blocking mode (#696): when set to a truthy value, a ConfidenceHigh
+// detection causes the Scanner to block delivery/persistence of the
+// affected output instead of only redacting it in place. Disabled
+// (redact-and-continue) by default — this is an explicit opt-in, matching
+// this codebase's fail-safe-by-default / explicit-opt-in-for-stricter-
+// behavior convention (see the environment-passphrase opt-in flag).
+const EnvStrictMode = "SYMVAULT_REDACT_STRICT_MODE"
+
+// StrictModeEnabled reports whether strict blocking mode is currently
+// opted into via EnvStrictMode. Recognized truthy values are "1", "t",
+// "true", "yes", "on" (case-insensitive); anything else, including unset,
+// is treated as disabled.
+func StrictModeEnabled() bool {
+	return isTruthy(os.Getenv(EnvStrictMode))
+}
+
+func isTruthy(v string) bool {
+	switch v {
+	case "1", "t", "T", "true", "TRUE", "True", "yes", "YES", "Yes", "on", "ON", "On":
+		return true
+	default:
+		return false
+	}
+}
+
+// NewCorrelationID returns a random, unpredictable correlation ID suitable
+// for tying a Scan call's audit event(s) back to the originating request.
+// It carries no information about any scanned content.
+func NewCorrelationID() string {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		// Fall back to a fixed-but-unique-enough marker rather than
+		// panicking: correlation IDs are an observability aid, not a
+		// security boundary, so degrading gracefully is preferable to
+		// failing the calling request over an audit nicety.
+		return "corr-unavailable"
+	}
+	return hex.EncodeToString(b)
+}

--- a/internal/redact/strict_test.go
+++ b/internal/redact/strict_test.go
@@ -1,0 +1,127 @@
+package redact
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestScanner_StrictMode_BlocksHighConfidenceMatch(t *testing.T) {
+	var events []AuditEvent
+	sc := NewScanner(NewExactValueDetector([]string{"blockmehardvalue1"}))
+	sc.Audit = func(e AuditEvent) { events = append(events, e) }
+
+	res, err := sc.Scan("output containing blockmehardvalue1 here", ScanOptions{Strict: true, CorrelationID: "corr-1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !res.Blocked {
+		t.Fatalf("expected strict mode to block a high-confidence match")
+	}
+	if strings.Contains(res.Text, "blockmehardvalue1") {
+		t.Fatalf("blocked text must never contain the secret: %q", res.Text)
+	}
+	if len(events) != 1 {
+		t.Fatalf("expected exactly 1 audit event, got %d", len(events))
+	}
+	if !events[0].Blocked {
+		t.Fatalf("expected audit event to record Blocked=true")
+	}
+	if events[0].CorrelationID != "corr-1" {
+		t.Fatalf("correlation ID not propagated: got %q", events[0].CorrelationID)
+	}
+}
+
+func TestScanner_NonStrictMode_RedactsAndContinues(t *testing.T) {
+	var events []AuditEvent
+	sc := NewScanner(NewExactValueDetector([]string{"redactmesoftvalue1"}))
+	sc.Audit = func(e AuditEvent) { events = append(events, e) }
+
+	res, err := sc.Scan("output containing redactmesoftvalue1 here, and more text after", ScanOptions{Strict: false, CorrelationID: "corr-2"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Blocked {
+		t.Fatalf("non-strict mode must not block")
+	}
+	if strings.Contains(res.Text, "redactmesoftvalue1") {
+		t.Fatalf("secret leaked: %q", res.Text)
+	}
+	if !strings.Contains(res.Text, "and more text after") {
+		t.Fatalf("non-strict mode must preserve surrounding output, got %q", res.Text)
+	}
+	if len(events) != 1 || events[0].Blocked {
+		t.Fatalf("expected 1 non-blocked audit event, got %+v", events)
+	}
+}
+
+func TestScanner_AuditEvents_NeverContainSecretMaterial(t *testing.T) {
+	secret := "hyperconfidentialvalue42"
+	var events []AuditEvent
+	sc := NewScanner(NewExactValueDetector([]string{secret}))
+	sc.Audit = func(e AuditEvent) { events = append(events, e) }
+
+	for _, strict := range []bool{true, false} {
+		events = nil
+		_, err := sc.Scan("leaked here: "+secret, ScanOptions{Strict: strict, CorrelationID: "corr-3"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		for _, e := range events {
+			// AuditEvent's fields are all metadata-typed (strings/ints/bools
+			// that describe the detection, not the value) — assert none of
+			// them, when formatted, contain the secret or a hash of it.
+			if strings.Contains(e.Detector, secret) || strings.Contains(e.Channel, secret) || strings.Contains(e.CorrelationID, secret) {
+				t.Fatalf("audit event leaked secret material: %+v", e)
+			}
+		}
+	}
+}
+
+func TestScanner_CorrelationID_TiesBlockToCall(t *testing.T) {
+	var events []AuditEvent
+	sc := NewScanner(NewExactValueDetector([]string{"corrtiedvalue123"}))
+	sc.Audit = func(e AuditEvent) { events = append(events, e) }
+
+	if _, err := sc.Scan("a corrtiedvalue123 b", ScanOptions{Strict: true, CorrelationID: "call-A"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, err := sc.Scan("a corrtiedvalue123 b", ScanOptions{Strict: false, CorrelationID: "call-B"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(events) != 2 {
+		t.Fatalf("expected 2 audit events, got %d", len(events))
+	}
+	if events[0].CorrelationID != "call-A" || !events[0].Blocked {
+		t.Fatalf("event 0 does not tie back to call-A block: %+v", events[0])
+	}
+	if events[1].CorrelationID != "call-B" || events[1].Blocked {
+		t.Fatalf("event 1 does not tie back to call-B redaction: %+v", events[1])
+	}
+}
+
+func TestStrictModeEnabled_OptInEnvVar(t *testing.T) {
+	t.Setenv(EnvStrictMode, "")
+	if StrictModeEnabled() {
+		t.Fatalf("expected strict mode disabled by default")
+	}
+	t.Setenv(EnvStrictMode, "true")
+	if !StrictModeEnabled() {
+		t.Fatalf("expected strict mode enabled when %s=true", EnvStrictMode)
+	}
+	t.Setenv(EnvStrictMode, "0")
+	if StrictModeEnabled() {
+		t.Fatalf("expected strict mode disabled when %s=0", EnvStrictMode)
+	}
+}
+
+func TestNewCorrelationID_ReturnsNonEmptyUniqueValues(t *testing.T) {
+	a := NewCorrelationID()
+	b := NewCorrelationID()
+	if a == "" || b == "" {
+		t.Fatalf("expected non-empty correlation IDs")
+	}
+	if a == b {
+		t.Fatalf("expected unique correlation IDs, got two equal values %q", a)
+	}
+}

--- a/internal/secrets/runner.go
+++ b/internal/secrets/runner.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"sort"
 	"time"
+
+	"github.com/danieljustus/symaira-vault/internal/redact"
 )
 
 // RunResult contains the result of a command execution.
@@ -167,6 +169,20 @@ func RunCommand(opts RunOptions) (*RunResult, error) {
 		RejectedEnvVars: rejected,
 	}
 
+	// Redact explicit credential-shaped patterns out of the captured
+	// output before it can leave the process boundary — this is the
+	// output-scanning redaction core (#695), pattern-detection layer.
+	// RunCommand is a general-purpose executor (opts.Env is arbitrary
+	// caller-supplied values, not necessarily secret material — see the
+	// TestRunCommand_EnvOverlay-style callers), so it does not have
+	// enough context to safely exact-match opts.Env as "known secrets";
+	// that exact-value redaction happens one layer up, in
+	// internal/mcp/server (sanitizeKnownSecretValues /
+	// sanitizeRunOutput), where the caller knows which resolved values
+	// are actual vault secrets. This pattern-only pass is defense in
+	// depth that composes with, not replaces, that layer.
+	redactResult(result)
+
 	if runErr != nil {
 		var exitErr *exec.ExitError
 		if errors.As(runErr, &exitErr) {
@@ -181,6 +197,24 @@ func RunCommand(opts RunOptions) (*RunResult, error) {
 	}
 
 	return result, nil
+}
+
+// redactResult scans result.Stdout and result.Stderr for explicit
+// credential-shaped patterns (see internal/redact), replacing any match
+// with the stable redact.Marker in place. It fails closed: if scanning
+// itself errors, the affected field is replaced with a fixed "withheld"
+// marker rather than left unredacted.
+func redactResult(result *RunResult) {
+	scanner := redact.NewScanner(redact.NewPatternDetector())
+
+	// Result.Text is always safe to use regardless of the returned error —
+	// on a detector failure it is a fixed "withheld" marker, never the raw
+	// text (fail-closed).
+	stdoutRes, _ := scanner.Scan(result.Stdout, redact.ScanOptions{})
+	result.Stdout = stdoutRes.Text
+
+	stderrRes, _ := scanner.Scan(result.Stderr, redact.ScanOptions{})
+	result.Stderr = stderrRes.Text
 }
 
 // isSafeFileName reports whether name is safe to use both as an environment

--- a/internal/secrets/runner_test.go
+++ b/internal/secrets/runner_test.go
@@ -555,3 +555,15 @@ func TestRunCommand_NonSensitiveEnvAndPassthroughStillWork(t *testing.T) {
 		t.Errorf("RejectedEnvVars = %v, want none", result.RejectedEnvVars)
 	}
 }
+
+func TestRunCommand_RedactsCredentialShapedPatternFromOutput(t *testing.T) {
+	result, err := RunCommand(RunOptions{
+		Command: []string{"sh", "-c", "echo token=ghp_" + strings.Repeat("A", 36)},
+	})
+	if err != nil {
+		t.Fatalf("RunCommand() unexpected error: %v", err)
+	}
+	if strings.Contains(result.Stdout, strings.Repeat("A", 36)) {
+		t.Fatalf("pattern-shaped secret leaked into Stdout: %q", result.Stdout)
+	}
+}


### PR DESCRIPTION
Bundles fixes for multiple open issues. The list below grows as commits land; every linked issue will close automatically on merge.

<!-- closes-list-start -->
- Closes #680 Add proactive local secret-leak detection at process and output boundaries
- Closes #695 Add output-scanning redaction core for known secrets and credential patterns
- Closes #696 Add strict blocking mode and metadata-only audit events for leak detection
- Closes #697 Add conservative entropy/pattern heuristic layer for unrecognized secrets
- Closes #698 Document local secret-leak detection limits and false-positive trade-offs
<!-- closes-list-end -->
