### PR TITLE
perf(vault): batch mode for encrypted search index bulk writes

### DIFF
--- a/cmd/admin/import.go
+++ b/cmd/admin/import.go
@@ -122,6 +122,21 @@ Use --format to override auto-detection or when the file extension does not matc
 		}
 
 		return cli.WithVault(func(v *vaultpkg.Vault, vs *cli.VaultService) error {
+			// Batch mode: the write loop below would otherwise trigger a full
+			// decrypt/re-encrypt/persist of the search index per entry (O(N²)
+			// total). Suspend defers index maintenance; the deferred Resume
+			// performs exactly one rebuild — even when the import fails midway —
+			// and invalidates the index explicitly if that rebuild fails, so the
+			// index is never left silently stale.
+			if !options.DryRun {
+				vaultpkg.SuspendSearchIndex(v.Dir)
+				defer func() {
+					if err := vaultpkg.ResumeSearchIndex(v.Dir, v.Identity); err != nil {
+						cli.PrintQuietAware("Warning: search index rebuild failed after import; the index was invalidated and will be rebuilt on the next search: %v\n", err)
+					}
+				}()
+			}
+
 			imported, skipped := 0, 0
 			for _, entry := range entries {
 				entryPath := importEntryPath(options.Prefix, entry.Path)

--- a/internal/vault/search_index.go
+++ b/internal/vault/search_index.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"unicode"
 
 	"filippo.io/age"
@@ -56,6 +57,65 @@ type EncryptedIndex struct {
 	vaultDir   string            // vault directory the index covers
 	idHash     [sha256.Size]byte // sha256 of identity recipient for change detection
 	persistErr error             // last on-disk persistence failure, if any
+	suspended  bool              // batch mode: incremental writes defer to Resume
+	dirty      bool              // set when a write was skipped while suspended
+}
+
+// indexBuildCounter counts successful index builds (buildIndex commits). It
+// exists so tests and benchmarks can assert that a batch of writes triggers
+// exactly one full index build instead of one rebuild per write.
+var indexBuildCounter atomic.Int64
+
+// Suspend puts the index into batch mode: subsequent UpdateEntry/RemoveEntry
+// calls mark the index dirty instead of decrypting, re-marshaling,
+// re-encrypting, and re-persisting the whole document per write. Resume must
+// be called afterwards (typically deferred) to perform a single full rebuild
+// if any write was skipped. Suspend is idempotent.
+func (idx *EncryptedIndex) Suspend() {
+	idx.mu.Lock()
+	idx.suspended = true
+	idx.mu.Unlock()
+}
+
+// Resume leaves batch mode. If any incremental write was skipped while
+// suspended, it rebuilds the index exactly once from the current vault state
+// and persists it. If the rebuild fails, the index is explicitly invalidated
+// (in-memory and on-disk) so callers are never left with a silently stale
+// index, and the build error is returned. Resume on a non-suspended index is
+// a no-op.
+func (idx *EncryptedIndex) Resume(vaultDir string, identity *age.X25519Identity) error {
+	idx.mu.Lock()
+	if !idx.suspended {
+		idx.mu.Unlock()
+		return nil
+	}
+	idx.suspended = false
+	dirty := idx.dirty
+	idx.dirty = false
+	idx.mu.Unlock()
+
+	if !dirty {
+		return nil
+	}
+	if err := idx.buildIndex(vaultDir, identity, true); err != nil {
+		idx.Invalidate()
+		return err
+	}
+	return nil
+}
+
+// SuspendSearchIndex puts the search index for vaultDir into batch mode so a
+// bulk write loop (e.g. import) does not pay a full index re-encryption per
+// entry. Pair with a deferred ResumeSearchIndex.
+func SuspendSearchIndex(vaultDir string) {
+	searchIndexForVault(vaultDir).Suspend()
+}
+
+// ResumeSearchIndex leaves batch mode for vaultDir's search index. If writes
+// were skipped while suspended it performs exactly one full rebuild; on
+// rebuild failure the index is invalidated and the error returned.
+func ResumeSearchIndex(vaultDir string, identity *age.X25519Identity) error {
+	return searchIndexForVault(vaultDir).Resume(vaultDir, identity)
 }
 
 // LastPersistError returns the error from the most recent attempt to persist
@@ -101,6 +161,12 @@ type indexDoc struct {
 	// TokenIndex maps token → entry paths containing that token.
 	// Tokens are lowercased and split on whitespace/punctuation boundaries.
 	TokenIndex map[string]map[string]struct{} `json:"ti,omitempty"`
+	// PathTokens is the reverse of TokenIndex: entry path → the deduplicated
+	// tokens extracted from its values. It lets incremental updates remove a
+	// path from the token index in O(tokens of that path) instead of scanning
+	// every token in the index. May be nil in indices written before this
+	// field existed; it is rebuilt lazily on the first incremental update.
+	PathTokens map[string][]string `json:"pt,omitempty"`
 	// EntryCount is the number of entries in the vault when the index was built.
 	// Used for stale detection — if the count differs, the index is rebuilt.
 	EntryCount int `json:"c,omitempty"`
@@ -239,6 +305,7 @@ func (idx *EncryptedIndex) buildIndex(vaultDir string, identity *age.X25519Ident
 	doc := indexDoc{
 		Values:     make(map[string][]string, len(paths)),
 		TokenIndex: make(map[string]map[string]struct{}),
+		PathTokens: make(map[string][]string, len(paths)),
 		EntryCount: len(paths),
 	}
 
@@ -313,14 +380,7 @@ func (idx *EncryptedIndex) buildIndex(vaultDir string, identity *age.X25519Ident
 		}
 
 		doc.Values[result.path] = result.values
-		for _, val := range result.values {
-			for _, token := range tokenize(val) {
-				if doc.TokenIndex[token] == nil {
-					doc.TokenIndex[token] = make(map[string]struct{})
-				}
-				doc.TokenIndex[token][result.path] = struct{}{}
-			}
-		}
+		addToTokenIndex(doc.TokenIndex, doc.PathTokens, result.values, result.path)
 	}
 
 	// Refuse to commit an index that covers zero entries when the vault
@@ -355,6 +415,8 @@ func (idx *EncryptedIndex) buildIndex(vaultDir string, identity *age.X25519Ident
 	idx.vaultDir = vaultDir
 	idx.idHash = idHash
 	idx.mu.Unlock()
+
+	indexBuildCounter.Add(1)
 
 	if persist {
 		persistErr := idx.saveToDisk(vaultDir)
@@ -505,6 +567,13 @@ func (idx *EncryptedIndex) UpdateEntry(vaultDir, path string, identity *age.X255
 		return nil
 	}
 
+	// Batch mode: skip the per-write decrypt/re-encrypt/persist cycle and let
+	// Resume rebuild the index once.
+	if idx.suspended {
+		idx.dirty = true
+		return nil
+	}
+
 	storedSalt := idx.salt
 	key := deriveIndexKey(identity, storedSalt)
 	defer vaultcrypto.Wipe(key)
@@ -530,8 +599,9 @@ func (idx *EncryptedIndex) UpdateEntry(vaultDir, path string, identity *age.X255
 	if doc.TokenIndex == nil {
 		doc.TokenIndex = make(map[string]map[string]struct{})
 	}
+	ensurePathTokens(&doc)
 
-	removeFromTokenIndex(doc.TokenIndex, path)
+	removeFromTokenIndex(doc.TokenIndex, doc.PathTokens, path)
 	delete(doc.Values, path)
 
 	entry, readErr := ReadEntry(vaultDir, path, identity)
@@ -540,7 +610,7 @@ func (idx *EncryptedIndex) UpdateEntry(vaultDir, path string, identity *age.X255
 		collectStringValues(&values, entry.Data)
 		if len(values) > 0 {
 			doc.Values[path] = values
-			addToTokenIndex(doc.TokenIndex, values, path)
+			addToTokenIndex(doc.TokenIndex, doc.PathTokens, values, path)
 		}
 	}
 
@@ -578,6 +648,13 @@ func (idx *EncryptedIndex) RemoveEntry(path string, identity *age.X25519Identity
 		return
 	}
 
+	// Batch mode: skip the per-write decrypt/re-encrypt/persist cycle and let
+	// Resume rebuild the index once.
+	if idx.suspended {
+		idx.dirty = true
+		return
+	}
+
 	vaultDir := idx.vaultDir
 	dropDisk := func() {
 		idx.clearLocked()
@@ -610,7 +687,8 @@ func (idx *EncryptedIndex) RemoveEntry(path string, identity *age.X25519Identity
 
 	delete(doc.Values, path)
 	if doc.TokenIndex != nil {
-		removeFromTokenIndex(doc.TokenIndex, path)
+		ensurePathTokens(&doc)
+		removeFromTokenIndex(doc.TokenIndex, doc.PathTokens, path)
 	}
 	// A delete removes exactly one vault entry; keep the persisted entry count
 	// in step so the on-disk index stays valid (not flagged stale) on reload.
@@ -857,25 +935,68 @@ func isSingleToken(needle string) bool {
 }
 
 // addToTokenIndex adds all tokens from a set of values to the token index,
-// associating them with the given entry path.
-func addToTokenIndex(ti map[string]map[string]struct{}, values []string, path string) {
-	for _, val := range values {
-		for _, token := range tokenize(val) {
-			if ti[token] == nil {
-				ti[token] = make(map[string]struct{})
-			}
-			ti[token][path] = struct{}{}
+// associating them with the given entry path, and records the deduplicated
+// token set in the reverse path→tokens map.
+func addToTokenIndex(ti map[string]map[string]struct{}, pt map[string][]string, values []string, path string) {
+	tokens := uniqueTokens(values)
+	for _, token := range tokens {
+		if ti[token] == nil {
+			ti[token] = make(map[string]struct{})
 		}
+		ti[token][path] = struct{}{}
+	}
+	if pt != nil {
+		pt[path] = tokens
 	}
 }
 
-// removeFromTokenIndex removes all references to a path from the token index.
-// Empty token maps are cleaned up to keep the index compact.
-func removeFromTokenIndex(ti map[string]map[string]struct{}, path string) {
-	for token, paths := range ti {
+// uniqueTokens returns the deduplicated set of tokens across all values.
+func uniqueTokens(values []string) []string {
+	seen := make(map[string]struct{})
+	var tokens []string
+	for _, val := range values {
+		for _, token := range tokenize(val) {
+			if _, ok := seen[token]; ok {
+				continue
+			}
+			seen[token] = struct{}{}
+			tokens = append(tokens, token)
+		}
+	}
+	return tokens
+}
+
+// ensurePathTokens lazily rebuilds the reverse path→tokens map from Values
+// for index documents written before PathTokens existed. This runs at most
+// once per legacy document; afterwards removals are O(tokens of the path).
+func ensurePathTokens(doc *indexDoc) {
+	if doc.PathTokens != nil {
+		return
+	}
+	doc.PathTokens = make(map[string][]string, len(doc.Values))
+	for path, values := range doc.Values {
+		doc.PathTokens[path] = uniqueTokens(values)
+	}
+}
+
+// removeFromTokenIndex removes all references to a path from the token index
+// using the reverse path→tokens map, so only the tokens that actually occur
+// in the removed path are touched. Empty token maps are cleaned up to keep
+// the index compact.
+func removeFromTokenIndex(ti map[string]map[string]struct{}, pt map[string][]string, path string) {
+	tokens, ok := pt[path]
+	if !ok {
+		return
+	}
+	for _, token := range tokens {
+		paths, found := ti[token]
+		if !found {
+			continue
+		}
 		delete(paths, path)
 		if len(paths) == 0 {
 			delete(ti, token)
 		}
 	}
+	delete(pt, path)
 }

--- a/internal/vault/search_index_batch_bench_test.go
+++ b/internal/vault/search_index_batch_bench_test.go
@@ -1,0 +1,125 @@
+package vault
+
+import (
+	"fmt"
+	"testing"
+)
+
+// BenchmarkEncryptedIndexUpdateEntry_1kEntries measures the cost of a single
+// incremental UpdateEntry on a 1k-entry vault: each call decrypts, re-marshals,
+// re-encrypts, and re-persists the whole index document.
+func BenchmarkEncryptedIndexUpdateEntry_1kEntries(b *testing.B) {
+	benchmarkIndexUpdateEntry(b, 1000)
+}
+
+// BenchmarkEncryptedIndexUpdateEntry_2kEntries measures the per-write cost on
+// a 2k-entry vault, showing the O(N) growth that makes bulk imports O(N²).
+func BenchmarkEncryptedIndexUpdateEntry_2kEntries(b *testing.B) {
+	benchmarkIndexUpdateEntry(b, 2000)
+}
+
+// BenchmarkEncryptedIndexBatchUpdate_1kEntries_100Writes measures a batch of
+// 100 writes on a 1k-entry vault with Suspend/Resume: one full index build
+// total instead of 100 per-write re-encryptions. Reports builds/op == 1.
+func BenchmarkEncryptedIndexBatchUpdate_1kEntries_100Writes(b *testing.B) {
+	benchmarkIndexBatchUpdate(b, 1000, 100)
+}
+
+// BenchmarkEncryptedIndexBatchUpdate_2kEntries_100Writes is the 2k-entry
+// variant of the batch benchmark.
+func BenchmarkEncryptedIndexBatchUpdate_2kEntries_100Writes(b *testing.B) {
+	benchmarkIndexBatchUpdate(b, 2000, 100)
+}
+
+// BenchmarkEncryptedIndexRemoveEntry_2kEntries measures an incremental
+// RemoveEntry, whose token cleanup now uses the reverse path→tokens map
+// instead of scanning every token in the index.
+func BenchmarkEncryptedIndexRemoveEntry_2kEntries(b *testing.B) {
+	benchmarkIndexRemoveEntry(b, 2000)
+}
+
+func benchmarkIndexUpdateEntry(b *testing.B, numEntries int) {
+	vaultDir := b.TempDir()
+	identity := generateTestIdentity(b)
+	createTestEntries(b, vaultDir, identity, numEntries)
+
+	idx := &EncryptedIndex{}
+	if err := idx.Build(vaultDir, identity); err != nil {
+		b.Fatalf("Build failed: %v", err)
+	}
+
+	target := fmt.Sprintf("service-%d/entry-%05d", 0, 0)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		if err := idx.UpdateEntry(vaultDir, target, identity); err != nil {
+			b.Fatalf("UpdateEntry failed: %v", err)
+		}
+	}
+}
+
+func benchmarkIndexBatchUpdate(b *testing.B, numEntries, numWrites int) {
+	vaultDir := b.TempDir()
+	identity := generateTestIdentity(b)
+	createTestEntries(b, vaultDir, identity, numEntries)
+
+	idx := &EncryptedIndex{}
+	if err := idx.Build(vaultDir, identity); err != nil {
+		b.Fatalf("Build failed: %v", err)
+	}
+
+	paths := make([]string, 0, numWrites)
+	for i := 0; i < numWrites; i++ {
+		paths = append(paths, fmt.Sprintf("service-%d/entry-%05d", i/100, i))
+	}
+
+	buildsBefore := indexBuildCounter.Load()
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		idx.Suspend()
+		for _, p := range paths {
+			if err := idx.UpdateEntry(vaultDir, p, identity); err != nil {
+				b.Fatalf("UpdateEntry failed: %v", err)
+			}
+		}
+		if err := idx.Resume(vaultDir, identity); err != nil {
+			b.Fatalf("Resume failed: %v", err)
+		}
+	}
+
+	b.StopTimer()
+	buildsPerOp := float64(indexBuildCounter.Load()-buildsBefore) / float64(b.N)
+	b.ReportMetric(buildsPerOp, "builds/op")
+	if buildsPerOp != 1 {
+		b.Fatalf("batch of %d writes triggered %f index builds per batch, want exactly 1", numWrites, buildsPerOp)
+	}
+}
+
+func benchmarkIndexRemoveEntry(b *testing.B, numEntries int) {
+	vaultDir := b.TempDir()
+	identity := generateTestIdentity(b)
+	createTestEntries(b, vaultDir, identity, numEntries)
+
+	idx := &EncryptedIndex{}
+	if err := idx.Build(vaultDir, identity); err != nil {
+		b.Fatalf("Build failed: %v", err)
+	}
+
+	target := fmt.Sprintf("service-%d/entry-%05d", 0, 0)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		idx.RemoveEntry(target, identity)
+		// Re-add so the next iteration measures a real removal again.
+		if err := idx.UpdateEntry(vaultDir, target, identity); err != nil {
+			b.Fatalf("UpdateEntry failed: %v", err)
+		}
+	}
+}

--- a/internal/vault/search_index_batch_test.go
+++ b/internal/vault/search_index_batch_test.go
@@ -1,0 +1,294 @@
+package vault
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/danieljustus/symaira-vault/internal/testutil"
+)
+
+// TestSuspendResumeSingleBuild verifies that a batch of writes between
+// Suspend and Resume triggers exactly one full index build instead of one
+// rebuild per write, and that the rebuilt index returns correct results.
+func TestSuspendResumeSingleBuild(t *testing.T) {
+	searchIndexStore.invalidateAll()
+	t.Cleanup(searchIndexStore.invalidateAll)
+
+	vaultDir := t.TempDir()
+	identity := testutil.TempIdentity(t)
+	mustWriteEntry(t, vaultDir, identity, "keep", map[string]interface{}{"user": "keepvalue"})
+	mustWriteEntry(t, vaultDir, identity, "gone", map[string]interface{}{"user": "gonevalue"})
+
+	idx := searchIndexForVault(vaultDir)
+	if err := idx.Build(vaultDir, identity); err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+
+	buildsBefore := indexBuildCounter.Load()
+
+	idx.Suspend()
+
+	// Simulate a bulk import loop: adds, an in-place edit, and a delete.
+	mustWriteEntry(t, vaultDir, identity, "new1", map[string]interface{}{"user": "alphavalue"})
+	mustWriteEntry(t, vaultDir, identity, "new2", map[string]interface{}{"user": "bravovalue"})
+	mustWriteEntry(t, vaultDir, identity, "keep", map[string]interface{}{"user": "keepedited"})
+	for _, p := range []string{"new1", "new2", "keep"} {
+		if err := idx.UpdateEntry(vaultDir, p, identity); err != nil {
+			t.Fatalf("UpdateEntry(%s) error = %v", p, err)
+		}
+	}
+	if err := DeleteEntry(vaultDir, "gone", identity); err != nil {
+		t.Fatalf("DeleteEntry() error = %v", err)
+	}
+	idx.RemoveEntry("gone", identity)
+
+	if err := idx.Resume(vaultDir, identity); err != nil {
+		t.Fatalf("Resume() error = %v", err)
+	}
+
+	if got := indexBuildCounter.Load() - buildsBefore; got != 1 {
+		t.Fatalf("index builds during batch = %d, want exactly 1", got)
+	}
+
+	candidates, err := List(vaultDir, "", identity)
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+
+	assertMatch := func(needle string, want ...string) {
+		t.Helper()
+		m, err := idx.MatchEntries(vaultDir, identity, candidates, needle)
+		if err != nil {
+			t.Fatalf("MatchEntries(%q) error = %v", needle, err)
+		}
+		got := make([]string, 0, len(m))
+		for p := range m {
+			got = append(got, p)
+		}
+		sort.Strings(got)
+		if want == nil {
+			want = []string{}
+		}
+		sort.Strings(want)
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("MatchEntries(%q) = %v, want %v", needle, got, want)
+		}
+	}
+	assertMatch("alphavalue", "new1")
+	assertMatch("bravovalue", "new2")
+	assertMatch("keepedited", "keep")
+	assertMatch("gonevalue")
+	assertMatch("keepvalue")
+}
+
+// TestBatchVsIndividualWritesIdenticalResults verifies that search results
+// after a suspended batch (Suspend + skipped writes + Resume) are identical
+// to results after applying the same writes via the individual incremental
+// update path.
+func TestBatchVsIndividualWritesIdenticalResults(t *testing.T) {
+	searchIndexStore.invalidateAll()
+	t.Cleanup(searchIndexStore.invalidateAll)
+
+	identity := testutil.TempIdentity(t)
+
+	setup := func() string {
+		dir := t.TempDir()
+		mustWriteEntry(t, dir, identity, "a", map[string]interface{}{"user": "sharedtoken alpha-one"})
+		mustWriteEntry(t, dir, identity, "b", map[string]interface{}{"user": "sharedtoken beta-two"})
+		mustWriteEntry(t, dir, identity, "c", map[string]interface{}{"user": "charlie-three"})
+		return dir
+	}
+	mutate := func(dir string) {
+		mustWriteEntry(t, dir, identity, "a", map[string]interface{}{"user": "edited alpha-one"})
+		mustWriteEntry(t, dir, identity, "d", map[string]interface{}{"user": "delta-four sharedtoken"})
+		if err := DeleteEntry(dir, "b", identity); err != nil {
+			t.Fatalf("DeleteEntry() error = %v", err)
+		}
+	}
+
+	// Reference: individual incremental updates.
+	dirA := setup()
+	idxA := searchIndexForVault(dirA)
+	if err := idxA.Build(dirA, identity); err != nil {
+		t.Fatalf("Build(A) error = %v", err)
+	}
+	mutate(dirA)
+	for _, p := range []string{"a", "d"} {
+		if err := idxA.UpdateEntry(dirA, p, identity); err != nil {
+			t.Fatalf("UpdateEntry(A, %s) error = %v", p, err)
+		}
+	}
+	idxA.RemoveEntry("b", identity)
+
+	// Batch: suspended writes + single Resume.
+	dirB := setup()
+	idxB := searchIndexForVault(dirB)
+	if err := idxB.Build(dirB, identity); err != nil {
+		t.Fatalf("Build(B) error = %v", err)
+	}
+	idxB.Suspend()
+	mutate(dirB)
+	for _, p := range []string{"a", "d"} {
+		if err := idxB.UpdateEntry(dirB, p, identity); err != nil {
+			t.Fatalf("UpdateEntry(B, %s) error = %v", p, err)
+		}
+	}
+	idxB.RemoveEntry("b", identity)
+	if err := idxB.Resume(dirB, identity); err != nil {
+		t.Fatalf("Resume(B) error = %v", err)
+	}
+
+	candidates, err := List(dirA, "", identity)
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+
+	for _, needle := range []string{"sharedtoken", "alpha", "edited", "delta-four", "beta-two", "charlie-three", "token alpha"} {
+		mA, err := idxA.MatchEntries(dirA, identity, candidates, needle)
+		if err != nil {
+			t.Fatalf("MatchEntries(A, %q) error = %v", needle, err)
+		}
+		mB, err := idxB.MatchEntries(dirB, identity, candidates, needle)
+		if err != nil {
+			t.Fatalf("MatchEntries(B, %q) error = %v", needle, err)
+		}
+		if !reflect.DeepEqual(mA, mB) {
+			t.Errorf("needle %q: individual = %v, batch = %v — results differ", needle, mA, mB)
+		}
+	}
+}
+
+// TestResumeFailureInvalidatesIndex verifies that when the single rebuild at
+// Resume fails (here: every entry became undecryptable mid-batch), the index
+// is explicitly invalidated — in memory and on disk — rather than left
+// silently stale.
+func TestResumeFailureInvalidatesIndex(t *testing.T) {
+	searchIndexStore.invalidateAll()
+	t.Cleanup(searchIndexStore.invalidateAll)
+
+	vaultDir := t.TempDir()
+	identity := testutil.TempIdentity(t)
+	mustWriteEntry(t, vaultDir, identity, "x", map[string]interface{}{"user": "xvalue"})
+	mustWriteEntry(t, vaultDir, identity, "y", map[string]interface{}{"user": "yvalue"})
+
+	idx := searchIndexForVault(vaultDir)
+	if err := idx.Build(vaultDir, identity); err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+
+	idx.Suspend()
+	mustWriteEntry(t, vaultDir, identity, "z", map[string]interface{}{"user": "zvalue"})
+	if err := idx.UpdateEntry(vaultDir, "z", identity); err != nil {
+		t.Fatalf("UpdateEntry() error = %v", err)
+	}
+
+	// Mid-import failure: corrupt every entry file so the Resume rebuild
+	// cannot decrypt anything (ErrIndexBuildEmpty).
+	entriesDir := filepath.Join(vaultDir, "entries")
+	err := filepath.Walk(entriesDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		return os.WriteFile(path, []byte("not-an-age-file"), 0o600)
+	})
+	if err != nil {
+		t.Fatalf("corrupting entries: %v", err)
+	}
+	listCacheFor(vaultDir).Invalidate()
+
+	if err := idx.Resume(vaultDir, identity); err == nil {
+		t.Fatal("Resume() error = nil, want rebuild failure")
+	}
+	if idx.IsBuilt() {
+		t.Error("index still built after failed Resume; want explicit invalidation")
+	}
+	if _, statErr := os.Stat(indexFilePath(vaultDir)); !os.IsNotExist(statErr) {
+		t.Error("on-disk index file still present after failed Resume; want it removed")
+	}
+}
+
+// TestResumeWithoutSuspendNoop verifies Resume on a non-suspended index is a
+// no-op and triggers no build.
+func TestResumeWithoutSuspendNoop(t *testing.T) {
+	searchIndexStore.invalidateAll()
+	t.Cleanup(searchIndexStore.invalidateAll)
+
+	vaultDir := t.TempDir()
+	identity := testutil.TempIdentity(t)
+	mustWriteEntry(t, vaultDir, identity, "x", map[string]interface{}{"user": "xvalue"})
+
+	idx := searchIndexForVault(vaultDir)
+	if err := idx.Build(vaultDir, identity); err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+
+	before := indexBuildCounter.Load()
+	if err := idx.Resume(vaultDir, identity); err != nil {
+		t.Fatalf("Resume() error = %v", err)
+	}
+	if got := indexBuildCounter.Load() - before; got != 0 {
+		t.Fatalf("Resume without Suspend triggered %d builds, want 0", got)
+	}
+
+	// Suspend without any skipped writes must also not rebuild.
+	idx.Suspend()
+	if err := idx.Resume(vaultDir, identity); err != nil {
+		t.Fatalf("Resume() error = %v", err)
+	}
+	if got := indexBuildCounter.Load() - before; got != 0 {
+		t.Fatalf("Resume with clean Suspend triggered %d builds, want 0", got)
+	}
+}
+
+// TestRemoveFromTokenIndexReverseMap verifies that removal via the reverse
+// path→tokens map removes exactly the removed path's token references and
+// keeps other paths' references intact — including for legacy documents
+// where PathTokens is rebuilt lazily by ensurePathTokens.
+func TestRemoveFromTokenIndexReverseMap(t *testing.T) {
+	doc := indexDoc{
+		Values: map[string][]string{
+			"p1": {"alpha beta shared"},
+			"p2": {"gamma shared"},
+		},
+		TokenIndex: map[string]map[string]struct{}{
+			"alpha":  {"p1": {}},
+			"beta":   {"p1": {}},
+			"shared": {"p1": {}, "p2": {}},
+			"gamma":  {"p2": {}},
+		},
+		// PathTokens deliberately nil: legacy document.
+	}
+
+	ensurePathTokens(&doc)
+	if len(doc.PathTokens) != 2 {
+		t.Fatalf("ensurePathTokens rebuilt %d paths, want 2", len(doc.PathTokens))
+	}
+
+	removeFromTokenIndex(doc.TokenIndex, doc.PathTokens, "p1")
+
+	if _, ok := doc.TokenIndex["alpha"]; ok {
+		t.Error("token 'alpha' survived removal of its only path")
+	}
+	if _, ok := doc.TokenIndex["beta"]; ok {
+		t.Error("token 'beta' survived removal of its only path")
+	}
+	shared, ok := doc.TokenIndex["shared"]
+	if !ok {
+		t.Fatal("token 'shared' wrongly removed; still used by p2")
+	}
+	if _, ok := shared["p2"]; !ok {
+		t.Error("token 'shared' lost reference to p2")
+	}
+	if _, ok := doc.TokenIndex["gamma"]["p2"]; !ok {
+		t.Error("token 'gamma' lost reference to p2")
+	}
+	if _, ok := doc.PathTokens["p1"]; ok {
+		t.Error("reverse map still contains removed path p1")
+	}
+}


### PR DESCRIPTION
Closes #723

## Summary
Bulk import previously paid the full search-index cost per entry: decrypt, unmarshal, full token-index scan, marshal, re-encrypt and a complete index file rewrite on every write — O(N²) plus N full rewrites for an N-entry import.

## Changes
- `internal/vault/search_index.go`: `Suspend()`/`Resume(vaultDir, identity)` batch mode. Suspended writes only mark the index dirty; `Resume` performs exactly one `buildIndex`. On rebuild failure the index is explicitly invalidated (RAM and disk) — never silently stale. Package-level wrappers `SuspendSearchIndex`/`ResumeSearchIndex` for cmd use.
- Reverse `path -> tokens` map (`PathTokens`) in `indexDoc`: `removeFromTokenIndex` is now O(tokens of that path) instead of scanning the whole token map. Legacy documents without the map rebuild it lazily.
- `cmd/admin/import.go`: import loop wrapped in suspend/resume with a deferred resume, so an aborted import leaves a correct or explicitly invalidated index.
- New tests: single index build per batch (atomic counter assertion), identical `find` results for batch vs individual writes, mid-import failure invalidation, resume no-ops, reverse-map unit tests.
- New benchmarks over synthetic 1k/2k-entry vaults (style of `internal/crypto/crypto_bench_test.go`): batch of 100 writes performs 1.000 index builds; ~78 ms batch vs ~1.2 s individual on the 1k vault (≈15×).

## Verification
- `go test ./internal/vault/... ./cmd/...` green (run with `SYMVAULT_PASSPHRASE` unset to avoid ambient-env contamination).
- `go vet` clean, gofmt clean.
- `internal/vault` coverage 84.8% (threshold 72%).