### PR TITLE
test(cmd/file): add unit tests for add/get/use CLI commands

### DIFF
--- a/cmd/file/add_test.go
+++ b/cmd/file/add_test.go
@@ -1,0 +1,125 @@
+package file
+
+import (
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"testing"
+
+	vaultpkg "github.com/danieljustus/symaira-vault/internal/vault"
+)
+
+func resetAddFlags(t *testing.T) {
+	t.Helper()
+	origField, origFrom, origType, origMaxSize, origShred := AddField, AddFrom, AddType, AddMaxSize, AddShred
+	t.Cleanup(func() {
+		AddField, AddFrom, AddType, AddMaxSize, AddShred = origField, origFrom, origType, origMaxSize, origShred
+	})
+}
+
+func TestRunFileAdd_StoresAttachmentWithMetadata(t *testing.T) {
+	setupTestVault(t)
+	resetAddFlags(t)
+
+	srcPath := filepath.Join(t.TempDir(), "cert.pfx")
+	content := []byte("fake-certificate-bytes")
+	if err := os.WriteFile(srcPath, content, 0o600); err != nil {
+		t.Fatalf("write source file: %v", err)
+	}
+
+	AddField = "cert_p12"
+	AddFrom = srcPath
+	AddType = string(vaultpkg.SecretTypeCertificate)
+	AddMaxSize = DefaultMaxAttachmentSize
+	AddShred = false
+
+	if err := runFileAdd(nil, []string{"elster/cert"}); err != nil {
+		t.Fatalf("runFileAdd: %v", err)
+	}
+
+	entry := getTestEntry(t, "elster/cert")
+	encoded, ok := entry.Data["cert_p12"].(string)
+	if !ok {
+		t.Fatalf("entry.Data[cert_p12] = %v (%T), want string", entry.Data["cert_p12"], entry.Data["cert_p12"])
+	}
+	decoded, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		t.Fatalf("decode stored content: %v", err)
+	}
+	if string(decoded) != string(content) {
+		t.Errorf("stored content = %q, want %q", decoded, content)
+	}
+
+	attachment, ok := entry.SecretMetadata.Attachments["cert_p12"]
+	if !ok {
+		t.Fatal("expected attachment metadata for cert_p12")
+	}
+	if attachment.Filename != "cert.pfx" {
+		t.Errorf("attachment.Filename = %q, want %q", attachment.Filename, "cert.pfx")
+	}
+	if attachment.Size != int64(len(content)) {
+		t.Errorf("attachment.Size = %d, want %d", attachment.Size, len(content))
+	}
+	wantSHA := vaultpkg.HashAttachmentSHA256(content)
+	if attachment.SHA256 != wantSHA {
+		t.Errorf("attachment.SHA256 = %q, want %q", attachment.SHA256, wantSHA)
+	}
+	if entry.SecretMetadata.Type != vaultpkg.SecretTypeCertificate {
+		t.Errorf("entry type = %q, want %q", entry.SecretMetadata.Type, vaultpkg.SecretTypeCertificate)
+	}
+}
+
+func TestRunFileAdd_MissingFieldFlag(t *testing.T) {
+	setupTestVault(t)
+	resetAddFlags(t)
+
+	AddField = ""
+	AddFrom = filepath.Join(t.TempDir(), "unused")
+
+	if err := runFileAdd(nil, []string{"elster/cert"}); err == nil {
+		t.Fatal("expected error for missing --field, got nil")
+	}
+}
+
+func TestRunFileAdd_MissingFromFlag(t *testing.T) {
+	setupTestVault(t)
+	resetAddFlags(t)
+
+	AddField = "cert_p12"
+	AddFrom = ""
+
+	if err := runFileAdd(nil, []string{"elster/cert"}); err == nil {
+		t.Fatal("expected error for missing --from, got nil")
+	}
+}
+
+func TestRunFileAdd_SourceExceedsMaxSize(t *testing.T) {
+	setupTestVault(t)
+	resetAddFlags(t)
+
+	srcPath := filepath.Join(t.TempDir(), "big.bin")
+	if err := os.WriteFile(srcPath, []byte("0123456789"), 0o600); err != nil {
+		t.Fatalf("write source file: %v", err)
+	}
+
+	AddField = "cert_p12"
+	AddFrom = srcPath
+	AddMaxSize = 5 // smaller than the 10-byte source file
+
+	if err := runFileAdd(nil, []string{"elster/cert"}); err == nil {
+		t.Fatal("expected error for oversized source file, got nil")
+	}
+}
+
+func TestRunFileAdd_SourceFileMissing(t *testing.T) {
+	setupTestVault(t)
+	resetAddFlags(t)
+
+	AddField = "cert_p12"
+	AddFrom = filepath.Join(t.TempDir(), "does-not-exist.pfx")
+	AddMaxSize = DefaultMaxAttachmentSize
+
+	if err := runFileAdd(nil, []string{"elster/cert"}); err == nil {
+		t.Fatal("expected error for missing source file, got nil")
+	}
+}

--- a/cmd/file/field_test.go
+++ b/cmd/file/field_test.go
@@ -1,0 +1,133 @@
+package file
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	errorspkg "github.com/danieljustus/symaira-vault/internal/errors"
+	vaultpkg "github.com/danieljustus/symaira-vault/internal/vault"
+)
+
+func TestSplitPathField(t *testing.T) {
+	tests := []struct {
+		name      string
+		arg       string
+		wantPath  string
+		wantField string
+	}{
+		{name: "no separator", arg: "elster/cert", wantPath: "elster/cert", wantField: ""},
+		{name: "with field", arg: "elster/cert#cert_p12", wantPath: "elster/cert", wantField: "cert_p12"},
+		{name: "hash not at start uses last occurrence", arg: "a#b#c", wantPath: "a#b", wantField: "c"},
+		{name: "leading hash is not treated as a separator", arg: "#field", wantPath: "#field", wantField: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path, field := splitPathField(tt.arg)
+			if path != tt.wantPath {
+				t.Errorf("path = %q, want %q", path, tt.wantPath)
+			}
+			if field != tt.wantField {
+				t.Errorf("field = %q, want %q", field, tt.wantField)
+			}
+		})
+	}
+}
+
+func TestResolveAttachmentField(t *testing.T) {
+	t.Run("explicit field found in metadata", func(t *testing.T) {
+		entry := &vaultpkg.Entry{
+			SecretMetadata: vaultpkg.SecretMetadata{
+				Attachments: map[string]vaultpkg.AttachmentInfo{
+					"cert_p12": {Filename: "cert.pfx", Size: 10, SHA256: "abc"},
+				},
+			},
+		}
+		field, info, err := resolveAttachmentField(entry, "cert_p12")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if field != "cert_p12" {
+			t.Errorf("field = %q, want %q", field, "cert_p12")
+		}
+		if info == nil || info.SHA256 != "abc" {
+			t.Errorf("info = %+v, want SHA256=abc", info)
+		}
+	})
+
+	t.Run("explicit field not in metadata is not an error", func(t *testing.T) {
+		entry := &vaultpkg.Entry{SecretMetadata: vaultpkg.SecretMetadata{}}
+		field, info, err := resolveAttachmentField(entry, "custom_field")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if field != "custom_field" {
+			t.Errorf("field = %q, want %q", field, "custom_field")
+		}
+		if info != nil {
+			t.Errorf("info = %+v, want nil", info)
+		}
+	})
+
+	t.Run("no explicit field, zero attachments errors", func(t *testing.T) {
+		entry := &vaultpkg.Entry{SecretMetadata: vaultpkg.SecretMetadata{}}
+		_, _, err := resolveAttachmentField(entry, "")
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		var cliErr *errorspkg.CLIError
+		if !errors.As(err, &cliErr) {
+			t.Fatalf("expected *errorspkg.CLIError, got %T", err)
+		}
+		if cliErr.Code != errorspkg.ExitInvalidInput {
+			t.Errorf("code = %v, want ExitInvalidInput", cliErr.Code)
+		}
+	})
+
+	t.Run("no explicit field, exactly one attachment auto-selects it", func(t *testing.T) {
+		entry := &vaultpkg.Entry{
+			SecretMetadata: vaultpkg.SecretMetadata{
+				Attachments: map[string]vaultpkg.AttachmentInfo{
+					"only_field": {Filename: "f.bin", Size: 5, SHA256: "deadbeef"},
+				},
+			},
+		}
+		field, info, err := resolveAttachmentField(entry, "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if field != "only_field" {
+			t.Errorf("field = %q, want %q", field, "only_field")
+		}
+		if info == nil || info.SHA256 != "deadbeef" {
+			t.Errorf("info = %+v, want SHA256=deadbeef", info)
+		}
+	})
+
+	t.Run("no explicit field, multiple attachments errors listing names", func(t *testing.T) {
+		entry := &vaultpkg.Entry{
+			SecretMetadata: vaultpkg.SecretMetadata{
+				Attachments: map[string]vaultpkg.AttachmentInfo{
+					"field_b": {SHA256: "b"},
+					"field_a": {SHA256: "a"},
+				},
+			},
+		}
+		_, _, err := resolveAttachmentField(entry, "")
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		var cliErr *errorspkg.CLIError
+		if !errors.As(err, &cliErr) {
+			t.Fatalf("expected *errorspkg.CLIError, got %T", err)
+		}
+		if cliErr.Code != errorspkg.ExitInvalidInput {
+			t.Errorf("code = %v, want ExitInvalidInput", cliErr.Code)
+		}
+		msg := cliErr.Error()
+		if !strings.Contains(msg, "field_a") || !strings.Contains(msg, "field_b") {
+			t.Errorf("error message %q does not list both field names", msg)
+		}
+	})
+}

--- a/cmd/file/file_test.go
+++ b/cmd/file/file_test.go
@@ -1,0 +1,65 @@
+package file
+
+import (
+	"testing"
+
+	cli "github.com/danieljustus/symaira-vault/internal/cli"
+	configpkg "github.com/danieljustus/symaira-vault/internal/config"
+	vaultpkg "github.com/danieljustus/symaira-vault/internal/vault"
+)
+
+// setupTestVault initializes a temp vault, points the global --vault flag at
+// it, and unlocks it non-interactively for the duration of the test — the
+// same fixture shape cmd/crud's package uses, reimplemented here because
+// cmd's helpers are unexported to that package.
+func setupTestVault(t *testing.T) {
+	t.Helper()
+
+	vaultDir := t.TempDir()
+	passphrase := []byte("test-passphrase")
+	if _, err := vaultpkg.InitWithPassphrase(vaultDir, passphrase, configpkg.Default()); err != nil {
+		t.Fatalf("init vault: %v", err)
+	}
+	t.Cleanup(vaultpkg.FlushManifestUpdates)
+
+	origVault := cli.Vault
+	var origChanged bool
+	if cli.VaultFlag != nil {
+		origChanged = cli.VaultFlag.Changed
+	}
+	cli.Vault = vaultDir
+	if cli.VaultFlag != nil {
+		_ = cli.VaultFlag.Value.Set(vaultDir)
+		cli.VaultFlag.Changed = true
+	}
+	t.Cleanup(func() {
+		cli.Vault = origVault
+		if cli.VaultFlag != nil {
+			_ = cli.VaultFlag.Value.Set(origVault)
+			cli.VaultFlag.Changed = origChanged
+		}
+	})
+
+	t.Setenv("SYMVAULT_ALLOW_ENV_PASSPHRASE", "1")
+	t.Setenv("SYMVAULT_PASSPHRASE", string(passphrase))
+}
+
+// getTestEntry re-reads an entry from the vault via a fresh WithVaultRaw call,
+// so assertions observe exactly what runFileAdd persisted rather than
+// in-memory state.
+func getTestEntry(t *testing.T, path string) *vaultpkg.Entry {
+	t.Helper()
+	var got *vaultpkg.Entry
+	err := cli.WithVaultRaw(func(_ *vaultpkg.Vault, vs *cli.VaultService) error {
+		entry, err := vs.GetEntry(path)
+		if err != nil {
+			return err
+		}
+		got = entry
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("read back entry %q: %v", path, err)
+	}
+	return got
+}

--- a/cmd/file/get_test.go
+++ b/cmd/file/get_test.go
@@ -1,0 +1,119 @@
+package file
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func resetGetFlags(t *testing.T) {
+	t.Helper()
+	origField, origOut := GetField, GetOut
+	t.Cleanup(func() {
+		GetField, GetOut = origField, origOut
+	})
+}
+
+// addFixtureAttachment stores content under elster/cert#cert_p12 using
+// runFileAdd, so get/use tests exercise the real round trip instead of
+// hand-building entries.
+func addFixtureAttachment(t *testing.T, content []byte) {
+	t.Helper()
+	resetAddFlags(t)
+
+	srcPath := filepath.Join(t.TempDir(), "fixture.bin")
+	if err := os.WriteFile(srcPath, content, 0o600); err != nil {
+		t.Fatalf("write fixture source: %v", err)
+	}
+
+	AddField = "cert_p12"
+	AddFrom = srcPath
+	AddMaxSize = DefaultMaxAttachmentSize
+	AddShred = false
+
+	if err := runFileAdd(nil, []string{"elster/cert"}); err != nil {
+		t.Fatalf("seed fixture via runFileAdd: %v", err)
+	}
+}
+
+func TestRunFileGet_ExportsStoredAttachment(t *testing.T) {
+	setupTestVault(t)
+	content := []byte("elster-cert-bytes")
+	addFixtureAttachment(t, content)
+
+	resetGetFlags(t)
+	outPath := filepath.Join(t.TempDir(), "exported.pfx")
+	GetField = ""
+	GetOut = outPath
+
+	if err := runFileGet(nil, []string{"elster/cert#cert_p12"}); err != nil {
+		t.Fatalf("runFileGet: %v", err)
+	}
+
+	got, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("read exported file: %v", err)
+	}
+	if string(got) != string(content) {
+		t.Errorf("exported content = %q, want %q", got, content)
+	}
+}
+
+func TestRunFileGet_AutoDetectsSingleAttachment(t *testing.T) {
+	setupTestVault(t)
+	content := []byte("only-attachment")
+	addFixtureAttachment(t, content)
+
+	resetGetFlags(t)
+	outPath := filepath.Join(t.TempDir(), "exported.pfx")
+	GetField = ""
+	GetOut = outPath
+
+	// No "#field" suffix and no --field: must auto-select the sole attachment.
+	if err := runFileGet(nil, []string{"elster/cert"}); err != nil {
+		t.Fatalf("runFileGet: %v", err)
+	}
+
+	got, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("read exported file: %v", err)
+	}
+	if string(got) != string(content) {
+		t.Errorf("exported content = %q, want %q", got, content)
+	}
+}
+
+func TestRunFileGet_MissingOutFlag(t *testing.T) {
+	setupTestVault(t)
+	addFixtureAttachment(t, []byte("data"))
+
+	resetGetFlags(t)
+	GetOut = ""
+
+	if err := runFileGet(nil, []string{"elster/cert#cert_p12"}); err == nil {
+		t.Fatal("expected error for missing --out, got nil")
+	}
+}
+
+func TestRunFileGet_FieldNotFound(t *testing.T) {
+	setupTestVault(t)
+	addFixtureAttachment(t, []byte("data"))
+
+	resetGetFlags(t)
+	GetOut = filepath.Join(t.TempDir(), "out.bin")
+
+	if err := runFileGet(nil, []string{"elster/cert#nonexistent"}); err == nil {
+		t.Fatal("expected error for nonexistent field, got nil")
+	}
+}
+
+func TestRunFileGet_EntryNotFound(t *testing.T) {
+	setupTestVault(t)
+
+	resetGetFlags(t)
+	GetOut = filepath.Join(t.TempDir(), "out.bin")
+
+	if err := runFileGet(nil, []string{"does/not-exist#field"}); err == nil {
+		t.Fatal("expected error for missing entry, got nil")
+	}
+}

--- a/cmd/file/use_test.go
+++ b/cmd/file/use_test.go
@@ -1,0 +1,99 @@
+package file
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+func resetUseFlags(t *testing.T) {
+	t.Helper()
+	origField, origAs, origTimeout := UseField, UseAs, UseTimeout
+	t.Cleanup(func() {
+		UseField, UseAs, UseTimeout = origField, origAs, origTimeout
+	})
+}
+
+func TestRunFileUse_MaterializesAttachmentForCommand(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows: relies on a POSIX shell")
+	}
+	setupTestVault(t)
+	content := []byte("elster-cert-bytes")
+	addFixtureAttachment(t, content)
+
+	resetUseFlags(t)
+	UseField = ""
+	UseAs = ""
+	UseTimeout = 5 * time.Second
+
+	args := []string{"elster/cert#cert_p12", "sh", "-c", `cat "$SYMVAULT_FILE_CERT_P12"`}
+	if err := runFileUse(nil, args); err != nil {
+		t.Fatalf("runFileUse: %v", err)
+	}
+}
+
+func TestRunFileUse_CustomExposedName(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows: relies on a POSIX shell")
+	}
+	setupTestVault(t)
+	addFixtureAttachment(t, []byte("data"))
+
+	resetUseFlags(t)
+	UseField = ""
+	UseAs = "MYCERT"
+	UseTimeout = 5 * time.Second
+
+	args := []string{"elster/cert#cert_p12", "sh", "-c", `test -n "$SYMVAULT_FILE_MYCERT"`}
+	if err := runFileUse(nil, args); err != nil {
+		t.Fatalf("runFileUse with custom --as name: %v", err)
+	}
+}
+
+func TestRunFileUse_NonZeroExitPropagates(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows: relies on a POSIX shell")
+	}
+	setupTestVault(t)
+	addFixtureAttachment(t, []byte("data"))
+
+	resetUseFlags(t)
+	UseField = ""
+	UseTimeout = 5 * time.Second
+
+	args := []string{"elster/cert#cert_p12", "sh", "-c", "exit 7"}
+	err := runFileUse(nil, args)
+	if err == nil {
+		t.Fatal("expected error for non-zero command exit, got nil")
+	}
+	if !strings.Contains(err.Error(), "7") {
+		t.Errorf("error %q does not mention the exit code", err.Error())
+	}
+}
+
+func TestRunFileUse_FieldNotFound(t *testing.T) {
+	setupTestVault(t)
+	addFixtureAttachment(t, []byte("data"))
+
+	resetUseFlags(t)
+	UseField = ""
+
+	args := []string{"elster/cert#missing", "true"}
+	if err := runFileUse(nil, args); err == nil {
+		t.Fatal("expected error for nonexistent field, got nil")
+	}
+}
+
+func TestRunFileUse_EntryNotFound(t *testing.T) {
+	setupTestVault(t)
+
+	resetUseFlags(t)
+	UseField = ""
+
+	args := []string{"does/not-exist#field", "true"}
+	if err := runFileUse(nil, args); err == nil {
+		t.Fatal("expected error for missing entry, got nil")
+	}
+}


### PR DESCRIPTION
Covers runFileAdd, runFileGet, runFileUse, splitPathField and
resolveAttachmentField. Package coverage 0.0% -> 86.8%.

Closes #711

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
