### PR TITLE
feat(cli): group top-level commands in --help output

### DIFF
--- a/cmd/admin/audit.go
+++ b/cmd/admin/audit.go
@@ -217,6 +217,7 @@ func init() {
 	AuditCmd.Flags().StringVarP(&AuditSince, "since", "s", "", "Show entries since duration (e.g. 1h, 24h, 7d)")
 	AuditCmd.Flags().BoolVar(&AuditFailed, "failed", false, "Show only failed entries")
 	AuditCmd.AddCommand(rotateKeyCmd)
+	AuditCmd.GroupID = cli.GroupIDAdministration
 	cli.RootCmd.AddCommand(AuditCmd)
 }
 

--- a/cmd/admin/backup.go
+++ b/cmd/admin/backup.go
@@ -317,6 +317,8 @@ func ComputeSHA256(path string) (string, error) {
 
 func init() {
 	backupCmd.Flags().BoolVar(&BackupExcludeGit, "exclude-git", false, "Exclude .git/ directory from backup")
+	backupCmd.GroupID = cli.GroupIDSharingSync
 	cli.RootCmd.AddCommand(backupCmd)
+	restoreCmd.GroupID = cli.GroupIDSharingSync
 	cli.RootCmd.AddCommand(restoreCmd)
 }

--- a/cmd/admin/config.go
+++ b/cmd/admin/config.go
@@ -310,5 +310,6 @@ func init() {
 	configCmd.AddCommand(configGetCmd)
 	configCmd.AddCommand(configSetCmd)
 	configCmd.AddCommand(configListCmd)
+	configCmd.GroupID = cli.GroupIDAdministration
 	cli.RootCmd.AddCommand(configCmd)
 }

--- a/cmd/admin/doctor.go
+++ b/cmd/admin/doctor.go
@@ -187,6 +187,7 @@ func outputDoctorJSON(cmd *cobra.Command, vaultDir string, results []health.Resu
 }
 
 func init() {
+	DoctorCmd.GroupID = cli.GroupIDEssentials
 	cli.RootCmd.AddCommand(DoctorCmd)
 	DoctorCmd.Flags().BoolVar(&DoctorJSON, "json", false, "Output in JSON format (deprecated: use --output=json)")
 	DoctorCmd.Flags().BoolVar(&DoctorNoNetwork, "no-network", false, "Skip network-dependent checks")

--- a/cmd/admin/export.go
+++ b/cmd/admin/export.go
@@ -208,6 +208,7 @@ func init() {
 	exportCmd.Flags().StringVar(&ExportOutput, "output", "", "Output file path (default: stdout)")
 	exportCmd.Flags().BoolVarP(&ExportYes, "yes", "y", false, "Skip confirmation prompt")
 	_ = exportCmd.MarkFlagRequired("format") //nolint:errcheck
+	exportCmd.GroupID = cli.GroupIDSharingSync
 	cli.RootCmd.AddCommand(exportCmd)
 }
 

--- a/cmd/admin/import.go
+++ b/cmd/admin/import.go
@@ -196,6 +196,7 @@ func init() {
 	importCmd.Flags().StringVar(&ImportMapping, "mapping", "", "CSV column mapping (format: title=col1,username=col2,...)")
 	importCmd.Flags().BoolVar(&ImportQuarantine, "quarantine", false, "Import entries into quarantine/<import-id>/ for human review before agent access")
 	importCmd.Flags().StringVar(&ImportFormat, "format", "", "Import format (auto-detected from file extension when omitted)")
+	importCmd.GroupID = cli.GroupIDSharingSync
 	cli.RootCmd.AddCommand(importCmd)
 }
 

--- a/cmd/admin/init.go
+++ b/cmd/admin/init.go
@@ -156,6 +156,7 @@ func printPostInitHints(vaultDir string) {
 }
 
 func init() {
+	initCmd.GroupID = cli.GroupIDEssentials
 	cli.RootCmd.AddCommand(initCmd)
 	initCmd.Flags().StringVar(&initAuthMethod, "auth", "ask", "unlock method for this vault (ask, passphrase, touchid)")
 }

--- a/cmd/admin/migrate.go
+++ b/cmd/admin/migrate.go
@@ -367,5 +367,6 @@ func init() {
 	MigrateCmd.AddCommand(migrateV4Cmd)
 	migrateV4Cmd.Flags().BoolVarP(&MigrateYes, "yes", "y", false, "Skip confirmation prompt")
 	migrateV4Cmd.Flags().BoolVar(&MigrateV4DryRun, "dry-run", false, "Preview changes without writing")
+	MigrateCmd.GroupID = cli.GroupIDAdministration
 	cli.RootCmd.AddCommand(MigrateCmd)
 }

--- a/cmd/admin/setup.go
+++ b/cmd/admin/setup.go
@@ -56,5 +56,6 @@ For non-interactive environments (CI, scripts), use 'symvault init' instead.`,
 func init() {
 	setupCmd.Flags().BoolVar(&setupKeepOnError, "keep-on-error", false, "do not rollback vault init artifacts when subsequent steps fail")
 	setupCmd.Flags().BoolVar(&setupNoResume, "no-resume", false, "disable setup resume after abort")
+	setupCmd.GroupID = cli.GroupIDEssentials
 	cli.RootCmd.AddCommand(setupCmd)
 }

--- a/cmd/admin/startup_profile.go
+++ b/cmd/admin/startup_profile.go
@@ -51,6 +51,7 @@ func init() {
 	startupProfileCmd.Flags().IntVarP(&startupProfileCount, "count", "n", 10, "number of benchmark iterations")
 	startupProfileCmd.Flags().IntVar(&startupProfileTopN, "top", 5, "show top N slowest phases in trace breakdown")
 	startupProfileCmd.Flags().StringVar(&startupProfileTraceFile, "trace", "", "write a runtime trace file (viewable with 'go tool trace')")
+	startupProfileCmd.GroupID = cli.GroupIDAdministration
 	cli.RootCmd.AddCommand(startupProfileCmd)
 }
 

--- a/cmd/admin/update.go
+++ b/cmd/admin/update.go
@@ -348,5 +348,6 @@ func init() {
 	UpdateCmd.AddCommand(UpdateCheckCmd)
 	UpdateCmd.AddCommand(updateApplyCmd)
 	UpdateCmd.AddCommand(updateInfoCmd)
+	UpdateCmd.GroupID = cli.GroupIDAdministration
 	cli.RootCmd.AddCommand(UpdateCmd)
 }

--- a/cmd/admin/verify.go
+++ b/cmd/admin/verify.go
@@ -93,6 +93,7 @@ check and only rebuild.`,
 }
 
 func init() {
+	verifyCmd.GroupID = cli.GroupIDAdministration
 	cli.RootCmd.AddCommand(verifyCmd)
 	verifyCmd.Flags().BoolVar(&verifyRebuild, "rebuild", false, "Rebuild the manifest from on-disk entries after the integrity check")
 	verifyCmd.Flags().BoolVar(&verifyRebuildOnly, "rebuild-only", false, "Rebuild the manifest and skip the integrity check")

--- a/cmd/auth/auth.go
+++ b/cmd/auth/auth.go
@@ -135,6 +135,7 @@ func init() {
 	AuthStatusCmd.Flags().BoolVar(&AuthStatusJSON, "json", false, "output auth status as JSON (deprecated: use --output=json)")
 	AuthCmd.AddCommand(AuthStatusCmd)
 	AuthCmd.AddCommand(AuthSetCmd)
+	AuthCmd.GroupID = cli.GroupIDAuthAccess
 	cli.RootCmd.AddCommand(AuthCmd)
 }
 

--- a/cmd/auth/lock.go
+++ b/cmd/auth/lock.go
@@ -38,5 +38,6 @@ var lockCmd = &cobra.Command{
 }
 
 func init() {
+	lockCmd.GroupID = cli.GroupIDAuthAccess
 	cli.RootCmd.AddCommand(lockCmd)
 }

--- a/cmd/auth/unlock.go
+++ b/cmd/auth/unlock.go
@@ -79,6 +79,7 @@ alone is ignored (default-deny). It should NOT be used on shared machines
 }
 
 func init() {
+	AuthUnlockCmd.GroupID = cli.GroupIDAuthAccess
 	cli.RootCmd.AddCommand(AuthUnlockCmd)
 	AuthUnlockCmd.Flags().Duration("ttl", cli.DefaultSessionTTL(), "Session duration (overrides config sessionTimeout)")
 	AuthUnlockCmd.Flags().Bool("check", false, "Check if session is active (exit 0 = active, exit 1 = expired)")

--- a/cmd/cmd_reg_test.go
+++ b/cmd/cmd_reg_test.go
@@ -59,6 +59,28 @@ func TestCommandRegistration(t *testing.T) {
 	}
 }
 
+func TestAllTopLevelCommandsHaveGroup(t *testing.T) {
+	validGroups := map[string]bool{}
+	for _, g := range cli.RootCmd.Groups() {
+		validGroups[g.ID] = true
+	}
+	if len(validGroups) == 0 {
+		t.Fatal("no command groups declared on root command")
+	}
+	for _, c := range rootCmd.Commands() {
+		if c.Name() == "help" || c.Name() == "completion" || c.Name() == "version" {
+			continue
+		}
+		if c.GroupID == "" {
+			t.Errorf("top-level command %q has no GroupID", c.Name())
+			continue
+		}
+		if !validGroups[c.GroupID] {
+			t.Errorf("top-level command %q has unknown GroupID %q", c.Name(), c.GroupID)
+		}
+	}
+}
+
 func TestSubcommandRegistration(t *testing.T) {
 	recipientsSubcommands := []string{"list", "add", "remove"}
 	for _, sub := range recipientsSubcommands {

--- a/cmd/crud/add.go
+++ b/cmd/crud/add.go
@@ -357,5 +357,6 @@ func init() {
 	addCmd.Flags().StringVar(&AddUsageHint, "usage-hint", "", "Usage hint for AI agents")
 	addCmd.Flags().BoolVar(&AddAutoRotate, "auto-rotate", false, "Enable automatic rotation reminder")
 	addCmd.Flags().StringVar(&AddExpiresAt, "expires-at", "", "Expiration date (RFC3339 format)")
+	addCmd.GroupID = cli.GroupIDEssentials
 	cli.RootCmd.AddCommand(addCmd)
 }

--- a/cmd/crud/delete.go
+++ b/cmd/crud/delete.go
@@ -67,5 +67,6 @@ var deleteCmd = &cobra.Command{
 
 func init() {
 	deleteCmd.Flags().BoolVarP(&DeleteYes, "yes", "y", false, "Skip confirmation prompt")
+	deleteCmd.GroupID = cli.GroupIDEssentials
 	cli.RootCmd.AddCommand(deleteCmd)
 }

--- a/cmd/crud/edit.go
+++ b/cmd/crud/edit.go
@@ -74,5 +74,6 @@ The editor is determined by the --editor flag or EDITOR environment variable (de
 
 func init() {
 	editCmd.Flags().StringVar(&EditorFlag, "editor", "", "Editor to use (overrides EDITOR env var)")
+	editCmd.GroupID = cli.GroupIDEssentials
 	cli.RootCmd.AddCommand(editCmd)
 }

--- a/cmd/crud/find.go
+++ b/cmd/crud/find.go
@@ -84,5 +84,6 @@ var findCmd = &cobra.Command{
 }
 
 func init() {
+	findCmd.GroupID = cli.GroupIDEssentials
 	cli.RootCmd.AddCommand(findCmd)
 }

--- a/cmd/crud/get.go
+++ b/cmd/crud/get.go
@@ -273,6 +273,7 @@ var getCmd = &cobra.Command{
 
 func init() {
 	getCmd.Flags().BoolVarP(&GetPrint, "print", "p", false, "Print value to stdout instead of copying to clipboard")
+	getCmd.GroupID = cli.GroupIDEssentials
 	cli.RootCmd.AddCommand(getCmd)
 }
 

--- a/cmd/crud/list.go
+++ b/cmd/crud/list.go
@@ -63,5 +63,6 @@ var listCmd = &cobra.Command{
 }
 
 func init() {
+	listCmd.GroupID = cli.GroupIDEssentials
 	cli.RootCmd.AddCommand(listCmd)
 }

--- a/cmd/crud/set.go
+++ b/cmd/crud/set.go
@@ -133,5 +133,6 @@ func init() {
 	setCmd.Flags().StringVar(&SetTOTPIssuer, "totp-issuer", "", "TOTP issuer/service name")
 	setCmd.Flags().StringVar(&SetTOTPAccount, "totp-account", "", "TOTP account name/username")
 	setCmd.Flags().BoolVar(&SetForce, "force", false, "Skip password strength validation")
+	setCmd.GroupID = cli.GroupIDEssentials
 	cli.RootCmd.AddCommand(setCmd)
 }

--- a/cmd/device.go
+++ b/cmd/device.go
@@ -640,6 +640,7 @@ access to all vault entries.`,
 }
 
 func init() {
+	deviceCmd.GroupID = cli.GroupIDSharingSync
 	rootCmd.AddCommand(deviceCmd)
 	deviceCmd.AddCommand(devicePairCmd)
 	deviceCmd.AddCommand(deviceJoinCmd)

--- a/cmd/diag.go
+++ b/cmd/diag.go
@@ -5,6 +5,7 @@ package cmd
 import (
 	"bytes"
 	"fmt"
+	cli "github.com/danieljustus/symaira-vault/internal/cli"
 
 	"github.com/prometheus/common/expfmt"
 	"github.com/spf13/cobra"
@@ -59,6 +60,7 @@ func printMetrics(cmd *cobra.Command) error {
 }
 
 func init() {
+	diagCmd.GroupID = cli.GroupIDAdministration
 	rootCmd.AddCommand(diagCmd)
 	diagCmd.AddCommand(diagMetricsCmd)
 }

--- a/cmd/dynamic.go
+++ b/cmd/dynamic.go
@@ -77,5 +77,6 @@ func init() {
 	_ = dynamicGenerateCmd.MarkFlagRequired("role")
 
 	dynamicCmd.AddCommand(dynamicGenerateCmd)
+	dynamicCmd.GroupID = cli.GroupIDVault
 	rootCmd.AddCommand(dynamicCmd)
 }

--- a/cmd/file/file.go
+++ b/cmd/file/file.go
@@ -20,5 +20,6 @@ sha256, original filename and size recorded as attachment metadata.`,
 }
 
 func init() {
+	fileCmd.GroupID = cli.GroupIDVault
 	cli.RootCmd.AddCommand(fileCmd)
 }

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -108,5 +108,6 @@ func init() {
 	generateCmd.Flags().BoolVar(&genReveal, "reveal", false, "Include generated password in output when using --store")
 	generateCmd.Flags().BoolVar(&genQuiet, "quiet", false, "Suppress success output when using --store")
 	generateCmd.AddCommand(manpagesCmd)
+	generateCmd.GroupID = cli.GroupIDVault
 	rootCmd.AddCommand(generateCmd)
 }

--- a/cmd/git.go
+++ b/cmd/git.go
@@ -70,5 +70,6 @@ var gitCmd = &cobra.Command{
 }
 
 func init() {
+	gitCmd.GroupID = cli.GroupIDSharingSync
 	rootCmd.AddCommand(gitCmd)
 }

--- a/cmd/mcp/agent.go
+++ b/cmd/mcp/agent.go
@@ -170,5 +170,6 @@ func outputAgentMCPSnippet(name, rawToken string) {
 
 func init() {
 	agentCmd.AddCommand(agentSetupCmd)
+	agentCmd.GroupID = cli.GroupIDAgentsMCP
 	cli.RootCmd.AddCommand(agentCmd)
 }

--- a/cmd/mcp/mcp_config.go
+++ b/cmd/mcp/mcp_config.go
@@ -314,7 +314,9 @@ func OutputAgentHTTPConfig(agentName, serverKey, displayName string, redact bool
 }
 
 func init() {
+	McpConfigCmd.GroupID = cli.GroupIDAgentsMCP
 	cli.RootCmd.AddCommand(McpConfigCmd)
+	mcpTokenRotateCmd.GroupID = cli.GroupIDAgentsMCP
 	cli.RootCmd.AddCommand(mcpTokenRotateCmd)
 }
 

--- a/cmd/mcp/mcp_token.go
+++ b/cmd/mcp/mcp_token.go
@@ -135,6 +135,7 @@ func parseDurationNumber(s string) (int, error) {
 }
 
 func init() {
+	mcpCmd.GroupID = cli.GroupIDAgentsMCP
 	cli.RootCmd.AddCommand(mcpCmd)
 	mcpCmd.AddCommand(McpTokenCmd)
 	McpTokenCmd.AddCommand(TokenCreateCmd)

--- a/cmd/mcp/serve.go
+++ b/cmd/mcp/serve.go
@@ -46,6 +46,7 @@ var ServeCmd = &cobra.Command{
 }
 
 func init() {
+	ServeCmd.GroupID = cli.GroupIDAgentsMCP
 	cli.RootCmd.AddCommand(ServeCmd)
 	ServeCmd.Flags().String("agent", "", "Agent name (required for --stdio; HTTP mode resolves agents per-request via X-Symaira-Agent header)")
 	ServeCmd.Flags().Int("port", 8080, "Server port")

--- a/cmd/policy.go
+++ b/cmd/policy.go
@@ -232,5 +232,6 @@ func init() {
 	policyCmd.AddCommand(policyApplyCmd)
 	policyCmd.AddCommand(policyListCmd)
 	policyCmd.AddCommand(policyRemoveCmd)
+	policyCmd.GroupID = cli.GroupIDAdministration
 	rootCmd.AddCommand(policyCmd)
 }

--- a/cmd/profile.go
+++ b/cmd/profile.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	cli "github.com/danieljustus/symaira-vault/internal/cli"
 	"os"
 	"path/filepath"
 	"strings"
@@ -168,5 +169,6 @@ func init() {
 	profileCmd.AddCommand(profileListCmd)
 	profileCmd.AddCommand(profileAddCmd)
 	profileCmd.AddCommand(profileUseCmd)
+	profileCmd.GroupID = cli.GroupIDAdministration
 	rootCmd.AddCommand(profileCmd)
 }

--- a/cmd/profile.go
+++ b/cmd/profile.go
@@ -2,12 +2,12 @@ package cmd
 
 import (
 	"fmt"
-	cli "github.com/danieljustus/symaira-vault/internal/cli"
 	"os"
 	"path/filepath"
 	"strings"
 	"text/tabwriter"
 
+	cli "github.com/danieljustus/symaira-vault/internal/cli"
 	"github.com/spf13/cobra"
 
 	configpkg "github.com/danieljustus/symaira-vault/internal/config"

--- a/cmd/profile.go
+++ b/cmd/profile.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 	"text/tabwriter"
 
-	cli "github.com/danieljustus/symaira-vault/internal/cli"
 	"github.com/spf13/cobra"
 
+	cli "github.com/danieljustus/symaira-vault/internal/cli"
 	configpkg "github.com/danieljustus/symaira-vault/internal/config"
 	errorspkg "github.com/danieljustus/symaira-vault/internal/errors"
 )

--- a/cmd/recipients.go
+++ b/cmd/recipients.go
@@ -190,6 +190,7 @@ Use --yes to skip confirmation (useful for scripts).`,
 }
 
 func init() {
+	recipientsCmd.GroupID = cli.GroupIDVault
 	rootCmd.AddCommand(recipientsCmd)
 	recipientsCmd.AddCommand(recipientsListCmd)
 	recipientsCmd.AddCommand(recipientsAddCmd)

--- a/cmd/remote.go
+++ b/cmd/remote.go
@@ -77,6 +77,7 @@ var remoteStatusCmd = &cobra.Command{
 }
 
 func init() {
+	remoteCmd.GroupID = cli.GroupIDSharingSync
 	rootCmd.AddCommand(remoteCmd)
 	remoteCmd.AddCommand(remoteInitCmd)
 	remoteCmd.AddCommand(remoteStatusCmd)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -150,5 +150,6 @@ func init() {
 	runCmd.Flags().StringArrayVar(&runPassthrough, "passthrough", nil, "Parent env var names to pass through to the child process (comma-separated)")
 	runCmd.Flags().StringVarP(&runWorkingDir, "working-dir", "C", "", "Working directory for the command")
 	runCmd.Flags().DurationVarP(&runTimeout, "timeout", "t", 0, "Timeout for the command (e.g., 30s)")
+	runCmd.GroupID = cli.GroupIDVault
 	rootCmd.AddCommand(runCmd)
 }

--- a/cmd/share.go
+++ b/cmd/share.go
@@ -146,6 +146,7 @@ var shareRevokeCmd = &cobra.Command{
 }
 
 func init() {
+	shareCmd.GroupID = cli.GroupIDSharingSync
 	rootCmd.AddCommand(shareCmd)
 	shareCmd.AddCommand(shareListCmd)
 	shareCmd.AddCommand(shareRevokeCmd)

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -98,6 +98,7 @@ var syncCmd = &cobra.Command{
 func init() {
 	syncCmd.Flags().BoolVarP(&syncPush, "push", "p", false, "also push after pull")
 	syncCmd.Flags().BoolVarP(&syncForce, "force", "f", false, "force pull (reset local changes)")
+	syncCmd.GroupID = cli.GroupIDSharingSync
 	rootCmd.AddCommand(syncCmd)
 }
 

--- a/cmd/template.go
+++ b/cmd/template.go
@@ -144,5 +144,6 @@ func init() {
 	_ = templateGenerateCmd.MarkFlagRequired("type")
 
 	templateCmd.AddCommand(templateGenerateCmd)
+	templateCmd.GroupID = cli.GroupIDVault
 	rootCmd.AddCommand(templateCmd)
 }

--- a/cmd/ui.go
+++ b/cmd/ui.go
@@ -59,5 +59,6 @@ func init() {
 	// --experimental is kept as a no-op for backward compatibility with scripts
 	// that used it while the TUI was gated. It no longer has any effect.
 	uiCmd.Flags().BoolVar(&uiExperimental, "experimental", false, "(deprecated, no longer needed)")
+	uiCmd.GroupID = cli.GroupIDEssentials
 	rootCmd.AddCommand(uiCmd)
 }

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -186,6 +186,29 @@ func syncToContext(ctx *CLIContext) {
 	ctx.profileFlag = ProfileFlag
 }
 
+// Command group IDs used to organize the top-level commands in --help
+// output. Every top-level command registered on RootCmd must set one of
+// these via Command.GroupID at its registration site.
+const (
+	GroupIDEssentials     = "essentials"
+	GroupIDVault          = "vault"
+	GroupIDSharingSync    = "sharing-sync"
+	GroupIDAgentsMCP      = "agents-mcp"
+	GroupIDAuthAccess     = "auth-access"
+	GroupIDAdministration = "administration"
+)
+
+// commandGroups declares the help-output groups for the root command in
+// display order.
+var commandGroups = []*cobra.Group{
+	{ID: GroupIDEssentials, Title: "Essentials:"},
+	{ID: GroupIDVault, Title: "Vault:"},
+	{ID: GroupIDSharingSync, Title: "Sharing & Sync:"},
+	{ID: GroupIDAgentsMCP, Title: "Agents & MCP:"},
+	{ID: GroupIDAuthAccess, Title: "Auth & Access:"},
+	{ID: GroupIDAdministration, Title: "Administration:"},
+}
+
 var RootCmd = &cobra.Command{
 	Use:   "symvault",
 	Short: "Symaira Vault is a Go CLI password manager",
@@ -297,6 +320,7 @@ func PrintlnQuietAware(args ...interface{}) {
 }
 
 func init() {
+	RootCmd.AddGroup(commandGroups...)
 	RootCmd.PersistentFlags().StringVar(&Vault, "vault", "~/"+configpkg.DefaultVaultSubdir, "path to the password vault")
 	VaultFlag = RootCmd.PersistentFlags().Lookup("vault")
 	RootCmd.PersistentFlags().BoolVar(&QuietMode, "quiet", false, "suppress non-error output")


### PR DESCRIPTION
Closes #720

## Summary
`symvault --help` listed 43 top-level commands as one flat alphabetical wall. This declares cobra command groups on the root command and assigns every top-level command to one, so help renders as a scannable, task-oriented list.

## Changes
- `internal/cli/cli.go`: exported group ID constants (Essentials, Vault, Sharing & Sync, Agents & MCP, Auth & Access, Administration) plus `RootCmd.AddGroup(...)`.
- All 43 top-level commands got a `GroupID` at their existing registration site (44 files under `cmd/**`). `lock`/`unlock`/`auth` are listed under Auth & Access; command paths, aliases and flags are unchanged.
- `cmd/cmd_reg_test.go`: new `TestAllTopLevelCommandsHaveGroup` asserts every top-level command carries a non-empty, declared GroupID, so new commands cannot silently fall back into the ungrouped bucket.
- Checked-in completions regenerated — no diff, as group IDs do not affect completion scripts.

## Verification
- `symvault --help` shows the six groups; everyday verbs in the first group.
- `go test ./cmd/... ./internal/cli/...` green, `go vet` clean, gofmt clean.
- No command path, alias or flag changes.

## Note
This touches the same registration sites as the planned `init()`-wiring refactor (#722); landing this first keeps that follow-up conflict-free on the current structure.