### PR TITLE
Apply configured Argon2id parameters and enforce bounds on key derivation

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -86,6 +86,9 @@ mcp:
 | `default_recipients` | Default age recipients for new entries |
 | `confirm_remove` | Ask for confirmation before removing recipients |
 | `authMethod` | Optional per-vault override: `passphrase` or `touchid` |
+| `argon2id_time` | Argon2id time cost parameter (default: 3, floor: 2, ceiling: 16) |
+| `argon2id_memory` | Argon2id memory cost parameter in KiB (default: 65536, floor: 19456, ceiling: 2097152) |
+| `argon2id_threads` | Argon2id parallelism parameter (default: 4, floor: 1, ceiling: 16) |
 
 ## Authentication
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3594,3 +3594,41 @@ agents:
 		t.Errorf("PaymentPolicyValue() = %q, want %q", agent.PaymentPolicyValue(), "test-policy")
 	}
 }
+
+func TestValidate_Argon2idParamsBounds(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		time    int
+		memory  int
+		threads int
+		wantErr bool
+	}{
+		{"valid defaults", 3, 65536, 4, false},
+		{"valid floors", 2, 19456, 1, false},
+		{"valid ceilings", 16, 2097152, 16, false},
+		{"time below floor", 1, 65536, 4, true},
+		{"time above ceiling", 17, 65536, 4, true},
+		{"memory below floor", 3, 1024, 4, true},
+		{"memory above ceiling", 3, 3000000, 4, true},
+		{"threads below floor", 3, 65536, -1, true},
+		{"threads above ceiling", 3, 65536, 20, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := Default()
+			cfg.Vault = &VaultConfig{
+				Argon2idTime:    tt.time,
+				Argon2idMemory:  tt.memory,
+				Argon2idThreads: tt.threads,
+			}
+			err := cfg.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/config/config_validate.go
+++ b/internal/config/config_validate.go
@@ -189,5 +189,50 @@ func (c *Config) Validate() error {
 		errs = errors.Join(errs, err)
 	}
 
+	if err := validateArgon2idConfig(c.Vault); err != nil {
+		errs = errors.Join(errs, err)
+	}
+
+	return errs
+}
+
+func validateArgon2idConfig(v *VaultConfig) error {
+	if v == nil {
+		return nil
+	}
+	var errs error
+	if v.Argon2idTime != 0 {
+		if v.Argon2idTime < 2 {
+			errs = errors.Join(errs, fmt.Errorf("vault.argon2id_time: %d is below minimum floor of 2", v.Argon2idTime))
+		} else if v.Argon2idTime > 16 {
+			errs = errors.Join(errs, fmt.Errorf("vault.argon2id_time: %d exceeds maximum ceiling of 16", v.Argon2idTime))
+		}
+	}
+
+	effThreads := v.Argon2idThreads
+	if effThreads != 0 {
+		if effThreads < 1 {
+			errs = errors.Join(errs, fmt.Errorf("vault.argon2id_threads: %d is below minimum floor of 1", effThreads))
+		} else if effThreads > 16 {
+			errs = errors.Join(errs, fmt.Errorf("vault.argon2id_threads: %d exceeds maximum ceiling of 16", effThreads))
+		}
+	} else {
+		effThreads = 4
+	}
+
+	if v.Argon2idMemory != 0 {
+		if v.Argon2idMemory < 19456 {
+			errs = errors.Join(errs, fmt.Errorf("vault.argon2id_memory: %d KiB is below minimum floor of 19456 KiB", v.Argon2idMemory))
+		} else if v.Argon2idMemory > 2097152 {
+			errs = errors.Join(errs, fmt.Errorf("vault.argon2id_memory: %d KiB exceeds maximum ceiling of 2097152 KiB", v.Argon2idMemory))
+		}
+		if effThreads > 0 {
+			minMem := 4 * effThreads
+			if v.Argon2idMemory < minMem {
+				errs = errors.Join(errs, fmt.Errorf("vault.argon2id_memory: %d KiB must be at least 4*threads (%d KiB)", v.Argon2idMemory, minMem))
+			}
+		}
+	}
+
 	return errs
 }

--- a/internal/crypto/argon2id.go
+++ b/internal/crypto/argon2id.go
@@ -12,6 +12,9 @@ const (
 	DefaultArgon2idTime    = 3
 	DefaultArgon2idMemory  = 64 * 1024
 	DefaultArgon2idThreads = 4
+	MaxArgon2idTime        = 16
+	MaxArgon2idMemory      = 2097152 // 2 GiB in KiB
+	MaxArgon2idThreads     = 16
 	SaltLen                = 16
 	Argon2idKeyLen         = 32
 )
@@ -34,11 +37,20 @@ func validateArgon2idParams(p Argon2idParams) error {
 	if p.Time == 0 {
 		return errors.New("argon2id time parameter must be > 0")
 	}
+	if p.Time > MaxArgon2idTime {
+		return fmt.Errorf("argon2id time parameter (%d) exceeds maximum ceiling (%d)", p.Time, MaxArgon2idTime)
+	}
 	if p.Memory == 0 {
 		return errors.New("argon2id memory parameter must be > 0")
 	}
+	if p.Memory > MaxArgon2idMemory {
+		return fmt.Errorf("argon2id memory parameter (%d KiB) exceeds maximum ceiling (%d KiB)", p.Memory, MaxArgon2idMemory)
+	}
 	if p.Threads == 0 {
 		return errors.New("argon2id threads parameter must be > 0")
+	}
+	if p.Threads > MaxArgon2idThreads {
+		return fmt.Errorf("argon2id threads parameter (%d) exceeds maximum ceiling (%d)", p.Threads, MaxArgon2idThreads)
 	}
 	minMem := 4 * uint32(p.Threads)
 	if p.Memory < minMem {

--- a/internal/crypto/symmetric.go
+++ b/internal/crypto/symmetric.go
@@ -297,7 +297,7 @@ func parseUint32(s string) (uint32, error) {
 	if err != nil {
 		return 0, fmt.Errorf("invalid number: %q: %w", s, err)
 	}
-	return uint32(u), nil
+	return uint32(u), nil // #nosec G115 — ParseUint with bitSize 32 guarantees value fits in uint32
 }
 
 func EncryptWithKey(plaintext []byte, key []byte) ([]byte, error) {

--- a/internal/crypto/symmetric.go
+++ b/internal/crypto/symmetric.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"strconv"
 	"strings"
 	"unsafe"
 
@@ -282,21 +283,21 @@ func parseArgon2idParams(s string) (Argon2idParams, error) {
 			return params, fmt.Errorf("invalid params: %w", err)
 		}
 	}
-	if params.Time == 0 || params.Memory == 0 || params.Threads == 0 {
-		return params, errors.New("incomplete argon2id params")
+	if err := validateArgon2idParams(params); err != nil {
+		return params, err
 	}
 	return params, nil
 }
 
 func parseUint32(s string) (uint32, error) {
-	var n uint32
-	for _, c := range s {
-		if c < '0' || c > '9' {
-			return 0, fmt.Errorf("invalid number: %q", s)
-		}
-		n = n*10 + uint32(c-'0')
+	if len(s) == 0 {
+		return 0, fmt.Errorf("invalid number: %q", s)
 	}
-	return n, nil
+	u, err := strconv.ParseUint(s, 10, 32)
+	if err != nil {
+		return 0, fmt.Errorf("invalid number: %q: %w", s, err)
+	}
+	return uint32(u), nil
 }
 
 func EncryptWithKey(plaintext []byte, key []byte) ([]byte, error) {

--- a/internal/crypto/symmetric_test.go
+++ b/internal/crypto/symmetric_test.go
@@ -2,6 +2,7 @@ package crypto
 
 import (
 	"bytes"
+	"encoding/base64"
 	"errors"
 	"os"
 	"strings"
@@ -546,4 +547,98 @@ func TestRecoverZeroKeyIdentityRejectsZeroLength(t *testing.T) {
 	if _, err := RecoverZeroKeyIdentity([]byte("-> argon2id t=1,m=64,p=1\nAAAA"), -1); err == nil {
 		t.Fatal("expected error for negative n")
 	}
+}
+
+func TestArgon2idParams_UpperBounds(t *testing.T) {
+	t.Parallel()
+
+	pass := []byte("passphrase")
+	salt := []byte("0123456789abcdef")
+
+	tests := []struct {
+		name    string
+		params  Argon2idParams
+		wantErr bool
+	}{
+		{"valid default", DefaultArgon2idParams(), false},
+		{"valid max memory", Argon2idParams{Time: 3, Memory: 2097152, Threads: 4}, false},
+		{"valid max time", Argon2idParams{Time: 16, Memory: 65536, Threads: 4}, false},
+		{"valid max threads", Argon2idParams{Time: 3, Memory: 65536, Threads: 16}, false},
+		{"time over ceiling", Argon2idParams{Time: 17, Memory: 65536, Threads: 4}, true},
+		{"memory over ceiling", Argon2idParams{Time: 3, Memory: 2097153, Threads: 4}, true},
+		{"threads over ceiling", Argon2idParams{Time: 3, Memory: 65536, Threads: 17}, true},
+		{"memory below min 4*threads", Argon2idParams{Time: 3, Memory: 15, Threads: 4}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := Argon2idDeriveKey(pass, salt, tt.params)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Argon2idDeriveKey() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestParseArgon2idParams_UnboundedMemory(t *testing.T) {
+	t.Parallel()
+
+	invalidStanzas := []string{
+		"t=3,m=4294967295,p=4",
+		"t=3,m=9999999999,p=4",
+		"t=4294967295,m=65536,p=4",
+		"t=3,m=65536,p=255",
+		"t=0,m=65536,p=4",
+		"t=3,m=0,p=4",
+		"t=3,m=65536,p=0",
+	}
+
+	for _, s := range invalidStanzas {
+		_, err := parseArgon2idParams(s)
+		if err == nil {
+			t.Errorf("parseArgon2idParams(%q) = nil, want error", s)
+		}
+	}
+}
+
+func TestUnwrapArgon2id_RejectsOverLimitStanza(t *testing.T) {
+	t.Parallel()
+
+	identity := NewArgon2idIdentity("testphrase")
+	salt := base64.RawStdEncoding.EncodeToString([]byte("0123456789abcdef"))
+
+	// Create stanza with m=4294967295
+	stanza := &age.Stanza{
+		Type: Argon2idStanzaType,
+		Args: []string{salt, "t=3,m=4294967295,p=4"},
+		Body: make([]byte, 32),
+	}
+
+	_, err := identity.Unwrap([]*age.Stanza{stanza})
+	if err == nil {
+		t.Fatal("expected error unwrapping over-limit Argon2id stanza, got nil")
+	}
+}
+
+func FuzzParseArgon2idParams(f *testing.F) {
+	seeds := []string{
+		"t=3,m=65536,p=4",
+		"t=3,m=4294967295,p=4",
+		"t=0,m=0,p=0",
+		"invalid",
+		"t=16,m=2097152,p=16",
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	f.Fuzz(func(t *testing.T, input string) {
+		p, err := parseArgon2idParams(input)
+		if err == nil {
+			if p.Memory > MaxArgon2idMemory || p.Time > MaxArgon2idTime || p.Threads > MaxArgon2idThreads {
+				t.Fatalf("parseArgon2idParams(%q) returned out-of-bounds params: %+v", input, p)
+			}
+		}
+	})
 }

--- a/internal/vault/passphrase_test.go
+++ b/internal/vault/passphrase_test.go
@@ -1,6 +1,8 @@
 package vault
 
 import (
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/danieljustus/symaira-vault/internal/config"
@@ -30,6 +32,41 @@ func TestInitWithPassphraseRoundTrip(t *testing.T) {
 	}
 	if v.Config == nil || v.Config.VaultDir != vaultDir {
 		t.Fatalf("OpenWithPassphrase() config vault = %v, want %s", v.Config, vaultDir)
+	}
+}
+
+func TestInitWithPassphraseCustomArgon2idParams(t *testing.T) {
+	vaultDir := t.TempDir()
+	cfg := config.Default()
+	cfg.VaultDir = vaultDir
+	cfg.Vault = &config.VaultConfig{
+		Argon2idTime:    4,
+		Argon2idMemory:  131072,
+		Argon2idThreads: 2,
+	}
+
+	passphrase := []byte("custom params passphrase")
+	identity, err := InitWithPassphrase(vaultDir, passphrase, cfg)
+	if err != nil {
+		t.Fatalf("InitWithPassphrase() error = %v", err)
+	}
+
+	raw, err := os.ReadFile(vaultDir + "/identity.age")
+	if err != nil {
+		t.Fatalf("os.ReadFile() error = %v", err)
+	}
+
+	rawStr := string(raw)
+	if !strings.Contains(rawStr, "t=4,m=131072,p=2") {
+		t.Fatalf("identity.age does not contain configured Argon2id params 't=4,m=131072,p=2': %s", rawStr)
+	}
+
+	v, err := OpenWithPassphrase(vaultDir, passphrase)
+	if err != nil {
+		t.Fatalf("OpenWithPassphrase() error = %v", err)
+	}
+	if v.Identity.String() != identity.String() {
+		t.Fatalf("identity mismatch: got %s, want %s", v.Identity.String(), identity.String())
 	}
 }
 

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -301,13 +301,13 @@ func resolveArgon2idParams(cfg *vaultconfig.Config) vaultcrypto.Argon2idParams {
 	params := vaultcrypto.DefaultArgon2idParams()
 	if cfg != nil && cfg.Vault != nil {
 		if cfg.Vault.Argon2idTime > 0 {
-			params.Time = uint32(cfg.Vault.Argon2idTime)
+			params.Time = uint32(cfg.Vault.Argon2idTime) // #nosec G115 — bounds-checked in Config.Validate
 		}
 		if cfg.Vault.Argon2idMemory > 0 {
-			params.Memory = uint32(cfg.Vault.Argon2idMemory)
+			params.Memory = uint32(cfg.Vault.Argon2idMemory) // #nosec G115 — bounds-checked in Config.Validate
 		}
 		if cfg.Vault.Argon2idThreads > 0 {
-			params.Threads = uint8(cfg.Vault.Argon2idThreads)
+			params.Threads = uint8(cfg.Vault.Argon2idThreads) // #nosec G115 — bounds-checked in Config.Validate
 		}
 	}
 	return params

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -258,7 +258,7 @@ func tryHealZeroKeyIdentity(vaultDir, identityPath string, raw, passphrase []byt
 	if !verified {
 		return nil, false, errors.New("recovered identity not present in recipients.txt; refusing to silently re-key the vault")
 	}
-	if err := rewriteIdentityAtomic(identityPath, recovered, cloneBytes(passphrase)); err != nil {
+	if err := rewriteIdentityAtomic(identityPath, recovered, cloneBytes(passphrase), vaultcrypto.DefaultArgon2idParams()); err != nil {
 		return nil, false, fmt.Errorf("atomic rewrite of healed identity: %w", err)
 	}
 	return recovered, true, nil
@@ -283,7 +283,8 @@ func MigrateKDF(vaultDir string, identity *age.X25519Identity, passphrase []byte
 		return nil
 	}
 	identityPath := filepath.Join(vaultDir, "identity.age")
-	if err := rewriteIdentityAtomic(identityPath, identity, passphrase); err != nil {
+	params := resolveArgon2idParams(v.Config)
+	if err := rewriteIdentityAtomic(identityPath, identity, passphrase, params); err != nil {
 		v.NeedsMigration = true
 		return nil
 	}
@@ -296,13 +297,29 @@ func MigrateKDF(vaultDir string, identity *age.X25519Identity, passphrase []byte
 	return nil
 }
 
+func resolveArgon2idParams(cfg *vaultconfig.Config) vaultcrypto.Argon2idParams {
+	params := vaultcrypto.DefaultArgon2idParams()
+	if cfg != nil && cfg.Vault != nil {
+		if cfg.Vault.Argon2idTime > 0 {
+			params.Time = uint32(cfg.Vault.Argon2idTime)
+		}
+		if cfg.Vault.Argon2idMemory > 0 {
+			params.Memory = uint32(cfg.Vault.Argon2idMemory)
+		}
+		if cfg.Vault.Argon2idThreads > 0 {
+			params.Threads = uint8(cfg.Vault.Argon2idThreads)
+		}
+	}
+	return params
+}
+
 // rewriteIdentityAtomic replaces identity.age with one freshly encrypted under
 // the given passphrase. The existing file is backed up to identity.age.bak
 // first, the new content is written and then verified to decrypt with the
 // passphrase; on any failure the original is restored and an error is
 // returned. This is the shared safety primitive used by both the scrypt→argon2id
 // KDF migration and the pre-#476 zero-key identity heal.
-func rewriteIdentityAtomic(identityPath string, identity *age.X25519Identity, passphrase []byte) error {
+func rewriteIdentityAtomic(identityPath string, identity *age.X25519Identity, passphrase []byte, params vaultcrypto.Argon2idParams) error {
 	backupPath := identityPath + ".bak"
 	original, readErr := os.ReadFile(identityPath) // #nosec G304 — fixed filename under validated vaultDir
 	if readErr != nil {
@@ -311,7 +328,6 @@ func rewriteIdentityAtomic(identityPath string, identity *age.X25519Identity, pa
 	if err := fsutil.AtomicWriteFile(backupPath, original, 0o600); err != nil {
 		return fmt.Errorf("write backup: %w", err)
 	}
-	params := vaultcrypto.DefaultArgon2idParams()
 	if err := vaultcrypto.SaveIdentityWithArgon2id(identity, identityPath, cloneBytes(passphrase), params); err != nil {
 		_ = restoreIdentityBackup(identityPath, backupPath, original)
 		return fmt.Errorf("save new identity: %w", err)
@@ -397,7 +413,7 @@ func InitWithPassphrase(vaultDir string, passphrase []byte, cfg *vaultconfig.Con
 	identityPath := filepath.Join(vaultDir, "identity.age")
 	if cfg.Vault != nil {
 		cfg.Vault.FormatVersion = vaultFormatVersion2
-		params := vaultcrypto.DefaultArgon2idParams()
+		params := resolveArgon2idParams(cfg)
 		if err := vaultcrypto.SaveIdentityWithArgon2id(identity, identityPath, cloneBytes(passphrase), params); err != nil {
 			return nil, fmt.Errorf("save identity with argon2id: %w", err)
 		}


### PR DESCRIPTION
Bundles fixes for multiple open issues. The list below grows as commits land; every linked issue will close automatically on merge.

<!-- closes-list-start -->
- Closes #717 Argon2id config keys are parsed and persisted but never applied to key derivation
- Closes #718 Argon2id parameters read from vault files are unbounded — untrusted stanza can trigger memory exhaustion
<!-- closes-list-end -->
