### PR TITLE
fix(cli): explicit hint when SYMVAULT_PASSPHRASE is set but the opt-in gate is off

### DIFF
--- a/cmd/auth/unlock.go
+++ b/cmd/auth/unlock.go
@@ -22,8 +22,12 @@ OS keyring. This allows MCP servers to start without interactive prompts.
 
 Use --check to verify if an active session exists without prompting.
 
-Environment variable OPENPASS_PASSPHRASE can be used in CI/CD environments
-but should NOT be used on shared machines (visible in process listings).`,
+Environment variable SYMVAULT_PASSPHRASE (legacy alias OPENPASS_PASSPHRASE)
+can be used for non-interactive unlock in CI/CD environments, but only when
+explicitly allowed via SYMVAULT_ALLOW_ENV_PASSPHRASE=1 or
+security.allow_env_passphrase: true in config.yaml — the passphrase variable
+alone is ignored (default-deny). It should NOT be used on shared machines
+(visible in process listings).`,
 	Example: `  # Unlock the vault
   symvault unlock
 

--- a/docs/agent-integration.md
+++ b/docs/agent-integration.md
@@ -305,7 +305,9 @@ and port as needed:
 
 The vault must be unlockable non-interactively. Run `symvault unlock` once so
 the passphrase is cached in the OS keyring, or provide a controlled environment
-for `SYMVAULT_PASSPHRASE`.
+for `SYMVAULT_PASSPHRASE`. Note that `SYMVAULT_PASSPHRASE` alone is ignored
+(default-deny): also set `SYMVAULT_ALLOW_ENV_PASSPHRASE=1` or
+`security.allow_env_passphrase: true` in config.yaml.
 
 ## Token Management
 

--- a/docs/scripting-contract.md
+++ b/docs/scripting-contract.md
@@ -62,10 +62,16 @@ Full exit code reference: [cli-exit-codes.md](cli-exit-codes.md).
 
 | Variable                | Purpose                                              |
 | ----------------------- | ---------------------------------------------------- |
-| `SYMVAULT_PASSPHRASE`   | Passphrase for non-interactive unlock (preferred).   |
+| `SYMVAULT_PASSPHRASE`   | Passphrase for non-interactive unlock (preferred). Requires the opt-in gate below — alone it is ignored (default-deny). |
 | `OPENPASS_PASSPHRASE`   | Alias for `SYMVAULT_PASSPHRASE` (legacy compat).    |
+| `SYMVAULT_ALLOW_ENV_PASSPHRASE` | Set to `1` to allow unlock via `SYMVAULT_PASSPHRASE` (alternatively `security.allow_env_passphrase: true` in config.yaml). |
 | `SYMVAULT_NO_ENV_WARNING` | Set to `1` to suppress env passphrase warning.     |
 | `SYMVAULT_NO_PIPE_WARNING` | Set to `1` to suppress pipe-read warning.         |
+
+> **Note:** For security, `SYMVAULT_PASSPHRASE` is ignored unless
+> `SYMVAULT_ALLOW_ENV_PASSPHRASE=1` (or `security.allow_env_passphrase: true`)
+> is also set. When the variable is detected but not allowed, the CLI exits
+> with `ExitLocked` and an explicit hint instead of silently prompting.
 
 ## Example: Go Integration with Timeout
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -265,7 +265,7 @@ func Execute() {
 			case errorspkg.ExitNotInitialized:
 				cliout.Hintf("Run 'symvault init' for a quick start, or 'symvault setup' for the guided wizard.")
 			case errorspkg.ExitLocked:
-				cliout.Hintf("Unlock with 'symvault unlock', or set SYMVAULT_PASSPHRASE (or OPENPASS_PASSPHRASE) for non-interactive use.")
+				cliout.Hintf("Unlock with 'symvault unlock'. For non-interactive use, set SYMVAULT_PASSPHRASE together with SYMVAULT_ALLOW_ENV_PASSPHRASE=1 (or security.allow_env_passphrase: true in config.yaml) — the passphrase variable alone is ignored.")
 			case errorspkg.ExitConfigError:
 				cliout.Hintf("Run 'symvault doctor' to diagnose and fix configuration issues.")
 			case errorspkg.ExitSuccess, errorspkg.ExitGeneralError, errorspkg.ExitPermissionDenied, errorspkg.ExitInvalidInput, errorspkg.ExitDoctorWarn, errorspkg.ExitDoctorFail, errorspkg.ExitUpdateAvailable:

--- a/internal/cli/unlock.go
+++ b/internal/cli/unlock.go
@@ -126,6 +126,21 @@ func IsEnvPassphraseAllowed(cfg *configpkg.Config) bool {
 	return v == "1" || v == "true" || v == "yes"
 }
 
+// envPassphraseIgnored reports whether an environment passphrase is available
+// (cached from main() or still set in the environment) but will be ignored
+// because the opt-in gate (security.allow_env_passphrase in config.yaml or
+// SYMVAULT_ALLOW_ENV_PASSPHRASE=1) is not enabled. Used to surface an explicit
+// hint instead of silently discarding SYMVAULT_PASSPHRASE.
+func envPassphraseIgnored(cfg *configpkg.Config) bool {
+	if IsEnvPassphraseAllowed(cfg) {
+		return false
+	}
+	if HasCachedEnvPassphrase() {
+		return true
+	}
+	return envutil.Getenv("SYMVAULT_PASSPHRASE", "OPENPASS_PASSPHRASE") != ""
+}
+
 func resolveUnlockPassphrase(vaultDir string, interactive bool, cfg *configpkg.Config) ([]byte, bool, bool, error) {
 	passphrase, err := SessionLoadPassphrase(vaultDir)
 	passphraseFromEnv := false
@@ -155,6 +170,14 @@ func resolveUnlockPassphrase(vaultDir string, interactive bool, cfg *configpkg.C
 			}
 		}
 		if len(passphrase) == 0 {
+			if envPassphraseIgnored(cfg) {
+				if !interactive {
+					return nil, false, false, errorspkg.NewCLIError(errorspkg.ExitLocked,
+						"vault locked: SYMVAULT_PASSPHRASE is set but env passphrase unlock is disabled", nil).
+						WithHint("Set SYMVAULT_ALLOW_ENV_PASSPHRASE=1 or security.allow_env_passphrase: true in config.yaml to allow SYMVAULT_PASSPHRASE for non-interactive use.")
+				}
+				cliout.Warnf("SYMVAULT_PASSPHRASE is set but ignored: env passphrase unlock is disabled. Set SYMVAULT_ALLOW_ENV_PASSPHRASE=1 or security.allow_env_passphrase: true in config.yaml to allow it.")
+			}
 			if !interactive {
 				return nil, false, false, errorspkg.NewCLIError(errorspkg.ExitLocked, lockedMessageForCache(), nil)
 			}

--- a/internal/cli/unlock_test.go
+++ b/internal/cli/unlock_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	configpkg "github.com/danieljustus/symaira-vault/internal/config"
+	errorspkg "github.com/danieljustus/symaira-vault/internal/errors"
 	"github.com/danieljustus/symaira-vault/internal/session"
 	vaultpkg "github.com/danieljustus/symaira-vault/internal/vault"
 )
@@ -162,6 +163,91 @@ func TestUnlockVaultWithTTLDoesNotSaveTouchIDItemForUncachedEnvPassphrase(t *tes
 	}
 	if v == nil {
 		t.Fatal("UnlockVaultWithTTL() returned nil vault")
+	}
+}
+
+// TestUnlockVaultWithTTL_EnvPassphraseSetButGateDisabled reproduces issue #714:
+// SYMVAULT_PASSPHRASE alone (without the explicit opt-in gate) is silently
+// ignored in non-interactive mode. The error must now say why.
+func TestUnlockVaultWithTTL_EnvPassphraseSetButGateDisabled(t *testing.T) {
+	vaultDir := t.TempDir()
+	passphrase := []byte("test-passphrase")
+	cfg := configpkg.Default()
+	if _, err := vaultpkg.InitWithPassphrase(vaultDir, passphrase, cfg); err != nil {
+		t.Fatalf("InitWithPassphrase() error = %v", err)
+	}
+
+	oldLoadPassphrase := SessionLoadPassphrase
+	oldLoadIdentity := SessionLoadIdentity
+	t.Cleanup(func() {
+		SessionLoadPassphrase = oldLoadPassphrase
+		SessionLoadIdentity = oldLoadIdentity
+		ClearCachedEnvPassphrase()
+	})
+	SessionLoadIdentity = func(string) (string, error) { return "", errors.New("miss") }
+	SessionLoadPassphrase = func(string) ([]byte, error) { return nil, errors.New("miss") }
+
+	// Isolate from ambient environments where the gate may be enabled.
+	t.Setenv("SYMVAULT_ALLOW_ENV_PASSPHRASE", "")
+	t.Setenv("OPENPASS_ALLOW_ENV_PASSPHRASE", "")
+
+	// Env passphrase is available but the opt-in gate is NOT enabled.
+	SetCachedEnvPassphrase(append([]byte(nil), passphrase...))
+
+	_, _, err := UnlockVaultWithTTL(vaultDir, false, 0, false)
+	if err == nil {
+		t.Fatal("expected locked error when the env passphrase gate is disabled")
+	}
+	var cliErr *errorspkg.CLIError
+	if !errors.As(err, &cliErr) {
+		t.Fatalf("expected *CLIError, got %T: %v", err, err)
+	}
+	if cliErr.Code != errorspkg.ExitLocked {
+		t.Errorf("expected ExitLocked, got %v", cliErr.Code)
+	}
+	if !strings.Contains(err.Error(), "disabled") {
+		t.Errorf("expected error to state that the env passphrase is disabled, got: %v", err)
+	}
+	if !strings.Contains(cliErr.Hint, "SYMVAULT_ALLOW_ENV_PASSPHRASE") ||
+		!strings.Contains(cliErr.Hint, "security.allow_env_passphrase") {
+		t.Errorf("expected hint to name SYMVAULT_ALLOW_ENV_PASSPHRASE and security.allow_env_passphrase, got: %q", cliErr.Hint)
+	}
+	// The security gate must be preserved: the cached passphrase is not consumed.
+	if !HasCachedEnvPassphrase() {
+		t.Error("cached env passphrase must not be consumed when the gate is disabled")
+	}
+}
+
+func TestEnvPassphraseIgnored(t *testing.T) {
+	ClearCachedEnvPassphrase()
+	t.Cleanup(ClearCachedEnvPassphrase)
+	// Isolate from ambient developer/CI environments where the gate may be enabled.
+	t.Setenv("SYMVAULT_ALLOW_ENV_PASSPHRASE", "")
+	t.Setenv("OPENPASS_ALLOW_ENV_PASSPHRASE", "")
+
+	// Nothing set: not "ignored", simply absent.
+	if envPassphraseIgnored(configpkg.Default()) {
+		t.Error("expected false when no env passphrase is set")
+	}
+
+	// Set but not allowed: ignored.
+	t.Setenv("SYMVAULT_PASSPHRASE", "x")
+	if !envPassphraseIgnored(configpkg.Default()) {
+		t.Error("expected true when SYMVAULT_PASSPHRASE is set without the opt-in gate")
+	}
+
+	// Set and allowed via env: honored, not ignored.
+	t.Setenv("SYMVAULT_ALLOW_ENV_PASSPHRASE", "1")
+	if envPassphraseIgnored(configpkg.Default()) {
+		t.Error("expected false when SYMVAULT_ALLOW_ENV_PASSPHRASE=1 allows the env passphrase")
+	}
+
+	// Set and allowed via config: honored, not ignored.
+	allowedCfg := configpkg.Default()
+	allowedCfg.Security = &configpkg.SecurityConfig{AllowEnvPassphrase: true}
+	t.Setenv("SYMVAULT_ALLOW_ENV_PASSPHRASE", "")
+	if envPassphraseIgnored(allowedCfg) {
+		t.Error("expected false when security.allow_env_passphrase allows the env passphrase")
 	}
 }
 

--- a/internal/i18n/catalog_de.go
+++ b/internal/i18n/catalog_de.go
@@ -13,7 +13,7 @@ func init() {
 		"error.passphrase.mismatch":   "Passphrasen stimmen nicht überein",
 		"error.vault.locked":          "Vault ist gesperrt",
 		"error.vault.not_initialized": "Vault nicht initialisiert — führe 'symvault init' aus",
-		"hint.unlock":                 "Mit 'symvault unlock' entsperren, oder OPENPASS_PASSPHRASE für nicht-interaktive Nutzung setzen.", //nolint:misspell
+		"hint.unlock":                 "Mit 'symvault unlock' entsperren. Für nicht-interaktive Nutzung SYMVAULT_PASSPHRASE zusammen mit SYMVAULT_ALLOW_ENV_PASSPHRASE=1 setzen (oder security.allow_env_passphrase: true in config.yaml).", //nolint:misspell
 		"hint.find":                   "Versuche: symvault find <Suchbegriff>",
 		"hint.first_run":              "Führe 'symvault init' für einen schnellen Start aus oder 'symvault setup' für den geführten Assistenten.",
 		"notify.security_alert":       "Symaira Vault Sicherheitswarnung",

--- a/internal/i18n/catalog_en.go
+++ b/internal/i18n/catalog_en.go
@@ -18,7 +18,7 @@ func init() {
 		"error.passphrase.mismatch":   "passphrases did not match",
 		"error.vault.locked":          "vault is locked",
 		"error.vault.not_initialized": "vault not initialized — run 'symvault init' first",
-		"hint.unlock":                 "Unlock with 'symvault unlock', or set OPENPASS_PASSPHRASE for non-interactive use.",
+		"hint.unlock":                 "Unlock with 'symvault unlock'. For non-interactive use, set SYMVAULT_PASSPHRASE together with SYMVAULT_ALLOW_ENV_PASSPHRASE=1 (or security.allow_env_passphrase: true in config.yaml).",
 		"hint.find":                   "Try: symvault find <search-term>",
 		"hint.first_run":              "Run 'symvault init' for a quick start, or 'symvault setup' for the guided wizard.",
 		"notify.security_alert":       "Symaira Vault security alert",


### PR DESCRIPTION
## Problem

In non-interactive use (CI, scripts, MCP subprocesses) `SYMVAULT_PASSPHRASE` was silently ignored unless `SYMVAULT_ALLOW_ENV_PASSPHRASE=1` (or `security.allow_env_passphrase: true` in config.yaml) was also set. The CLI then hung at the passphrase prompt or exited `ExitLocked` without saying *why* the variable was not honored. The lock hint (`set SYMVAULT_PASSPHRASE … for non-interactive use`) was factually wrong — the variable alone is not sufficient.

## Change

- `resolveUnlockPassphrase` now detects a set-but-not-allowed env passphrase and returns `ExitLocked` with a concrete remediation hint naming both opt-in mechanisms; in interactive mode it warns instead of silently discarding. The default-deny security gate is **preserved** — the cached/env passphrase is not consumed.
- Corrected the misleading lock hint in `internal/cli/cli.go` and the (currently unused) `hint.unlock` i18n catalog entries (en/de).
- Documented the gate in `symvault unlock --help`, `docs/scripting-contract.md`, and `docs/agent-integration.md`.
- New tests cover the gate-disabled error path and `envPassphraseIgnored`, isolated from ambient developer environments where the gate may be enabled.

## Verification

- `go test ./...` — all packages pass (clean env)
- `make lint`, `make fmt-check`, `make docs-check` — pass

Closes #714