### PR TITLE
fix(admin): make symvault init use argon2id for new vaults

### DIFF
--- a/cmd/admin/init.go
+++ b/cmd/admin/init.go
@@ -83,6 +83,13 @@ var initCmd = &cobra.Command{
 
 		cfg := config.Default()
 		cfg.VaultDir = vaultDir
+		// A non-nil Vault section is required for InitWithPassphrase to take
+		// the argon2id path (see internal/vault/vault.go); without it, new
+		// vaults would silently fall back to legacy scrypt.
+		cfg.Vault = &config.VaultConfig{
+			SearchIndex:     true,
+			AutoHealZeroKey: true,
+		}
 		if authErr := cfg.SetAuthMethod(authMethod); authErr != nil {
 			return authErr
 		}

--- a/cmd/admin/init_test.go
+++ b/cmd/admin/init_test.go
@@ -1,0 +1,36 @@
+package admin
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	cli "github.com/danieljustus/symaira-vault/internal/cli"
+	cryptopkg "github.com/danieljustus/symaira-vault/internal/crypto"
+)
+
+// TestInit_NewVaultUsesArgon2id reproduces the real `symvault init` CLI path
+// end-to-end and asserts the resulting identity.age is argon2id, as documented
+// by `migrate kdf` ("New vaults already use argon2id.") and the doctor hint
+// in internal/health/doctor_crypto.go.
+func TestInit_NewVaultUsesArgon2id(t *testing.T) {
+	vaultDir := filepath.Join(t.TempDir(), "vault")
+	passphrase := "test-passphrase-1234"
+
+	cli.SetCachedEnvPassphrase([]byte(passphrase))
+	t.Cleanup(cli.ClearCachedEnvPassphrase)
+
+	cmd := cli.RootCmd
+	cmd.SetArgs([]string{"init", vaultDir, "--auth", "passphrase"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(vaultDir, "identity.age"))
+	if err != nil {
+		t.Fatalf("read identity.age: %v", err)
+	}
+	if format := cryptopkg.DetectEncryptedIdentityFormat(raw); format != "argon2id" {
+		t.Errorf("new vault identity.age format = %q, want argon2id", format)
+	}
+}


### PR DESCRIPTION
## Summary
- `cmd/admin/init.go`'s `RunE` built its config via `config.Default()` and never set `cfg.Vault`, so `InitWithPassphrase` (`internal/vault/vault.go`) always branched into legacy scrypt instead of argon2id, regardless of what `migrate kdf` and the doctor hint claim ("new vaults already use argon2id").
- Set `cfg.Vault` to a non-nil `*config.VaultConfig` before `SetAuthMethod` is called, so new vaults take the argon2id path and `SetAuthMethod` correctly syncs `cfg.Vault.AuthMethod`/`UseTouchID` (previously silently skipped since it only writes into an already-non-nil `cfg.Vault`).
- Audited every `cfg.Vault == nil` / `!= nil` branch in the repo (config load/merge/save/validate, vault init/search/entry read-write, health doctor, MCP/crud search-workers) — none of them treat `nil` as an "uninitialized vault" signal in a way this change would break; they all just fall back to sane zero-value defaults.

## Test plan
- [x] Added `cmd/admin/init_test.go::TestInit_NewVaultUsesArgon2id`, which drives the real `symvault init` CLI path (`cli.RootCmd.Execute()` with `["init", vaultDir, "--auth", "passphrase"]`) and asserts the resulting `identity.age` is argon2id, not scrypt. Confirmed red before the fix, green after.
- [x] `go build ./...`
- [x] `go test ./cmd/... ./internal/config/... ./internal/vault/... ./internal/health/...`
- [x] `GOWORK=off make vet`
- [x] `GOWORK=off make lint` (0 issues)

Fixes #704

🤖 Generated with [Claude Code](https://claude.com/claude-code)