### PR TITLE
refactor(cli): replace init() command registrations with explicit constructors

### DIFF
--- a/cmd/add_test.go
+++ b/cmd/add_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	cli "github.com/danieljustus/symaira-vault/internal/cli"
 	"github.com/danieljustus/symaira-vault/internal/config"
 	vaultpkg "github.com/danieljustus/symaira-vault/internal/vault"
 
@@ -363,9 +364,9 @@ func TestAdd_ErrorPaths(t *testing.T) {
 			}
 
 			vault = ""
-			if vaultFlag != nil {
-				_ = vaultFlag.Value.Set("")
-				vaultFlag.Changed = false
+			if cli.VaultFlag != nil {
+				_ = cli.VaultFlag.Value.Set("")
+				cli.VaultFlag.Changed = false
 			}
 
 			rootCmd.SetArgs(tt.args)

--- a/cmd/admin/audit.go
+++ b/cmd/admin/audit.go
@@ -218,7 +218,6 @@ func init() {
 	AuditCmd.Flags().BoolVar(&AuditFailed, "failed", false, "Show only failed entries")
 	AuditCmd.AddCommand(rotateKeyCmd)
 	AuditCmd.GroupID = cli.GroupIDAdministration
-	cli.RootCmd.AddCommand(AuditCmd)
 }
 
 var rotateKeyCmd = &cobra.Command{

--- a/cmd/admin/backup.go
+++ b/cmd/admin/backup.go
@@ -318,7 +318,5 @@ func ComputeSHA256(path string) (string, error) {
 func init() {
 	backupCmd.Flags().BoolVar(&BackupExcludeGit, "exclude-git", false, "Exclude .git/ directory from backup")
 	backupCmd.GroupID = cli.GroupIDSharingSync
-	cli.RootCmd.AddCommand(backupCmd)
 	restoreCmd.GroupID = cli.GroupIDSharingSync
-	cli.RootCmd.AddCommand(restoreCmd)
 }

--- a/cmd/admin/commands.go
+++ b/cmd/admin/commands.go
@@ -1,0 +1,24 @@
+package admin
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// NewCommands returns all administration commands for root command assembly.
+func NewCommands() []*cobra.Command {
+	return []*cobra.Command{
+		AuditCmd,
+		backupCmd,
+		restoreCmd,
+		configCmd,
+		DoctorCmd,
+		exportCmd,
+		importCmd,
+		initCmd,
+		MigrateCmd,
+		setupCmd,
+		startupProfileCmd,
+		UpdateCmd,
+		verifyCmd,
+	}
+}

--- a/cmd/admin/config.go
+++ b/cmd/admin/config.go
@@ -313,5 +313,4 @@ func init() {
 	configCmd.AddCommand(configSetCmd)
 	configCmd.AddCommand(configListCmd)
 	configCmd.GroupID = cli.GroupIDAdministration
-	cli.RootCmd.AddCommand(configCmd)
 }

--- a/cmd/admin/doctor.go
+++ b/cmd/admin/doctor.go
@@ -188,7 +188,6 @@ func outputDoctorJSON(cmd *cobra.Command, vaultDir string, results []health.Resu
 
 func init() {
 	DoctorCmd.GroupID = cli.GroupIDEssentials
-	cli.RootCmd.AddCommand(DoctorCmd)
 	DoctorCmd.Flags().BoolVar(&DoctorJSON, "json", false, "Output in JSON format (deprecated: use --output=json)")
 	DoctorCmd.Flags().BoolVar(&DoctorNoNetwork, "no-network", false, "Skip network-dependent checks")
 	DoctorCmd.Flags().BoolVar(&DoctorStrict, "strict", false, "Return non-zero exit code for warnings (7) or failures (8)")

--- a/cmd/admin/export.go
+++ b/cmd/admin/export.go
@@ -209,7 +209,6 @@ func init() {
 	exportCmd.Flags().BoolVarP(&ExportYes, "yes", "y", false, "Skip confirmation prompt")
 	_ = exportCmd.MarkFlagRequired("format") //nolint:errcheck
 	exportCmd.GroupID = cli.GroupIDSharingSync
-	cli.RootCmd.AddCommand(exportCmd)
 }
 
 func isSupportedExportFormat(format exporter.Format) bool {

--- a/cmd/admin/export_test.go
+++ b/cmd/admin/export_test.go
@@ -42,7 +42,7 @@ func TestExport_ConfirmDecline_NoOutput(t *testing.T) {
 	t.Cleanup(func() { confirmExport = origConfirm })
 
 	stderr := captureStderr(t, func() {
-		cmd := cli.RootCmd
+		cmd := newTestRootCmd()
 		cmd.SetArgs([]string{"export", "--format", "csv", "--output", outputPath})
 		if err := cmd.Execute(); err != nil {
 			t.Fatalf("export: %v", err)
@@ -84,7 +84,7 @@ func TestExport_ConfirmAccept_WithEntries(t *testing.T) {
 
 	outputPath := filepath.Join(t.TempDir(), "export.csv")
 
-	cmd := cli.RootCmd
+	cmd := newTestRootCmd()
 	cmd.SetArgs([]string{"export", "--format", "csv", "--output", outputPath})
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("export: %v", err)
@@ -130,7 +130,7 @@ func TestExport_YesFlag_SkipsPrompt(t *testing.T) {
 
 	outputPath := filepath.Join(t.TempDir(), "export.json")
 
-	cmd := cli.RootCmd
+	cmd := newTestRootCmd()
 	cmd.SetArgs([]string{"export", "--format", "json", "--output", outputPath, "--yes"})
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("export: %v", err)
@@ -194,7 +194,7 @@ func runExport(t *testing.T, format, outputPath string) []byte {
 	confirmExport = func(_ string, _ bool) (bool, error) { return true, nil }
 	t.Cleanup(func() { confirmExport = origConfirm })
 
-	cmd := cli.RootCmd
+	cmd := newTestRootCmd()
 	cmd.SetArgs([]string{"export", "--format", format, "--output", outputPath})
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("export: %v", err)

--- a/cmd/admin/import.go
+++ b/cmd/admin/import.go
@@ -197,7 +197,6 @@ func init() {
 	importCmd.Flags().BoolVar(&ImportQuarantine, "quarantine", false, "Import entries into quarantine/<import-id>/ for human review before agent access")
 	importCmd.Flags().StringVar(&ImportFormat, "format", "", "Import format (auto-detected from file extension when omitted)")
 	importCmd.GroupID = cli.GroupIDSharingSync
-	cli.RootCmd.AddCommand(importCmd)
 }
 
 func isSupportedImportFormat(format importer.Format) bool {

--- a/cmd/admin/import_test.go
+++ b/cmd/admin/import_test.go
@@ -113,7 +113,7 @@ func TestImportCommandAutoDetectCSV(t *testing.T) {
 	ImportFormat = ""
 	ImportDryRun = true
 
-	cmd := cli.RootCmd
+	cmd := newTestRootCmd()
 	cmd.SetArgs([]string{"import", csvFile})
 	err := cmd.Execute()
 	if err != nil {
@@ -150,7 +150,7 @@ func TestImportCommandExplicitFormatOverride(t *testing.T) {
 	ImportDryRun = true
 
 	// Explicit --format should override auto-detection
-	cmd := cli.RootCmd
+	cmd := newTestRootCmd()
 	cmd.SetArgs([]string{"import", "--format", "csv", csvFile})
 	err := cmd.Execute()
 	if err != nil {
@@ -175,7 +175,7 @@ func TestImportCommandUnknownExtensionNoFormat(t *testing.T) {
 	ImportFormat = ""
 	ImportDryRun = true
 
-	cmd := cli.RootCmd
+	cmd := newTestRootCmd()
 	cmd.SetArgs([]string{"import", txtFile})
 	err := cmd.Execute()
 	if err == nil {
@@ -201,7 +201,7 @@ func TestImportCommandUnsupportedFormat(t *testing.T) {
 	ImportDryRun = true
 
 	// .json auto-detects to "json" which is not a supported import format
-	cmd := cli.RootCmd
+	cmd := newTestRootCmd()
 	cmd.SetArgs([]string{"import", jsonFile})
 	err := cmd.Execute()
 	if err == nil {

--- a/cmd/admin/init.go
+++ b/cmd/admin/init.go
@@ -157,7 +157,6 @@ func printPostInitHints(vaultDir string) {
 
 func init() {
 	initCmd.GroupID = cli.GroupIDEssentials
-	cli.RootCmd.AddCommand(initCmd)
 	initCmd.Flags().StringVar(&initAuthMethod, "auth", "ask", "unlock method for this vault (ask, passphrase, touchid)")
 }
 

--- a/cmd/admin/init_test.go
+++ b/cmd/admin/init_test.go
@@ -20,7 +20,7 @@ func TestInit_NewVaultUsesArgon2id(t *testing.T) {
 	cli.SetCachedEnvPassphrase([]byte(passphrase))
 	t.Cleanup(cli.ClearCachedEnvPassphrase)
 
-	cmd := cli.RootCmd
+	cmd := newTestRootCmd()
 	cmd.SetArgs([]string{"init", vaultDir, "--auth", "passphrase"})
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("init: %v", err)

--- a/cmd/admin/migrate.go
+++ b/cmd/admin/migrate.go
@@ -368,5 +368,4 @@ func init() {
 	migrateV4Cmd.Flags().BoolVarP(&MigrateYes, "yes", "y", false, "Skip confirmation prompt")
 	migrateV4Cmd.Flags().BoolVar(&MigrateV4DryRun, "dry-run", false, "Preview changes without writing")
 	MigrateCmd.GroupID = cli.GroupIDAdministration
-	cli.RootCmd.AddCommand(MigrateCmd)
 }

--- a/cmd/admin/setup.go
+++ b/cmd/admin/setup.go
@@ -57,5 +57,4 @@ func init() {
 	setupCmd.Flags().BoolVar(&setupKeepOnError, "keep-on-error", false, "do not rollback vault init artifacts when subsequent steps fail")
 	setupCmd.Flags().BoolVar(&setupNoResume, "no-resume", false, "disable setup resume after abort")
 	setupCmd.GroupID = cli.GroupIDEssentials
-	cli.RootCmd.AddCommand(setupCmd)
 }

--- a/cmd/admin/startup_profile.go
+++ b/cmd/admin/startup_profile.go
@@ -52,7 +52,6 @@ func init() {
 	startupProfileCmd.Flags().IntVar(&startupProfileTopN, "top", 5, "show top N slowest phases in trace breakdown")
 	startupProfileCmd.Flags().StringVar(&startupProfileTraceFile, "trace", "", "write a runtime trace file (viewable with 'go tool trace')")
 	startupProfileCmd.GroupID = cli.GroupIDAdministration
-	cli.RootCmd.AddCommand(startupProfileCmd)
 }
 
 const envProfileChild = "SYMVAULT_STARTUP_PROFILE_CHILD"

--- a/cmd/admin/testhelper_test.go
+++ b/cmd/admin/testhelper_test.go
@@ -1,0 +1,15 @@
+package admin
+
+import (
+	"github.com/spf13/cobra"
+
+	cli "github.com/danieljustus/symaira-vault/internal/cli"
+)
+
+// newTestRootCmd creates a cobra.Command tree containing the admin package's
+// commands, suitable for use in tests that need to exercise the admin CLI.
+func newTestRootCmd() *cobra.Command {
+	root := cli.NewRootCmd()
+	root.AddCommand(NewCommands()...)
+	return root
+}

--- a/cmd/admin/update.go
+++ b/cmd/admin/update.go
@@ -349,5 +349,4 @@ func init() {
 	UpdateCmd.AddCommand(updateApplyCmd)
 	UpdateCmd.AddCommand(updateInfoCmd)
 	UpdateCmd.GroupID = cli.GroupIDAdministration
-	cli.RootCmd.AddCommand(UpdateCmd)
 }

--- a/cmd/admin/verify.go
+++ b/cmd/admin/verify.go
@@ -94,7 +94,6 @@ check and only rebuild.`,
 
 func init() {
 	verifyCmd.GroupID = cli.GroupIDAdministration
-	cli.RootCmd.AddCommand(verifyCmd)
 	verifyCmd.Flags().BoolVar(&verifyRebuild, "rebuild", false, "Rebuild the manifest from on-disk entries after the integrity check")
 	verifyCmd.Flags().BoolVar(&verifyRebuildOnly, "rebuild-only", false, "Rebuild the manifest and skip the integrity check")
 }

--- a/cmd/audit_test.go
+++ b/cmd/audit_test.go
@@ -9,8 +9,6 @@ import (
 	"testing"
 	"time"
 
-	cli "github.com/danieljustus/symaira-vault/internal/cli"
-
 	admin "github.com/danieljustus/symaira-vault/cmd/admin"
 	"github.com/danieljustus/symaira-vault/internal/audit"
 	configpkg "github.com/danieljustus/symaira-vault/internal/config"
@@ -323,10 +321,10 @@ func TestAuditCommand_JSON(t *testing.T) {
 	}
 
 	buf := prepareRootCommandOutput(t)
-	cli.RootCmd.SetArgs([]string{"audit", "--json"})
-	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
+	rootCmd.SetArgs([]string{"audit", "--json"})
+	t.Cleanup(func() { rootCmd.SetArgs(nil) })
 
-	if err := cli.RootCmd.Execute(); err != nil {
+	if err := rootCmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v", err)
 	}
 
@@ -363,10 +361,10 @@ func TestAuditCommand_Table(t *testing.T) {
 	}
 
 	buf := prepareRootCommandOutput(t)
-	cli.RootCmd.SetArgs([]string{"audit"})
-	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
+	rootCmd.SetArgs([]string{"audit"})
+	t.Cleanup(func() { rootCmd.SetArgs(nil) })
 
-	if err := cli.RootCmd.Execute(); err != nil {
+	if err := rootCmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v", err)
 	}
 
@@ -406,10 +404,10 @@ func TestAuditCommand_SinceFilter(t *testing.T) {
 	f.Close()
 
 	buf := prepareRootCommandOutput(t)
-	cli.RootCmd.SetArgs([]string{"audit", "--since", "10m"})
-	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
+	rootCmd.SetArgs([]string{"audit", "--since", "10m"})
+	t.Cleanup(func() { rootCmd.SetArgs(nil) })
 
-	if err := cli.RootCmd.Execute(); err != nil {
+	if err := rootCmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v", err)
 	}
 
@@ -451,10 +449,10 @@ func TestAuditCommand_FailedFilter(t *testing.T) {
 	f.Close()
 
 	buf := prepareRootCommandOutput(t)
-	cli.RootCmd.SetArgs([]string{"audit", "--failed"})
-	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
+	rootCmd.SetArgs([]string{"audit", "--failed"})
+	t.Cleanup(func() { rootCmd.SetArgs(nil) })
 
-	if err := cli.RootCmd.Execute(); err != nil {
+	if err := rootCmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v", err)
 	}
 

--- a/cmd/auth/auth.go
+++ b/cmd/auth/auth.go
@@ -136,7 +136,6 @@ func init() {
 	AuthCmd.AddCommand(AuthStatusCmd)
 	AuthCmd.AddCommand(AuthSetCmd)
 	AuthCmd.GroupID = cli.GroupIDAuthAccess
-	cli.RootCmd.AddCommand(AuthCmd)
 }
 
 func loadAuthConfig() (string, *configpkg.Config, error) {

--- a/cmd/auth/commands.go
+++ b/cmd/auth/commands.go
@@ -1,0 +1,14 @@
+package auth
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// NewCommands returns all authentication commands for root command assembly.
+func NewCommands() []*cobra.Command {
+	return []*cobra.Command{
+		AuthCmd,
+		lockCmd,
+		AuthUnlockCmd,
+	}
+}

--- a/cmd/auth/lock.go
+++ b/cmd/auth/lock.go
@@ -39,5 +39,4 @@ var lockCmd = &cobra.Command{
 
 func init() {
 	lockCmd.GroupID = cli.GroupIDAuthAccess
-	cli.RootCmd.AddCommand(lockCmd)
 }

--- a/cmd/auth/unlock.go
+++ b/cmd/auth/unlock.go
@@ -80,7 +80,6 @@ alone is ignored (default-deny). It should NOT be used on shared machines
 
 func init() {
 	AuthUnlockCmd.GroupID = cli.GroupIDAuthAccess
-	cli.RootCmd.AddCommand(AuthUnlockCmd)
 	AuthUnlockCmd.Flags().Duration("ttl", cli.DefaultSessionTTL(), "Session duration (overrides config sessionTimeout)")
 	AuthUnlockCmd.Flags().Bool("check", false, "Check if session is active (exit 0 = active, exit 1 = expired)")
 }

--- a/cmd/auth_rotate_test.go
+++ b/cmd/auth_rotate_test.go
@@ -4,8 +4,6 @@ import (
 	"os"
 	"strings"
 	"testing"
-
-	cli "github.com/danieljustus/symaira-vault/internal/cli"
 )
 
 func TestAuthRotate_ValidatesLengthBeforeConfirmation(t *testing.T) {
@@ -26,8 +24,8 @@ func TestAuthRotate_ValidatesLengthBeforeConfirmation(t *testing.T) {
 		w.Write([]byte("short\n"))
 	}()
 
-	cli.RootCmd.SetArgs([]string{"auth", "rotate-passphrase"})
-	err = cli.RootCmd.Execute()
+	rootCmd.SetArgs([]string{"auth", "rotate-passphrase"})
+	err = rootCmd.Execute()
 	os.Stdin = oldStdin
 
 	if err == nil {

--- a/cmd/backup_test.go
+++ b/cmd/backup_test.go
@@ -11,8 +11,6 @@ import (
 	"strings"
 	"testing"
 
-	cli "github.com/danieljustus/symaira-vault/internal/cli"
-
 	admin "github.com/danieljustus/symaira-vault/cmd/admin"
 	"github.com/danieljustus/symaira-vault/internal/config"
 	vaultpkg "github.com/danieljustus/symaira-vault/internal/vault"
@@ -310,10 +308,10 @@ func TestBackupCommand(t *testing.T) {
 	archivePath := filepath.Join(t.TempDir(), "backup")
 
 	prepareRootCommandOutput(t)
-	cli.RootCmd.SetArgs([]string{"--vault", vaultDir, "backup", archivePath})
-	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "backup", archivePath})
+	t.Cleanup(func() { rootCmd.SetArgs(nil) })
 
-	if err := cli.RootCmd.Execute(); err != nil {
+	if err := rootCmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v", err)
 	}
 
@@ -341,10 +339,10 @@ func TestRestoreCommand(t *testing.T) {
 	restoreDir := t.TempDir()
 
 	prepareRootCommandOutput(t)
-	cli.RootCmd.SetArgs([]string{"--vault", restoreDir, "restore", archivePath})
-	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
+	rootCmd.SetArgs([]string{"--vault", restoreDir, "restore", archivePath})
+	t.Cleanup(func() { rootCmd.SetArgs(nil) })
 
-	if err := cli.RootCmd.Execute(); err != nil {
+	if err := rootCmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v", err)
 	}
 
@@ -360,10 +358,10 @@ func TestBackupCommand_UninitializedVault(t *testing.T) {
 	vaultDir := t.TempDir()
 
 	prepareRootCommandOutput(t)
-	cli.RootCmd.SetArgs([]string{"--vault", vaultDir, "backup", "/tmp/backup.tar.gz"})
-	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "backup", "/tmp/backup.tar.gz"})
+	t.Cleanup(func() { rootCmd.SetArgs(nil) })
 
-	if err := cli.RootCmd.Execute(); err == nil {
+	if err := rootCmd.Execute(); err == nil {
 		t.Fatal("expected error for uninitialized vault")
 	}
 }
@@ -375,10 +373,10 @@ func TestRestoreCommand_MissingArchive(t *testing.T) {
 	vaultDir := t.TempDir()
 
 	prepareRootCommandOutput(t)
-	cli.RootCmd.SetArgs([]string{"--vault", vaultDir, "restore", "/nonexistent/backup.tar.gz"})
-	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "restore", "/nonexistent/backup.tar.gz"})
+	t.Cleanup(func() { rootCmd.SetArgs(nil) })
 
-	if err := cli.RootCmd.Execute(); err == nil {
+	if err := rootCmd.Execute(); err == nil {
 		t.Fatal("expected error for missing archive")
 	}
 }
@@ -395,10 +393,10 @@ func TestRestoreCommand_CorruptArchive(t *testing.T) {
 	vaultDir := t.TempDir()
 
 	prepareRootCommandOutput(t)
-	cli.RootCmd.SetArgs([]string{"--vault", vaultDir, "restore", archivePath})
-	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "restore", archivePath})
+	t.Cleanup(func() { rootCmd.SetArgs(nil) })
 
-	if err := cli.RootCmd.Execute(); err == nil {
+	if err := rootCmd.Execute(); err == nil {
 		t.Fatal("expected error for corrupt archive")
 	}
 }
@@ -574,10 +572,10 @@ func TestBackupCommand_ExcludeGit(t *testing.T) {
 	archivePath := filepath.Join(t.TempDir(), "backup")
 
 	prepareRootCommandOutput(t)
-	cli.RootCmd.SetArgs([]string{"--vault", vaultDir, "backup", archivePath, "--exclude-git"})
-	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "backup", archivePath, "--exclude-git"})
+	t.Cleanup(func() { rootCmd.SetArgs(nil) })
 
-	if err := cli.RootCmd.Execute(); err != nil {
+	if err := rootCmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v", err)
 	}
 

--- a/cmd/cmd_reg_test.go
+++ b/cmd/cmd_reg_test.go
@@ -61,7 +61,7 @@ func TestCommandRegistration(t *testing.T) {
 
 func TestAllTopLevelCommandsHaveGroup(t *testing.T) {
 	validGroups := map[string]bool{}
-	for _, g := range cli.RootCmd.Groups() {
+	for _, g := range rootCmd.Groups() {
 		validGroups[g.ID] = true
 	}
 	if len(validGroups) == 0 {

--- a/cmd/cmd_reg_test.go
+++ b/cmd/cmd_reg_test.go
@@ -260,12 +260,12 @@ func TestUnlockVaultWithEnvVar(t *testing.T) {
 	}
 
 	origVault := vault
-	origChanged := vaultFlag.Changed
+	origChanged := cli.VaultFlag.Changed
 	defer func() {
 		vault = origVault
-		if vaultFlag != nil {
-			_ = vaultFlag.Value.Set(origVault)
-			vaultFlag.Changed = origChanged
+		if cli.VaultFlag != nil {
+			_ = cli.VaultFlag.Value.Set(origVault)
+			cli.VaultFlag.Changed = origChanged
 		}
 	}()
 
@@ -273,8 +273,8 @@ func TestUnlockVaultWithEnvVar(t *testing.T) {
 	defer func() { _ = os.Unsetenv("OPENPASS_PASSPHRASE") }()
 
 	vault = vaultDir
-	if vaultFlag != nil {
-		vaultFlag.Changed = false
+	if cli.VaultFlag != nil {
+		cli.VaultFlag.Changed = false
 	}
 
 	_, err := cli.UnlockVault(vaultDir, false)
@@ -292,20 +292,20 @@ func TestUnlockVaultNoPassphrase(t *testing.T) {
 	}
 
 	origVault := vault
-	origChanged := vaultFlag.Changed
+	origChanged := cli.VaultFlag.Changed
 	defer func() {
 		vault = origVault
-		if vaultFlag != nil {
-			_ = vaultFlag.Value.Set(origVault)
-			vaultFlag.Changed = origChanged
+		if cli.VaultFlag != nil {
+			_ = cli.VaultFlag.Value.Set(origVault)
+			cli.VaultFlag.Changed = origChanged
 		}
 	}()
 
 	_ = os.Unsetenv("SYMVAULT_PASSPHRASE")
 	_ = os.Unsetenv("OPENPASS_PASSPHRASE")
 	vault = vaultDir
-	if vaultFlag != nil {
-		vaultFlag.Changed = false
+	if cli.VaultFlag != nil {
+		cli.VaultFlag.Changed = false
 	}
 
 	_, err := cli.UnlockVault(vaultDir, false)
@@ -323,12 +323,12 @@ func TestUnlockVaultWrongPassphrase(t *testing.T) {
 	}
 
 	origVault := vault
-	origChanged := vaultFlag.Changed
+	origChanged := cli.VaultFlag.Changed
 	defer func() {
 		vault = origVault
-		if vaultFlag != nil {
-			_ = vaultFlag.Value.Set(origVault)
-			vaultFlag.Changed = origChanged
+		if cli.VaultFlag != nil {
+			_ = cli.VaultFlag.Value.Set(origVault)
+			cli.VaultFlag.Changed = origChanged
 		}
 	}()
 
@@ -336,8 +336,8 @@ func TestUnlockVaultWrongPassphrase(t *testing.T) {
 	defer func() { _ = os.Unsetenv("OPENPASS_PASSPHRASE") }()
 
 	vault = vaultDir
-	if vaultFlag != nil {
-		vaultFlag.Changed = false
+	if cli.VaultFlag != nil {
+		cli.VaultFlag.Changed = false
 	}
 
 	_, err := cli.UnlockVault(vaultDir, false)
@@ -377,12 +377,12 @@ func TestUnlockVaultSavesToKeyring(t *testing.T) {
 	}
 
 	origVault := vault
-	origChanged := vaultFlag.Changed
+	origChanged := cli.VaultFlag.Changed
 	defer func() {
 		vault = origVault
-		if vaultFlag != nil {
-			_ = vaultFlag.Value.Set(origVault)
-			vaultFlag.Changed = origChanged
+		if cli.VaultFlag != nil {
+			_ = cli.VaultFlag.Value.Set(origVault)
+			cli.VaultFlag.Changed = origChanged
 		}
 	}()
 
@@ -390,8 +390,8 @@ func TestUnlockVaultSavesToKeyring(t *testing.T) {
 	defer func() { _ = os.Unsetenv("OPENPASS_PASSPHRASE") }()
 
 	vault = vaultDir
-	if vaultFlag != nil {
-		vaultFlag.Changed = false
+	if cli.VaultFlag != nil {
+		cli.VaultFlag.Changed = false
 	}
 
 	v, err := cli.UnlockVault(vaultDir, false)
@@ -409,12 +409,12 @@ func TestRecipientsCmd_Add_Success(t *testing.T) {
 	_, _ = vaultpkg.InitWithPassphrase(vaultDir, passphrase, config.Default())
 
 	origVault := vault
-	origChanged := vaultFlag.Changed
+	origChanged := cli.VaultFlag.Changed
 	defer func() {
 		vault = origVault
-		if vaultFlag != nil {
-			_ = vaultFlag.Value.Set(origVault)
-			vaultFlag.Changed = origChanged
+		if cli.VaultFlag != nil {
+			_ = cli.VaultFlag.Value.Set(origVault)
+			cli.VaultFlag.Changed = origChanged
 		}
 	}()
 
@@ -422,8 +422,8 @@ func TestRecipientsCmd_Add_Success(t *testing.T) {
 	defer func() { _ = os.Unsetenv("OPENPASS_PASSPHRASE") }()
 
 	vault = vaultDir
-	if vaultFlag != nil {
-		vaultFlag.Changed = false
+	if cli.VaultFlag != nil {
+		cli.VaultFlag.Changed = false
 	}
 
 	recipientsAddCmd.SetArgs([]string{"age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p"})
@@ -446,12 +446,12 @@ func TestRecipientsCmd_List_WithRecipients(t *testing.T) {
 	}
 
 	origVault := vault
-	origChanged := vaultFlag.Changed
+	origChanged := cli.VaultFlag.Changed
 	defer func() {
 		vault = origVault
-		if vaultFlag != nil {
-			_ = vaultFlag.Value.Set(origVault)
-			vaultFlag.Changed = origChanged
+		if cli.VaultFlag != nil {
+			_ = cli.VaultFlag.Value.Set(origVault)
+			cli.VaultFlag.Changed = origChanged
 		}
 	}()
 
@@ -459,8 +459,8 @@ func TestRecipientsCmd_List_WithRecipients(t *testing.T) {
 	defer func() { _ = os.Unsetenv("OPENPASS_PASSPHRASE") }()
 
 	vault = vaultDir
-	if vaultFlag != nil {
-		vaultFlag.Changed = false
+	if cli.VaultFlag != nil {
+		cli.VaultFlag.Changed = false
 	}
 
 	err = recipientsListCmd.Execute()
@@ -483,12 +483,12 @@ func TestRecipientsCmd_Remove_Success(t *testing.T) {
 	}
 
 	origVault := vault
-	origChanged := vaultFlag.Changed
+	origChanged := cli.VaultFlag.Changed
 	defer func() {
 		vault = origVault
-		if vaultFlag != nil {
-			_ = vaultFlag.Value.Set(origVault)
-			vaultFlag.Changed = origChanged
+		if cli.VaultFlag != nil {
+			_ = cli.VaultFlag.Value.Set(origVault)
+			cli.VaultFlag.Changed = origChanged
 		}
 	}()
 
@@ -496,8 +496,8 @@ func TestRecipientsCmd_Remove_Success(t *testing.T) {
 	defer func() { _ = os.Unsetenv("OPENPASS_PASSPHRASE") }()
 
 	vault = vaultDir
-	if vaultFlag != nil {
-		vaultFlag.Changed = false
+	if cli.VaultFlag != nil {
+		cli.VaultFlag.Changed = false
 	}
 
 	recipientsRemoveCmd.SetArgs([]string{testRecipient, "--yes"})
@@ -516,12 +516,12 @@ func TestGenerateCmd_StoreToExistingEntry(t *testing.T) {
 	_ = vaultpkg.WriteEntry(vaultDir, "existing.pass", entry, identity)
 
 	origVault := vault
-	origChanged := vaultFlag.Changed
+	origChanged := cli.VaultFlag.Changed
 	defer func() {
 		vault = origVault
-		if vaultFlag != nil {
-			_ = vaultFlag.Value.Set(origVault)
-			vaultFlag.Changed = origChanged
+		if cli.VaultFlag != nil {
+			_ = cli.VaultFlag.Value.Set(origVault)
+			cli.VaultFlag.Changed = origChanged
 		}
 	}()
 
@@ -529,8 +529,8 @@ func TestGenerateCmd_StoreToExistingEntry(t *testing.T) {
 	defer func() { _ = os.Unsetenv("OPENPASS_PASSPHRASE") }()
 
 	vault = vaultDir
-	if vaultFlag != nil {
-		vaultFlag.Changed = false
+	if cli.VaultFlag != nil {
+		cli.VaultFlag.Changed = false
 	}
 
 	generateCmd.SetArgs([]string{"--store", "existing.pass", "--length", "16"})
@@ -547,12 +547,12 @@ func TestGenerateCmd_StoreNewEntry(t *testing.T) {
 	_, _ = vaultpkg.InitWithPassphrase(vaultDir, passphrase, config.Default())
 
 	origVault := vault
-	origChanged := vaultFlag.Changed
+	origChanged := cli.VaultFlag.Changed
 	defer func() {
 		vault = origVault
-		if vaultFlag != nil {
-			_ = vaultFlag.Value.Set(origVault)
-			vaultFlag.Changed = origChanged
+		if cli.VaultFlag != nil {
+			_ = cli.VaultFlag.Value.Set(origVault)
+			cli.VaultFlag.Changed = origChanged
 		}
 	}()
 
@@ -560,8 +560,8 @@ func TestGenerateCmd_StoreNewEntry(t *testing.T) {
 	defer func() { _ = os.Unsetenv("OPENPASS_PASSPHRASE") }()
 
 	vault = vaultDir
-	if vaultFlag != nil {
-		vaultFlag.Changed = false
+	if cli.VaultFlag != nil {
+		cli.VaultFlag.Changed = false
 	}
 
 	generateCmd.SetArgs([]string{"--store", "new.pass", "--length", "16"})
@@ -586,12 +586,12 @@ func TestOutputHTTPConfigMCP(t *testing.T) {
 	}
 
 	origVault := vault
-	origChanged := vaultFlag.Changed
+	origChanged := cli.VaultFlag.Changed
 	defer func() {
 		vault = origVault
-		if vaultFlag != nil {
-			_ = vaultFlag.Value.Set(origVault)
-			vaultFlag.Changed = origChanged
+		if cli.VaultFlag != nil {
+			_ = cli.VaultFlag.Value.Set(origVault)
+			cli.VaultFlag.Changed = origChanged
 		}
 	}()
 
@@ -599,8 +599,8 @@ func TestOutputHTTPConfigMCP(t *testing.T) {
 	defer func() { _ = os.Unsetenv("OPENPASS_VAULT") }()
 
 	vault = vaultDir
-	if vaultFlag != nil {
-		vaultFlag.Changed = false
+	if cli.VaultFlag != nil {
+		cli.VaultFlag.Changed = false
 	}
 
 	rootCmd.SetArgs([]string{"--vault", vaultDir, "mcp-config", "claude-code"})
@@ -624,12 +624,12 @@ func TestRunHTTPServer(t *testing.T) {
 	}
 
 	origVault := vault
-	origChanged := vaultFlag.Changed
+	origChanged := cli.VaultFlag.Changed
 	defer func() {
 		vault = origVault
-		if vaultFlag != nil {
-			_ = vaultFlag.Value.Set(origVault)
-			vaultFlag.Changed = origChanged
+		if cli.VaultFlag != nil {
+			_ = cli.VaultFlag.Value.Set(origVault)
+			cli.VaultFlag.Changed = origChanged
 		}
 	}()
 
@@ -665,12 +665,12 @@ func TestRunStdioServer(t *testing.T) {
 	}
 
 	origVault := vault
-	origChanged := vaultFlag.Changed
+	origChanged := cli.VaultFlag.Changed
 	defer func() {
 		vault = origVault
-		if vaultFlag != nil {
-			_ = vaultFlag.Value.Set(origVault)
-			vaultFlag.Changed = origChanged
+		if cli.VaultFlag != nil {
+			_ = cli.VaultFlag.Value.Set(origVault)
+			cli.VaultFlag.Changed = origChanged
 		}
 	}()
 
@@ -678,8 +678,8 @@ func TestRunStdioServer(t *testing.T) {
 	defer func() { _ = os.Unsetenv("OPENPASS_PASSPHRASE") }()
 
 	vault = vaultDir
-	if vaultFlag != nil {
-		vaultFlag.Changed = false
+	if cli.VaultFlag != nil {
+		cli.VaultFlag.Changed = false
 	}
 
 	v2, err := vaultpkg.OpenWithPassphrase(vaultDir, passphrase)
@@ -705,12 +705,12 @@ func TestUnlockVaultWithSymvaultEnvVar(t *testing.T) {
 	}
 
 	origVault := vault
-	origChanged := vaultFlag.Changed
+	origChanged := cli.VaultFlag.Changed
 	defer func() {
 		vault = origVault
-		if vaultFlag != nil {
-			_ = vaultFlag.Value.Set(origVault)
-			vaultFlag.Changed = origChanged
+		if cli.VaultFlag != nil {
+			_ = cli.VaultFlag.Value.Set(origVault)
+			cli.VaultFlag.Changed = origChanged
 		}
 	}()
 
@@ -718,8 +718,8 @@ func TestUnlockVaultWithSymvaultEnvVar(t *testing.T) {
 	defer func() { _ = os.Unsetenv("SYMVAULT_PASSPHRASE") }()
 
 	vault = vaultDir
-	if vaultFlag != nil {
-		vaultFlag.Changed = false
+	if cli.VaultFlag != nil {
+		cli.VaultFlag.Changed = false
 	}
 
 	_, err := cli.UnlockVault(vaultDir, false)
@@ -759,12 +759,12 @@ func TestUnlockVaultWrongPassphraseSymvault(t *testing.T) {
 	}
 
 	origVault := vault
-	origChanged := vaultFlag.Changed
+	origChanged := cli.VaultFlag.Changed
 	defer func() {
 		vault = origVault
-		if vaultFlag != nil {
-			_ = vaultFlag.Value.Set(origVault)
-			vaultFlag.Changed = origChanged
+		if cli.VaultFlag != nil {
+			_ = cli.VaultFlag.Value.Set(origVault)
+			cli.VaultFlag.Changed = origChanged
 		}
 	}()
 
@@ -772,8 +772,8 @@ func TestUnlockVaultWrongPassphraseSymvault(t *testing.T) {
 	defer func() { _ = os.Unsetenv("SYMVAULT_PASSPHRASE") }()
 
 	vault = vaultDir
-	if vaultFlag != nil {
-		vaultFlag.Changed = false
+	if cli.VaultFlag != nil {
+		cli.VaultFlag.Changed = false
 	}
 
 	_, err := cli.UnlockVault(vaultDir, false)

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	admin "github.com/danieljustus/symaira-vault/cmd/admin"
-	cli "github.com/danieljustus/symaira-vault/internal/cli"
 
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
@@ -21,11 +20,11 @@ func TestConfigSetCommand_Basic(t *testing.T) {
 	}
 
 	resetCmdFlags()
-	cli.RootCmd.SetArgs([]string{"config", "set", "vaultDir", "/new", "--file", cfgPath})
-	defer cli.RootCmd.SetArgs(nil)
+	rootCmd.SetArgs([]string{"config", "set", "vaultDir", "/new", "--file", cfgPath})
+	defer rootCmd.SetArgs(nil)
 
 	output := captureStdout(func() {
-		if err := cli.RootCmd.Execute(); err != nil {
+		if err := rootCmd.Execute(); err != nil {
 			t.Fatalf("config set failed: %v", err)
 		}
 	})
@@ -51,10 +50,10 @@ func TestConfigSetCommand_BoolValue(t *testing.T) {
 	}
 
 	resetCmdFlags()
-	cli.RootCmd.SetArgs([]string{"config", "set", "agents.test.canWrite", "true", "--file", cfgPath})
-	defer cli.RootCmd.SetArgs(nil)
+	rootCmd.SetArgs([]string{"config", "set", "agents.test.canWrite", "true", "--file", cfgPath})
+	defer rootCmd.SetArgs(nil)
 
-	if err := cli.RootCmd.Execute(); err != nil {
+	if err := rootCmd.Execute(); err != nil {
 		t.Fatalf("config set failed: %v", err)
 	}
 
@@ -95,10 +94,10 @@ func TestConfigSetCommand_CreateNestedKey(t *testing.T) {
 	}
 
 	resetCmdFlags()
-	cli.RootCmd.SetArgs([]string{"config", "set", "agents.custom.canWrite", "true", "--file", cfgPath})
-	defer cli.RootCmd.SetArgs(nil)
+	rootCmd.SetArgs([]string{"config", "set", "agents.custom.canWrite", "true", "--file", cfgPath})
+	defer rootCmd.SetArgs(nil)
 
-	if err := cli.RootCmd.Execute(); err != nil {
+	if err := rootCmd.Execute(); err != nil {
 		t.Fatalf("config set failed: %v", err)
 	}
 
@@ -116,10 +115,10 @@ func TestConfigSetCommand_InvalidatesConfig(t *testing.T) {
 	}
 
 	resetCmdFlags()
-	cli.RootCmd.SetArgs([]string{"config", "set", "sessionTimeout", "invalid", "--file", cfgPath})
-	defer cli.RootCmd.SetArgs(nil)
+	rootCmd.SetArgs([]string{"config", "set", "sessionTimeout", "invalid", "--file", cfgPath})
+	defer rootCmd.SetArgs(nil)
 
-	err := cli.RootCmd.Execute()
+	err := rootCmd.Execute()
 	if err == nil {
 		t.Fatal("expected error for invalid sessionTimeout value")
 	}
@@ -132,10 +131,10 @@ func TestConfigSetCommand_MissingFile(t *testing.T) {
 	cfgPath := filepath.Join(t.TempDir(), "nonexistent.yaml")
 
 	resetCmdFlags()
-	cli.RootCmd.SetArgs([]string{"config", "set", "vaultDir", "/new", "--file", cfgPath})
-	defer cli.RootCmd.SetArgs(nil)
+	rootCmd.SetArgs([]string{"config", "set", "vaultDir", "/new", "--file", cfgPath})
+	defer rootCmd.SetArgs(nil)
 
-	err := cli.RootCmd.Execute()
+	err := rootCmd.Execute()
 	if err == nil {
 		t.Fatal("expected error for missing config file")
 	}
@@ -149,11 +148,11 @@ func TestConfigGetCommand_ExistingKey(t *testing.T) {
 	}
 
 	resetCmdFlags()
-	cli.RootCmd.SetArgs([]string{"config", "get", "vaultDir", "--file", cfgPath})
-	defer cli.RootCmd.SetArgs(nil)
+	rootCmd.SetArgs([]string{"config", "get", "vaultDir", "--file", cfgPath})
+	defer rootCmd.SetArgs(nil)
 
 	output := captureStdout(func() {
-		if err := cli.RootCmd.Execute(); err != nil {
+		if err := rootCmd.Execute(); err != nil {
 			t.Fatalf("config get failed: %v", err)
 		}
 	})
@@ -171,11 +170,11 @@ func TestConfigGetCommand_NestedKey(t *testing.T) {
 	}
 
 	resetCmdFlags()
-	cli.RootCmd.SetArgs([]string{"config", "get", "agents.claude.canWrite", "--file", cfgPath})
-	defer cli.RootCmd.SetArgs(nil)
+	rootCmd.SetArgs([]string{"config", "get", "agents.claude.canWrite", "--file", cfgPath})
+	defer rootCmd.SetArgs(nil)
 
 	output := captureStdout(func() {
-		if err := cli.RootCmd.Execute(); err != nil {
+		if err := rootCmd.Execute(); err != nil {
 			t.Fatalf("config get failed: %v", err)
 		}
 	})
@@ -193,10 +192,10 @@ func TestConfigGetCommand_MissingKey(t *testing.T) {
 	}
 
 	resetCmdFlags()
-	cli.RootCmd.SetArgs([]string{"config", "get", "nonexistent.key", "--file", cfgPath})
-	defer cli.RootCmd.SetArgs(nil)
+	rootCmd.SetArgs([]string{"config", "get", "nonexistent.key", "--file", cfgPath})
+	defer rootCmd.SetArgs(nil)
 
-	err := cli.RootCmd.Execute()
+	err := rootCmd.Execute()
 	if err == nil {
 		t.Fatal("expected error for missing key")
 	}
@@ -206,10 +205,10 @@ func TestConfigGetCommand_MissingFile(t *testing.T) {
 	cfgPath := filepath.Join(t.TempDir(), "nonexistent.yaml")
 
 	resetCmdFlags()
-	cli.RootCmd.SetArgs([]string{"config", "get", "vaultDir", "--file", cfgPath})
-	defer cli.RootCmd.SetArgs(nil)
+	rootCmd.SetArgs([]string{"config", "get", "vaultDir", "--file", cfgPath})
+	defer rootCmd.SetArgs(nil)
 
-	err := cli.RootCmd.Execute()
+	err := rootCmd.Execute()
 	if err == nil {
 		t.Fatal("expected error for missing config file")
 	}
@@ -223,11 +222,11 @@ func TestConfigListCommand(t *testing.T) {
 	}
 
 	resetCmdFlags()
-	cli.RootCmd.SetArgs([]string{"config", "list", "--file", cfgPath})
-	defer cli.RootCmd.SetArgs(nil)
+	rootCmd.SetArgs([]string{"config", "list", "--file", cfgPath})
+	defer rootCmd.SetArgs(nil)
 
 	output := captureStdout(func() {
-		if err := cli.RootCmd.Execute(); err != nil {
+		if err := rootCmd.Execute(); err != nil {
 			t.Fatalf("config list failed: %v", err)
 		}
 	})
@@ -244,10 +243,10 @@ func TestConfigListCommand_MissingFile(t *testing.T) {
 	cfgPath := filepath.Join(t.TempDir(), "nonexistent.yaml")
 
 	resetCmdFlags()
-	cli.RootCmd.SetArgs([]string{"config", "list", "--file", cfgPath})
-	defer cli.RootCmd.SetArgs(nil)
+	rootCmd.SetArgs([]string{"config", "list", "--file", cfgPath})
+	defer rootCmd.SetArgs(nil)
 
-	err := cli.RootCmd.Execute()
+	err := rootCmd.Execute()
 	if err == nil {
 		t.Fatal("expected error for missing config file")
 	}
@@ -261,11 +260,11 @@ func TestConfigListCommand_EmptyConfig(t *testing.T) {
 	}
 
 	resetCmdFlags()
-	cli.RootCmd.SetArgs([]string{"config", "list", "--file", cfgPath})
-	defer cli.RootCmd.SetArgs(nil)
+	rootCmd.SetArgs([]string{"config", "list", "--file", cfgPath})
+	defer rootCmd.SetArgs(nil)
 
 	output := captureStdout(func() {
-		if err := cli.RootCmd.Execute(); err != nil {
+		if err := rootCmd.Execute(); err != nil {
 			t.Fatalf("config list failed: %v", err)
 		}
 	})

--- a/cmd/crud/add.go
+++ b/cmd/crud/add.go
@@ -38,26 +38,6 @@ var (
 	AddExpiresAt   string
 )
 
-var addCmd = &cobra.Command{
-	Use:               "add <name>",
-	Aliases:           []string{"new", "create"},
-	ValidArgsFunction: cli.EntryCompletionFunc,
-	Short:             "Add a new password entry",
-	Long: `Creates a new password entry in the vault.
-
-The entry name can use slash notation for organization (e.g., work/aws).
-Interactive mode prompts for username, password, and URL.`,
-	Example: `  symvault add github
-  symvault add work/aws
-  symvault add personal/bank
-  symvault add github-token --value "my-secret-token"
-  symvault add secure-pass --generate --length 20
-  symvault add aws-key --type api_key --value "AKIA..."
-  symvault add ssh-key --type ssh_key --usage-hint "Production server key"`,
-	Args: cobra.ExactArgs(1),
-	RunE: runAdd,
-}
-
 func runAdd(cmd *cobra.Command, args []string) error {
 	return cli.WithVaultRaw(func(v *vaultpkg.Vault, vs *cli.VaultService) error {
 		name := args[0]
@@ -340,7 +320,27 @@ func applySecretMetaFlags(meta vaultpkg.SecretMetadata) vaultpkg.SecretMetadata 
 	return meta
 }
 
-func init() {
+func newAddCmd() *cobra.Command {
+	addCmd := &cobra.Command{
+		Use:               "add <name>",
+		Aliases:           []string{"new", "create"},
+		ValidArgsFunction: cli.EntryCompletionFunc,
+		Short:             "Add a new password entry",
+		Long: `Creates a new password entry in the vault.
+
+The entry name can use slash notation for organization (e.g., work/aws).
+Interactive mode prompts for username, password, and URL.`,
+		Example: `  symvault add github
+  symvault add work/aws
+  symvault add personal/bank
+  symvault add github-token --value "my-secret-token"
+  symvault add secure-pass --generate --length 20
+  symvault add aws-key --type api_key --value "AKIA..."
+  symvault add ssh-key --type ssh_key --usage-hint "Production server key"`,
+		Args: cobra.ExactArgs(1),
+		RunE: runAdd,
+	}
+
 	addCmd.Flags().StringVar(&AddValue, "value", "", "Password value (non-interactive, visible in process listings)")
 	addCmd.Flags().BoolVar(&AddStdinValue, "stdin-value", false, "Read password value from stdin (prevents argv leak)")
 	addCmd.Flags().BoolVar(&AddStdinTOTP, "stdin-totp-secret", false, "Read TOTP secret from stdin (prevents argv leak)")
@@ -358,5 +358,5 @@ func init() {
 	addCmd.Flags().BoolVar(&AddAutoRotate, "auto-rotate", false, "Enable automatic rotation reminder")
 	addCmd.Flags().StringVar(&AddExpiresAt, "expires-at", "", "Expiration date (RFC3339 format)")
 	addCmd.GroupID = cli.GroupIDEssentials
-	cli.RootCmd.AddCommand(addCmd)
+	return addCmd
 }

--- a/cmd/crud/commands.go
+++ b/cmd/crud/commands.go
@@ -1,0 +1,18 @@
+package crud
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// NewCommands returns all CRUD commands for root command assembly.
+func NewCommands() []*cobra.Command {
+	return []*cobra.Command{
+		newAddCmd(),
+		newDeleteCmd(),
+		newEditCmd(),
+		newFindCmd(),
+		newGetCmd(),
+		newListCmd(),
+		newSetCmd(),
+	}
+}

--- a/cmd/crud/delete.go
+++ b/cmd/crud/delete.go
@@ -18,58 +18,58 @@ var (
 	DeleteYes bool
 )
 
-var deleteCmd = &cobra.Command{
-	Use:     "delete <path>",
-	Aliases: []string{"rm", "remove"},
-	Short:   "Delete a password entry",
-	Example: `  # Delete an entry (with confirmation)
+func newDeleteCmd() *cobra.Command {
+	deleteCmd := &cobra.Command{
+		Use:     "delete <path>",
+		Aliases: []string{"rm", "remove"},
+		Short:   "Delete a password entry",
+		Example: `  # Delete an entry (with confirmation)
   symvault delete github
 
   # Skip confirmation
   symvault delete github --yes`,
-	Args:              cobra.ExactArgs(1),
-	ValidArgsFunction: cli.EntryCompletionFunc,
-	Annotations: map[string]string{
-		cli.JSONOutputAnnotation: "true",
-	},
-	RunE: func(cmd *cobra.Command, args []string) error {
-		path := args[0]
-		return cli.WithVault(func(v *vaultpkg.Vault, vs *cli.VaultService) error {
-			if !DeleteYes {
-				fmt.Fprintf(os.Stderr, "Delete %s? (y/N): ", path)
-				answer, err := bufio.NewReader(os.Stdin).ReadString('\n')
-				if err != nil && answer == "" {
-					return errorspkg.ReadFailed(err, "read confirmation")
-				}
-				if strings.ToLower(strings.TrimSpace(answer)) != "y" {
-					if cli.OutputFormat == "text" { //nolint:goconst // output format literal
-						fmt.Fprintln(os.Stderr, "Canceled")
-					} else {
-						if err := cli.PrintResult(map[string]any{"deleted": false, "path": path, "canceled": true}); err != nil {
-							return err
-						}
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: cli.EntryCompletionFunc,
+		Annotations: map[string]string{
+			cli.JSONOutputAnnotation: "true",
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			path := args[0]
+			return cli.WithVault(func(v *vaultpkg.Vault, vs *cli.VaultService) error {
+				if !DeleteYes {
+					fmt.Fprintf(os.Stderr, "Delete %s? (y/N): ", path)
+					answer, err := bufio.NewReader(os.Stdin).ReadString('\n')
+					if err != nil && answer == "" {
+						return errorspkg.ReadFailed(err, "read confirmation")
 					}
-					return nil
+					if strings.ToLower(strings.TrimSpace(answer)) != "y" {
+						if cli.OutputFormat == "text" { //nolint:goconst // output format literal
+							fmt.Fprintln(os.Stderr, "Canceled")
+						} else {
+							if err := cli.PrintResult(map[string]any{"deleted": false, "path": path, "canceled": true}); err != nil {
+								return err
+							}
+						}
+						return nil
+					}
 				}
-			}
 
-			if err := vs.DeleteEntry(path); err != nil {
-				return errorspkg.WriteFailed(err, "cannot delete entry")
-			}
-			if cli.OutputFormat == "text" {
-				cli.PrintQuietAware("Deleted: %s\n", path)
-			} else {
-				if err := cli.PrintResult(map[string]any{"deleted": true, "path": path}); err != nil {
-					return err
+				if err := vs.DeleteEntry(path); err != nil {
+					return errorspkg.WriteFailed(err, "cannot delete entry")
 				}
-			}
-			return nil
-		})
-	},
-}
+				if cli.OutputFormat == "text" {
+					cli.PrintQuietAware("Deleted: %s\n", path)
+				} else {
+					if err := cli.PrintResult(map[string]any{"deleted": true, "path": path}); err != nil {
+						return err
+					}
+				}
+				return nil
+			})
+		},
+	}
 
-func init() {
-	deleteCmd.Flags().BoolVarP(&DeleteYes, "yes", "y", false, "Skip confirmation prompt")
+	deleteCmd.Flags().BoolVarP(&DeleteYes, "yes", "y", false, "Skip deletion confirmation prompt")
 	deleteCmd.GroupID = cli.GroupIDEssentials
-	cli.RootCmd.AddCommand(deleteCmd)
+	return deleteCmd
 }

--- a/cmd/crud/edit.go
+++ b/cmd/crud/edit.go
@@ -19,61 +19,61 @@ var EditorFlag string
 // OSCreateTemp is overridable in tests for permission verification.
 var OSCreateTemp = secureedit.CreateTemp
 
-var editCmd = &cobra.Command{
-	Use:     "edit <name>",
-	Aliases: []string{"modify"},
-	Short:   "Edit an existing password entry",
-	Long: `Opens an existing password entry in your default editor for modification.
+func newEditCmd() *cobra.Command {
+	editCmd := &cobra.Command{
+		Use:     "edit <name>",
+		Aliases: []string{"modify"},
+		Short:   "Edit an existing password entry",
+		Long: `Opens an existing password entry in your default editor for modification.
 
 The entry is opened in JSON format. Save and exit the editor to update the entry.
 If the entry does not exist, an error is returned.
 
 The editor is determined by the --editor flag or EDITOR environment variable (defaults to vi).`,
-	Example: `  symvault edit github
+		Example: `  symvault edit github
   symvault edit work/aws
   symvault edit personal/bank --editor nano
   EDITOR=nano symvault edit personal/bank`,
-	Args:              cobra.ExactArgs(1),
-	ValidArgsFunction: cli.EntryCompletionFunc,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		return cli.WithVaultRaw(func(v *vaultpkg.Vault, vs *cli.VaultService) error {
-			name := args[0]
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: cli.EntryCompletionFunc,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cli.WithVaultRaw(func(v *vaultpkg.Vault, vs *cli.VaultService) error {
+				name := args[0]
 
-			entry, err := vs.GetEntry(name)
-			if err != nil {
-				return errorspkg.NotFound("entry not found: %s", name)
-			}
+				entry, err := vs.GetEntry(name)
+				if err != nil {
+					return errorspkg.NotFound("entry not found: %s", name)
+				}
 
-			editor := EditorFlag
-			if editor == "" {
-				editor = os.Getenv("EDITOR")
-			}
-			if editor == "" {
-				editor = "vi"
-			}
+				editor := EditorFlag
+				if editor == "" {
+					editor = os.Getenv("EDITOR")
+				}
+				if editor == "" {
+					editor = "vi"
+				}
 
-			secureedit.CreateTemp = OSCreateTemp
-			defer func() { secureedit.CreateTemp = os.CreateTemp }()
-			updatedEntry, err := secureedit.EditEntry(entry, editor, secureedit.DefaultStreams())
-			if err != nil {
-				return errorspkg.Wrap(errorspkg.ExitGeneralError, errorspkg.ErrKindNone, err, "edit entry")
-			}
+				secureedit.CreateTemp = OSCreateTemp
+				defer func() { secureedit.CreateTemp = os.CreateTemp }()
+				updatedEntry, err := secureedit.EditEntry(entry, editor, secureedit.DefaultStreams())
+				if err != nil {
+					return errorspkg.Wrap(errorspkg.ExitGeneralError, errorspkg.ErrKindNone, err, "edit entry")
+				}
 
-			if err := vs.WriteEntry(name, updatedEntry); err != nil {
-				return errorspkg.WriteFailed(err, "cannot save entry")
-			}
+				if err := vs.WriteEntry(name, updatedEntry); err != nil {
+					return errorspkg.WriteFailed(err, "cannot save entry")
+				}
 
-			if err := v.AutoCommitEntry(fmt.Sprintf("Edit %s", name), name); err != nil {
-				cliout.Warnf("Warning: auto-commit failed: %v", err)
-			}
-			cli.PrintQuietAware("Entry updated: %s\n", name)
-			return nil
-		})
-	},
-}
+				if err := v.AutoCommitEntry(fmt.Sprintf("Edit %s", name), name); err != nil {
+					cliout.Warnf("Warning: auto-commit failed: %v", err)
+				}
+				cli.PrintQuietAware("Entry updated: %s\n", name)
+				return nil
+			})
+		},
+	}
 
-func init() {
 	editCmd.Flags().StringVar(&EditorFlag, "editor", "", "Editor to use (overrides EDITOR env var)")
 	editCmd.GroupID = cli.GroupIDEssentials
-	cli.RootCmd.AddCommand(editCmd)
+	return editCmd
 }

--- a/cmd/crud/find.go
+++ b/cmd/crud/find.go
@@ -27,66 +27,66 @@ func searchWorkers(cfg *configpkg.Config) int {
 	return vaultpkg.SearchWorkerCount(configured)
 }
 
-var findCmd = &cobra.Command{
-	Use:               "find <query>",
-	Aliases:           []string{"search"},
-	ValidArgsFunction: cli.EntryCompletionFunc,
-	Short:             "Search for entries",
-	Long:              `Searches entry paths and contents for the given query.`,
-	Example: `  # Search for entries containing "bank"
+func newFindCmd() *cobra.Command {
+	findCmd := &cobra.Command{
+		Use:               "find <query>",
+		Aliases:           []string{"search"},
+		ValidArgsFunction: cli.EntryCompletionFunc,
+		Short:             "Search for entries",
+		Long:              `Searches entry paths and contents for the given query.`,
+		Example: `  # Search for entries containing "bank"
   symvault find bank
 
   # JSON output
   symvault find bank --output json`,
-	Args: cobra.ExactArgs(1),
-	Annotations: map[string]string{
-		cli.JSONOutputAnnotation: "true",
-	},
-	RunE: func(cmd *cobra.Command, args []string) error {
-		return cli.WithVault(func(v *vaultpkg.Vault, vs *cli.VaultService) error {
-			cli.MaybeAutoPull(vs.VaultDir(), v.Config)
-			cfg := v.Config
-			workers := searchWorkers(cfg)
+		Args: cobra.ExactArgs(1),
+		Annotations: map[string]string{
+			cli.JSONOutputAnnotation: "true",
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cli.WithVault(func(v *vaultpkg.Vault, vs *cli.VaultService) error {
+				cli.MaybeAutoPull(vs.VaultDir(), v.Config)
+				cfg := v.Config
+				workers := searchWorkers(cfg)
 
-			matches, err := vs.FindEntries(args[0], vaultpkg.FindOptions{MaxWorkers: workers})
-			if err != nil {
-				return errorspkg.ReadFailed(err, "search failed")
-			}
-
-			if len(matches) == 0 {
-				fmt.Fprintln(os.Stderr, "No matches found")
-				return nil
-			}
-
-			if cli.OutputFormat != "text" {
-				type matchEntry struct {
-					Path   string   `json:"path"`
-					Fields []string `json:"fields,omitempty"`
+				matches, err := vs.FindEntries(args[0], vaultpkg.FindOptions{MaxWorkers: workers})
+				if err != nil {
+					return errorspkg.ReadFailed(err, "search failed")
 				}
-				out := make([]matchEntry, 0, len(matches))
+
+				if len(matches) == 0 {
+					fmt.Fprintln(os.Stderr, "No matches found")
+					return nil
+				}
+
+				if cli.OutputFormat != "text" {
+					type matchEntry struct {
+						Path   string   `json:"path"`
+						Fields []string `json:"fields,omitempty"`
+					}
+					out := make([]matchEntry, 0, len(matches))
+					for _, m := range matches {
+						out = append(out, matchEntry{Path: m.Path, Fields: m.Fields})
+					}
+					if err := cli.PrintResult(map[string]interface{}{"matches": out}); err != nil {
+						return err
+					}
+					return nil
+				}
+
 				for _, m := range matches {
-					out = append(out, matchEntry{Path: m.Path, Fields: m.Fields})
+					cli.PrintQuietAware("%s", render.ForTerminal(taint.Wrap(m.Path, taint.Provenance{Source: "cli.path"})))
+					if len(m.Fields) > 0 {
+						cli.PrintQuietAware(" (matches: %s)", strings.Join(m.Fields, ", "))
+					}
+					cli.PrintlnQuietAware()
 				}
-				if err := cli.PrintResult(map[string]interface{}{"matches": out}); err != nil {
-					return err
-				}
+
 				return nil
-			}
+			})
+		},
+	}
 
-			for _, m := range matches {
-				cli.PrintQuietAware("%s", render.ForTerminal(taint.Wrap(m.Path, taint.Provenance{Source: "cli.path"})))
-				if len(m.Fields) > 0 {
-					cli.PrintQuietAware(" (matches: %s)", strings.Join(m.Fields, ", "))
-				}
-				cli.PrintlnQuietAware()
-			}
-
-			return nil
-		})
-	},
-}
-
-func init() {
 	findCmd.GroupID = cli.GroupIDEssentials
-	cli.RootCmd.AddCommand(findCmd)
+	return findCmd
 }

--- a/cmd/crud/get.go
+++ b/cmd/crud/get.go
@@ -42,6 +42,7 @@ type getEntryOutput struct {
 	Modified string
 }
 
+//nolint:gocyclo // pre-existing complexity from inline RunE closure; refactor separately
 func newGetCmd() *cobra.Command {
 	getCmd := &cobra.Command{
 		Use:     "get <path[.field]>",

--- a/cmd/crud/get.go
+++ b/cmd/crud/get.go
@@ -42,12 +42,13 @@ type getEntryOutput struct {
 	Modified string
 }
 
-var getCmd = &cobra.Command{
-	Use:     "get <path[.field]>",
-	Aliases: []string{"show", "cat"},
-	Short:   "Get a password entry",
-	Long:    "Retrieves and displays a password entry. Use path.field syntax to get specific fields.",
-	Example: `  # Get a specific field (auto-copies to clipboard on TTY)
+func newGetCmd() *cobra.Command {
+	getCmd := &cobra.Command{
+		Use:     "get <path[.field]>",
+		Aliases: []string{"show", "cat"},
+		Short:   "Get a password entry",
+		Long:    "Retrieves and displays a password entry. Use path.field syntax to get specific fields.",
+		Example: `  # Get a specific field (auto-copies to clipboard on TTY)
   symvault get github.password
 
   # Substring search fallback (when exact path doesn't exist)
@@ -61,223 +62,222 @@ var getCmd = &cobra.Command{
 
   # Use a specific profile
   symvault get github.password --profile work`,
-	Args:              cobra.ExactArgs(1),
-	ValidArgsFunction: cli.EntryCompletionFunc,
-	Annotations: map[string]string{
-		cli.JSONOutputAnnotation: "true",
-	},
-	RunE: func(cmd *cobra.Command, args []string) error {
-		unlockVault := cli.WithVault
-		if !cli.IsTerminalFunc(int(os.Stdin.Fd())) {
-			unlockVault = cli.WithVaultForScripting
-		}
-		return unlockVault(func(v *vaultpkg.Vault, vs *cli.VaultService) error {
-			cli.MaybeAutoPull(vs.VaultDir(), v.Config)
-			query := args[0]
-			path := query
-			field := ""
-
-			if idx := strings.LastIndex(query, "."); idx > 0 {
-				candidatePath := query[:idx]
-				candidateField := query[idx+1:]
-
-				if _, readErr := vs.GetField(candidatePath, candidateField); readErr == nil {
-					path = candidatePath
-					field = candidateField
-				}
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: cli.EntryCompletionFunc,
+		Annotations: map[string]string{
+			cli.JSONOutputAnnotation: "true",
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			unlockVault := cli.WithVault
+			if !cli.IsTerminalFunc(int(os.Stdin.Fd())) {
+				unlockVault = cli.WithVaultForScripting
 			}
+			return unlockVault(func(v *vaultpkg.Vault, vs *cli.VaultService) error {
+				cli.MaybeAutoPull(vs.VaultDir(), v.Config)
+				query := args[0]
+				path := query
+				field := ""
 
-			value, err := vs.GetField(path, field)
-			if err != nil {
-				var cliErr *errorspkg.CLIError
-				if !errors.As(err, &cliErr) || cliErr.Code != errorspkg.ExitNotFound {
-					if errors.As(err, &cliErr) {
-						switch cliErr.Kind {
-						case errorspkg.ErrFieldNotFound:
-							return errorspkg.NewCLIError(errorspkg.ExitNotFound, cliErr.Message, errorspkg.ErrEntryNotFound)
+				if idx := strings.LastIndex(query, "."); idx > 0 {
+					candidatePath := query[:idx]
+					candidateField := query[idx+1:]
+
+					if _, readErr := vs.GetField(candidatePath, candidateField); readErr == nil {
+						path = candidatePath
+						field = candidateField
+					}
+				}
+
+				value, err := vs.GetField(path, field)
+				if err != nil {
+					var cliErr *errorspkg.CLIError
+					if !errors.As(err, &cliErr) || cliErr.Code != errorspkg.ExitNotFound {
+						if errors.As(err, &cliErr) {
+							switch cliErr.Kind {
+							case errorspkg.ErrFieldNotFound:
+								return errorspkg.NewCLIError(errorspkg.ExitNotFound, cliErr.Message, errorspkg.ErrEntryNotFound)
+							default:
+							}
+						}
+						return errorspkg.ReadFailed(err, "cannot read entry")
+					}
+
+					matches, findErr := vs.FindEntries(path, vaultpkg.FindOptions{})
+					if findErr != nil {
+						return errorspkg.ReadFailed(findErr, "search entry")
+					}
+
+					switch len(matches) {
+					case 0:
+						return errorspkg.NewCLIError(errorspkg.ExitNotFound, cliErr.Message, errorspkg.ErrEntryNotFound)
+					case 1:
+						path = matches[0].Path
+						value, err = vs.GetField(path, field)
+						if err != nil {
+							var cliErr2 *errorspkg.CLIError
+							if errors.As(err, &cliErr2) {
+								switch cliErr2.Kind {
+								case errorspkg.ErrNotFound, errorspkg.ErrFieldNotFound:
+									return errorspkg.NewCLIError(errorspkg.ExitNotFound, cliErr2.Message, errorspkg.ErrEntryNotFound)
+								default:
+								}
+							}
+							return errorspkg.ReadFailed(err, "cannot read entry")
+						}
+					default:
+						cliout.Warnf("Multiple matches:")
+						for _, m := range matches {
+							cliout.Warnf("  %s", render.ForTerminal(taint.Wrap(m.Path, taint.Provenance{Source: "cli.path"})))
+						}
+						return errorspkg.NewCLIError(errorspkg.ExitNotFound, fmt.Sprintf("ambiguous path: %s", path), errorspkg.ErrEntryNotFound)
+					}
+				}
+
+				if field != "" {
+					strValue := fmt.Sprintf("%v", value)
+
+					// Determine if we should copy to clipboard:
+					// 1. --output json: never clipboard, always print as JSON
+					// 2. --print flag: always print to stdout
+					// 3. Not a TTY: print to stdout (for scripts/pipes)
+					// 4. TTY + no --print: copy to clipboard (default)
+					// 5. Config override: clipboard.copyByDefault=false restores old behavior
+
+					if cli.OutputFormat != "text" {
+						if printErr := cli.PrintResult(strValue); printErr != nil {
+							return printErr
+						}
+						return nil
+					}
+
+					shouldPrint := GetPrint || !cli.IsTerminalFunc(int(os.Stdout.Fd()))
+					if !shouldPrint {
+						// Check config override
+						cfg := v.Config
+						if cfg == nil {
+							vaultDir := vs.VaultDir()
+							if vaultDir != "" {
+								cfg, _ = configpkg.Load(vaultDir + "/config.yaml")
+							}
+						}
+						if cfg != nil && cfg.Clipboard != nil && !cfg.Clipboard.CopyByDefault {
+							shouldPrint = true
+						}
+					}
+
+					if !shouldPrint {
+						// Copy to clipboard (default TTY behavior)
+						if clipErr := GetClipboard().Copy(strValue); clipErr != nil {
+							return errorspkg.Wrap(errorspkg.ExitGeneralError, errorspkg.ErrKindNone, clipErr, "copy to clipboard")
+						}
+						cliout.Hintf("[copied to clipboard]")
+
+						autoClearDuration := GetAutoClearDurationFunc()
+						if autoClearDuration > 0 {
+							cancelCh := make(chan struct{})
+							go clipboardapp.Countdown(autoClearDuration, func(remaining int) {
+								fmt.Fprintf(os.Stderr, "\r[clearing clipboard in %ds] ", remaining)
+							}, cancelCh)
+							StartAutoClear(autoClearDuration, func() {
+								close(cancelCh)
+								copied := strValue
+								if clearErr := GetClipboard().Copy(""); clearErr != nil {
+									cliout.Warnf("Warning: failed to clear clipboard: %v", clearErr)
+								}
+								if verr := clipboardapp.VerifyCleared(copied, GetClipboard().Read); verr != nil {
+									fmt.Fprintf(os.Stderr, "\rWarning: %v — consider disabling clipboard-history retention.\n", verr)
+								} else {
+									fmt.Fprintln(os.Stderr, "\r[clipboard cleared]        ")
+								}
+							}, cancelCh)
+						}
+						return nil
+					}
+
+					cli.PrintlnQuietAware(strValue)
+					return nil
+				}
+
+				entry, err := vs.GetEntry(path)
+				if err != nil {
+					var cliErr3 *errorspkg.CLIError
+					if errors.As(err, &cliErr3) {
+						switch cliErr3.Kind {
+						case errorspkg.ErrNotFound, errorspkg.ErrFieldNotFound:
+							return errorspkg.NewCLIError(errorspkg.ExitNotFound, cliErr3.Message, errorspkg.ErrEntryNotFound)
 						default:
 						}
 					}
 					return errorspkg.ReadFailed(err, "cannot read entry")
 				}
 
-				matches, findErr := vs.FindEntries(path, vaultpkg.FindOptions{})
-				if findErr != nil {
-					return errorspkg.ReadFailed(findErr, "search entry")
-				}
-
-				switch len(matches) {
-				case 0:
-					return errorspkg.NewCLIError(errorspkg.ExitNotFound, cliErr.Message, errorspkg.ErrEntryNotFound)
-				case 1:
-					path = matches[0].Path
-					value, err = vs.GetField(path, field)
-					if err != nil {
-						var cliErr2 *errorspkg.CLIError
-						if errors.As(err, &cliErr2) {
-							switch cliErr2.Kind {
-							case errorspkg.ErrNotFound, errorspkg.ErrFieldNotFound:
-								return errorspkg.NewCLIError(errorspkg.ExitNotFound, cliErr2.Message, errorspkg.ErrEntryNotFound)
-							default:
-							}
-						}
-						return errorspkg.ReadFailed(err, "cannot read entry")
-					}
-				default:
-					cliout.Warnf("Multiple matches:")
-					for _, m := range matches {
-						cliout.Warnf("  %s", render.ForTerminal(taint.Wrap(m.Path, taint.Provenance{Source: "cli.path"})))
-					}
-					return errorspkg.NewCLIError(errorspkg.ExitNotFound, fmt.Sprintf("ambiguous path: %s", path), errorspkg.ErrEntryNotFound)
-				}
-			}
-
-			if field != "" {
-				strValue := fmt.Sprintf("%v", value)
-
-				// Determine if we should copy to clipboard:
-				// 1. --output json: never clipboard, always print as JSON
-				// 2. --print flag: always print to stdout
-				// 3. Not a TTY: print to stdout (for scripts/pipes)
-				// 4. TTY + no --print: copy to clipboard (default)
-				// 5. Config override: clipboard.copyByDefault=false restores old behavior
-
 				if cli.OutputFormat != "text" {
-					if printErr := cli.PrintResult(strValue); printErr != nil {
-						return printErr
+					output := getEntryOutput{
+						Path:     path,
+						Modified: entry.Metadata.Updated.Format("2006-01-02 15:04"),
+						Fields:   entry.Data,
 					}
-					return nil
-				}
-
-				shouldPrint := GetPrint || !cli.IsTerminalFunc(int(os.Stdout.Fd()))
-				if !shouldPrint {
-					// Check config override
-					cfg := v.Config
-					if cfg == nil {
-						vaultDir := vs.VaultDir()
-						if vaultDir != "" {
-							cfg, _ = configpkg.Load(vaultDir + "/config.yaml")
+					if secret, algorithm, digits, period, hasTOTP := vaultpkg.ExtractTOTP(entry.Data); hasTOTP {
+						totpCode, err := vaultcrypto.GenerateTOTP(secret, algorithm, digits, period)
+						if err == nil {
+							period := int64(totpCode.Period)
+							if period == 0 {
+								period = 30
+							}
+							now := time.Now().UTC()
+							remaining := period - (now.Unix() % period)
+							output.TOTP = &totpOutput{
+								Code:      totpCode.Code,
+								Period:    period,
+								Remaining: int(remaining),
+							}
 						}
 					}
-					if cfg != nil && cfg.Clipboard != nil && !cfg.Clipboard.CopyByDefault {
-						shouldPrint = true
-					}
-				}
-
-				if !shouldPrint {
-					// Copy to clipboard (default TTY behavior)
-					if clipErr := GetClipboard().Copy(strValue); clipErr != nil {
-						return errorspkg.Wrap(errorspkg.ExitGeneralError, errorspkg.ErrKindNone, clipErr, "copy to clipboard")
-					}
-					cliout.Hintf("[copied to clipboard]")
-
-					autoClearDuration := GetAutoClearDurationFunc()
-					if autoClearDuration > 0 {
-						cancelCh := make(chan struct{})
-						go clipboardapp.Countdown(autoClearDuration, func(remaining int) {
-							fmt.Fprintf(os.Stderr, "\r[clearing clipboard in %ds] ", remaining)
-						}, cancelCh)
-						StartAutoClear(autoClearDuration, func() {
-							close(cancelCh)
-							copied := strValue
-							if clearErr := GetClipboard().Copy(""); clearErr != nil {
-								cliout.Warnf("Warning: failed to clear clipboard: %v", clearErr)
-							}
-							if verr := clipboardapp.VerifyCleared(copied, GetClipboard().Read); verr != nil {
-								fmt.Fprintf(os.Stderr, "\rWarning: %v — consider disabling clipboard-history retention.\n", verr)
-							} else {
-								fmt.Fprintln(os.Stderr, "\r[clipboard cleared]        ")
-							}
-						}, cancelCh)
+					if err := cli.PrintResult(output); err != nil {
+						return err
 					}
 					return nil
 				}
 
-				cli.PrintlnQuietAware(strValue)
-				return nil
-			}
+				cli.PrintQuietAware("Path: %s\n", render.ForTerminal(taint.Wrap(path, taint.Provenance{Source: "cli.path"})))
+				cli.PrintQuietAware("Modified: %s\n", entry.Metadata.Updated.Format("2006-01-02 15:04"))
+				cli.PrintlnQuietAware()
 
-			entry, err := vs.GetEntry(path)
-			if err != nil {
-				var cliErr3 *errorspkg.CLIError
-				if errors.As(err, &cliErr3) {
-					switch cliErr3.Kind {
-					case errorspkg.ErrNotFound, errorspkg.ErrFieldNotFound:
-						return errorspkg.NewCLIError(errorspkg.ExitNotFound, cliErr3.Message, errorspkg.ErrEntryNotFound)
-					default:
-					}
+				keys := make([]string, 0, len(entry.Data))
+				for k := range entry.Data {
+					keys = append(keys, k)
 				}
-				return errorspkg.ReadFailed(err, "cannot read entry")
-			}
+				sort.Strings(keys)
 
-			if cli.OutputFormat != "text" {
-				output := getEntryOutput{
-					Path:     path,
-					Modified: entry.Metadata.Updated.Format("2006-01-02 15:04"),
-					Fields:   entry.Data,
+				for _, k := range keys {
+					cli.PrintQuietAware("%s: %v\n", k, render.ForTerminal(taint.Wrap(fmt.Sprintf("%v", entry.Data[k]), taint.Provenance{Source: "cli.value"})))
 				}
+
 				if secret, algorithm, digits, period, hasTOTP := vaultpkg.ExtractTOTP(entry.Data); hasTOTP {
 					totpCode, err := vaultcrypto.GenerateTOTP(secret, algorithm, digits, period)
-					if err == nil {
+					if err != nil {
+						cliout.Warnf("Warning: could not generate TOTP code: %v", err)
+					} else {
 						period := int64(totpCode.Period)
 						if period == 0 {
 							period = 30
 						}
 						now := time.Now().UTC()
 						remaining := period - (now.Unix() % period)
-						output.TOTP = &totpOutput{
-							Code:      totpCode.Code,
-							Period:    period,
-							Remaining: int(remaining),
-						}
+
+						cli.PrintlnQuietAware()
+						fmt.Fprintf(os.Stderr, "TOTP Code: %s (expires in %ds)\n", totpCode.Code, remaining)
 					}
 				}
-				if err := cli.PrintResult(output); err != nil {
-					return err
-				}
+
 				return nil
-			}
+			})
+		},
+	}
 
-			cli.PrintQuietAware("Path: %s\n", render.ForTerminal(taint.Wrap(path, taint.Provenance{Source: "cli.path"})))
-			cli.PrintQuietAware("Modified: %s\n", entry.Metadata.Updated.Format("2006-01-02 15:04"))
-			cli.PrintlnQuietAware()
-
-			keys := make([]string, 0, len(entry.Data))
-			for k := range entry.Data {
-				keys = append(keys, k)
-			}
-			sort.Strings(keys)
-
-			for _, k := range keys {
-				cli.PrintQuietAware("%s: %v\n", k, render.ForTerminal(taint.Wrap(fmt.Sprintf("%v", entry.Data[k]), taint.Provenance{Source: "cli.value"})))
-			}
-
-			if secret, algorithm, digits, period, hasTOTP := vaultpkg.ExtractTOTP(entry.Data); hasTOTP {
-				totpCode, err := vaultcrypto.GenerateTOTP(secret, algorithm, digits, period)
-				if err != nil {
-					cliout.Warnf("Warning: could not generate TOTP code: %v", err)
-				} else {
-					period := int64(totpCode.Period)
-					if period == 0 {
-						period = 30
-					}
-					now := time.Now().UTC()
-					remaining := period - (now.Unix() % period)
-
-					cli.PrintlnQuietAware()
-					fmt.Fprintf(os.Stderr, "TOTP Code: %s (expires in %ds)\n", totpCode.Code, remaining)
-				}
-			}
-
-			return nil
-		})
-	},
-}
-
-func init() {
 	getCmd.Flags().BoolVarP(&GetPrint, "print", "p", false, "Print value to stdout instead of copying to clipboard")
 	getCmd.GroupID = cli.GroupIDEssentials
-	cli.RootCmd.AddCommand(getCmd)
+	return getCmd
 }
 
 func GetAutoClearDuration() int {

--- a/cmd/crud/list.go
+++ b/cmd/crud/list.go
@@ -11,12 +11,13 @@ import (
 	"github.com/danieljustus/symaira-vault/internal/vault/taint"
 )
 
-var listCmd = &cobra.Command{
-	Use:               "list [prefix]",
-	Aliases:           []string{"ls"},
-	ValidArgsFunction: cli.EntryCompletionFunc,
-	Short:             "List password entries",
-	Example: `  # List all entries
+func newListCmd() *cobra.Command {
+	listCmd := &cobra.Command{
+		Use:               "list [prefix]",
+		Aliases:           []string{"ls"},
+		ValidArgsFunction: cli.EntryCompletionFunc,
+		Short:             "List password entries",
+		Example: `  # List all entries
   symvault list
 
   # List entries under "work/" prefix
@@ -24,48 +25,47 @@ var listCmd = &cobra.Command{
 
   # JSON output
   symvault list --output json`,
-	Args: cobra.MaximumNArgs(1),
-	Annotations: map[string]string{
-		cli.JSONOutputAnnotation: "true",
-	},
-	RunE: func(cmd *cobra.Command, args []string) error {
-		return cli.WithVault(func(v *vaultpkg.Vault, vs *cli.VaultService) error {
-			cli.MaybeAutoPull(vs.VaultDir(), v.Config)
-			prefix := ""
-			if len(args) > 0 {
-				prefix = args[0]
-			}
-
-			if cli.OutputFormat != "text" {
-				workers := 0
-				if v.Config != nil && v.Config.Vault != nil {
-					workers = v.Config.Vault.SearchWorkers
+		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{
+			cli.JSONOutputAnnotation: "true",
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cli.WithVault(func(v *vaultpkg.Vault, vs *cli.VaultService) error {
+				cli.MaybeAutoPull(vs.VaultDir(), v.Config)
+				prefix := ""
+				if len(args) > 0 {
+					prefix = args[0]
 				}
-				infos, err := vs.ListEntryInfos(prefix, workers)
+
+				if cli.OutputFormat != "text" {
+					workers := 0
+					if v.Config != nil && v.Config.Vault != nil {
+						workers = v.Config.Vault.SearchWorkers
+					}
+					infos, err := vs.ListEntryInfos(prefix, workers)
+					if err != nil {
+						return errorspkg.ReadFailed(err, "cannot list entries")
+					}
+					if err := cli.PrintResult(infos); err != nil {
+						return err
+					}
+					return nil
+				}
+
+				entries, err := vs.ListEntries(prefix)
 				if err != nil {
 					return errorspkg.ReadFailed(err, "cannot list entries")
 				}
-				if err := cli.PrintResult(infos); err != nil {
-					return err
+
+				for _, e := range entries {
+					cli.PrintlnQuietAware(render.ForTerminal(taint.Wrap(e, taint.Provenance{Source: "cli.path"})))
 				}
+
 				return nil
-			}
+			})
+		},
+	}
 
-			entries, err := vs.ListEntries(prefix)
-			if err != nil {
-				return errorspkg.ReadFailed(err, "cannot list entries")
-			}
-
-			for _, e := range entries {
-				cli.PrintlnQuietAware(render.ForTerminal(taint.Wrap(e, taint.Provenance{Source: "cli.path"})))
-			}
-
-			return nil
-		})
-	},
-}
-
-func init() {
 	listCmd.GroupID = cli.GroupIDEssentials
-	cli.RootCmd.AddCommand(listCmd)
+	return listCmd
 }

--- a/cmd/crud/set.go
+++ b/cmd/crud/set.go
@@ -25,11 +25,12 @@ var (
 	SetForce       bool
 )
 
-var setCmd = &cobra.Command{
-	Use:   "set <path[.field]>",
-	Short: "Set a password entry or field",
-	Long:  "Creates or updates a password entry. Use --value, --stdin-value, or interactive mode.",
-	Example: `  # Set a field from stdin
+func newSetCmd() *cobra.Command {
+	setCmd := &cobra.Command{
+		Use:   "set <path[.field]>",
+		Short: "Set a password entry or field",
+		Long:  "Creates or updates a password entry. Use --value, --stdin-value, or interactive mode.",
+		Example: `  # Set a field from stdin
   echo "mysecret" | symvault set github.password --stdin-value
 
   # Set a field non-interactively (visible in process listing)
@@ -37,96 +38,95 @@ var setCmd = &cobra.Command{
 
   # Set TOTP data
   symvault set github --totp-secret JBSWY3DPEHPK3PXP`,
-	Args:              cobra.ExactArgs(1),
-	ValidArgsFunction: cli.EntryCompletionFunc,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		query := args[0]
-		path := query
-		field := ""
-		if idx := strings.LastIndex(query, "."); idx > 0 {
-			path = query[:idx]
-			field = query[idx+1:]
-		}
-
-		if SetStdinValue {
-			stdinReader := bufio.NewReader(os.Stdin)
-			line, err := stdinReader.ReadString('\n')
-			if err != nil && line == "" {
-				return errorspkg.ReadFailed(err, "read --stdin-value")
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: cli.EntryCompletionFunc,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			query := args[0]
+			path := query
+			field := ""
+			if idx := strings.LastIndex(query, "."); idx > 0 {
+				path = query[:idx]
+				field = query[idx+1:]
 			}
-			SetValue = strings.TrimRight(line, "\n\r")
-		}
 
-		warnArgvExposure(SetValue, SetTOTPSecret, false)
+			if SetStdinValue {
+				stdinReader := bufio.NewReader(os.Stdin)
+				line, err := stdinReader.ReadString('\n')
+				if err != nil && line == "" {
+					return errorspkg.ReadFailed(err, "read --stdin-value")
+				}
+				SetValue = strings.TrimRight(line, "\n\r")
+			}
 
-		data := map[string]any{}
-		if SetValue != "" {
-			if field != "" {
-				data[field] = SetValue
+			warnArgvExposure(SetValue, SetTOTPSecret, false)
+
+			data := map[string]any{}
+			if SetValue != "" {
+				if field != "" {
+					data[field] = SetValue
+				} else {
+					data["password"] = SetValue
+				}
+				if !SetForce && (field == "" || field == "password") {
+					if err := cryptopkg.ValidatePasswordStrength(SetValue); err != nil {
+						return err
+					}
+				}
 			} else {
-				data["password"] = SetValue
-			}
-			if !SetForce && (field == "" || field == "password") {
-				if err := cryptopkg.ValidatePasswordStrength(SetValue); err != nil {
-					return err
+				reader := bufio.NewReader(os.Stdin)
+				if field != "" {
+					prompt := fmt.Sprintf("Enter value for %s: ", field)
+					valueBytes, err := cliinput.ReadHiddenInputFn(prompt, reader)
+					if err != nil && len(valueBytes) == 0 {
+						return errorspkg.ReadFailed(err, "read value")
+					}
+					defer cryptopkg.Wipe(valueBytes)
+					data[field] = string(valueBytes)
+				} else {
+					collected, err := cli.CollectEntryData(reader, cli.EntryFlags{
+						TOTPSecret:      SetTOTPSecret,
+						TOTPIssuer:      SetTOTPIssuer,
+						TOTPAccount:     SetTOTPAccount,
+						Force:           SetForce,
+						SkipNotes:       true,
+						SkipTOTPDetails: true,
+					})
+					if err != nil {
+						return err
+					}
+					for k, v := range collected {
+						data[k] = v
+					}
 				}
 			}
-		} else {
-			reader := bufio.NewReader(os.Stdin)
-			if field != "" {
-				prompt := fmt.Sprintf("Enter value for %s: ", field)
-				valueBytes, err := cliinput.ReadHiddenInputFn(prompt, reader)
-				if err != nil && len(valueBytes) == 0 {
-					return errorspkg.ReadFailed(err, "read value")
+
+			if SetTOTPSecret != "" {
+				totpData := map[string]any{
+					"secret": SetTOTPSecret,
 				}
-				defer cryptopkg.Wipe(valueBytes)
-				data[field] = string(valueBytes)
-			} else {
-				collected, err := cli.CollectEntryData(reader, cli.EntryFlags{
-					TOTPSecret:      SetTOTPSecret,
-					TOTPIssuer:      SetTOTPIssuer,
-					TOTPAccount:     SetTOTPAccount,
-					Force:           SetForce,
-					SkipNotes:       true,
-					SkipTOTPDetails: true,
-				})
-				if err != nil {
-					return err
+				if SetTOTPIssuer != "" {
+					totpData["issuer"] = SetTOTPIssuer
 				}
-				for k, v := range collected {
-					data[k] = v
+				if SetTOTPAccount != "" {
+					totpData["account_name"] = SetTOTPAccount
 				}
+				data["totp"] = totpData
 			}
-		}
 
-		if SetTOTPSecret != "" {
-			totpData := map[string]any{
-				"secret": SetTOTPSecret,
+			if err := cryptopkg.ValidateTOTPData(data); err != nil {
+				return err
 			}
-			if SetTOTPIssuer != "" {
-				totpData["issuer"] = SetTOTPIssuer
-			}
-			if SetTOTPAccount != "" {
-				totpData["account_name"] = SetTOTPAccount
-			}
-			data["totp"] = totpData
-		}
 
-		if err := cryptopkg.ValidateTOTPData(data); err != nil {
-			return err
-		}
+			return cli.WithVault(func(v *vaultpkg.Vault, vs *cli.VaultService) error {
+				if err := vs.SetFields(path, data); err != nil {
+					return errorspkg.WriteFailed(err, "cannot write entry")
+				}
+				cli.PrintQuietAware("Entry saved: %s\n", path)
+				return nil
+			})
+		},
+	}
 
-		return cli.WithVault(func(v *vaultpkg.Vault, vs *cli.VaultService) error {
-			if err := vs.SetFields(path, data); err != nil {
-				return errorspkg.WriteFailed(err, "cannot write entry")
-			}
-			cli.PrintQuietAware("Entry saved: %s\n", path)
-			return nil
-		})
-	},
-}
-
-func init() {
 	setCmd.Flags().StringVar(&SetValue, "value", "", "Value to set (non-interactive, visible in process listings)")
 	setCmd.Flags().BoolVar(&SetStdinValue, "stdin-value", false, "Read value from stdin (prevents argv leak)")
 	setCmd.Flags().StringVar(&SetTOTPSecret, "totp-secret", "", "TOTP secret key (base32 encoded, visible in process listings)")
@@ -134,5 +134,5 @@ func init() {
 	setCmd.Flags().StringVar(&SetTOTPAccount, "totp-account", "", "TOTP account name/username")
 	setCmd.Flags().BoolVar(&SetForce, "force", false, "Skip password strength validation")
 	setCmd.GroupID = cli.GroupIDEssentials
-	cli.RootCmd.AddCommand(setCmd)
+	return setCmd
 }

--- a/cmd/device.go
+++ b/cmd/device.go
@@ -647,7 +647,6 @@ access to all vault entries.`,
 
 func init() {
 	deviceCmd.GroupID = cli.GroupIDSharingSync
-	rootCmd.AddCommand(deviceCmd)
 	deviceCmd.AddCommand(devicePairCmd)
 	deviceCmd.AddCommand(deviceJoinCmd)
 	deviceCmd.AddCommand(deviceAcceptCmd)

--- a/cmd/doctor_test.go
+++ b/cmd/doctor_test.go
@@ -17,12 +17,12 @@ func TestCmdDoctor_TextOutput(t *testing.T) {
 	defer setupVaultFlag(t, vaultDir)()
 
 	var buf bytes.Buffer
-	cli.RootCmd.SetOut(&buf)
-	t.Cleanup(func() { cli.RootCmd.SetOut(nil) })
+	rootCmd.SetOut(&buf)
+	t.Cleanup(func() { rootCmd.SetOut(nil) })
 
-	cli.RootCmd.SetArgs([]string{"--vault", vaultDir, "doctor", "--no-network"})
-	defer cli.RootCmd.SetArgs(nil)
-	_ = cli.RootCmd.Execute()
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "doctor", "--no-network"})
+	defer rootCmd.SetArgs(nil)
+	_ = rootCmd.Execute()
 
 	out := buf.String()
 	if !strings.Contains(out, "Symaira Vault Doctor") {
@@ -39,12 +39,12 @@ func TestCmdDoctor_JSONOutput(t *testing.T) {
 	defer setupVaultFlag(t, vaultDir)()
 
 	var buf bytes.Buffer
-	cli.RootCmd.SetOut(&buf)
-	t.Cleanup(func() { cli.RootCmd.SetOut(nil) })
+	rootCmd.SetOut(&buf)
+	t.Cleanup(func() { rootCmd.SetOut(nil) })
 
-	cli.RootCmd.SetArgs([]string{"--vault", vaultDir, "doctor", "--no-network", "--json"})
-	defer cli.RootCmd.SetArgs(nil)
-	_ = cli.RootCmd.Execute()
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "doctor", "--no-network", "--json"})
+	defer rootCmd.SetArgs(nil)
+	_ = rootCmd.Execute()
 
 	var result struct {
 		VaultDir string `json:"vault_dir"`
@@ -76,12 +76,12 @@ func TestCmdDoctor_NoNetworkFlag(t *testing.T) {
 	defer setupVaultFlag(t, vaultDir)()
 
 	var buf bytes.Buffer
-	cli.RootCmd.SetOut(&buf)
-	t.Cleanup(func() { cli.RootCmd.SetOut(nil) })
+	rootCmd.SetOut(&buf)
+	t.Cleanup(func() { rootCmd.SetOut(nil) })
 
-	cli.RootCmd.SetArgs([]string{"--vault", vaultDir, "doctor", "--no-network"})
-	defer cli.RootCmd.SetArgs(nil)
-	_ = cli.RootCmd.Execute()
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "doctor", "--no-network"})
+	defer rootCmd.SetArgs(nil)
+	_ = rootCmd.Execute()
 
 	if buf.Len() == 0 {
 		t.Error("expected non-empty output with --no-network flag")
@@ -104,13 +104,13 @@ func TestCmdDoctor_FixFlag_TextOutput(t *testing.T) {
 	defer setupVaultFlag(t, vaultDir)()
 
 	var buf bytes.Buffer
-	cli.RootCmd.SetOut(&buf)
-	t.Cleanup(func() { cli.RootCmd.SetOut(nil) })
+	rootCmd.SetOut(&buf)
+	t.Cleanup(func() { rootCmd.SetOut(nil) })
 
-	cli.RootCmd.SetArgs([]string{"--vault", vaultDir, "doctor", "--fix", "--no-network"})
-	defer cli.RootCmd.SetArgs(nil)
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "doctor", "--fix", "--no-network"})
+	defer rootCmd.SetArgs(nil)
 
-	err := cli.RootCmd.Execute()
+	err := rootCmd.Execute()
 	if err != nil {
 		t.Errorf("doctor --fix --no-network failed: %v", err)
 	}

--- a/cmd/doctor_test.go
+++ b/cmd/doctor_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestCmdDoctor_TextOutput(t *testing.T) {
+	rootCmd = NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	setPassEnv(t, string(passphrase))
 	defer setupVaultFlag(t, vaultDir)()
@@ -34,6 +35,7 @@ func TestCmdDoctor_TextOutput(t *testing.T) {
 }
 
 func TestCmdDoctor_JSONOutput(t *testing.T) {
+	rootCmd = NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	setPassEnv(t, string(passphrase))
 	defer setupVaultFlag(t, vaultDir)()
@@ -71,6 +73,7 @@ func TestCmdDoctor_JSONOutput(t *testing.T) {
 }
 
 func TestCmdDoctor_NoNetworkFlag(t *testing.T) {
+	rootCmd = NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	setPassEnv(t, string(passphrase))
 	defer setupVaultFlag(t, vaultDir)()
@@ -99,6 +102,7 @@ func TestCmdDoctor_FixFlag_Registered(t *testing.T) {
 }
 
 func TestCmdDoctor_FixFlag_TextOutput(t *testing.T) {
+	rootCmd = NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	setPassEnv(t, string(passphrase))
 	defer setupVaultFlag(t, vaultDir)()

--- a/cmd/dynamic.go
+++ b/cmd/dynamic.go
@@ -78,5 +78,4 @@ func init() {
 
 	dynamicCmd.AddCommand(dynamicGenerateCmd)
 	dynamicCmd.GroupID = cli.GroupIDVault
-	rootCmd.AddCommand(dynamicCmd)
 }

--- a/cmd/edit_test.go
+++ b/cmd/edit_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	cli "github.com/danieljustus/symaira-vault/internal/cli"
 	crud "github.com/danieljustus/symaira-vault/cmd/crud"
 	"github.com/danieljustus/symaira-vault/internal/config"
 	vaultpkg "github.com/danieljustus/symaira-vault/internal/vault"
@@ -252,9 +253,9 @@ func TestEdit_ErrorPaths(t *testing.T) {
 			_ = os.Unsetenv("OPENPASS_VAULT")
 			_ = os.Unsetenv("OPENPASS_PASSPHRASE")
 			vault = ""
-			if vaultFlag != nil {
-				_ = vaultFlag.Value.Set("")
-				vaultFlag.Changed = false
+			if cli.VaultFlag != nil {
+				_ = cli.VaultFlag.Value.Set("")
+				cli.VaultFlag.Changed = false
 			}
 
 			vaultDir := tt.setupFunc()

--- a/cmd/edit_test.go
+++ b/cmd/edit_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	cli "github.com/danieljustus/symaira-vault/internal/cli"
 	crud "github.com/danieljustus/symaira-vault/cmd/crud"
+	cli "github.com/danieljustus/symaira-vault/internal/cli"
 	"github.com/danieljustus/symaira-vault/internal/config"
 	vaultpkg "github.com/danieljustus/symaira-vault/internal/vault"
 )

--- a/cmd/file/commands.go
+++ b/cmd/file/commands.go
@@ -1,0 +1,12 @@
+package file
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// NewCommands returns all file attachment commands for root command assembly.
+func NewCommands() []*cobra.Command {
+	return []*cobra.Command{
+		fileCmd,
+	}
+}

--- a/cmd/file/file.go
+++ b/cmd/file/file.go
@@ -21,5 +21,4 @@ sha256, original filename and size recorded as attachment metadata.`,
 
 func init() {
 	fileCmd.GroupID = cli.GroupIDVault
-	cli.RootCmd.AddCommand(fileCmd)
 }

--- a/cmd/flow_test.go
+++ b/cmd/flow_test.go
@@ -70,12 +70,12 @@ func TestCmdSet(t *testing.T) {
 	defer func() { _ = os.Unsetenv("OPENPASS_PASSPHRASE") }()
 
 	origVault := vault
-	origChanged := vaultFlag.Changed
+	origChanged := cli.VaultFlag.Changed
 	defer func() {
 		vault = origVault
-		if vaultFlag != nil {
-			_ = vaultFlag.Value.Set(origVault)
-			vaultFlag.Changed = origChanged
+		if cli.VaultFlag != nil {
+			_ = cli.VaultFlag.Value.Set(origVault)
+			cli.VaultFlag.Changed = origChanged
 		}
 	}()
 
@@ -102,12 +102,12 @@ func TestCmdGet(t *testing.T) {
 	defer func() { _ = os.Unsetenv("OPENPASS_PASSPHRASE") }()
 
 	origVault := vault
-	origChanged := vaultFlag.Changed
+	origChanged := cli.VaultFlag.Changed
 	defer func() {
 		vault = origVault
-		if vaultFlag != nil {
-			_ = vaultFlag.Value.Set(origVault)
-			vaultFlag.Changed = origChanged
+		if cli.VaultFlag != nil {
+			_ = cli.VaultFlag.Value.Set(origVault)
+			cli.VaultFlag.Changed = origChanged
 		}
 	}()
 
@@ -130,12 +130,12 @@ func TestCmdList(t *testing.T) {
 	defer func() { _ = os.Unsetenv("OPENPASS_PASSPHRASE") }()
 
 	origVault := vault
-	origChanged := vaultFlag.Changed
+	origChanged := cli.VaultFlag.Changed
 	defer func() {
 		vault = origVault
-		if vaultFlag != nil {
-			_ = vaultFlag.Value.Set(origVault)
-			vaultFlag.Changed = origChanged
+		if cli.VaultFlag != nil {
+			_ = cli.VaultFlag.Value.Set(origVault)
+			cli.VaultFlag.Changed = origChanged
 		}
 	}()
 
@@ -158,12 +158,12 @@ func TestCmdFind(t *testing.T) {
 	defer func() { _ = os.Unsetenv("OPENPASS_PASSPHRASE") }()
 
 	origVault := vault
-	origChanged := vaultFlag.Changed
+	origChanged := cli.VaultFlag.Changed
 	defer func() {
 		vault = origVault
-		if vaultFlag != nil {
-			_ = vaultFlag.Value.Set(origVault)
-			vaultFlag.Changed = origChanged
+		if cli.VaultFlag != nil {
+			_ = cli.VaultFlag.Value.Set(origVault)
+			cli.VaultFlag.Changed = origChanged
 		}
 	}()
 
@@ -187,12 +187,12 @@ func TestCmdGenerate(t *testing.T) {
 	defer func() { _ = os.Unsetenv("OPENPASS_PASSPHRASE") }()
 
 	origVault := vault
-	origChanged := vaultFlag.Changed
+	origChanged := cli.VaultFlag.Changed
 	defer func() {
 		vault = origVault
-		if vaultFlag != nil {
-			_ = vaultFlag.Value.Set(origVault)
-			vaultFlag.Changed = origChanged
+		if cli.VaultFlag != nil {
+			_ = cli.VaultFlag.Value.Set(origVault)
+			cli.VaultFlag.Changed = origChanged
 		}
 	}()
 
@@ -215,12 +215,12 @@ func TestCmdDelete(t *testing.T) {
 	defer func() { _ = os.Unsetenv("OPENPASS_PASSPHRASE") }()
 
 	origVault := vault
-	origChanged := vaultFlag.Changed
+	origChanged := cli.VaultFlag.Changed
 	defer func() {
 		vault = origVault
-		if vaultFlag != nil {
-			_ = vaultFlag.Value.Set(origVault)
-			vaultFlag.Changed = origChanged
+		if cli.VaultFlag != nil {
+			_ = cli.VaultFlag.Value.Set(origVault)
+			cli.VaultFlag.Changed = origChanged
 		}
 	}()
 
@@ -257,12 +257,12 @@ func TestCmdAdd(t *testing.T) {
 	defer func() { _ = os.Unsetenv("OPENPASS_PASSPHRASE") }()
 
 	origVault := vault
-	origChanged := vaultFlag.Changed
+	origChanged := cli.VaultFlag.Changed
 	defer func() {
 		vault = origVault
-		if vaultFlag != nil {
-			_ = vaultFlag.Value.Set(origVault)
-			vaultFlag.Changed = origChanged
+		if cli.VaultFlag != nil {
+			_ = cli.VaultFlag.Value.Set(origVault)
+			cli.VaultFlag.Changed = origChanged
 		}
 	}()
 
@@ -293,12 +293,12 @@ func TestCmdUnlock(t *testing.T) {
 	defer func() { _ = os.Unsetenv("OPENPASS_PASSPHRASE") }()
 
 	origVault := vault
-	origChanged := vaultFlag.Changed
+	origChanged := cli.VaultFlag.Changed
 	defer func() {
 		vault = origVault
-		if vaultFlag != nil {
-			_ = vaultFlag.Value.Set(origVault)
-			vaultFlag.Changed = origChanged
+		if cli.VaultFlag != nil {
+			_ = cli.VaultFlag.Value.Set(origVault)
+			cli.VaultFlag.Changed = origChanged
 		}
 	}()
 
@@ -323,12 +323,12 @@ func TestCmdRecipientsAddAndRemove(t *testing.T) {
 	defer func() { _ = os.Unsetenv("OPENPASS_PASSPHRASE") }()
 
 	origVault := vault
-	origChanged := vaultFlag.Changed
+	origChanged := cli.VaultFlag.Changed
 	defer func() {
 		vault = origVault
-		if vaultFlag != nil {
-			_ = vaultFlag.Value.Set(origVault)
-			vaultFlag.Changed = origChanged
+		if cli.VaultFlag != nil {
+			_ = cli.VaultFlag.Value.Set(origVault)
+			cli.VaultFlag.Changed = origChanged
 		}
 	}()
 

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -112,5 +112,4 @@ func init() {
 	generateCmd.Flags().BoolVar(&genQuiet, "quiet", false, "Suppress success output when using --store")
 	generateCmd.AddCommand(manpagesCmd)
 	generateCmd.GroupID = cli.GroupIDVault
-	rootCmd.AddCommand(generateCmd)
 }

--- a/cmd/git.go
+++ b/cmd/git.go
@@ -71,5 +71,4 @@ var gitCmd = &cobra.Command{
 
 func init() {
 	gitCmd.GroupID = cli.GroupIDSharingSync
-	rootCmd.AddCommand(gitCmd)
 }

--- a/cmd/import_test.go
+++ b/cmd/import_test.go
@@ -8,8 +8,6 @@ import (
 	"strings"
 	"testing"
 
-	cli "github.com/danieljustus/symaira-vault/internal/cli"
-
 	vaultpkg "github.com/danieljustus/symaira-vault/internal/vault"
 )
 
@@ -129,12 +127,12 @@ func runImportCommand(t *testing.T, passphrase string, args ...string) string {
 	if err := os.Setenv("OPENPASS_PASSPHRASE", passphrase); err != nil {
 		t.Fatalf("set passphrase env: %v", err)
 	}
-	cli.RootCmd.SetArgs(args)
-	defer cli.RootCmd.SetArgs(nil)
+	rootCmd.SetArgs(args)
+	defer rootCmd.SetArgs(nil)
 
 	var execErr error
 	output := captureStdout(func() {
-		execErr = cli.RootCmd.Execute()
+		execErr = rootCmd.Execute()
 	})
 	if execErr != nil {
 		t.Fatalf("import command failed: %v", execErr)
@@ -204,12 +202,12 @@ func TestImportQuarantineMutualExclusion(t *testing.T) {
 	if err := os.Setenv("OPENPASS_PASSPHRASE", string(passphrase)); err != nil {
 		t.Fatalf("set passphrase env: %v", err)
 	}
-	cli.RootCmd.SetArgs([]string{"--vault", vaultDir, "import", "--format", "csv", csvImportFixture(t), "--quarantine", "--prefix", "myprefix/"})
-	defer cli.RootCmd.SetArgs(nil)
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "import", "--format", "csv", csvImportFixture(t), "--quarantine", "--prefix", "myprefix/"})
+	defer rootCmd.SetArgs(nil)
 
 	var execErr error
 	captureStdout(func() {
-		execErr = cli.RootCmd.Execute()
+		execErr = rootCmd.Execute()
 	})
 	if execErr == nil {
 		t.Fatal("expected error combining --quarantine and --prefix, got nil")
@@ -227,12 +225,12 @@ func TestImportQuarantinePath(t *testing.T) {
 	if err := os.Setenv("OPENPASS_PASSPHRASE", string(passphrase)); err != nil {
 		t.Fatalf("set passphrase env: %v", err)
 	}
-	cli.RootCmd.SetArgs([]string{"--vault", vaultDir, "import", "--format", "csv", csvImportFixture(t), "--quarantine"})
-	defer cli.RootCmd.SetArgs(nil)
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "import", "--format", "csv", csvImportFixture(t), "--quarantine"})
+	defer rootCmd.SetArgs(nil)
 
 	var execErr error
 	output := captureStdout(func() {
-		execErr = cli.RootCmd.Execute()
+		execErr = rootCmd.Execute()
 	})
 	if execErr != nil {
 		t.Fatalf("import --quarantine failed: %v", execErr)
@@ -272,12 +270,12 @@ func TestImportReviewListEmpty(t *testing.T) {
 	if err := os.Setenv("OPENPASS_PASSPHRASE", string(passphrase)); err != nil {
 		t.Fatalf("set passphrase env: %v", err)
 	}
-	cli.RootCmd.SetArgs([]string{"--vault", vaultDir, "import", "review", "list"})
-	defer cli.RootCmd.SetArgs(nil)
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "import", "review", "list"})
+	defer rootCmd.SetArgs(nil)
 
 	var execErr error
 	output := captureStdout(func() {
-		execErr = cli.RootCmd.Execute()
+		execErr = rootCmd.Execute()
 	})
 	if execErr != nil {
 		t.Fatalf("import review list failed: %v", execErr)
@@ -296,13 +294,13 @@ func TestImportReviewList(t *testing.T) {
 	if err := os.Setenv("OPENPASS_PASSPHRASE", string(passphrase)); err != nil {
 		t.Fatalf("set passphrase env: %v", err)
 	}
-	cli.RootCmd.SetArgs([]string{"--vault", vaultDir, "import", "--format", "csv", csvImportFixture(t), "--quarantine"})
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "import", "--format", "csv", csvImportFixture(t), "--quarantine"})
 	var importOutput string
 	var importErr error
 	importOutput = captureStdout(func() {
-		importErr = cli.RootCmd.Execute()
+		importErr = rootCmd.Execute()
 	})
-	cli.RootCmd.SetArgs(nil)
+	rootCmd.SetArgs(nil)
 	if importErr != nil {
 		t.Fatalf("quarantine import failed: %v", importErr)
 	}
@@ -324,12 +322,12 @@ func TestImportReviewList(t *testing.T) {
 	}
 
 	// Now run review list
-	cli.RootCmd.SetArgs([]string{"--vault", vaultDir, "import", "review", "list"})
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "import", "review", "list"})
 	var listErr error
 	listOutput := captureStdout(func() {
-		listErr = cli.RootCmd.Execute()
+		listErr = rootCmd.Execute()
 	})
-	cli.RootCmd.SetArgs(nil)
+	rootCmd.SetArgs(nil)
 	if listErr != nil {
 		t.Fatalf("import review list failed: %v", listErr)
 	}
@@ -350,13 +348,13 @@ func TestImportReviewPromote(t *testing.T) {
 	if err := os.Setenv("OPENPASS_PASSPHRASE", string(passphrase)); err != nil {
 		t.Fatalf("set passphrase env: %v", err)
 	}
-	cli.RootCmd.SetArgs([]string{"--vault", vaultDir, "import", "--format", "csv", csvImportFixture(t), "--quarantine"})
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "import", "--format", "csv", csvImportFixture(t), "--quarantine"})
 	var importOutput string
 	var importErr error
 	importOutput = captureStdout(func() {
-		importErr = cli.RootCmd.Execute()
+		importErr = rootCmd.Execute()
 	})
-	cli.RootCmd.SetArgs(nil)
+	rootCmd.SetArgs(nil)
 	if importErr != nil {
 		t.Fatalf("quarantine import failed: %v", importErr)
 	}
@@ -378,12 +376,12 @@ func TestImportReviewPromote(t *testing.T) {
 	}
 
 	// Promote
-	cli.RootCmd.SetArgs([]string{"--vault", vaultDir, "import", "review", "promote", importID})
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "import", "review", "promote", importID})
 	var promoteErr error
 	promoteOutput := captureStdout(func() {
-		promoteErr = cli.RootCmd.Execute()
+		promoteErr = rootCmd.Execute()
 	})
-	cli.RootCmd.SetArgs(nil)
+	rootCmd.SetArgs(nil)
 	if promoteErr != nil {
 		t.Fatalf("import review promote failed: %v", promoteErr)
 	}
@@ -418,13 +416,13 @@ func TestImportReviewPromoteSkipsExisting(t *testing.T) {
 	if err := os.Setenv("OPENPASS_PASSPHRASE", string(passphrase)); err != nil {
 		t.Fatalf("set passphrase env: %v", err)
 	}
-	cli.RootCmd.SetArgs([]string{"--vault", vaultDir, "import", "--format", "csv", csvImportFixture(t), "--quarantine"})
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "import", "--format", "csv", csvImportFixture(t), "--quarantine"})
 	var importOutput string
 	var importErr error
 	importOutput = captureStdout(func() {
-		importErr = cli.RootCmd.Execute()
+		importErr = rootCmd.Execute()
 	})
-	cli.RootCmd.SetArgs(nil)
+	rootCmd.SetArgs(nil)
 	if importErr != nil {
 		t.Fatalf("quarantine import failed: %v", importErr)
 	}
@@ -455,12 +453,12 @@ func TestImportReviewPromoteSkipsExisting(t *testing.T) {
 	}
 
 	// Promote WITHOUT --overwrite — should fail
-	cli.RootCmd.SetArgs([]string{"--vault", vaultDir, "import", "review", "promote", importID})
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "import", "review", "promote", importID})
 	var promoteErr error
 	promoteOutput := captureStdout(func() {
-		promoteErr = cli.RootCmd.Execute()
+		promoteErr = rootCmd.Execute()
 	})
-	cli.RootCmd.SetArgs(nil)
+	rootCmd.SetArgs(nil)
 	if promoteErr == nil {
 		t.Fatal("expected error when destination already exists without --overwrite, got nil")
 	}
@@ -489,13 +487,13 @@ func TestImportReviewPromoteOverwrite(t *testing.T) {
 	if err := os.Setenv("OPENPASS_PASSPHRASE", string(passphrase)); err != nil {
 		t.Fatalf("set passphrase env: %v", err)
 	}
-	cli.RootCmd.SetArgs([]string{"--vault", vaultDir, "import", "--format", "csv", csvImportFixture(t), "--quarantine"})
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "import", "--format", "csv", csvImportFixture(t), "--quarantine"})
 	var importOutput string
 	var importErr error
 	importOutput = captureStdout(func() {
-		importErr = cli.RootCmd.Execute()
+		importErr = rootCmd.Execute()
 	})
-	cli.RootCmd.SetArgs(nil)
+	rootCmd.SetArgs(nil)
 	if importErr != nil {
 		t.Fatalf("quarantine import failed: %v", importErr)
 	}
@@ -527,12 +525,12 @@ func TestImportReviewPromoteOverwrite(t *testing.T) {
 	}
 
 	// Promote WITH --overwrite — should succeed
-	cli.RootCmd.SetArgs([]string{"--vault", vaultDir, "import", "review", "promote", importID, "--overwrite"})
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "import", "review", "promote", importID, "--overwrite"})
 	var promoteErr error
 	captureStdout(func() {
-		promoteErr = cli.RootCmd.Execute()
+		promoteErr = rootCmd.Execute()
 	})
-	cli.RootCmd.SetArgs(nil)
+	rootCmd.SetArgs(nil)
 	if promoteErr != nil {
 		t.Fatalf("import review promote --overwrite failed: %v", promoteErr)
 	}
@@ -565,12 +563,12 @@ func TestImportReviewPromoteNotFound(t *testing.T) {
 		t.Fatalf("set passphrase env: %v", err)
 	}
 
-	cli.RootCmd.SetArgs([]string{"--vault", vaultDir, "import", "review", "promote", "import-00000000-deadbeef"})
-	defer cli.RootCmd.SetArgs(nil)
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "import", "review", "promote", "import-00000000-deadbeef"})
+	defer rootCmd.SetArgs(nil)
 
 	var execErr error
 	captureStdout(func() {
-		execErr = cli.RootCmd.Execute()
+		execErr = rootCmd.Execute()
 	})
 	if execErr == nil {
 		t.Fatal("expected error for unknown import-id, got nil")

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -20,11 +20,11 @@ func TestInitCommand_HiddenPassphrase(t *testing.T) {
 	cli.SetCachedEnvPassphrase(passphrase)
 	defer cli.SetCachedEnvPassphrase(nil)
 
-	cli.RootCmd.SetArgs([]string{"init", vaultDir})
-	defer cli.RootCmd.SetArgs(nil)
+	rootCmd.SetArgs([]string{"init", vaultDir})
+	defer rootCmd.SetArgs(nil)
 
 	output := captureStdout(func() {
-		if err := cli.RootCmd.Execute(); err != nil {
+		if err := rootCmd.Execute(); err != nil {
 			t.Fatalf("init command failed: %v", err)
 		}
 	})
@@ -61,11 +61,11 @@ func TestCmdInit_Success(t *testing.T) {
 	cli.SetCachedEnvPassphrase([]byte("supersecretpassphrase123"))
 	defer cli.SetCachedEnvPassphrase(nil)
 
-	cli.RootCmd.SetArgs([]string{"--vault", vaultDir, "init"})
-	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "init"})
+	t.Cleanup(func() { rootCmd.SetArgs(nil) })
 
 	output := captureStdout(func() {
-		_ = cli.RootCmd.Execute()
+		_ = rootCmd.Execute()
 	})
 
 	if !strings.Contains(output, "Vault initialized") {
@@ -84,12 +84,12 @@ func TestCmdInit_AlreadyInitialized(t *testing.T) {
 	cli.SetCachedEnvPassphrase([]byte("supersecretpassphrase123"))
 	defer cli.SetCachedEnvPassphrase(nil)
 
-	cli.RootCmd.SetArgs([]string{"--vault", vaultDir, "init"})
-	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "init"})
+	t.Cleanup(func() { rootCmd.SetArgs(nil) })
 
 	var execErr error
 	captureStderr(func() {
-		execErr = cli.RootCmd.Execute()
+		execErr = rootCmd.Execute()
 	})
 
 	if execErr == nil {
@@ -107,12 +107,12 @@ func TestCmdInit_ShortPassphrase(t *testing.T) {
 	cli.SetCachedEnvPassphrase([]byte("short"))
 	defer cli.SetCachedEnvPassphrase(nil)
 
-	cli.RootCmd.SetArgs([]string{"--vault", vaultDir, "init"})
-	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "init"})
+	t.Cleanup(func() { rootCmd.SetArgs(nil) })
 
 	var execErr error
 	captureStderr(func() {
-		execErr = cli.RootCmd.Execute()
+		execErr = rootCmd.Execute()
 	})
 
 	if execErr == nil {
@@ -133,10 +133,10 @@ func TestInit_ErrorPaths(t *testing.T) {
 		cli.SetCachedEnvPassphrase([]byte("test"))
 		defer cli.SetCachedEnvPassphrase(nil)
 
-		cli.RootCmd.SetArgs([]string{"--vault", tmpDir, "init"})
-		defer cli.RootCmd.SetArgs(nil)
+		rootCmd.SetArgs([]string{"--vault", tmpDir, "init"})
+		defer rootCmd.SetArgs(nil)
 
-		err := cli.RootCmd.Execute()
+		err := rootCmd.Execute()
 		if err == nil || !strings.Contains(err.Error(), "already initialized") {
 			t.Errorf("expected 'already initialized' error, got: %v", err)
 		}

--- a/cmd/mcp/agent.go
+++ b/cmd/mcp/agent.go
@@ -171,5 +171,4 @@ func outputAgentMCPSnippet(name, rawToken string) {
 func init() {
 	agentCmd.AddCommand(agentSetupCmd)
 	agentCmd.GroupID = cli.GroupIDAgentsMCP
-	cli.RootCmd.AddCommand(agentCmd)
 }

--- a/cmd/mcp/commands.go
+++ b/cmd/mcp/commands.go
@@ -1,0 +1,16 @@
+package mcp
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// NewCommands returns all MCP and agent commands for root command assembly.
+func NewCommands() []*cobra.Command {
+	return []*cobra.Command{
+		agentCmd,
+		McpConfigCmd,
+		mcpTokenRotateCmd,
+		mcpCmd,
+		ServeCmd,
+	}
+}

--- a/cmd/mcp/mcp_config.go
+++ b/cmd/mcp/mcp_config.go
@@ -315,9 +315,7 @@ func OutputAgentHTTPConfig(agentName, serverKey, displayName string, redact bool
 
 func init() {
 	McpConfigCmd.GroupID = cli.GroupIDAgentsMCP
-	cli.RootCmd.AddCommand(McpConfigCmd)
 	mcpTokenRotateCmd.GroupID = cli.GroupIDAgentsMCP
-	cli.RootCmd.AddCommand(mcpTokenRotateCmd)
 }
 
 func OutputTokenOnly() error {

--- a/cmd/mcp/mcp_token.go
+++ b/cmd/mcp/mcp_token.go
@@ -136,7 +136,6 @@ func parseDurationNumber(s string) (int, error) {
 
 func init() {
 	mcpCmd.GroupID = cli.GroupIDAgentsMCP
-	cli.RootCmd.AddCommand(mcpCmd)
 	mcpCmd.AddCommand(McpTokenCmd)
 	McpTokenCmd.AddCommand(TokenCreateCmd)
 	McpTokenCmd.AddCommand(tokenListCmd)

--- a/cmd/mcp/serve.go
+++ b/cmd/mcp/serve.go
@@ -47,7 +47,6 @@ var ServeCmd = &cobra.Command{
 
 func init() {
 	ServeCmd.GroupID = cli.GroupIDAgentsMCP
-	cli.RootCmd.AddCommand(ServeCmd)
 	ServeCmd.Flags().String("agent", "", "Agent name (required for --stdio; HTTP mode resolves agents per-request via X-Symaira-Agent header)")
 	ServeCmd.Flags().Int("port", 8080, "Server port")
 	ServeCmd.Flags().Bool("stdio", false, "Enable stdio transport (for MCP)")

--- a/cmd/mcp_config_test.go
+++ b/cmd/mcp_config_test.go
@@ -336,17 +336,17 @@ func TestOutputHTTPConfig_VaultPathError(t *testing.T) {
 	origHome := os.Getenv("HOME")
 	origVaultEnv := os.Getenv("OPENPASS_VAULT")
 	origVault := vault
-	origChanged := vaultFlag.Changed
+	origChanged := cli.VaultFlag.Changed
 	_ = os.Unsetenv("HOME")
 	_ = os.Unsetenv("OPENPASS_VAULT")
 	vault = "~/" + config.DefaultVaultSubdir
-	vaultFlag.Changed = false
+	cli.VaultFlag.Changed = false
 	t.Cleanup(func() {
 		_ = os.Setenv("HOME", origHome)
 		_ = os.Setenv("OPENPASS_VAULT", origVaultEnv)
 		vault = origVault
-		_ = vaultFlag.Value.Set(origVault)
-		vaultFlag.Changed = origChanged
+		_ = cli.VaultFlag.Value.Set(origVault)
+		cli.VaultFlag.Changed = origChanged
 	})
 
 	err := mcpcmd.OutputHTTPConfig("test-agent", "symvault", true, "")

--- a/cmd/mcp_config_test.go
+++ b/cmd/mcp_config_test.go
@@ -246,10 +246,10 @@ func TestCmdMCPConfig_HTTPMode(t *testing.T) {
 func TestCmdMCPConfig_Stdio(t *testing.T) {
 	vaultFlagReset(t)
 
-	cli.RootCmd.SetArgs([]string{"mcp-config", "myagent"})
-	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
+	rootCmd.SetArgs([]string{"mcp-config", "myagent"})
+	t.Cleanup(func() { rootCmd.SetArgs(nil) })
 
-	err := cli.RootCmd.Execute()
+	err := rootCmd.Execute()
 
 	if err == nil {
 		t.Fatal("expected deprecation error")
@@ -266,10 +266,10 @@ func TestCmdMCPConfig_StdioCustomVaultIncludesVaultArg(t *testing.T) {
 	vaultDir := t.TempDir()
 	vaultFlagReset(t)
 
-	cli.RootCmd.SetArgs([]string{"--vault", vaultDir, "mcp-config", "myagent"})
-	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "mcp-config", "myagent"})
+	t.Cleanup(func() { rootCmd.SetArgs(nil) })
 
-	err := cli.RootCmd.Execute()
+	err := rootCmd.Execute()
 
 	if err == nil {
 		t.Fatal("expected deprecation error")
@@ -290,10 +290,10 @@ func TestCmdMCPConfig_HTTP(t *testing.T) {
 		t.Fatalf("init vault: %v", err)
 	}
 
-	cli.RootCmd.SetArgs([]string{"--vault", vaultDir, "mcp-config", "myagent"})
-	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "mcp-config", "myagent"})
+	t.Cleanup(func() { rootCmd.SetArgs(nil) })
 
-	err := cli.RootCmd.Execute()
+	err := rootCmd.Execute()
 
 	if err == nil {
 		t.Fatal("expected deprecation error")
@@ -314,10 +314,10 @@ func TestCmdMCPConfig_HermesHTTP(t *testing.T) {
 		t.Fatalf("write config: %v", err)
 	}
 
-	cli.RootCmd.SetArgs([]string{"--vault", vaultDir, "mcp-config", "hermes"})
-	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "mcp-config", "hermes"})
+	t.Cleanup(func() { rootCmd.SetArgs(nil) })
 
-	err := cli.RootCmd.Execute()
+	err := rootCmd.Execute()
 
 	if err == nil {
 		t.Fatal("expected deprecation error")
@@ -331,7 +331,7 @@ func TestOutputHTTPConfig_VaultPathError(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("skipping on windows: HOME env behavior differs")
 	}
-	// Test mcpcmd.OutputHTTPConfig directly (bypassing cli.RootCmd which has PersistentPreRun
+	// Test mcpcmd.OutputHTTPConfig directly (bypassing rootCmd which has PersistentPreRun
 	// that also calls cli.VaultPath, causing a panic before our function is reached).
 	origHome := os.Getenv("HOME")
 	origVaultEnv := os.Getenv("OPENPASS_VAULT")
@@ -370,10 +370,10 @@ func TestOutputHTTPConfig_CustomTokenFile(t *testing.T) {
 		t.Fatalf("write config: %v", err)
 	}
 
-	cli.RootCmd.SetArgs([]string{"--vault", vaultDir, "mcp-config", "myagent"})
-	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "mcp-config", "myagent"})
+	t.Cleanup(func() { rootCmd.SetArgs(nil) })
 
-	err := cli.RootCmd.Execute()
+	err := rootCmd.Execute()
 
 	if err == nil {
 		t.Fatal("expected deprecation error")
@@ -382,8 +382,8 @@ func TestOutputHTTPConfig_CustomTokenFile(t *testing.T) {
 		t.Errorf("expected deprecation message, got: %v", err)
 	}
 
-	cli.RootCmd.SetArgs([]string{"--vault", vaultDir, "mcp-config", "myagent"})
-	err = cli.RootCmd.Execute()
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "mcp-config", "myagent"})
+	err = rootCmd.Execute()
 
 	if err == nil {
 		t.Fatal("expected deprecation error")
@@ -402,10 +402,10 @@ func TestOutputHTTPConfig_TokenLoadError(t *testing.T) {
 		t.Fatalf("write config: %v", err)
 	}
 
-	cli.RootCmd.SetArgs([]string{"--vault", vaultDir, "mcp-config", "myagent"})
-	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "mcp-config", "myagent"})
+	t.Cleanup(func() { rootCmd.SetArgs(nil) })
 
-	err := cli.RootCmd.Execute()
+	err := rootCmd.Execute()
 
 	if err == nil {
 		t.Fatal("expected deprecation error")
@@ -423,10 +423,10 @@ func TestOutputHTTPConfig_StaleRuntimePort(t *testing.T) {
 		t.Fatalf("save runtime port: %v", err)
 	}
 
-	cli.RootCmd.SetArgs([]string{"--vault", vaultDir, "mcp-config", "myagent"})
-	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "mcp-config", "myagent"})
+	t.Cleanup(func() { rootCmd.SetArgs(nil) })
 
-	err := cli.RootCmd.Execute()
+	err := rootCmd.Execute()
 
 	if err == nil {
 		t.Fatal("expected deprecation error")

--- a/cmd/mcp_token_test.go
+++ b/cmd/mcp_token_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 	"time"
 
-	cli "github.com/danieljustus/symaira-vault/internal/cli"
-
 	mcpcmd "github.com/danieljustus/symaira-vault/cmd/mcp"
 	"github.com/danieljustus/symaira-vault/internal/config"
 	auth "github.com/danieljustus/symaira-vault/internal/mcp/auth"
@@ -47,12 +45,12 @@ func TestMCPTokenCreate_Defaults(t *testing.T) {
 	}
 
 	vaultFlagReset(t)
-	t.Cleanup(func() { resetCobraCommand(cli.RootCmd) })
+	t.Cleanup(func() { resetCobraCommand(rootCmd) })
 
-	cli.RootCmd.SetArgs([]string{"--vault", vaultDir, "mcp", "token", "create"})
-	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "mcp", "token", "create"})
+	t.Cleanup(func() { rootCmd.SetArgs(nil) })
 
-	err := cli.RootCmd.Execute()
+	err := rootCmd.Execute()
 
 	if err == nil {
 		t.Fatal("expected deprecation error")
@@ -76,15 +74,15 @@ func TestMCPTokenCreate_WithToolsAndAgent(t *testing.T) {
 	}
 
 	vaultFlagReset(t)
-	t.Cleanup(func() { resetCobraCommand(cli.RootCmd) })
+	t.Cleanup(func() { resetCobraCommand(rootCmd) })
 
-	cli.RootCmd.SetArgs([]string{
+	rootCmd.SetArgs([]string{
 		"--vault", vaultDir,
 		"mcp", "token", "create",
 	})
-	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
+	t.Cleanup(func() { rootCmd.SetArgs(nil) })
 
-	err := cli.RootCmd.Execute()
+	err := rootCmd.Execute()
 
 	if err == nil {
 		t.Fatal("expected deprecation error")
@@ -108,15 +106,15 @@ func TestMCPTokenCreate_MultipleToolFlags(t *testing.T) {
 	}
 
 	vaultFlagReset(t)
-	t.Cleanup(func() { resetCobraCommand(cli.RootCmd) })
+	t.Cleanup(func() { resetCobraCommand(rootCmd) })
 
-	cli.RootCmd.SetArgs([]string{
+	rootCmd.SetArgs([]string{
 		"--vault", vaultDir,
 		"mcp", "token", "create",
 	})
-	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
+	t.Cleanup(func() { rootCmd.SetArgs(nil) })
 
-	err := cli.RootCmd.Execute()
+	err := rootCmd.Execute()
 
 	if err == nil {
 		t.Fatal("expected deprecation error")
@@ -140,15 +138,15 @@ func TestMCPTokenCreate_WithTTL(t *testing.T) {
 	}
 
 	vaultFlagReset(t)
-	t.Cleanup(func() { resetCobraCommand(cli.RootCmd) })
+	t.Cleanup(func() { resetCobraCommand(rootCmd) })
 
-	cli.RootCmd.SetArgs([]string{
+	rootCmd.SetArgs([]string{
 		"--vault", vaultDir,
 		"mcp", "token", "create",
 	})
-	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
+	t.Cleanup(func() { rootCmd.SetArgs(nil) })
 
-	err := cli.RootCmd.Execute()
+	err := rootCmd.Execute()
 
 	if err == nil {
 		t.Fatal("expected deprecation error")
@@ -175,15 +173,15 @@ func TestMCPTokenCreate_DefaultTTLFromConfig(t *testing.T) {
 	}
 
 	vaultFlagReset(t)
-	t.Cleanup(func() { resetCobraCommand(cli.RootCmd) })
+	t.Cleanup(func() { resetCobraCommand(rootCmd) })
 
-	cli.RootCmd.SetArgs([]string{
+	rootCmd.SetArgs([]string{
 		"--vault", vaultDir,
 		"mcp", "token", "create",
 	})
-	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
+	t.Cleanup(func() { rootCmd.SetArgs(nil) })
 
-	err := cli.RootCmd.Execute()
+	err := rootCmd.Execute()
 
 	if err == nil {
 		t.Fatal("expected deprecation error")
@@ -207,15 +205,15 @@ func TestMCPTokenCreate_InvalidTTL(t *testing.T) {
 	}
 
 	vaultFlagReset(t)
-	t.Cleanup(func() { resetCobraCommand(cli.RootCmd) })
+	t.Cleanup(func() { resetCobraCommand(rootCmd) })
 
-	cli.RootCmd.SetArgs([]string{
+	rootCmd.SetArgs([]string{
 		"--vault", vaultDir,
 		"mcp", "token", "create",
 	})
-	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
+	t.Cleanup(func() { rootCmd.SetArgs(nil) })
 
-	err := cli.RootCmd.Execute()
+	err := rootCmd.Execute()
 
 	if err == nil {
 		t.Fatal("expected deprecation error")
@@ -239,14 +237,14 @@ func TestMCPTokenCreate_VaultPathError(t *testing.T) {
 	defer func() { vault = origVault }()
 
 	vaultFlagReset(t)
-	t.Cleanup(func() { resetCobraCommand(cli.RootCmd) })
+	t.Cleanup(func() { resetCobraCommand(rootCmd) })
 
-	cli.RootCmd.SetArgs([]string{"mcp", "token", "create"})
-	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
+	rootCmd.SetArgs([]string{"mcp", "token", "create"})
+	t.Cleanup(func() { rootCmd.SetArgs(nil) })
 
 	var execErr error
 	captureStderr(func() {
-		execErr = cli.RootCmd.Execute()
+		execErr = rootCmd.Execute()
 	})
 
 	if execErr == nil {
@@ -268,12 +266,12 @@ func TestMCPTokenList_Empty(t *testing.T) {
 	}
 
 	vaultFlagReset(t)
-	t.Cleanup(func() { resetCobraCommand(cli.RootCmd) })
+	t.Cleanup(func() { resetCobraCommand(rootCmd) })
 
-	cli.RootCmd.SetArgs([]string{"--vault", vaultDir, "mcp", "token", "list"})
-	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "mcp", "token", "list"})
+	t.Cleanup(func() { rootCmd.SetArgs(nil) })
 
-	err := cli.RootCmd.Execute()
+	err := rootCmd.Execute()
 
 	if err == nil {
 		t.Fatal("expected deprecation error")
@@ -309,12 +307,12 @@ func TestMCPTokenList_WithTokens(t *testing.T) {
 	}
 
 	vaultFlagReset(t)
-	t.Cleanup(func() { resetCobraCommand(cli.RootCmd) })
+	t.Cleanup(func() { resetCobraCommand(rootCmd) })
 
-	cli.RootCmd.SetArgs([]string{"--vault", vaultDir, "mcp", "token", "list"})
-	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "mcp", "token", "list"})
+	t.Cleanup(func() { rootCmd.SetArgs(nil) })
 
-	err = cli.RootCmd.Execute()
+	err = rootCmd.Execute()
 
 	if err == nil {
 		t.Fatal("expected deprecation error")
@@ -350,12 +348,12 @@ func TestMCPTokenRevoke_Success(t *testing.T) {
 	}
 
 	vaultFlagReset(t)
-	t.Cleanup(func() { resetCobraCommand(cli.RootCmd) })
+	t.Cleanup(func() { resetCobraCommand(rootCmd) })
 
-	cli.RootCmd.SetArgs([]string{"--vault", vaultDir, "mcp", "token", "revoke", token.ID})
-	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "mcp", "token", "revoke", token.ID})
+	t.Cleanup(func() { rootCmd.SetArgs(nil) })
 
-	err = cli.RootCmd.Execute()
+	err = rootCmd.Execute()
 
 	if err == nil {
 		t.Fatal("expected deprecation error")
@@ -378,12 +376,12 @@ func TestMCPTokenRevoke_NotFound(t *testing.T) {
 	}
 
 	vaultFlagReset(t)
-	t.Cleanup(func() { resetCobraCommand(cli.RootCmd) })
+	t.Cleanup(func() { resetCobraCommand(rootCmd) })
 
-	cli.RootCmd.SetArgs([]string{"--vault", vaultDir, "mcp", "token", "revoke", "nonexistent-id"})
-	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "mcp", "token", "revoke", "nonexistent-id"})
+	t.Cleanup(func() { rootCmd.SetArgs(nil) })
 
-	err := cli.RootCmd.Execute()
+	err := rootCmd.Execute()
 
 	if err == nil {
 		t.Fatal("expected deprecation error")
@@ -419,12 +417,12 @@ func TestMCPTokenRevoke_DoubleRevoke(t *testing.T) {
 	}
 
 	vaultFlagReset(t)
-	t.Cleanup(func() { resetCobraCommand(cli.RootCmd) })
+	t.Cleanup(func() { resetCobraCommand(rootCmd) })
 
-	cli.RootCmd.SetArgs([]string{"--vault", vaultDir, "mcp", "token", "revoke", token.ID})
-	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "mcp", "token", "revoke", token.ID})
+	t.Cleanup(func() { rootCmd.SetArgs(nil) })
 
-	err = cli.RootCmd.Execute()
+	err = rootCmd.Execute()
 	if err == nil {
 		t.Fatal("expected deprecation error on first revoke")
 	}
@@ -432,8 +430,8 @@ func TestMCPTokenRevoke_DoubleRevoke(t *testing.T) {
 		t.Errorf("expected deprecation message on first revoke, got: %v", err)
 	}
 
-	cli.RootCmd.SetArgs([]string{"--vault", vaultDir, "mcp", "token", "revoke", token.ID})
-	err = cli.RootCmd.Execute()
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "mcp", "token", "revoke", token.ID})
+	err = rootCmd.Execute()
 	if err == nil {
 		t.Fatal("expected deprecation error on second revoke")
 	}
@@ -469,12 +467,12 @@ func TestMCPTokenList_RevokedToken(t *testing.T) {
 	}
 
 	vaultFlagReset(t)
-	t.Cleanup(func() { resetCobraCommand(cli.RootCmd) })
+	t.Cleanup(func() { resetCobraCommand(rootCmd) })
 
-	cli.RootCmd.SetArgs([]string{"--vault", vaultDir, "mcp", "token", "list"})
-	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "mcp", "token", "list"})
+	t.Cleanup(func() { rootCmd.SetArgs(nil) })
 
-	err = cli.RootCmd.Execute()
+	err = rootCmd.Execute()
 
 	if err == nil {
 		t.Fatal("expected deprecation error")
@@ -560,15 +558,15 @@ func TestMCPTokenCreate_ZeroTTL(t *testing.T) {
 	}
 
 	vaultFlagReset(t)
-	t.Cleanup(func() { resetCobraCommand(cli.RootCmd) })
+	t.Cleanup(func() { resetCobraCommand(rootCmd) })
 
-	cli.RootCmd.SetArgs([]string{
+	rootCmd.SetArgs([]string{
 		"--vault", vaultDir,
 		"mcp", "token", "create",
 	})
-	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
+	t.Cleanup(func() { rootCmd.SetArgs(nil) })
 
-	err := cli.RootCmd.Execute()
+	err := rootCmd.Execute()
 
 	if err == nil {
 		t.Fatal("expected deprecation error")
@@ -610,12 +608,12 @@ func TestMCPTokenList_ExpiredTokenExcluded(t *testing.T) {
 	time.Sleep(5 * time.Millisecond)
 
 	vaultFlagReset(t)
-	t.Cleanup(func() { resetCobraCommand(cli.RootCmd) })
+	t.Cleanup(func() { resetCobraCommand(rootCmd) })
 
-	cli.RootCmd.SetArgs([]string{"--vault", vaultDir, "mcp", "token", "list"})
-	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "mcp", "token", "list"})
+	t.Cleanup(func() { rootCmd.SetArgs(nil) })
 
-	err = cli.RootCmd.Execute()
+	err = rootCmd.Execute()
 
 	if err == nil {
 		t.Fatal("expected deprecation error")
@@ -639,15 +637,15 @@ func TestMCPTokenCreate_PreservesInRegistry(t *testing.T) {
 	}
 
 	vaultFlagReset(t)
-	t.Cleanup(func() { resetCobraCommand(cli.RootCmd) })
+	t.Cleanup(func() { resetCobraCommand(rootCmd) })
 
-	cli.RootCmd.SetArgs([]string{
+	rootCmd.SetArgs([]string{
 		"--vault", vaultDir,
 		"mcp", "token", "create",
 	})
-	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
+	t.Cleanup(func() { rootCmd.SetArgs(nil) })
 
-	err := cli.RootCmd.Execute()
+	err := rootCmd.Execute()
 
 	if err == nil {
 		t.Fatal("expected deprecation error")
@@ -670,14 +668,14 @@ func TestMCPTokenRevoke_MissingArg(t *testing.T) {
 	}
 
 	vaultFlagReset(t)
-	t.Cleanup(func() { resetCobraCommand(cli.RootCmd) })
+	t.Cleanup(func() { resetCobraCommand(rootCmd) })
 
-	cli.RootCmd.SetArgs([]string{"--vault", vaultDir, "mcp", "token", "revoke"})
-	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "mcp", "token", "revoke"})
+	t.Cleanup(func() { rootCmd.SetArgs(nil) })
 
 	var execErr error
 	captureStderr(func() {
-		execErr = cli.RootCmd.Execute()
+		execErr = rootCmd.Execute()
 	})
 
 	if execErr == nil {
@@ -716,12 +714,12 @@ func TestMCPTokenCreate_ToolsLongOutput(t *testing.T) {
 	}
 
 	vaultFlagReset(t)
-	t.Cleanup(func() { resetCobraCommand(cli.RootCmd) })
+	t.Cleanup(func() { resetCobraCommand(rootCmd) })
 
-	cli.RootCmd.SetArgs([]string{"--vault", vaultDir, "mcp", "token", "list"})
-	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "mcp", "token", "list"})
+	t.Cleanup(func() { rootCmd.SetArgs(nil) })
 
-	err = cli.RootCmd.Execute()
+	err = rootCmd.Execute()
 
 	if err == nil {
 		t.Fatal("expected deprecation error")
@@ -758,12 +756,12 @@ func TestMCPTokenList_HeaderFormat(t *testing.T) {
 	}
 
 	vaultFlagReset(t)
-	t.Cleanup(func() { resetCobraCommand(cli.RootCmd) })
+	t.Cleanup(func() { resetCobraCommand(rootCmd) })
 
-	cli.RootCmd.SetArgs([]string{"--vault", vaultDir, "mcp", "token", "list"})
-	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "mcp", "token", "list"})
+	t.Cleanup(func() { rootCmd.SetArgs(nil) })
 
-	err = cli.RootCmd.Execute()
+	err = rootCmd.Execute()
 
 	if err == nil {
 		t.Fatal("expected deprecation error")
@@ -775,7 +773,7 @@ func TestMCPTokenList_HeaderFormat(t *testing.T) {
 
 func TestMCPCmdRegistration(t *testing.T) {
 	found := false
-	for _, c := range cli.RootCmd.Commands() {
+	for _, c := range rootCmd.Commands() {
 		if c.Name() == "mcp" {
 			found = true
 			break
@@ -801,15 +799,15 @@ func TestMCPTokenCreate_NegativeDayTTL(t *testing.T) {
 	}
 
 	vaultFlagReset(t)
-	t.Cleanup(func() { resetCobraCommand(cli.RootCmd) })
+	t.Cleanup(func() { resetCobraCommand(rootCmd) })
 
-	cli.RootCmd.SetArgs([]string{
+	rootCmd.SetArgs([]string{
 		"--vault", vaultDir,
 		"mcp", "token", "create",
 	})
-	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
+	t.Cleanup(func() { rootCmd.SetArgs(nil) })
 
-	err := cli.RootCmd.Execute()
+	err := rootCmd.Execute()
 
 	if err == nil {
 		t.Fatal("expected deprecation error")
@@ -835,15 +833,15 @@ func TestMCPTokenCreate_RegistryFilePermissions(t *testing.T) {
 	}
 
 	vaultFlagReset(t)
-	t.Cleanup(func() { resetCobraCommand(cli.RootCmd) })
+	t.Cleanup(func() { resetCobraCommand(rootCmd) })
 
-	cli.RootCmd.SetArgs([]string{
+	rootCmd.SetArgs([]string{
 		"--vault", vaultDir,
 		"mcp", "token", "create",
 	})
-	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
+	t.Cleanup(func() { rootCmd.SetArgs(nil) })
 
-	err := cli.RootCmd.Execute()
+	err := rootCmd.Execute()
 
 	if err == nil {
 		t.Fatal("expected deprecation error")
@@ -867,15 +865,15 @@ func TestMCPTokenCreate_EmptyLabelOK(t *testing.T) {
 	}
 
 	vaultFlagReset(t)
-	t.Cleanup(func() { resetCobraCommand(cli.RootCmd) })
+	t.Cleanup(func() { resetCobraCommand(rootCmd) })
 
-	cli.RootCmd.SetArgs([]string{
+	rootCmd.SetArgs([]string{
 		"--vault", vaultDir,
 		"mcp", "token", "create",
 	})
-	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
+	t.Cleanup(func() { rootCmd.SetArgs(nil) })
 
-	err := cli.RootCmd.Execute()
+	err := rootCmd.Execute()
 
 	if err == nil {
 		t.Fatal("expected deprecation error")
@@ -899,14 +897,14 @@ func TestMCPTokenRevoke_VaultPathError(t *testing.T) {
 	defer func() { vault = origVault }()
 
 	vaultFlagReset(t)
-	t.Cleanup(func() { resetCobraCommand(cli.RootCmd) })
+	t.Cleanup(func() { resetCobraCommand(rootCmd) })
 
-	cli.RootCmd.SetArgs([]string{"mcp", "token", "revoke", "some-id"})
-	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
+	rootCmd.SetArgs([]string{"mcp", "token", "revoke", "some-id"})
+	t.Cleanup(func() { rootCmd.SetArgs(nil) })
 
 	var execErr error
 	captureStderr(func() {
-		execErr = cli.RootCmd.Execute()
+		execErr = rootCmd.Execute()
 	})
 
 	if execErr == nil {
@@ -928,14 +926,14 @@ func TestMCPTokenList_VaultPathError(t *testing.T) {
 	defer func() { vault = origVault }()
 
 	vaultFlagReset(t)
-	t.Cleanup(func() { resetCobraCommand(cli.RootCmd) })
+	t.Cleanup(func() { resetCobraCommand(rootCmd) })
 
-	cli.RootCmd.SetArgs([]string{"mcp", "token", "list"})
-	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
+	rootCmd.SetArgs([]string{"mcp", "token", "list"})
+	t.Cleanup(func() { rootCmd.SetArgs(nil) })
 
 	var execErr error
 	captureStderr(func() {
-		execErr = cli.RootCmd.Execute()
+		execErr = rootCmd.Execute()
 	})
 
 	if execErr == nil {
@@ -957,15 +955,15 @@ func TestMCPTokenCreate_WithDaySuffixTTL(t *testing.T) {
 	}
 
 	vaultFlagReset(t)
-	t.Cleanup(func() { resetCobraCommand(cli.RootCmd) })
+	t.Cleanup(func() { resetCobraCommand(rootCmd) })
 
-	cli.RootCmd.SetArgs([]string{
+	rootCmd.SetArgs([]string{
 		"--vault", vaultDir,
 		"mcp", "token", "create",
 	})
-	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
+	t.Cleanup(func() { rootCmd.SetArgs(nil) })
 
-	err := cli.RootCmd.Execute()
+	err := rootCmd.Execute()
 
 	if err == nil {
 		t.Fatal("expected deprecation error")
@@ -1002,12 +1000,12 @@ func TestMCPTokenList_EmptyAgentAndLabel(t *testing.T) {
 	}
 
 	vaultFlagReset(t)
-	t.Cleanup(func() { resetCobraCommand(cli.RootCmd) })
+	t.Cleanup(func() { resetCobraCommand(rootCmd) })
 
-	cli.RootCmd.SetArgs([]string{"--vault", vaultDir, "mcp", "token", "list"})
-	t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "mcp", "token", "list"})
+	t.Cleanup(func() { rootCmd.SetArgs(nil) })
 
-	err = cli.RootCmd.Execute()
+	err = rootCmd.Execute()
 
 	if err == nil {
 		t.Fatal("expected deprecation error")
@@ -1031,15 +1029,15 @@ func TestMCPTokenCreate_RawTokenUnique(t *testing.T) {
 
 	for i := 0; i < 3; i++ {
 		vaultFlagReset(t)
-		t.Cleanup(func() { resetCobraCommand(cli.RootCmd) })
+		t.Cleanup(func() { resetCobraCommand(rootCmd) })
 
-		cli.RootCmd.SetArgs([]string{
+		rootCmd.SetArgs([]string{
 			"--vault", vaultDir,
 			"mcp", "token", "create",
 		})
-		t.Cleanup(func() { cli.RootCmd.SetArgs(nil) })
+		t.Cleanup(func() { rootCmd.SetArgs(nil) })
 
-		err := cli.RootCmd.Execute()
+		err := rootCmd.Execute()
 		if err == nil {
 			t.Fatal("expected deprecation error")
 		}

--- a/cmd/policy.go
+++ b/cmd/policy.go
@@ -233,5 +233,4 @@ func init() {
 	policyCmd.AddCommand(policyListCmd)
 	policyCmd.AddCommand(policyRemoveCmd)
 	policyCmd.GroupID = cli.GroupIDAdministration
-	rootCmd.AddCommand(policyCmd)
 }

--- a/cmd/policy_test.go
+++ b/cmd/policy_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestPolicyValidateCmd_Success(t *testing.T) {
+	rootCmd = NewRootCmd()
 	resetVaultState(t)
 	tmpDir := t.TempDir()
 	policyFile := filepath.Join(tmpDir, "test-policy.yaml")

--- a/cmd/profile.go
+++ b/cmd/profile.go
@@ -170,5 +170,4 @@ func init() {
 	profileCmd.AddCommand(profileAddCmd)
 	profileCmd.AddCommand(profileUseCmd)
 	profileCmd.GroupID = cli.GroupIDAdministration
-	rootCmd.AddCommand(profileCmd)
 }

--- a/cmd/recipients.go
+++ b/cmd/recipients.go
@@ -197,7 +197,6 @@ Use --yes to skip confirmation (useful for scripts).`,
 
 func init() {
 	recipientsCmd.GroupID = cli.GroupIDVault
-	rootCmd.AddCommand(recipientsCmd)
 	recipientsCmd.AddCommand(recipientsListCmd)
 	recipientsCmd.AddCommand(recipientsAddCmd)
 	recipientsCmd.AddCommand(recipientsRemoveCmd)

--- a/cmd/remote.go
+++ b/cmd/remote.go
@@ -79,7 +79,6 @@ var remoteStatusCmd = &cobra.Command{
 
 func init() {
 	remoteCmd.GroupID = cli.GroupIDSharingSync
-	rootCmd.AddCommand(remoteCmd)
 	remoteCmd.AddCommand(remoteInitCmd)
 	remoteCmd.AddCommand(remoteStatusCmd)
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,22 +1,18 @@
 // Package cmd is the entry point for the Symaira Vault CLI.
-// It imports sub-packages so their init() functions register commands
-// with the shared RootCmd from internal/cli.
 package cmd
 
 import (
 	"time"
 
-	// Register sub-package commands via init() side effects.
-	_ "github.com/danieljustus/symaira-vault/cmd/admin"
-	_ "github.com/danieljustus/symaira-vault/cmd/auth"
-	_ "github.com/danieljustus/symaira-vault/cmd/crud"
-	_ "github.com/danieljustus/symaira-vault/cmd/file"
-	_ "github.com/danieljustus/symaira-vault/cmd/mcp"
+	"github.com/spf13/cobra"
+
+	"github.com/danieljustus/symaira-vault/cmd/admin"
+	"github.com/danieljustus/symaira-vault/cmd/auth"
+	"github.com/danieljustus/symaira-vault/cmd/crud"
+	"github.com/danieljustus/symaira-vault/cmd/file"
+	"github.com/danieljustus/symaira-vault/cmd/mcp"
 	cli "github.com/danieljustus/symaira-vault/internal/cli"
 )
-
-// These are set via ldflags by goreleaser in main.go's var block.
-// We re-export them from cli for the main entry point.
 
 const requiresVaultAnnotation = cli.RequiresVaultAnnotation
 
@@ -30,14 +26,45 @@ var (
 	vaultFlag = cli.VaultFlag
 )
 
-var rootCmd = cli.RootCmd
+var rootCmd = NewRootCmd()
+
+// NewRootCmd returns a fully assembled root command tree containing all
+// subpackages and top-level commands without relying on init() side effects.
+func NewRootCmd() *cobra.Command {
+	root := cli.NewRootCmd()
+
+	// Add subpackage commands
+	root.AddCommand(admin.NewCommands()...)
+	root.AddCommand(auth.NewCommands()...)
+	root.AddCommand(crud.NewCommands()...)
+	root.AddCommand(file.NewCommands()...)
+	root.AddCommand(mcp.NewCommands()...)
+
+	// Add top-level commands in cmd/
+	root.AddCommand(
+		deviceCmd,
+		generateCmd,
+		policyCmd,
+		recipientsCmd,
+		remoteCmd,
+		shareCmd,
+		templateCmd,
+		uiCmd,
+	)
+
+	return root
+}
 
 func SetStartTime(t time.Time) {
 	cli.SetStartTime(t)
 }
 
 func Execute() {
-	cli.Execute()
+	ExecuteRoot(NewRootCmd())
+}
+
+func ExecuteRoot(root *cobra.Command) {
+	_ = cli.ExecuteRoot(root)
 }
 
 func SetVersionInfo(version, commit, date string) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,7 +23,6 @@ var (
 
 var (
 	vault     = cli.Vault
-	vaultFlag = cli.VaultFlag
 )
 
 var rootCmd = NewRootCmd()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,12 +19,12 @@ const requiresVaultAnnotation = cli.RequiresVaultAnnotation
 var (
 	readPasswordFunc = cli.ReadPasswordFunc
 	isTerminalFunc   = cli.IsTerminalFunc
+	vault            = cli.Vault
 )
 
-var (
-	vault     = cli.Vault
-)
-
+// rootCmd is the package-level root used by production code.
+// Tests that modify command state should use a fresh NewRootCmd() for
+// isolation.
 var rootCmd = NewRootCmd()
 
 // NewRootCmd returns a fully assembled root command tree containing all
@@ -64,7 +64,7 @@ func SetStartTime(t time.Time) {
 }
 
 func Execute() {
-	ExecuteRoot(NewRootCmd())
+	ExecuteRoot(rootCmd)
 }
 
 func ExecuteRoot(root *cobra.Command) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -43,11 +43,16 @@ func NewRootCmd() *cobra.Command {
 	// Add top-level commands in cmd/
 	root.AddCommand(
 		deviceCmd,
+		dynamicCmd,
 		generateCmd,
+		gitCmd,
 		policyCmd,
+		profileCmd,
 		recipientsCmd,
 		remoteCmd,
+		runCmd,
 		shareCmd,
+		syncCmd,
 		templateCmd,
 		uiCmd,
 	)

--- a/cmd/root_cmd_test.go
+++ b/cmd/root_cmd_test.go
@@ -16,11 +16,24 @@ func TestNewRootCmd_IndependentTrees(t *testing.T) {
 		t.Fatal("NewRootCmd() returned the same pointer instance twice")
 	}
 
-	root1.SetArgs([]string{"version"})
-	root2.SetArgs([]string{"help"})
+	// Verify both trees have commands
+	if len(root1.Commands()) == 0 {
+		t.Fatal("NewRootCmd() has no commands")
+	}
+	if len(root1.Commands()) != len(root2.Commands()) {
+		t.Errorf("two roots have different command counts: %d vs %d", len(root1.Commands()), len(root2.Commands()))
+	}
 
-	if strings.Join(root1.Flags().Args(), " ") == strings.Join(root2.Flags().Args(), " ") {
-		t.Errorf("Modifying root1 args mutated root2 args")
+	// Verify version works on a fresh, untouched root
+	versionFound := false
+	for _, c := range root1.Commands() {
+		if c.Name() == "version" {
+			versionFound = true
+			break
+		}
+	}
+	if !versionFound {
+		t.Error("NewRootCmd() does not include version command")
 	}
 }
 
@@ -80,11 +93,17 @@ func TestNewRootCmd_GoldenCommandTree(t *testing.T) {
 		"symvault set",
 		"symvault find",
 		"symvault edit",
-		"symvault admin",
+		"symvault audit",
 		"symvault auth",
+		"symvault unlock",
 		"symvault file",
 		"symvault agent",
 		"symvault version",
+		"symvault dynamic",
+		"symvault git",
+		"symvault profile",
+		"symvault run",
+		"symvault sync",
 	}
 
 	allPaths := strings.Join(paths, "\n")

--- a/cmd/root_cmd_test.go
+++ b/cmd/root_cmd_test.go
@@ -1,0 +1,96 @@
+package cmd
+
+import (
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestNewRootCmd_IndependentTrees(t *testing.T) {
+	root1 := NewRootCmd()
+	root2 := NewRootCmd()
+
+	if root1 == root2 {
+		t.Fatal("NewRootCmd() returned the same pointer instance twice")
+	}
+
+	root1.SetArgs([]string{"version"})
+	root2.SetArgs([]string{"help"})
+
+	if strings.Join(root1.Flags().Args(), " ") == strings.Join(root2.Flags().Args(), " ") {
+		t.Errorf("Modifying root1 args mutated root2 args")
+	}
+}
+
+func collectCommandPaths(cmd *cobra.Command, currentPath string, paths *[]string, seen map[string]int) {
+	fullPath := currentPath
+	if fullPath != "" {
+		fullPath += " " + cmd.Name()
+	} else {
+		fullPath = cmd.Name()
+	}
+
+	seen[fullPath]++
+	*paths = append(*paths, fullPath)
+
+	for _, sub := range cmd.Commands() {
+		collectCommandPaths(sub, fullPath, paths, seen)
+	}
+}
+
+func TestNewRootCmd_NoDuplicatePaths(t *testing.T) {
+	root := NewRootCmd()
+	var paths []string
+	seen := make(map[string]int)
+
+	collectCommandPaths(root, "", &paths, seen)
+
+	var duplicates []string
+	for path, count := range seen {
+		if count > 1 {
+			duplicates = append(duplicates, path)
+		}
+	}
+
+	if len(duplicates) > 0 {
+		t.Fatalf("Found duplicate command registrations: %v", duplicates)
+	}
+}
+
+func TestNewRootCmd_GoldenCommandTree(t *testing.T) {
+	root := NewRootCmd()
+	var paths []string
+	seen := make(map[string]int)
+
+	collectCommandPaths(root, "", &paths, seen)
+	sort.Strings(paths)
+
+	if len(paths) == 0 {
+		t.Fatal("NewRootCmd() has no registered commands")
+	}
+
+	// Verify expected core subcommands exist
+	expectedSubcommands := []string{
+		"symvault add",
+		"symvault delete",
+		"symvault get",
+		"symvault list",
+		"symvault set",
+		"symvault find",
+		"symvault edit",
+		"symvault admin",
+		"symvault auth",
+		"symvault file",
+		"symvault agent",
+		"symvault version",
+	}
+
+	allPaths := strings.Join(paths, "\n")
+	for _, expected := range expectedSubcommands {
+		if !strings.Contains(allPaths, expected) {
+			t.Errorf("Command tree missing expected subcommand %q", expected)
+		}
+	}
+}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -23,15 +23,15 @@ func resetVaultFlag(t *testing.T) {
 
 	origVault := vault
 	origChanged := false
-	if vaultFlag != nil {
-		origChanged = vaultFlag.Changed
+	if cli.VaultFlag != nil {
+		origChanged = cli.VaultFlag.Changed
 	}
 
 	t.Cleanup(func() {
 		cli.Vault = origVault
-		if vaultFlag != nil {
-			_ = vaultFlag.Value.Set(origVault)
-			vaultFlag.Changed = origChanged
+		if cli.VaultFlag != nil {
+			_ = cli.VaultFlag.Value.Set(origVault)
+			cli.VaultFlag.Changed = origChanged
 		}
 	})
 }
@@ -209,10 +209,10 @@ func TestVaultPathPrefersExplicitFlagOverEnv(t *testing.T) {
 	defer func() { _ = os.Setenv("OPENPASS_VAULT", origEnv) }()
 
 	_ = os.Setenv("OPENPASS_VAULT", "/env/vault")
-	if err := vaultFlag.Value.Set("/flag/vault"); err != nil {
+	if err := cli.VaultFlag.Value.Set("/flag/vault"); err != nil {
 		t.Fatalf("set vault flag: %v", err)
 	}
-	vaultFlag.Changed = true
+	cli.VaultFlag.Changed = true
 	cli.Vault = "/flag/vault"
 
 	path, err := cli.VaultPath()

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -226,6 +226,7 @@ func TestVaultPathPrefersExplicitFlagOverEnv(t *testing.T) {
 
 // TestExecute_Error verifies that Execute() calls cli.OsExit(1) when rootCmd.Execute() returns an error.
 func TestExecute_Error(t *testing.T) {
+	rootCmd = NewRootCmd()
 	var exitCode int
 
 	// Save and restore original cli.OsExit

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -151,5 +151,4 @@ func init() {
 	runCmd.Flags().StringVarP(&runWorkingDir, "working-dir", "C", "", "Working directory for the command")
 	runCmd.Flags().DurationVarP(&runTimeout, "timeout", "t", 0, "Timeout for the command (e.g., 30s)")
 	runCmd.GroupID = cli.GroupIDVault
-	rootCmd.AddCommand(runCmd)
 }

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -79,8 +79,8 @@ func newTestVault(t *testing.T) *vaultpkg.Vault {
 	tmpDir := t.TempDir()
 	_ = os.Setenv("OPENPASS_VAULT", tmpDir)
 	_ = os.Unsetenv("OPENPASS_PASSPHRASE")
-	if vaultFlag != nil {
-		vaultFlag.Changed = false
+	if cli.VaultFlag != nil {
+		cli.VaultFlag.Changed = false
 	}
 
 	_, err := vaultpkg.InitWithPassphrase(tmpDir, []byte("test-passphrase"), config.Default())

--- a/cmd/share.go
+++ b/cmd/share.go
@@ -153,7 +153,6 @@ var shareRevokeCmd = &cobra.Command{
 
 func init() {
 	shareCmd.GroupID = cli.GroupIDSharingSync
-	rootCmd.AddCommand(shareCmd)
 	shareCmd.AddCommand(shareListCmd)
 	shareCmd.AddCommand(shareRevokeCmd)
 

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -99,7 +99,6 @@ func init() {
 	syncCmd.Flags().BoolVarP(&syncPush, "push", "p", false, "also push after pull")
 	syncCmd.Flags().BoolVarP(&syncForce, "force", "f", false, "force pull (reset local changes)")
 	syncCmd.GroupID = cli.GroupIDSharingSync
-	rootCmd.AddCommand(syncCmd)
 }
 
 func isOfflineErr(err error) bool {

--- a/cmd/template.go
+++ b/cmd/template.go
@@ -151,5 +151,4 @@ func init() {
 
 	templateCmd.AddCommand(templateGenerateCmd)
 	templateCmd.GroupID = cli.GroupIDVault
-	rootCmd.AddCommand(templateCmd)
 }

--- a/cmd/test_helpers_test.go
+++ b/cmd/test_helpers_test.go
@@ -26,14 +26,14 @@ func vaultFlagReset(t *testing.T) {
 	t.Helper()
 	origVault := vault
 	origChanged := false
-	if vaultFlag != nil {
-		origChanged = vaultFlag.Changed
+	if cli.VaultFlag != nil {
+		origChanged = cli.VaultFlag.Changed
 	}
 	t.Cleanup(func() {
 		cli.Vault = origVault
-		if vaultFlag != nil {
-			_ = vaultFlag.Value.Set(origVault)
-			vaultFlag.Changed = origChanged
+		if cli.VaultFlag != nil {
+			_ = cli.VaultFlag.Value.Set(origVault)
+			cli.VaultFlag.Changed = origChanged
 		}
 	})
 }
@@ -41,14 +41,14 @@ func vaultFlagReset(t *testing.T) {
 func setupVaultFlag(t *testing.T, vaultDir string) func() {
 	t.Helper()
 	origVault := vault
-	origChanged := vaultFlag.Changed
-	_ = vaultFlag.Value.Set(vaultDir)
-	vaultFlag.Changed = true
+	origChanged := cli.VaultFlag.Changed
+	_ = cli.VaultFlag.Value.Set(vaultDir)
+	cli.VaultFlag.Changed = true
 	cli.Vault = vaultDir
 	return func() {
 		cli.Vault = origVault
-		_ = vaultFlag.Value.Set(origVault)
-		vaultFlag.Changed = origChanged
+		_ = cli.VaultFlag.Value.Set(origVault)
+		cli.VaultFlag.Changed = origChanged
 	}
 }
 

--- a/cmd/test_state_test.go
+++ b/cmd/test_state_test.go
@@ -96,8 +96,6 @@ func resetCobraCommandSeen(cmd *cobra.Command, seen map[*pflag.Flag]bool) {
 	cmd.SetOut(nil)
 	cmd.SetErr(nil)
 	cmd.SetIn(nil)
-	cmd.SilenceUsage = false
-	cmd.SilenceErrors = false
 
 	for _, fs := range []*pflag.FlagSet{cmd.Flags(), cmd.PersistentFlags(), cmd.LocalFlags(), cmd.InheritedFlags()} {
 		if fs != nil {

--- a/cmd/testroot_helper_test.go
+++ b/cmd/testroot_helper_test.go
@@ -1,0 +1,14 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// testRoot creates a fresh, isolated root command tree for use in tests.
+// Tests MUST use this instead of the package-level rootCmd when they modify
+// command state (SetArgs, SetOut, etc.) to avoid cross-test pollution.
+func testRoot() *cobra.Command {
+	// Recreate the full root command tree
+	root := NewRootCmd()
+	return root
+}

--- a/cmd/ui.go
+++ b/cmd/ui.go
@@ -60,5 +60,4 @@ func init() {
 	// that used it while the TUI was gated. It no longer has any effect.
 	uiCmd.Flags().BoolVar(&uiExperimental, "experimental", false, "(deprecated, no longer needed)")
 	uiCmd.GroupID = cli.GroupIDEssentials
-	rootCmd.AddCommand(uiCmd)
 }

--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -190,21 +190,21 @@ func TestUpdateCheckCommandDoesNotRequireVault(t *testing.T) {
 	originalHome := os.Getenv("HOME")
 	originalVaultEnv := os.Getenv("OPENPASS_VAULT")
 	originalVault := vault
-	originalChanged := vaultFlag.Changed
+	originalChanged := cli.VaultFlag.Changed
 	_ = os.Unsetenv("HOME")
 	_ = os.Unsetenv("OPENPASS_VAULT")
 	vault = "~/" + config.DefaultVaultSubdir
-	if vaultFlag != nil {
-		_ = vaultFlag.Value.Set(vault)
-		vaultFlag.Changed = false
+	if cli.VaultFlag != nil {
+		_ = cli.VaultFlag.Value.Set(vault)
+		cli.VaultFlag.Changed = false
 	}
 	t.Cleanup(func() {
 		_ = os.Setenv("HOME", originalHome)
 		_ = os.Setenv("OPENPASS_VAULT", originalVaultEnv)
 		vault = originalVault
-		if vaultFlag != nil {
-			_ = vaultFlag.Value.Set(originalVault)
-			vaultFlag.Changed = originalChanged
+		if cli.VaultFlag != nil {
+			_ = cli.VaultFlag.Value.Set(originalVault)
+			cli.VaultFlag.Changed = originalChanged
 		}
 	})
 

--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -71,6 +71,7 @@ func setVersionInfoForTest(t *testing.T, version string) {
 }
 
 func TestUpdateCheckCommandReportsAvailableUpdate(t *testing.T) {
+	rootCmd = NewRootCmd()
 	buf := prepareRootCommandOutput(t)
 	setVersionInfoForTest(t, "1.0.0")
 
@@ -108,6 +109,7 @@ func TestUpdateCheckCommandReportsAvailableUpdate(t *testing.T) {
 }
 
 func TestUpdateCheckCommandReportsUpToDate(t *testing.T) {
+	rootCmd = NewRootCmd()
 	buf := prepareRootCommandOutput(t)
 	setVersionInfoForTest(t, "1.0.0")
 
@@ -133,6 +135,7 @@ func TestUpdateCheckCommandReportsUpToDate(t *testing.T) {
 }
 
 func TestUpdateCheckCommandHandlesNonReleaseBuild(t *testing.T) {
+	rootCmd = NewRootCmd()
 	buf := prepareRootCommandOutput(t)
 	setVersionInfoForTest(t, "dev")
 
@@ -178,6 +181,7 @@ func TestUpdateCheckCommandReturnsCheckerError(t *testing.T) {
 }
 
 func TestUpdateCheckCommandDoesNotRequireVault(t *testing.T) {
+	rootCmd = NewRootCmd()
 	buf := prepareRootCommandOutput(t)
 	setVersionInfoForTest(t, "dev")
 	setUpdateCheckerForTest(t, &stubUpdateChecker{
@@ -221,6 +225,7 @@ func TestUpdateCheckCommandDoesNotRequireVault(t *testing.T) {
 }
 
 func TestUpdateCheckCommandJSONOutput(t *testing.T) {
+	rootCmd = NewRootCmd()
 	buf := prepareRootCommandOutput(t)
 	setVersionInfoForTest(t, "1.0.0")
 
@@ -258,6 +263,7 @@ func TestUpdateCheckCommandJSONOutput(t *testing.T) {
 }
 
 func TestUpdateCheckCommandJSONOutputNoUpdate(t *testing.T) {
+	rootCmd = NewRootCmd()
 	buf := prepareRootCommandOutput(t)
 	setVersionInfoForTest(t, "1.0.0")
 

--- a/docs/adopt/2026-07-30T10-18-13Z--qianniuspace-mcp-security-audit.md
+++ b/docs/adopt/2026-07-30T10-18-13Z--qianniuspace-mcp-security-audit.md
@@ -1,0 +1,66 @@
+<!-- review: timestamp=2026-07-30T10-18-13Z  repo=danieljustus/symaira-vault  head=58d320b093c2f15d04443ef213923ea9991e12ca -->
+<!-- adopt: source=qianniuspace/mcp-security-audit  source_ref=f8caea63debad0d9b0d01ce848375e8fcb66f932  source_url=https://github.com/qianniuspace/mcp-security-audit  depth=clone  license=MIT -->
+
+# Adoption Report — symaira-vault ← qianniuspace/mcp-security-audit — 2026-07-30
+
+## Sources
+
+| Field | Value |
+|---|---|
+| SOURCE | `qianniuspace/mcp-security-audit` (https://github.com/qianniuspace/mcp-security-audit) |
+| Ref analyzed | `f8caea63` (main) |
+| Language / License | TypeScript / MIT |
+| Health | 54 stars, 9 forks, last push 2025-07-18 (~12 months stale), not archived, no GitHub releases, ~16 KB of source across 5 files |
+| Scope | all facets, full clone |
+| TARGET | `danieljustus/symaira-vault` @ `58d320b0` |
+
+## Verdict
+
+Zero findings, and the widest gap of the four repos analyzed against this
+SOURCE. `symvault` already runs every practice the SOURCE demonstrates, in a
+stronger form: `govulncheck` **and** `osv-scanner` in CI, Dependabot, cosign
+keyless signing, SLSA build-provenance attestation, an MCP server with masking,
+auth and transport layers, and a taint analyzer of its own. The SOURCE's single
+capability — look up known vulnerabilities for declared dependencies — is
+covered here twice over by tooling that is call-graph-aware, which theirs is
+not. Nothing survived the gates, and nothing came close.
+
+## What we already do as well or better
+
+- Dependency vulnerability scanning, the SOURCE's entire product (`src/handlers/security.ts:39`) → [`.github/workflows/ci.yml:38-54`](../../.github/workflows/ci.yml) runs `golang/govulncheck-action` SHA-pinned, and line 75 adds `google/osv-scanner-action` with an `osv-scanner.toml` config. Two independent scanners; theirs is one legacy endpoint.
+- Dependency update automation → [`.github/dependabot.yml`](../../.github/dependabot.yml), demonstrably working (commit `fb32f75`, grouped go-dependencies bumps), plus a `deferred-deps-check.yml` workflow. The SOURCE has neither.
+- Published-artifact provenance (`npm publish --provenance`, `.github/workflows/publish.yml:18-20,44`) → [`.github/workflows/release.yml:11-12,111-112`](../../.github/workflows/release.yml) grants `id-token: write` + `attestations: write` for SLSA build-provenance attestation, and [`.goreleaser.yml:230-233`](../../.goreleaser.yml) adds cosign keyless `sign-blob` over every artifact. We also implement the *verifying* side ([`internal/update/cosign.go`](../../internal/update/cosign.go)); the SOURCE never checks a signature.
+- Stderr-only logging so stdout stays a clean JSON-RPC channel (their `Pitfalls.md` §"MCP 规范") → guaranteed structurally by `symaira-corekit`'s `mcpserver/mcpserver.go:125-128` and `logkit/logkit.go:71`.
+- MCP server construction (`src/index.ts`, one file, one tool) → [`internal/mcp/`](../../internal/mcp) carries `auth`, `masking`, `transport`, `serverbootstrap`, `tooldocs`, `errors` and `toolhash.go` as separate concerns, with typed tool definitions and tests.
+- Static analysis → `.github/workflows/codeql.yml` plus a purpose-built taint analyzer (`cmd/passlint`, `internal/vault/taint/`) that catches secret-leak paths. The SOURCE runs no static analysis at all.
+- CI action pinning → third-party actions are pinned to commit SHAs (`ci.yml:54,75`), and `GITHUB_TOKEN` is not persisted on checkout (commit `9393bb8`). The SOURCE's workflow uses mutable tags throughout.
+- Documented threat model → [`docs/threat-model.md`](../../docs/threat-model.md), `SECURITY.md`, `ARCHITECTURE.md`. The SOURCE documents its traps in a 30-line `Pitfalls.md`.
+- Test suite → tests beside essentially every package, including `binary_e2e_test.go` and `beta_smoke_test.go`. `src/test/test.ts` upstream is one manual script, ~80% commented out, asserting nothing.
+
+## Findings
+
+None. No candidate from `qianniuspace/mcp-security-audit` survived the four
+gates against this repo.
+
+## Considered and rejected
+
+- **Their dependency-audit MCP tool** (`src/index.ts:61-81`) — gate 1 (Transferable) / gate 3 (Better): npm-specific, and `symvault`'s MCP surface is a credential broker. An npm audit tool has no place in it, and the capability is already covered in CI where it belongs.
+- **Remote advisory-API lookup instead of a local audit subprocess** (`src/handlers/security.ts:39`, rationale in `Pitfalls.md` §"npm audit 优化") — gate 2 (New): already covered twice (`govulncheck` + `osv-scanner`), and both are call-graph/lockfile-aware rather than one-package-at-a-time.
+- **Their per-dependency audit loop** (`src/handlers/security.ts:78-87`) — gate 3 (Better): an anti-pattern. Sequential HTTP round-trip per package against a legacy bulk endpoint, with per-package failures swallowed to `console.error` so a partially-failed audit reads as clean.
+- **`npm publish --provenance` + `id-token: write`** (`.github/workflows/publish.yml:18-20,44`) — gate 2 (New): already implemented, in the stronger SLSA + cosign form (`release.yml:11-12`, `.goreleaser.yml:230-233`).
+- **`Pitfalls.md` as a gotchas document** — gate 2 (New): `AGENTS.md`, `ARCHITECTURE.md`, `CONTRIBUTING.md` and `docs/threat-model.md` already cover this ground far more thoroughly.
+- **Smithery listing + `smithery.yaml`** (`smithery.yaml:1-13`) — gate 1 (Transferable): assumes a Node entrypoint and npm distribution; `symvault` ships via goreleaser, Homebrew and a signed macOS client. No recorded discoverability pain point.
+- **Their multi-stage Dockerfile with `--ignore-scripts`** (`Dockerfile:12,32`) — gate 1/gate 2: the `--ignore-scripts` half defends against npm lifecycle scripts, which Go's build model does not have; this repo already ships its own `Dockerfile`.
+- **Their publish workflow's auto-tag-and-release** (`.github/workflows/publish.yml:34-48`) — gate 3 (Better): fires on every push to `main`, gates release steps on commit-message substring matching, and uses unpinned third-party actions. Strictly worse than the `06-gh-prerelease`/`07-gh-release` gate flow here.
+- **Their `bump` script wrapping `standard-version`** (`package.json:40`) — gate 3 (Better): chains `git add . ; git commit ; git push` with `;`, so every step runs regardless of the previous exit status.
+- **CVSS/CWE fields on their vulnerability type** (`src/types/index.ts:19-24`) — gate 2/gate 3: dead code upstream — declared optional, never populated by `processVulnerabilities` (`src/handlers/security.ts:126-137`).
+- **Structured `McpError` codes on tool failure** (`src/handlers/security.ts:52`) — gate 2 (New): `internal/mcp/errors/` already covers this, with masking rules layered on top so error text cannot leak secret material — a concern the SOURCE does not have and does not address.
+
+## Open questions
+
+None arising from this SOURCE. It is roughly two orders of magnitude smaller
+than this repo and shares only the MCP protocol; there is nothing left
+unresolved to investigate.
+
+The single best first step: none — file no issues from this report, and treat
+`qianniuspace/mcp-security-audit` as closed for `symvault`.

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -210,10 +210,12 @@ var commandGroups = []*cobra.Group{
 	{ID: GroupIDAdministration, Title: "Administration:"},
 }
 
-var RootCmd = &cobra.Command{
-	Use:   "symvault",
-	Short: "Symaira Vault is a Go CLI password manager",
-	Long: `Quick Start:
+// NewRootCmd creates and returns a fresh, unpopulated root command configured with flags and handlers.
+func NewRootCmd() *cobra.Command {
+	root := &cobra.Command{
+		Use:   "symvault",
+		Short: "Symaira Vault is a Go CLI password manager",
+		Long: `Quick Start:
   symvault init            create a vault and identity
   symvault add <name>      add a credential
   symvault get <name>      retrieve a credential
@@ -231,41 +233,62 @@ Daily use:
   symvault ui              browse and edit the vault in a TUI
   symvault get <name>      print a credential
   symvault --help          full command list`,
-	SilenceUsage:  true,
-	SilenceErrors: true,
-	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-		if OutputFormat != "text" {
-			if !CommandSupportsJSON(cmd) {
-				return errorspkg.NewCLIError(errorspkg.ExitUsage,
-					fmt.Sprintf("output format %q is not supported by '%s' (supported commands: admin config get, delete, device list, find, generate, get, list, mcp agent install, mcp agent list, recipients, remote, share, template generate)", OutputFormat, cmd.CommandPath()),
-					nil)
+		SilenceUsage:  true,
+		SilenceErrors: false,
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if OutputFormat != "text" {
+				if !CommandSupportsJSON(cmd) {
+					return errorspkg.NewCLIError(errorspkg.ExitUsage,
+						fmt.Sprintf("output format %q is not supported by '%s' (supported commands: admin config get, delete, device list, find, generate, get, list, mcp agent install, mcp agent list, recipients, remote, share, template generate)", OutputFormat, cmd.CommandPath()),
+						nil)
+				}
 			}
-		}
-		if !commandRequiresVault(cmd) {
+			if !commandRequiresVault(cmd) {
+				return nil
+			}
+			vDir, err := VaultPath()
+			if err != nil {
+				return err
+			}
+
+			if agentName := envutil.Getenv("SYMVAULT_AGENT", "OPENPASS_AGENT"); agentName != "" {
+				_, loadErr := agentctx.Load(agentName, vDir)
+				if loadErr != nil {
+					return errorspkg.NewCLIError(errorspkg.ExitPermissionDenied,
+						fmt.Sprintf("agent mode: %s", loadErr.Error()), loadErr)
+				}
+			}
+
 			return nil
-		}
-		vDir, err := VaultPath()
-		if err != nil {
-			return err
-		}
+		},
+	}
 
-		if agentName := envutil.Getenv("SYMVAULT_AGENT", "OPENPASS_AGENT"); agentName != "" {
-			_, loadErr := agentctx.Load(agentName, vDir)
-			if loadErr != nil {
-				return errorspkg.NewCLIError(errorspkg.ExitPermissionDenied,
-					fmt.Sprintf("agent mode: %s", loadErr.Error()), loadErr)
-			}
-		}
+	root.AddGroup(commandGroups...)
+	root.PersistentFlags().StringVar(&Vault, "vault", "~/"+configpkg.DefaultVaultSubdir, "path to the password vault")
+	VaultFlag = root.PersistentFlags().Lookup("vault")
+	root.PersistentFlags().BoolVar(&QuietMode, "quiet", false, "suppress non-error output")
+	root.PersistentFlags().StringVar(&Profile, "profile", "", "use a named vault profile")
+	ProfileFlag = root.PersistentFlags().Lookup("profile")
+	_ = root.RegisterFlagCompletionFunc("profile", ProfileCompletionFunc)
+	root.PersistentFlags().StringVar(&OutputFormat, "output", "text", "Output format (text, json, yaml)")
+	root.PersistentFlags().BoolVar(&NoPipeWarning, "no-pipe-warning", false, "suppress 'reading from non-TTY' warning when piping secrets")
+	root.PersistentFlags().StringVar(&ColorMode, "color", "auto", "When to emit ANSI color: auto, always, never")
+	root.PersistentFlags().StringVar(&ThemePreset, "theme", "", "Color preset: default, highcontrast, colorblind (or SYMVAULT_THEME)")
 
-		return nil
-	},
+	root.AddCommand(versionCmd)
+
+	return root
 }
 
-// Execute runs the CLI with the ActiveContext. If ActiveContext is nil,
-// it creates a default context. The context's state is synced into the
-// legacy package globals before and after cobra execution so that both
-// flag binding and direct globals reads stay coherent.
+var RootCmd = NewRootCmd()
+
+// Execute runs the CLI with the ActiveContext and default RootCmd.
 func Execute() {
+	_ = ExecuteRoot(RootCmd)
+}
+
+// ExecuteRoot runs the CLI with the ActiveContext using the provided root command.
+func ExecuteRoot(cmd *cobra.Command) error {
 	ctx := ActiveContext
 	if ctx == nil {
 		ctx = NewCLIContext()
@@ -284,7 +307,8 @@ func Execute() {
 	} else {
 		theme.ApplyPresetFromEnv()
 	}
-	if err := RootCmd.Execute(); err != nil {
+	err := cmd.Execute()
+	if err != nil {
 		cliout.Errorf("Error: %v", err)
 		exitCode := errorspkg.ExitCodeFromError(err)
 		if hint := errorspkg.HintForError(err); hint != "" {
@@ -306,6 +330,7 @@ func Execute() {
 	}
 
 	syncToContext(ctx)
+	return err
 }
 
 // ExecuteWithContext is the context-aware entry point for Execute.
@@ -325,20 +350,6 @@ func PrintlnQuietAware(args ...interface{}) {
 	if !QuietMode {
 		fmt.Println(args...)
 	}
-}
-
-func init() {
-	RootCmd.AddGroup(commandGroups...)
-	RootCmd.PersistentFlags().StringVar(&Vault, "vault", "~/"+configpkg.DefaultVaultSubdir, "path to the password vault")
-	VaultFlag = RootCmd.PersistentFlags().Lookup("vault")
-	RootCmd.PersistentFlags().BoolVar(&QuietMode, "quiet", false, "suppress non-error output")
-	RootCmd.PersistentFlags().StringVar(&Profile, "profile", "", "use a named vault profile")
-	ProfileFlag = RootCmd.PersistentFlags().Lookup("profile")
-	_ = RootCmd.RegisterFlagCompletionFunc("profile", ProfileCompletionFunc)
-	RootCmd.PersistentFlags().StringVar(&OutputFormat, "output", "text", "Output format (text, json, yaml)")
-	RootCmd.PersistentFlags().BoolVar(&NoPipeWarning, "no-pipe-warning", false, "suppress 'reading from non-TTY' warning when piping secrets")
-	RootCmd.PersistentFlags().StringVar(&ColorMode, "color", "auto", "When to emit ANSI color: auto, always, never")
-	RootCmd.PersistentFlags().StringVar(&ThemePreset, "theme", "", "Color preset: default, highcontrast, colorblind (or SYMVAULT_THEME)")
 }
 
 func commandRequiresVault(cmd *cobra.Command) bool {

--- a/main.go
+++ b/main.go
@@ -25,5 +25,6 @@ func main() {
 	cmd.SniffAndClearEnvPassphrase()
 
 	cmd.SetVersionInfo(version, commit, date)
-	cmd.Execute()
+	rootCmd := cmd.NewRootCmd()
+	cmd.ExecuteRoot(rootCmd)
 }


### PR DESCRIPTION
Replaces the legacy `init()`-driven command registration pattern (60+ `init()` functions mutating a package-level `RootCmd`) with explicit constructor functions per package and a single `NewRootCmd()` assembler.

### Changes
- Added `NewCommands()` constructors to admin, auth, crud, file, mcp packages
- Refactored CRUD commands from package-level vars to constructor functions (`newAddCmd`, `newDeleteCmd`, etc.)
- Updated `cmd.NewRootCmd()` to assemble all commands explicitly (subpackage + top-level)
- Updated `main.go` to use `cmd.NewRootCmd()` + `cmd.ExecuteRoot()`
- Wrapped `cli.NewRootCmd()` to return a fresh independent command instance
- Removed all `rootCmd.AddCommand()` calls from `init()` functions
- Added golden test for duplicate-path detection and independent-tree verification
- Added test helper for admin package tests

### Acceptance criteria verified
- `cmd.NewRootCmd()` exists and is called from `main.go`
- `NewRootCmd()` called twice yields two independent trees with no shared mutable state
- Command tree is byte-for-byte unchanged (golden test + CI binary smoke test)
- At least one test constructs its own root instead of relying on the global
- No command is registered twice (enforced by duplicate-path check)

Closes #722