### PR TITLE
docs: document deliberate deviation from corekit/mcpserver and configkit

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -231,6 +231,11 @@ graph LR
     audit --> audit["audit/"]
 ```
 
+**Deliberate deviation from `corekit/mcpserver`:** This repository intentionally
+does not use `github.com/danieljustus/symaira-corekit/mcpserver` for its MCP
+layer, even though ten other Symaira tools do. The deviation is a documented
+design decision, not drift — see "Key Design Decisions" below.
+
 **Agent permissions:**
 - `AllowedPaths` — Path glob patterns for entry access
 - `CanWrite` — Whether write operations are allowed
@@ -464,6 +469,46 @@ Vaults created with the older root-level entry layout are migrated to `entries/`
 3. **Passphrase never stored:** Only cached in OS keyring with TTL
 4. **Build-tagged clipboard:** `internal/clipboard/` uses `//go:build` tags to switch between real clipboard (`!test_headless`) and no-op stub (`test_headless`)
 5. **HTTP MCP token:** Auto-generated, stored at `<vault>/mcp-token`
+
+6. **Own MCP layer instead of `corekit/mcpserver` (deliberate deviation):** The MCP
+   implementation lives in `internal/mcp/` (~29k lines across `transport`,
+   `server`, `auth`, `serverbootstrap`, `install`) instead of the shared
+   `corekit/mcpserver` package used by ten other Symaira tools. This is a
+   deliberate, security-driven deviation, not code drift:
+
+   - **Streamable HTTP + SSE:** `symvault` serves MCP over HTTP
+     (`--port <n>`) with Bearer-token auth, per-request agent resolution,
+     `Origin`-header checks (CSRF), SSE responses and protocol-version
+     negotiation. `corekit/mcpserver` v0.6.0 is stdio-only (protocol
+     `2024-11-05`); replacing the transport would require extending corekit
+     first.
+   - **Transport/protocol separation:** `internal/mcp/transport/` exposes a
+     `Transport` interface (start/stop lifecycle, injectable IO for tests) and
+     `internal/mcp/server/` layers approval modes (`none`/`deny`/`prompt`→
+     `deny`), token auth, audit, secret redaction (`sanitize_output`),
+     command policy, lean mode, prompt registry and sharing on top.
+     `mcpserver` fuses transport and protocol into one fixed server without
+     hooks for these security layers.
+   - **Zero-knowledge transport hygiene:** no secret values may ever reach
+     logs, stdout or error text. The own layer routes diagnostics through
+     `internal/ui/cliout` (stdout stays pure JSON-RPC) and redacts at the
+     tool boundary; `mcpserver` forwards raw handler errors to clients
+     (`err.Error()`), so redaction would have to live entirely in handlers.
+   - **Prompt-injection defense:** tool-cap enforcement
+     (`MaxToolDefinitions`), approval flows and secure-input dialogs are
+     server-layer features that cannot be expressed in the corekit transport.
+
+   Revisit only if `corekit/mcpserver` grows HTTP/SSE support plus an
+   injectable handler/approval layer; a switch must keep the tool catalog
+   behavior byte-identical and pass the value-exposure tests.
+
+7. **Own config layer instead of `corekit/configkit` (deliberate deviation):**
+   `internal/config/` (~8k lines) is domain-specific: XDG paths plus legacy
+   migration (`.symvault`/`.openpass`), `config.yaml` (YAML), auth methods
+   (passphrase/Touch ID), session TTL, validation and agent configuration.
+   `corekit/configkit` v0.6.0 is a generic TOML loader with env-var overrides
+   and a different file layout; adopting it would be a breaking config
+   migration with no security or maintenance gain.
 
 ## Tool Addition Review
 


### PR DESCRIPTION
Closes #732

## Decision

**Deliberate deviation, documented — no migration.**

Issue #732 asked whether `symvault`'s own MCP layer should be replaced by
`corekit/mcpserver` (and `configkit` for config). Review of both packages
(v0.6.0) against this repo's requirements shows the deviation is a
security-driven design decision, not drift:

### corekit/mcpserver (stdio-only, 412 lines) cannot host this stack

1. **Streamable HTTP + SSE**: `symvault` serves MCP over HTTP with Bearer
   token auth, per-request agent resolution, Origin-header CSRF checks,
   SSE responses and protocol-version negotiation. `mcpserver` v0.6.0
   implements only ServeStdio/ServeIO (protocol 2024-11-05).
2. **Transport/protocol separation**: `internal/mcp/transport/` exposes a
   Transport interface (lifecycle, injectable IO); `internal/mcp/server/`
   (~28.8k lines, heavily tested) layers approval modes (none/deny/
   prompt->deny), token auth, audit, secret redaction, command policy,
   lean mode, prompt registry and sharing on top. `mcpserver` fuses
   transport and protocol into one fixed server with no hooks for these
   layers.
3. **Zero-knowledge hygiene**: diagnostics route through `internal/ui/cliout`
   so stdout stays pure JSON-RPC and no secret value reaches logs or error
   text; `mcpserver` forwards raw handler errors (err.Error()) to clients.
4. **Prompt-injection defense**: MaxToolDefinitions cap, approval flows
   and secure-input dialogs are server-layer features the corekit transport
   cannot express.

A switch would require extending corekit with HTTP/SSE plus an injectable
handler/approval layer first — a corekit feature project, not a symvault
refactor. Revisit condition documented in ARCHITECTURE.md.

### corekit/configkit (generic TOML loader) cannot replace internal/config

`internal/config/` (~8k lines) is domain-specific: XDG paths plus legacy
migration (.symvault/.openpass), config.yaml (YAML), auth methods
(passphrase/Touch ID), session TTL, validation and agent configuration.
Adopting configkit would be a breaking config migration with no security
or maintenance gain.

## Fact correction

The issue's "821 lines without tests" estimate covers only the top-level
internal/mcp/*.go files. The real MCP layer is ~29k lines including
server (28.8k with extensive tests: approval, command policy, secure
input, prompt-injection e2e, value-exposure) plus transport, auth,
serverbootstrap, install.

## Acceptance criteria

- [x] Written decision: deviate deliberately (this PR + issue comment)
- [x] Deviation rationale names concrete requirements (ARCHITECTURE.md
      Key Design Decisions #6)
- [x] Same decision documented for configkit (Key Design Decisions #7)
- [x] Tests and lint green (CI)

## Changes

- ARCHITECTURE.md: Key Design Decisions #6/#7, note in internal/mcp section

## Verification

- make docs-check passes locally
- No code changes; CI runs the full suite on this HEAD
