### PR TITLE
ci(release): restrict notary key file permissions to 0600

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -238,6 +238,7 @@ jobs:
           else
             echo "$NOTARY_API_KEY" > "$RUNNER_TEMP/notary-key.p8"
           fi
+          chmod 600 "$RUNNER_TEMP/notary-key.p8"
           for ARCH in amd64 arm64; do
             for f in dist/*_darwin_${ARCH}*/*; do
               if [ -f "$f" ] && file "$f" | grep -q "Mach-O"; then
@@ -392,6 +393,7 @@ jobs:
           else
             echo "$NOTARY_API_KEY" > "$RUNNER_TEMP/notary-key.p8"
           fi
+          chmod 600 "$RUNNER_TEMP/notary-key.p8"
           echo "Submitting DMG for notarization: ${{ env.DMG_PATH }}"
           xcrun notarytool submit "${{ env.DMG_PATH }}" \
             -k "$RUNNER_TEMP/notary-key.p8" \


### PR DESCRIPTION
Restrict the Apple notary API key file (`$RUNNER_TEMP/notary-key.p8`, a `.p8` private key) to `0600` immediately after it is written, in both notarization jobs of `release.yml`. Previously the decoded key sat at default permissions (typically `0644`) for the whole notarization step.

- Adds `chmod 600 "$RUNNER_TEMP/notary-key.p8"` after the key write in the macOS binary notarization job and the DMG notarization job
- Existing `rm -f` cleanup is unchanged

Closes #745
