### PR TITLE
audit: per-entry HMAC key generation ID (kid) for rotation-safe verification

### DIFF
--- a/cmd/admin/audit.go
+++ b/cmd/admin/audit.go
@@ -237,12 +237,11 @@ in the vault directory. A new audit log file is started with the new key.`,
 		}
 
 		ks := audit.NewKeystore(vaultDir, nil)
-		newKey, err := ks.RotateKey()
+		newKey, archivePath, err := ks.RotateKey()
 		if err != nil {
 			return fmt.Errorf("rotate HMAC key: %w", err)
 		}
 
-		archivePath := audit.RotateKeyArchivePath(vaultDir)
 		cmd.Printf("HMAC key rotated successfully.\n")
 		cmd.Printf("New key: %x (first 4 bytes)\n", newKey[:4])
 		cmd.Printf("Old key archived to: %s\n", archivePath)

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -154,6 +154,7 @@ type LogEntry struct {
 	TokenID     string `json:"token_id,omitempty"`
 	RequestID   string `json:"req_id,omitempty"`
 	SessionID   string `json:"sess_id,omitempty"`
+	Kid         string `json:"kid,omitempty"`
 	HMAC        string `json:"hmac,omitempty"`
 	OK          bool   `json:"ok"`
 }
@@ -165,7 +166,12 @@ type VerifyResult struct {
 	Verified    int
 	Legacy      int
 	Tampered    int
-	FirstBadIdx int
+	// Unverifiable counts entries whose signing key generation is not
+	// among the keys the verifier was given (e.g. an archived key that has
+	// been lost). Unlike Tampered, this is not evidence of manipulation —
+	// it does not affect Valid.
+	Unverifiable int
+	FirstBadIdx  int
 }
 
 type Logger struct {
@@ -174,6 +180,7 @@ type Logger struct {
 	file      *os.File
 	mu        sync.Mutex
 	hmacKey   []byte
+	keyID     string
 	prevHMAC  []byte
 
 	entryCh     chan *LogEntry
@@ -247,6 +254,7 @@ func New(agentName string, vaultDir string, identity *age.X25519Identity) (*Logg
 		agentName:  agentName,
 		path:       cleanPath,
 		hmacKey:    hmacKey,
+		keyID:      KeyFingerprint(hmacKey),
 		bufferSize: defaultBufferSize,
 		entryCh:    make(chan *LogEntry, defaultBufferSize),
 		flushReq:   make(chan chan struct{}, 1),
@@ -696,6 +704,7 @@ func (l *Logger) writeEntry(entry *LogEntry) {
 	defer l.mu.Unlock()
 
 	if len(l.hmacKey) > 0 {
+		entry.Kid = l.keyID
 		entry.HMAC = computeHMAC(l.hmacKey, l.prevHMAC, *entry)
 	}
 
@@ -813,9 +822,39 @@ func canonicalJSON(entry LogEntry) []byte {
 	return data
 }
 
+// VerifyLog verifies a log file's HMAC chain against a single key. It is a
+// backward-compatible wrapper around VerifyLogAgainstKeys for callers that
+// only have one key on hand (e.g. no keystore access to archived
+// generations).
 func VerifyLog(logFilePath string, key []byte) (*VerifyResult, error) {
 	if len(key) == 0 {
 		return nil, errors.New("hmac key is empty")
+	}
+	kid := KeyFingerprint(key)
+	return VerifyLogAgainstKeys(logFilePath, map[string][]byte{kid: key}, kid)
+}
+
+// VerifyLogAgainstKeys verifies a log file's HMAC chain against a set of
+// known HMAC keys, keyed by key-generation fingerprint (kid, see
+// KeyFingerprint). currentKid identifies the caller's current key within
+// keys; it anchors the trial order used for entries that predate the kid
+// field.
+//
+// Entries carrying a kid look up their signing key directly, which
+// correctly verifies a log file that straddles a key rotation mid-stream
+// (some entries signed under an old key, later entries under a new one).
+// Entries without a kid (written before this field existed) are tried
+// against each known key in turn — current key first, then archived keys —
+// mirroring the original single-key verification behavior. A kid that
+// isn't present in keys, or a no-kid entry that matches no known key, is
+// reported as Unverifiable rather than Tampered: a missing key generation
+// (e.g. an archived key that was never recovered) is not evidence of
+// manipulation, only that this entry can't be checked. An entry whose
+// stored HMAC doesn't match its recomputed value under the resolved key is
+// always Tampered.
+func VerifyLogAgainstKeys(logFilePath string, keys map[string][]byte, currentKid string) (*VerifyResult, error) {
+	if len(keys) == 0 {
+		return nil, errors.New("no hmac keys provided")
 	}
 
 	data, err := os.ReadFile(logFilePath) //#nosec G304 -- logFilePath is provided by the caller and expected to be a trusted audit log path
@@ -843,7 +882,12 @@ func VerifyLog(logFilePath string, key []byte) (*VerifyResult, error) {
 		FirstBadIdx: -1,
 	}
 
-	mac := hmac.New(sha256.New, key)
+	macByKid := make(map[string]hash.Hash, len(keys))
+	for kid, key := range keys {
+		macByKid[kid] = hmac.New(sha256.New, key)
+	}
+	trialKids := trialKidOrder(keys, currentKid)
+
 	var prevHMAC []byte
 	chainStarted := false
 	for i, entry := range entries {
@@ -863,20 +907,52 @@ func VerifyLog(logFilePath string, key []byte) (*VerifyResult, error) {
 			continue
 		}
 
-		expectedHMAC := computeHMACWith(mac, prevHMAC, entry)
 		entryHMACBytes, decodeErr := hex.DecodeString(entry.HMAC)
-		expectedHMACBytes, decodeExpectedErr := hex.DecodeString(expectedHMAC)
-		if decodeErr != nil || decodeExpectedErr != nil || !hmac.Equal(expectedHMACBytes, entryHMACBytes) {
+		if decodeErr != nil {
 			result.Tampered++
 			result.Valid = false
 			if result.FirstBadIdx < 0 {
 				result.FirstBadIdx = i
 			}
-		} else {
-			result.Verified++
-			prevHMAC = entryHMACBytes
-			chainStarted = true
+			continue
 		}
+
+		var matched, known bool
+		if entry.Kid != "" {
+			if mac, ok := macByKid[entry.Kid]; ok {
+				known = true
+				expectedBytes, _ := hex.DecodeString(computeHMACWith(mac, prevHMAC, entry))
+				matched = hmac.Equal(expectedBytes, entryHMACBytes)
+			}
+		} else {
+			for _, kid := range trialKids {
+				expectedBytes, _ := hex.DecodeString(computeHMACWith(macByKid[kid], prevHMAC, entry))
+				if hmac.Equal(expectedBytes, entryHMACBytes) {
+					known, matched = true, true
+					break
+				}
+			}
+		}
+
+		switch {
+		case matched:
+			result.Verified++
+		case known:
+			result.Tampered++
+			result.Valid = false
+			if result.FirstBadIdx < 0 {
+				result.FirstBadIdx = i
+			}
+		default:
+			result.Unverifiable++
+		}
+
+		// Chain forward from this entry's own stored HMAC regardless of
+		// verification outcome: it's the literal value later entries were
+		// signed against, so one bad or unverifiable entry doesn't cascade
+		// into false failures for everything after it.
+		prevHMAC = entryHMACBytes
+		chainStarted = true
 	}
 
 	if result.Total == 0 {
@@ -886,9 +962,28 @@ func VerifyLog(logFilePath string, key []byte) (*VerifyResult, error) {
 	return result, nil
 }
 
+// trialKidOrder returns a deterministic key-trial order for entries with no
+// kid: the caller's current key first (matching historical single-key
+// verification behavior), then remaining keys in a stable order.
+func trialKidOrder(keys map[string][]byte, currentKid string) []string {
+	order := make([]string, 0, len(keys))
+	if _, ok := keys[currentKid]; ok {
+		order = append(order, currentKid)
+	}
+	rest := make([]string, 0, len(keys))
+	for kid := range keys {
+		if kid == currentKid {
+			continue
+		}
+		rest = append(rest, kid)
+	}
+	sort.Strings(rest)
+	return append(order, rest...)
+}
+
 func (l *Logger) Verify() (*VerifyResult, error) {
 	if l == nil {
 		return nil, errors.New("logger is nil")
 	}
-	return VerifyLog(l.path, l.hmacKey)
+	return VerifyLogAgainstKeys(l.path, map[string][]byte{l.keyID: l.hmacKey}, l.keyID)
 }

--- a/internal/audit/keystore.go
+++ b/internal/audit/keystore.go
@@ -2,8 +2,10 @@
 package audit
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
 	"path/filepath"
-	"time"
 )
 
 const (
@@ -20,14 +22,58 @@ type Keystore interface {
 	LoadHMACKey() ([]byte, error)
 
 	// RotateKey generates a new HMAC key, archives the existing key, and
-	// returns the new key bytes. The old key is archived to a timestamped
-	// backup file (e.g. audit-hmac-key.YYYY-MM-DD) in the audit directory.
-	RotateKey() ([]byte, error)
+	// returns the new key bytes together with the path the old key was
+	// archived to.
+	RotateKey() (newKey []byte, archivePath string, err error)
+
+	// LoadArchivedKeys returns every archived (rotated-out) HMAC key found
+	// in the audit directory, keyed by its fingerprint (see KeyFingerprint).
+	// Used by the verifier to check log entries written under a key
+	// generation that has since been rotated out.
+	LoadArchivedKeys() (map[string][]byte, error)
 }
 
-// RotateKeyArchivePath returns the archive path for an old HMAC key.
-func RotateKeyArchivePath(auditDir string) string {
-	return filepath.Join(auditDir, hmacKeyFileName+".rotated."+time.Now().UTC().Format("2006-01-02"))
+// KeyFingerprint returns a stable 8-hex-char identifier for an HMAC key
+// (the first 4 bytes of SHA-256(key), hex-encoded). It is recorded on audit
+// log entries as the "kid" (key-generation ID) so a verifier can pick the
+// matching key directly instead of trial-and-error, and is used as the
+// archive filename suffix on rotation so distinct key generations never
+// collide.
+func KeyFingerprint(key []byte) string {
+	sum := sha256.Sum256(key)
+	return hex.EncodeToString(sum[:4])
+}
+
+// RotateKeyArchivePath returns the archive path for an old HMAC key being
+// rotated out, keyed by the key's own fingerprint. Using the fingerprint
+// (rather than the rotation date) keeps multiple rotations on the same day
+// from overwriting each other's archived key.
+func RotateKeyArchivePath(auditDir string, oldKey []byte) string {
+	return filepath.Join(auditDir, hmacKeyFileName+".rotated."+KeyFingerprint(oldKey))
+}
+
+// LoadVerificationKeys returns the keystore's current HMAC key together
+// with every archived key generation, keyed by fingerprint (kid), plus the
+// fingerprint of the current key. The result is ready to pass to
+// VerifyLogAgainstKeys.
+func LoadVerificationKeys(ks Keystore) (keys map[string][]byte, currentKid string, err error) {
+	current, err := ks.LoadHMACKey()
+	if err != nil {
+		return nil, "", fmt.Errorf("load current hmac key: %w", err)
+	}
+	currentKid = KeyFingerprint(current)
+	keys = map[string][]byte{currentKid: current}
+
+	archived, err := ks.LoadArchivedKeys()
+	if err != nil {
+		return keys, currentKid, fmt.Errorf("load archived hmac keys: %w", err)
+	}
+	for kid, key := range archived {
+		if _, exists := keys[kid]; !exists {
+			keys[kid] = key
+		}
+	}
+	return keys, currentKid, nil
 }
 
 func keyringAccount(auditDir string) string {

--- a/internal/audit/keystore_fallback.go
+++ b/internal/audit/keystore_fallback.go
@@ -194,37 +194,61 @@ func (k *fallbackKeystore) LoadHMACKey() ([]byte, error) {
 	return data, nil
 }
 
-// RotateKey generates a new HMAC key, archives the existing key file to
-// a timestamped backup, and writes the new key to the key file.
-func (k *fallbackKeystore) RotateKey() ([]byte, error) {
+// RotateKey generates a new HMAC key, archives the existing key file to a
+// backup named after the old key's fingerprint (so repeated rotations never
+// collide), and writes the new key to the key file.
+func (k *fallbackKeystore) RotateKey() ([]byte, string, error) {
 	keyPath := filepath.Join(k.auditDir, hmacKeyFileName)
 
-	_, err := k.LoadHMACKey()
+	oldKey, err := k.LoadHMACKey()
 	if err != nil {
-		return nil, fmt.Errorf("load existing key for rotation: %w", err)
+		return nil, "", fmt.Errorf("load existing key for rotation: %w", err)
 	}
 
-	archivePath := RotateKeyArchivePath(k.auditDir)
+	archivePath := RotateKeyArchivePath(k.auditDir, oldKey)
 	if err := os.Rename(keyPath, archivePath); err != nil {
-		return nil, fmt.Errorf("archive old HMAC key: %w", err)
+		return nil, "", fmt.Errorf("archive old HMAC key: %w", err)
 	}
 
 	newKey := make([]byte, hmacKeySize)
 	if _, err := io.ReadFull(rand.Reader, newKey); err != nil {
-		return nil, fmt.Errorf("generate new HMAC key: %w", err)
+		return nil, "", fmt.Errorf("generate new HMAC key: %w", err)
 	}
 
 	if k.identity != nil {
 		if err := vaultcrypto.SaveEncryptedKey(keyPath, newKey, k.identity); err != nil {
-			return nil, fmt.Errorf("write encrypted HMAC key: %w", err)
+			return nil, "", fmt.Errorf("write encrypted HMAC key: %w", err)
 		}
 	} else {
 		if err := k.saveLocallyEncrypted(keyPath, newKey); err != nil {
-			return nil, fmt.Errorf("write locally-encrypted HMAC key: %w", err)
+			return nil, "", fmt.Errorf("write locally-encrypted HMAC key: %w", err)
 		}
 	}
 
-	return newKey, nil
+	return newKey, archivePath, nil
+}
+
+// LoadArchivedKeys reads every rotated-out HMAC key file in the audit
+// directory and returns them keyed by fingerprint. Archived files retain
+// whatever encryption format they had while live (age-encrypted,
+// locally-encrypted, or legacy plaintext), so they're loaded via the same
+// loadHMACKey path used for the current key.
+func (k *fallbackKeystore) LoadArchivedKeys() (map[string][]byte, error) {
+	pattern := filepath.Join(k.auditDir, hmacKeyFileName+".rotated.*")
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		return nil, fmt.Errorf("glob archived hmac keys: %w", err)
+	}
+
+	keys := make(map[string][]byte, len(matches))
+	for _, path := range matches {
+		key, loadErr := k.loadHMACKey(path)
+		if loadErr != nil || len(key) != hmacKeySize {
+			continue
+		}
+		keys[KeyFingerprint(key)] = key
+	}
+	return keys, nil
 }
 
 // NewKeystore creates a fallbackKeystore on platforms without OS keyring support.

--- a/internal/audit/keystore_os.go
+++ b/internal/audit/keystore_os.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -234,32 +235,58 @@ func (k *osKeystore) LoadHMACKey() ([]byte, error) {
 }
 
 // RotateKey generates a new HMAC key, archives the existing key as a
-// hex-encoded file in the audit directory, and stores the new key in
-// the OS keyring (with memory fallback).
-func (k *osKeystore) RotateKey() ([]byte, error) {
+// hex-encoded file in the audit directory (named after the old key's
+// fingerprint so repeated rotations never collide), and stores the new key
+// in the OS keyring (with memory fallback).
+func (k *osKeystore) RotateKey() ([]byte, string, error) {
 	oldKey, err := k.LoadHMACKey()
 	if err != nil {
-		return nil, fmt.Errorf("load existing key for rotation: %w", err)
+		return nil, "", fmt.Errorf("load existing key for rotation: %w", err)
 	}
 
-	archivePath := RotateKeyArchivePath(k.auditDir)
+	archivePath := RotateKeyArchivePath(k.auditDir, oldKey)
 	hexOld := hex.EncodeToString(oldKey)
 	if err := os.WriteFile(archivePath, []byte(hexOld), 0o600); err != nil {
-		return nil, fmt.Errorf("archive old HMAC key: %w", err)
+		return nil, "", fmt.Errorf("archive old HMAC key: %w", err)
 	}
 
 	newKey := make([]byte, hmacKeySize)
 	if _, err := io.ReadFull(rand.Reader, newKey); err != nil {
-		return nil, fmt.Errorf("generate new HMAC key: %w", err)
+		return nil, "", fmt.Errorf("generate new HMAC key: %w", err)
 	}
 
 	account := keyringAccount(k.auditDir)
 	hexNew := hex.EncodeToString(newKey)
 	if err := k.setWithFallback(keyringService, account, hexNew); err != nil {
-		return nil, fmt.Errorf("store new HMAC key in keyring: %w", err)
+		return nil, "", fmt.Errorf("store new HMAC key in keyring: %w", err)
 	}
 
-	return newKey, nil
+	return newKey, archivePath, nil
+}
+
+// LoadArchivedKeys reads every rotated-out HMAC key file in the audit
+// directory and returns them keyed by fingerprint. Archive files are
+// hex-encoded, matching the format RotateKey writes.
+func (k *osKeystore) LoadArchivedKeys() (map[string][]byte, error) {
+	pattern := filepath.Join(k.auditDir, hmacKeyFileName+".rotated.*")
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		return nil, fmt.Errorf("glob archived hmac keys: %w", err)
+	}
+
+	keys := make(map[string][]byte, len(matches))
+	for _, path := range matches {
+		data, readErr := os.ReadFile(path) //#nosec G304 -- path comes from Glob over k.auditDir
+		if readErr != nil {
+			continue
+		}
+		key, decodeErr := hex.DecodeString(strings.TrimSpace(string(data)))
+		if decodeErr != nil || len(key) != hmacKeySize {
+			continue
+		}
+		keys[KeyFingerprint(key)] = key
+	}
+	return keys, nil
 }
 
 // NewKeystore creates a Keystore backed by the OS keyring.

--- a/internal/audit/keystore_test.go
+++ b/internal/audit/keystore_test.go
@@ -53,7 +53,7 @@ func TestKeystoreRotateKey(t *testing.T) {
 		t.Fatalf("LoadOrCreateHMACKey() error = %v", err)
 	}
 
-	newKey, err := ks.RotateKey()
+	newKey, archivePath, err := ks.RotateKey()
 	if err != nil {
 		t.Fatalf("RotateKey() error = %v", err)
 	}
@@ -73,10 +73,32 @@ func TestKeystoreRotateKey(t *testing.T) {
 		t.Fatal("loaded key does not match rotated key")
 	}
 
-	archivePath := RotateKeyArchivePath(dir)
+	if archivePath != RotateKeyArchivePath(dir, key) {
+		t.Fatalf("archivePath = %s, want %s", archivePath, RotateKeyArchivePath(dir, key))
+	}
 	if _, err := os.Stat(archivePath); os.IsNotExist(err) {
 		t.Skipf("archive file not created at %s (expected on file-based keystore)", archivePath)
 	}
+
+	archived, err := ks.LoadArchivedKeys()
+	if err != nil {
+		t.Fatalf("LoadArchivedKeys() error = %v", err)
+	}
+	oldKeyLoaded, ok := archived[KeyFingerprint(key)]
+	if !ok {
+		t.Fatalf("LoadArchivedKeys() missing old key fingerprint %s, got %v", KeyFingerprint(key), keysOf(archived))
+	}
+	if hex.EncodeToString(oldKeyLoaded) != hex.EncodeToString(key) {
+		t.Fatal("archived key does not match original key")
+	}
+}
+
+func keysOf(m map[string][]byte) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
 }
 
 func TestKeystoreIdempotentLoadOrCreate(t *testing.T) {

--- a/internal/audit/verify_rotation_test.go
+++ b/internal/audit/verify_rotation_test.go
@@ -1,0 +1,232 @@
+package audit
+
+import (
+	"encoding/hex"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	configpkg "github.com/danieljustus/symaira-vault/internal/config"
+)
+
+// TestVerifyLogAgainstKeysStraddlesRotation covers the general case that the
+// original whole-file trial fallback (issue #685) could not handle: a
+// single physical log file with some entries signed under an old HMAC key
+// and later entries signed under a new one, because key rotation and log
+// file rotation are independent (rotating the key does not start a new log
+// file). Per-entry kid lookup must verify both halves correctly.
+func TestVerifyLogAgainstKeysStraddlesRotation(t *testing.T) {
+	// Guard against global audit config left polluted by an earlier test
+	// (rotateIfNeeded uses the package-level config; this test must not
+	// trigger a log-file rotation of its own).
+	ReloadConfig()
+	defer ReloadConfig()
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	logger1, err := New("straddle-test", "", nil)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	for i := 0; i < 3; i++ {
+		_ = logger1.LogEntry(LogEntry{
+			Agent:  "test-agent",
+			Action: fmt.Sprintf("pre-rotation-%d", i),
+			Path:   "test/path",
+			OK:     true,
+		})
+	}
+	_ = logger1.Close()
+
+	auditDir := filepath.Join(home, configpkg.DefaultVaultSubdir)
+	ks := NewKeystore(auditDir, nil)
+	oldKey, err := ks.LoadHMACKey()
+	if err != nil {
+		t.Fatalf("LoadHMACKey() error = %v", err)
+	}
+
+	newKey, archivePath, err := ks.RotateKey()
+	if err != nil {
+		t.Fatalf("RotateKey() error = %v", err)
+	}
+	if archivePath == "" {
+		t.Fatal("expected non-empty archive path")
+	}
+
+	// A logger constructed after rotation (e.g. a fresh process) picks up
+	// the new key but keeps appending to the same physical log file.
+	logger2, err := New("straddle-test", "", nil)
+	if err != nil {
+		t.Fatalf("New() error on reopen = %v", err)
+	}
+	defer func() { _ = logger2.Close() }()
+	if hex.EncodeToString(logger2.hmacKey) != hex.EncodeToString(newKey) {
+		t.Fatal("logger constructed after rotation should use the rotated key")
+	}
+	for i := 0; i < 3; i++ {
+		_ = logger2.LogEntry(LogEntry{
+			Agent:  "test-agent",
+			Action: fmt.Sprintf("post-rotation-%d", i),
+			Path:   "test/path",
+			OK:     true,
+		})
+	}
+
+	logFile := filepath.Join(auditDir, "audit-straddle-test.log")
+
+	keys, currentKid, err := LoadVerificationKeys(ks)
+	if err != nil {
+		t.Fatalf("LoadVerificationKeys() error = %v", err)
+	}
+	if _, ok := keys[KeyFingerprint(oldKey)]; !ok {
+		t.Fatal("expected archived (pre-rotation) key present in verification key set")
+	}
+	if currentKid != KeyFingerprint(newKey) {
+		t.Fatalf("currentKid = %s, want %s", currentKid, KeyFingerprint(newKey))
+	}
+
+	result, err := VerifyLogAgainstKeys(logFile, keys, currentKid)
+	if err != nil {
+		t.Fatalf("VerifyLogAgainstKeys() error = %v", err)
+	}
+	if !result.Valid {
+		t.Fatalf("expected valid straddling log, got Valid=false (verified=%d tampered=%d unverifiable=%d legacy=%d)",
+			result.Verified, result.Tampered, result.Unverifiable, result.Legacy)
+	}
+	if result.Total != 6 {
+		t.Fatalf("Total = %d, want 6", result.Total)
+	}
+	if result.Verified != 6 {
+		t.Fatalf("Verified = %d, want 6", result.Verified)
+	}
+	if result.Tampered != 0 {
+		t.Fatalf("Tampered = %d, want 0", result.Tampered)
+	}
+	if result.Unverifiable != 0 {
+		t.Fatalf("Unverifiable = %d, want 0", result.Unverifiable)
+	}
+}
+
+// TestVerifyLogAgainstKeysStraddlesRotationMissingArchiveIsUnverifiable
+// mirrors the real #685 report: a log file straddling rotation, but the old
+// key was never recovered. The pre-rotation entries must be reported
+// unverifiable, not tampered, while the post-rotation entries (signed under
+// the key we do have, via kid) verify normally.
+func TestVerifyLogAgainstKeysStraddlesRotationMissingArchiveIsUnverifiable(t *testing.T) {
+	// See TestVerifyLogAgainstKeysStraddlesRotation for why this guard is needed.
+	ReloadConfig()
+	defer ReloadConfig()
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	logger1, err := New("straddle-lost-key-test", "", nil)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	for i := 0; i < 2; i++ {
+		_ = logger1.LogEntry(LogEntry{Agent: "test-agent", Action: fmt.Sprintf("pre-%d", i), Path: "p", OK: true})
+	}
+	_ = logger1.Close()
+
+	auditDir := filepath.Join(home, configpkg.DefaultVaultSubdir)
+	ks := NewKeystore(auditDir, nil)
+
+	newKey, _, err := ks.RotateKey()
+	if err != nil {
+		t.Fatalf("RotateKey() error = %v", err)
+	}
+
+	logger2, err := New("straddle-lost-key-test", "", nil)
+	if err != nil {
+		t.Fatalf("New() error on reopen = %v", err)
+	}
+	defer func() { _ = logger2.Close() }()
+	for i := 0; i < 2; i++ {
+		_ = logger2.LogEntry(LogEntry{Agent: "test-agent", Action: fmt.Sprintf("post-%d", i), Path: "p", OK: true})
+	}
+
+	logFile := filepath.Join(auditDir, "audit-straddle-lost-key-test.log")
+	currentKid := KeyFingerprint(newKey)
+
+	// Verify with only the current key on hand — the archived key was lost.
+	result, err := VerifyLogAgainstKeys(logFile, map[string][]byte{currentKid: newKey}, currentKid)
+	if err != nil {
+		t.Fatalf("VerifyLogAgainstKeys() error = %v", err)
+	}
+	if !result.Valid {
+		t.Fatalf("missing archived key must not be reported as tampered (tampered=%d)", result.Tampered)
+	}
+	if result.Tampered != 0 {
+		t.Fatalf("Tampered = %d, want 0 (missing key is unverifiable, not tampered)", result.Tampered)
+	}
+	if result.Unverifiable != 2 {
+		t.Fatalf("Unverifiable = %d, want 2 (the two pre-rotation entries)", result.Unverifiable)
+	}
+	if result.Verified != 2 {
+		t.Fatalf("Verified = %d, want 2 (the two post-rotation entries)", result.Verified)
+	}
+}
+
+// TestKeystoreRotateKeyTwiceSameDayBothRecoverable covers the second #685
+// follow-up limitation: RotateKeyArchivePath used to be keyed only by date
+// (YYYY-MM-DD), so a second rotation on the same day silently overwrote the
+// first day's archive. Archive paths are now keyed by the old key's
+// fingerprint, so both generations from two same-day rotations must remain
+// individually recoverable.
+func TestKeystoreRotateKeyTwiceSameDayBothRecoverable(t *testing.T) {
+	dir := t.TempDir()
+	ks := NewKeystore(dir, nil)
+
+	key0, err := ks.LoadOrCreateHMACKey()
+	if err != nil {
+		t.Fatalf("LoadOrCreateHMACKey() error = %v", err)
+	}
+
+	key1, archive1, err := ks.RotateKey()
+	if err != nil {
+		t.Fatalf("first RotateKey() error = %v", err)
+	}
+
+	key2, archive2, err := ks.RotateKey()
+	if err != nil {
+		t.Fatalf("second RotateKey() error = %v", err)
+	}
+
+	if archive1 == archive2 {
+		t.Fatalf("expected distinct archive paths for two same-day rotations, both were %s", archive1)
+	}
+
+	archived, err := ks.LoadArchivedKeys()
+	if err != nil {
+		t.Fatalf("LoadArchivedKeys() error = %v", err)
+	}
+	if len(archived) != 2 {
+		t.Fatalf("LoadArchivedKeys() returned %d key(s), want 2 (got %v)", len(archived), keysOf(archived))
+	}
+
+	got0, ok := archived[KeyFingerprint(key0)]
+	if !ok {
+		t.Fatalf("first rotated-out key generation (fingerprint %s) not recoverable, got %v", KeyFingerprint(key0), keysOf(archived))
+	}
+	if hex.EncodeToString(got0) != hex.EncodeToString(key0) {
+		t.Fatal("recovered first archived key does not match original")
+	}
+
+	got1, ok := archived[KeyFingerprint(key1)]
+	if !ok {
+		t.Fatalf("second rotated-out key generation (fingerprint %s) not recoverable, got %v", KeyFingerprint(key1), keysOf(archived))
+	}
+	if hex.EncodeToString(got1) != hex.EncodeToString(key1) {
+		t.Fatal("recovered second archived key does not match original")
+	}
+
+	current, err := ks.LoadHMACKey()
+	if err != nil {
+		t.Fatalf("LoadHMACKey() error = %v", err)
+	}
+	if hex.EncodeToString(current) != hex.EncodeToString(key2) {
+		t.Fatal("current key after two rotations does not match latest RotateKey() result")
+	}
+}

--- a/internal/health/doctor_mcp.go
+++ b/internal/health/doctor_mcp.go
@@ -71,9 +71,12 @@ func checkAuditLog(vaultDir string, _ Options) Result {
 		return r
 	}
 
-	// HMAC key is shared across all audit logs in the vault directory.
+	// HMAC keys (current + archived generations) are shared across all
+	// audit logs in the vault directory. Archived keys let the verifier
+	// correctly check logs written under a since-rotated key instead of
+	// misreporting them as tampered.
 	ks := audit.NewKeystore(vaultDir, nil)
-	key, keyErr := ks.LoadHMACKey()
+	keys, currentKid, keyErr := audit.LoadVerificationKeys(ks)
 	if keyErr != nil {
 		r.Status = StatusWarn
 		r.Message = fmt.Sprintf("cannot read hmac key: %v", keyErr)
@@ -82,19 +85,24 @@ func checkAuditLog(vaultDir string, _ Options) Result {
 
 	var issues []string
 	var totalSize int64
+	var unverifiable int
 	for _, logPath := range matches {
 		info, statErr := os.Stat(logPath)
 		if statErr == nil {
 			totalSize += info.Size()
 		}
-		result, verErr := audit.VerifyLog(logPath, key)
+		result, verErr := audit.VerifyLogAgainstKeys(logPath, keys, currentKid)
 		if verErr != nil {
 			issues = append(issues, fmt.Sprintf("%s: verify error: %v", filepath.Base(logPath), verErr))
 			continue
 		}
-		if result != nil && !result.Valid {
+		if result == nil {
+			continue
+		}
+		if !result.Valid {
 			issues = append(issues, fmt.Sprintf("%s: integrity check failed", filepath.Base(logPath)))
 		}
+		unverifiable += result.Unverifiable
 	}
 
 	auditCfg := audit.GetConfig()
@@ -102,10 +110,16 @@ func checkAuditLog(vaultDir string, _ Options) Result {
 		issues = append(issues, fmt.Sprintf("total audit size %.1f MB at limit", float64(totalSize)/1024/1024))
 	}
 
-	if len(issues) > 0 {
+	switch {
+	case len(issues) > 0:
 		r.Status = StatusWarn
 		r.Message = strings.Join(issues, "; ")
-	} else {
+	case unverifiable > 0:
+		r.Status = StatusWarn
+		r.Message = fmt.Sprintf("%d log file(s), total %.1f MB, %d entries unverifiable (signing key generation unavailable)",
+			len(matches), float64(totalSize)/1024/1024, unverifiable)
+		r.Hint = "an archived HMAC key may be missing; this does not indicate tampering"
+	default:
 		r.Status = StatusOK
 		r.Message = fmt.Sprintf("%d log file(s), total %.1f MB, integrity OK", len(matches), float64(totalSize)/1024/1024)
 	}


### PR DESCRIPTION
## Summary

Fixes #685. The audit log verifier previously checked every entry against only the currently-loaded HMAC key, so any log segment written under a since-rotated key was reported as `tampered` instead of `unverifiable` — a normal key rotation or keychain recovery looked identical to real manipulation.

This adds a stable per-entry key-generation ID (`kid`) so the verifier can resolve the exact signing key for each entry directly, instead of trial-and-error against a single key or a whole-file heuristic. That also correctly handles the general case the simpler whole-file fallback can't: a single physical log file that straddles a rotation boundary (log file rotation and key rotation are independent, so this happens in practice whenever a process restarts after `rotate-key`).

- `KeyFingerprint()` — stable 8-hex-char SHA-256 fingerprint of an HMAC key, used both as the `kid` recorded on new log entries and as the archive filename suffix on rotation.
- `LogEntry.Kid` — stamped at write time from the logger's current key; included in the HMAC-covered canonical JSON, so tampering it invalidates the entry's signature like any other field.
- `VerifyLogAgainstKeys(path, keys, currentKid)` — resolves each entry's key via its `kid` when present; falls back to trying each known key in order (current first) for older entries written before `kid` existed. `VerifyResult.Unverifiable` is now reported separately from `Tampered`: a missing key generation is not evidence of tampering. `VerifyLog` / `Logger.Verify()` delegate to this, so existing call sites are unaffected.
- `Keystore.LoadArchivedKeys()` — loads every rotated-out key from the audit directory, keyed by fingerprint, so a verifier can check historical segments.
- `RotateKeyArchivePath` is now keyed by the old key's fingerprint instead of the rotation date, so two rotations on the same day no longer silently overwrite each other's archive. `Keystore.RotateKey()` returns the archive path directly.
- `symvault doctor`'s audit check loads archived keys and surfaces unverifiable entries distinctly from real integrity failures.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./internal/audit/... ./internal/health/... ./cmd/admin/...`
- [x] `go test ./internal/audit/... ./internal/health/... ./cmd/admin/...`
- [x] New tests: a log file straddling a rotation verifies fully via per-entry `kid` resolution; the same scenario with the archived key missing reports `Unverifiable`, not `Tampered`; two same-day rotations both remain individually recoverable via `LoadArchivedKeys`
- [x] All pre-existing audit/keystore/HMAC-chain tests still pass unmodified in behavior

## Note

While testing, ran into a pre-existing, unrelated test-isolation bug in `audit_test.go` (`defer ReloadConfig()` racing `t.Setenv`'s cleanup, leaking config between tests under `-shuffle=on`). Not fixed here — flagged as a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)