### PR TITLE
feat(importer): normalize otpauth:// URIs into structured TOTP data

### DIFF
--- a/internal/importer/bitwarden.go
+++ b/internal/importer/bitwarden.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strings"
 
 	vaultpkg "github.com/danieljustus/symaira-vault/internal/vault"
 )
@@ -20,7 +21,6 @@ const (
 	bitwardenFieldURLs     = "urls"
 	bitwardenFieldNotes    = "notes"
 	bitwardenFieldTOTP     = "totp"
-	bitwardenFieldSecret   = "secret"
 )
 
 type bitwardenImporter struct{}
@@ -136,20 +136,36 @@ func bitwardenParseLogin(item bitwardenItem, folders map[string]string) Imported
 		bitwardenFieldNotes:    item.Notes,
 	}
 
+	var warnings []string
 	for _, field := range item.Fields {
 		if field.Name == "" {
+			continue
+		}
+		if strings.EqualFold(field.Name, bitwardenFieldTOTP) {
+			if field.Value != "" {
+				if totp, err := ParseTOTP(field.Value); err == nil {
+					data[bitwardenFieldTOTP] = totp
+				} else {
+					warnings = append(warnings, fmt.Sprintf("totp: %v", err))
+				}
+			}
 			continue
 		}
 		data[field.Name] = field.Value
 	}
 
 	if item.Login.TOTP != "" {
-		data[bitwardenFieldTOTP] = map[string]any{bitwardenFieldSecret: item.Login.TOTP}
+		if totp, err := ParseTOTP(item.Login.TOTP); err == nil {
+			data[bitwardenFieldTOTP] = totp
+		} else {
+			warnings = append(warnings, fmt.Sprintf("totp: %v", err))
+		}
 	}
 
 	return ImportedEntry{
-		Path: bitwardenPath(item, folders),
-		Data: data,
+		Path:     bitwardenPath(item, folders),
+		Data:     data,
+		Warnings: warnings,
 	}
 }
 

--- a/internal/importer/csv.go
+++ b/internal/importer/csv.go
@@ -61,7 +61,12 @@ func (i *csvImporter) Parse(r io.Reader) ([]ImportedEntry, error) {
 				entry.Path = NormalizePath(value)
 			case "otp", "totp.secret":
 				if value != "" {
-					entry.Data["totp"] = map[string]any{"secret": value}
+					totp, err := ParseTOTP(value)
+					if err != nil {
+						entry.Warnings = append(entry.Warnings, fmt.Sprintf("totp: %v", err))
+						break
+					}
+					entry.Data["totp"] = totp
 				}
 			default:
 				entry.Data[field] = value

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -19,6 +19,10 @@ type ImportedEntry struct {
 	// SecretMetadata carries the semantic type and hints set by the importer.
 	// When set, the import pipeline writes this metadata to the vault entry.
 	SecretMetadata *vaultpkg.SecretMetadata
+	// Warnings lists per-entry issues found while parsing (for example a TOTP
+	// value that could not be normalized). The entry is still imported, minus
+	// the offending field. Nil when the entry parsed cleanly.
+	Warnings []string
 }
 
 // Importer parses a password export format and returns imported entries.

--- a/internal/importer/importer_fuzz_test.go
+++ b/internal/importer/importer_fuzz_test.go
@@ -123,13 +123,45 @@ func FuzzParsePassEntry(f *testing.F) {
 	f.Add("p\n..\n../secrets\n")
 
 	f.Fuzz(func(t *testing.T, content string) {
-		data := parsePassEntry(content)
+		data, _ := parsePassEntry(content)
 
 		if _, ok := data["password"]; !ok {
 			t.Errorf("password key missing in result")
 		}
 		if data == nil {
 			t.Errorf("parsePassEntry returned nil map")
+		}
+	})
+}
+
+// FuzzParseTOTP verifies the TOTP normalizer handles arbitrary input without
+// panic, including malformed otpauth URIs.
+func FuzzParseTOTP(f *testing.F) {
+	f.Add("JBSWY3DPEHPK3PXPJBSWY3DPEHPK3PXP")
+	f.Add("otpauth://totp/Example:user@example.com?secret=JBSWY3DPEHPK3PXPJBSWY3DPEHPK3PXP&issuer=Example")
+	f.Add("otpauth://totp/Example?secret=JBSWY3DPEHPK3PXPJBSWY3DPEHPK3PXP&algorithm=SHA256&digits=8&period=60")
+	f.Add("otpauth://hotp/Example?secret=JBSWY3DPEHPK3PXPJBSWY3DPEHPK3PXP")
+	f.Add("otpauth://totp/Example")
+	f.Add("otpauth://totp/Exa mple?secret=X")
+	f.Add("otpauth://totp/Example?secret=not-base32!!")
+	f.Add("otpauth://totp/Example?digits=abc")
+	f.Add("")
+	f.Add("not base32 at all")
+
+	f.Fuzz(func(t *testing.T, value string) {
+		result, err := ParseTOTP(value)
+
+		result2, err2 := ParseTOTP(value)
+		if (err == nil) != (err2 == nil) {
+			t.Errorf("deterministic error mismatch")
+		}
+		if err == nil && !reflect.DeepEqual(result, result2) {
+			t.Errorf("deterministic result mismatch")
+		}
+		if err == nil {
+			if result["secret"] == "" {
+				t.Errorf("secret empty for %q", value)
+			}
 		}
 	})
 }

--- a/internal/importer/importer_test.go
+++ b/internal/importer/importer_test.go
@@ -210,7 +210,15 @@ func TestBitwardenImporterParse(t *testing.T) {
 	assertStringField(t, github.Data, "password", "mysecretpassword")
 	assertStringField(t, github.Data, "url", "https://github.com/login")
 	assertStringSliceField(t, github.Data, "urls", []string{"https://github.com/login", "https://github.com/"})
-	assertTOTPSecret(t, github.Data, "JBSWY3DPEHPK3PXP")
+	// The fixture's 16-character TOTP secret decodes to 10 bytes, below the
+	// 16-byte minimum enforced by crypto.ValidateTOTPSecret, so it must be
+	// skipped with a per-entry warning instead of writing an unusable secret.
+	if _, ok := github.Data["totp"]; ok {
+		t.Fatal("GitHub entry unexpectedly contains TOTP data for an invalid secret")
+	}
+	if len(github.Warnings) == 0 {
+		t.Fatal("GitHub entry should carry a TOTP warning for the invalid secret")
+	}
 
 	aws := findEntry(t, entries, "Work/AWS-Console")
 	assertStringField(t, aws.Data, "username", "admin@company.com")
@@ -284,7 +292,7 @@ func TestCSVImporterParseDefaultMapping(t *testing.T) {
 func TestCSVImporterParseCustomMapping(t *testing.T) {
 	csvData := strings.NewReader(strings.Join([]string{
 		"name,login,secret,website,comment,authenticator",
-		"Example,user@example.com,password123,https://example.com,custom notes,JBSWY3DPEHPK3PXP",
+		"Example,user@example.com,password123,https://example.com,custom notes,JBSWY3DPEHPK3PXPJBSWY3DPEHPK3PXP",
 	}, "\n"))
 	mapping := "path=name,username=login,password=secret,url=website,notes=comment,totp.secret=authenticator"
 
@@ -304,7 +312,7 @@ func TestCSVImporterParseCustomMapping(t *testing.T) {
 	assertStringField(t, entry.Data, "password", "password123")
 	assertStringField(t, entry.Data, "url", "https://example.com")
 	assertStringField(t, entry.Data, "notes", "custom notes")
-	assertTOTPSecret(t, entry.Data, "JBSWY3DPEHPK3PXP")
+	assertTOTPSecret(t, entry.Data, "JBSWY3DPEHPK3PXPJBSWY3DPEHPK3PXP")
 }
 
 func TestParsePassEntry(t *testing.T) {
@@ -324,13 +332,18 @@ func TestParsePassEntry(t *testing.T) {
 				"work-aws-secret",
 				"url: https://aws.amazon.com",
 				"username: admin@company.com",
-				"otpauth://totp/Amazon?secret=JBSWY3DPEHPK3PXP&issuer=Amazon",
+				"otpauth://totp/Amazon?secret=JBSWY3DPEHPK3PXPJBSWY3DPEHPK3PXP&issuer=Amazon",
 			}, "\n"),
 			want: map[string]any{
 				"password": "work-aws-secret",
 				"url":      "https://aws.amazon.com",
 				"username": "admin@company.com",
-				"totp":     "otpauth://totp/Amazon?secret=JBSWY3DPEHPK3PXP&issuer=Amazon",
+				"totp": map[string]any{
+					"secret":    "JBSWY3DPEHPK3PXPJBSWY3DPEHPK3PXP",
+					"algorithm": "SHA1",
+					"digits":    float64(6),
+					"period":    float64(30),
+				},
 			},
 		},
 		{
@@ -345,11 +358,19 @@ func TestParsePassEntry(t *testing.T) {
 				"notes":    "first note line\nsecond note line",
 			},
 		},
+		{
+			name: "invalid totp uri skipped",
+			content: strings.Join([]string{
+				"secret",
+				"otpauth://totp/Example?secret=not-base32!!",
+			}, "\n"),
+			want: map[string]any{"password": "secret"},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := parsePassEntry(tt.content)
+			got, _ := parsePassEntry(tt.content)
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Fatalf("parsePassEntry() = %#v, want %#v", got, tt.want)
 			}

--- a/internal/importer/onepux.go
+++ b/internal/importer/onepux.go
@@ -64,7 +64,9 @@ type onePUXSection struct {
 
 type onePUXField struct {
 	Title string          `json:"title"`
-	Value json.RawMessage `json:"value"`
+	Name  string          `json:"n"`
+	Type  string          `json:"t"`
+	Value json.RawMessage `json:"v"`
 }
 
 type onePUXOverview struct {
@@ -110,16 +112,27 @@ func (i *onePUXImporter) Parse(r io.Reader) ([]ImportedEntry, error) {
 				}
 
 				username, password := onePUXCredentials(item.Details.LoginFields)
+				data := map[string]any{
+					"username": username,
+					"password": password,
+					"url":      onePUXPrimaryURL(item.Overview.URLs),
+					"notes":    item.Details.NotesPlain,
+					"tags":     onePUXTags(item.Overview.Tags),
+				}
+
+				var warnings []string
+				if otp, ok := onePUXTOTP(item.Details.Sections); ok {
+					if totp, err := ParseTOTP(otp); err == nil {
+						data["totp"] = totp
+					} else {
+						warnings = append(warnings, fmt.Sprintf("totp: %v", err))
+					}
+				}
+
 				entries = append(entries, ImportedEntry{
-					Path: item.Title,
-					Data: map[string]any{
-						"username": username,
-						"password": password,
-						"url":      onePUXPrimaryURL(item.Overview.URLs),
-						"notes":    item.Details.NotesPlain,
-						"tags":     onePUXTags(item.Overview.Tags),
-						"totp":     onePUXTOTP(item.Details.Sections),
-					},
+					Path:     item.Title,
+					Data:     data,
+					Warnings: warnings,
 				})
 			}
 		}
@@ -181,19 +194,29 @@ func onePUXTags(tags []string) []string {
 	return tags
 }
 
-func onePUXTOTP(sections []onePUXSection) string {
+// onePUXTOTP returns the first one-time-password value found in the item's
+// sections. The boolean reports whether a TOTP field was present at all.
+func onePUXTOTP(sections []onePUXSection) (string, bool) {
 	for _, section := range sections {
 		for _, field := range section.Fields {
-			if !strings.Contains(strings.ToLower(field.Title), "one-time password") {
+			if !onePUXFieldIsTOTP(field) {
 				continue
 			}
 
 			if otp := onePUXOTPValue(field.Value); otp != "" {
-				return otp
+				return otp, true
 			}
 		}
 	}
-	return ""
+	return "", false
+}
+
+// onePUXFieldIsTOTP reports whether a 1pux section field carries a one-time
+// password. Real exports identify the field through its type ("t") or name
+// ("n"), e.g. t="one-time password", n="totp".
+func onePUXFieldIsTOTP(f onePUXField) bool {
+	lower := strings.ToLower(f.Type + " " + f.Name + " " + f.Title)
+	return strings.Contains(lower, "one-time password") || strings.Contains(lower, "totp")
 }
 
 func onePUXOTPValue(value json.RawMessage) string {

--- a/internal/importer/pass.go
+++ b/internal/importer/pass.go
@@ -65,9 +65,11 @@ func (i *passImporter) Parse(r io.Reader) ([]ImportedEntry, error) {
 			return err
 		}
 
+		data, warnings := parsePassEntry(content)
 		entries = append(entries, ImportedEntry{
-			Path: passEntryPath(relPath),
-			Data: parsePassEntry(content),
+			Path:     passEntryPath(relPath),
+			Data:     data,
+			Warnings: warnings,
 		})
 		return nil
 	})
@@ -102,7 +104,9 @@ func passEntryPath(relPath string) string {
 	return NormalizePath(path)
 }
 
-func parsePassEntry(content string) map[string]any {
+// parsePassEntry parses a decrypted pass entry into vault data fields and a
+// list of per-entry warnings (e.g. a TOTP value that could not be normalized).
+func parsePassEntry(content string) (map[string]any, []string) {
 	content = strings.ReplaceAll(content, "\r\n", "\n")
 	content = strings.ReplaceAll(content, "\r", "\n")
 	content = strings.TrimSuffix(content, "\n")
@@ -110,11 +114,12 @@ func parsePassEntry(content string) map[string]any {
 	lines := strings.Split(content, "\n")
 	data := map[string]any{"password": ""}
 	if len(lines) == 0 {
-		return data
+		return data, nil
 	}
 
 	data["password"] = lines[0]
 	var notes []string
+	var warnings []string
 	for _, line := range lines[1:] {
 		switch {
 		case strings.HasPrefix(line, "url: "):
@@ -122,7 +127,12 @@ func parsePassEntry(content string) map[string]any {
 		case strings.HasPrefix(line, "username: "):
 			data["username"] = strings.TrimSpace(strings.TrimPrefix(line, "username: "))
 		case strings.HasPrefix(line, "otpauth://"):
-			data["totp"] = strings.TrimSpace(line)
+			totp, err := ParseTOTP(line)
+			if err != nil {
+				warnings = append(warnings, fmt.Sprintf("totp: %v", err))
+				continue
+			}
+			data["totp"] = totp
 		default:
 			notes = append(notes, line)
 		}
@@ -131,5 +141,5 @@ func parsePassEntry(content string) map[string]any {
 	if len(notes) > 0 {
 		data["notes"] = strings.Join(notes, "\n")
 	}
-	return data
+	return data, warnings
 }

--- a/internal/importer/testdata/totp/bitwarden.json
+++ b/internal/importer/testdata/totp/bitwarden.json
@@ -1,0 +1,46 @@
+{
+  "encrypted": false,
+  "folders": [],
+  "items": [
+    {
+      "id": "item-bare",
+      "type": 1,
+      "name": "Bare Secret",
+      "login": {
+        "username": "user@example.com",
+        "password": "bare-secret-password",
+        "totp": "JBSWY3DPEHPK3PXPJBSWY3DPEHPK3PXP"
+      }
+    },
+    {
+      "id": "item-uri",
+      "type": 1,
+      "name": "Plain URI",
+      "login": {
+        "username": "user@example.com",
+        "password": "plain-uri-password",
+        "totp": "otpauth://totp/Example:user@example.com?secret=JBSWY3DPEHPK3PXPJBSWY3DPEHPK3PXP&issuer=Example"
+      }
+    },
+    {
+      "id": "item-sha256",
+      "type": 1,
+      "name": "SHA256 URI",
+      "login": {
+        "username": "user@example.com",
+        "password": "sha256-uri-password",
+        "totp": "otpauth://totp/Example:user@example.com?secret=JBSWY3DPEHPK3PXPJBSWY3DPEHPK3PXP&algorithm=SHA256&digits=8&period=60&issuer=Example"
+      }
+    },
+    {
+      "id": "item-malformed",
+      "type": 1,
+      "name": "Malformed URI",
+      "login": {
+        "username": "user@example.com",
+        "password": "malformed-uri-password",
+        "totp": "otpauth://totp/Example:user@example.com?secret=not-a-valid-base32-secret!!&issuer=Example"
+      }
+    }
+  ]
+}

--- a/internal/importer/testdata/totp/csv.csv
+++ b/internal/importer/testdata/totp/csv.csv
@@ -1,0 +1,5 @@
+title,username,password,otp
+Bare Secret,user@example.com,bare-secret-password,JBSWY3DPEHPK3PXPJBSWY3DPEHPK3PXP
+Plain URI,user@example.com,plain-uri-password,otpauth://totp/Example:user@example.com?secret=JBSWY3DPEHPK3PXPJBSWY3DPEHPK3PXP&issuer=Example
+SHA256 URI,user@example.com,sha256-uri-password,otpauth://totp/Example:user@example.com?secret=JBSWY3DPEHPK3PXPJBSWY3DPEHPK3PXP&algorithm=SHA256&digits=8&period=60&issuer=Example
+Malformed URI,user@example.com,malformed-uri-password,otpauth://totp/Example:user@example.com?secret=not-a-valid-base32-secret!!&issuer=Example

--- a/internal/importer/testdata/totp/onepux.json
+++ b/internal/importer/testdata/totp/onepux.json
@@ -1,0 +1,166 @@
+{
+  "accounts": [
+    {
+      "attrs": {
+        "accountName": "TOTP Round Trip Fixture"
+      },
+      "vaults": [
+        {
+          "attrs": {
+            "name": "Personal"
+          },
+          "items": [
+            {
+              "uuid": "totp-fixture-bare",
+              "categoryUuid": "001",
+              "state": "active",
+              "title": "Bare Secret",
+              "overview": {
+                "title": "Bare Secret",
+                "urls": []
+              },
+              "details": {
+                "notesPlain": "",
+                "loginFields": [
+                  {
+                    "designation": "username",
+                    "value": "user@example.com"
+                  },
+                  {
+                    "designation": "password",
+                    "value": "bare-secret-password"
+                  }
+                ],
+                "sections": [
+                  {
+                    "title": "Security",
+                    "fields": [
+                      {
+                        "id": "totp",
+                        "k": "concealed",
+                        "n": "totp",
+                        "t": "one-time password",
+                        "v": "JBSWY3DPEHPK3PXPJBSWY3DPEHPK3PXP"
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "uuid": "totp-fixture-uri",
+              "categoryUuid": "001",
+              "state": "active",
+              "title": "Plain URI",
+              "overview": {
+                "title": "Plain URI",
+                "urls": []
+              },
+              "details": {
+                "notesPlain": "",
+                "loginFields": [
+                  {
+                    "designation": "username",
+                    "value": "user@example.com"
+                  },
+                  {
+                    "designation": "password",
+                    "value": "plain-uri-password"
+                  }
+                ],
+                "sections": [
+                  {
+                    "title": "Security",
+                    "fields": [
+                      {
+                        "id": "totp",
+                        "k": "concealed",
+                        "n": "totp",
+                        "t": "one-time password",
+                        "v": "otpauth://totp/Example:user@example.com?secret=JBSWY3DPEHPK3PXPJBSWY3DPEHPK3PXP&issuer=Example"
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "uuid": "totp-fixture-sha256",
+              "categoryUuid": "001",
+              "state": "active",
+              "title": "SHA256 URI",
+              "overview": {
+                "title": "SHA256 URI",
+                "urls": []
+              },
+              "details": {
+                "notesPlain": "",
+                "loginFields": [
+                  {
+                    "designation": "username",
+                    "value": "user@example.com"
+                  },
+                  {
+                    "designation": "password",
+                    "value": "sha256-uri-password"
+                  }
+                ],
+                "sections": [
+                  {
+                    "title": "Security",
+                    "fields": [
+                      {
+                        "id": "totp",
+                        "k": "concealed",
+                        "n": "totp",
+                        "t": "one-time password",
+                        "v": "otpauth://totp/Example:user@example.com?secret=JBSWY3DPEHPK3PXPJBSWY3DPEHPK3PXP&algorithm=SHA256&digits=8&period=60&issuer=Example"
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "uuid": "totp-fixture-malformed",
+              "categoryUuid": "001",
+              "state": "active",
+              "title": "Malformed URI",
+              "overview": {
+                "title": "Malformed URI",
+                "urls": []
+              },
+              "details": {
+                "notesPlain": "",
+                "loginFields": [
+                  {
+                    "designation": "username",
+                    "value": "user@example.com"
+                  },
+                  {
+                    "designation": "password",
+                    "value": "malformed-uri-password"
+                  }
+                ],
+                "sections": [
+                  {
+                    "title": "Security",
+                    "fields": [
+                      {
+                        "id": "totp",
+                        "k": "concealed",
+                        "n": "totp",
+                        "t": "one-time password",
+                        "v": "otpauth://totp/Example:user@example.com?secret=not-a-valid-base32-secret!!&issuer=Example"
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/internal/importer/testdata/totp/pass-malformed.txt
+++ b/internal/importer/testdata/totp/pass-malformed.txt
@@ -1,0 +1,4 @@
+malformed-uri-password
+url: https://example.com
+username: user@example.com
+otpauth://totp/Example:user@example.com?secret=not-a-valid-base32-secret!!&issuer=Example

--- a/internal/importer/testdata/totp/pass-sha256.txt
+++ b/internal/importer/testdata/totp/pass-sha256.txt
@@ -1,0 +1,4 @@
+sha256-uri-password
+url: https://example.com
+username: user@example.com
+otpauth://totp/Example:user@example.com?secret=JBSWY3DPEHPK3PXPJBSWY3DPEHPK3PXP&algorithm=SHA256&digits=8&period=60&issuer=Example

--- a/internal/importer/testdata/totp/pass-uri.txt
+++ b/internal/importer/testdata/totp/pass-uri.txt
@@ -1,0 +1,4 @@
+plain-uri-password
+url: https://example.com
+username: user@example.com
+otpauth://totp/Example:user@example.com?secret=JBSWY3DPEHPK3PXPJBSWY3DPEHPK3PXP&issuer=Example

--- a/internal/importer/totp.go
+++ b/internal/importer/totp.go
@@ -1,0 +1,104 @@
+package importer
+
+import (
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/danieljustus/symaira-vault/internal/crypto"
+)
+
+// TOTP default parameters per RFC 6238 and the otpauth Key URI Format
+// (https://github.com/google/google-authenticator/wiki/Key-Uri-Format).
+const (
+	totpDefaultAlgorithm = "SHA1"
+	totpDefaultDigits    = 6
+	totpDefaultPeriod    = 30
+)
+
+// ParseTOTP normalizes a TOTP value from an external export into the
+// structured shape used by vault entries:
+//
+//	map[string]any{"secret": ..., "algorithm": ..., "digits": ..., "period": ...}
+//
+// It accepts either a bare Base32 secret or a full otpauth://totp/... URI.
+// For URIs, the secret parameter is extracted and algorithm, digits and period
+// are read from the query string, falling back to the RFC 6238 defaults
+// (SHA1, 6, 30) when absent. The issuer and label are tolerated and ignored.
+// Other otpauth types (e.g. otpauth://hotp/...) are rejected with a clear
+// error. The secret is validated with the same rules the vault applies when
+// writing entries (see crypto.ValidateTOTPSecret).
+func ParseTOTP(value string) (map[string]any, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil, fmt.Errorf("empty TOTP value")
+	}
+
+	secret := value
+	algorithm := totpDefaultAlgorithm
+	digits := totpDefaultDigits
+	period := totpDefaultPeriod
+
+	if strings.HasPrefix(strings.ToLower(value), "otpauth://") {
+		parsed, err := url.Parse(value)
+		if err != nil {
+			return nil, fmt.Errorf("parse otpauth URI: %w", err)
+		}
+		if !strings.EqualFold(parsed.Scheme, "otpauth") {
+			return nil, fmt.Errorf("unsupported TOTP scheme %q: only otpauth is supported", parsed.Scheme)
+		}
+		if parsed.Host == "" {
+			return nil, fmt.Errorf("otpauth URI is missing the type (expected otpauth://totp/...)")
+		}
+		if !strings.EqualFold(parsed.Host, "totp") {
+			return nil, fmt.Errorf("unsupported otpauth type %q: only otpauth://totp/... is supported", parsed.Host)
+		}
+
+		query := parsed.Query()
+		if query.Get("secret") == "" {
+			return nil, fmt.Errorf("otpauth URI is missing the secret parameter")
+		}
+		secret = query.Get("secret")
+
+		if a := query.Get("algorithm"); a != "" {
+			algorithm = strings.ToUpper(a)
+		}
+		if d := query.Get("digits"); d != "" {
+			n, err := strconv.Atoi(d)
+			if err != nil {
+				return nil, fmt.Errorf("invalid TOTP digits %q in otpauth URI: %w", d, err)
+			}
+			if n != 6 && n != 8 {
+				return nil, fmt.Errorf("invalid TOTP digits %d in otpauth URI: must be 6 or 8", n)
+			}
+			digits = n
+		}
+		if p := query.Get("period"); p != "" {
+			n, err := strconv.Atoi(p)
+			if err != nil {
+				return nil, fmt.Errorf("invalid TOTP period %q in otpauth URI: %w", p, err)
+			}
+			if n <= 0 || n > 3600 {
+				return nil, fmt.Errorf("invalid TOTP period %d in otpauth URI: must be 1-3600 seconds", n)
+			}
+			period = n
+		}
+	}
+
+	if err := crypto.ValidateTOTPSecret(secret); err != nil {
+		return nil, fmt.Errorf("invalid TOTP secret: %w", err)
+	}
+	if err := crypto.ValidateTOTPParams(algorithm, digits, period); err != nil {
+		return nil, fmt.Errorf("invalid TOTP configuration: %w", err)
+	}
+
+	// digits and period are float64 to match the shape vault entries have
+	// after a JSON round trip (see vault.ExtractTOTP and crypto.ValidateTOTPData).
+	return map[string]any{
+		"secret":    secret,
+		"algorithm": algorithm,
+		"digits":    float64(digits),
+		"period":    float64(period),
+	}, nil
+}

--- a/internal/importer/totp_test.go
+++ b/internal/importer/totp_test.go
@@ -1,0 +1,330 @@
+package importer
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+
+	cryptopkg "github.com/danieljustus/symaira-vault/internal/crypto"
+)
+
+// validTOTPSecret is a 32-character Base32 secret that decodes to 20 bytes,
+// satisfying crypto.ValidateTOTPSecret's 16-byte minimum.
+const validTOTPSecret = "JBSWY3DPEHPK3PXPJBSWY3DPEHPK3PXP"
+
+var (
+	wantTOTPDefault = map[string]any{
+		"secret":    validTOTPSecret,
+		"algorithm": "SHA1",
+		"digits":    float64(6),
+		"period":    float64(30),
+	}
+	wantTOTPSHA256 = map[string]any{
+		"secret":    validTOTPSecret,
+		"algorithm": "SHA256",
+		"digits":    float64(8),
+		"period":    float64(60),
+	}
+)
+
+func TestParseTOTP(t *testing.T) {
+	uri := "otpauth://totp/Example:user@example.com?secret=" + validTOTPSecret + "&issuer=Example"
+
+	tests := []struct {
+		name    string
+		value   string
+		want    map[string]any
+		wantErr string
+	}{
+		{
+			name:  "bare base32 secret",
+			value: validTOTPSecret,
+			want:  wantTOTPDefault,
+		},
+		{
+			name:  "bare secret with spaces",
+			value: "JBSWY3DPEHPK3PXP JBSWY3DPEHPK3PXP",
+			want: map[string]any{
+				"secret":    "JBSWY3DPEHPK3PXP JBSWY3DPEHPK3PXP",
+				"algorithm": "SHA1",
+				"digits":    float64(6),
+				"period":    float64(30),
+			},
+		},
+		{
+			name:  "plain otpauth uri with issuer and label",
+			value: uri,
+			want:  wantTOTPDefault,
+		},
+		{
+			name:  "uri without issuer or label",
+			value: "otpauth://totp/Example?secret=" + validTOTPSecret,
+			want:  wantTOTPDefault,
+		},
+		{
+			name:  "uri with custom algorithm digits period",
+			value: "otpauth://totp/Example?secret=" + validTOTPSecret + "&algorithm=SHA256&digits=8&period=60",
+			want:  wantTOTPSHA256,
+		},
+		{
+			name:  "uri with lowercase algorithm",
+			value: "otpauth://totp/Example?secret=" + validTOTPSecret + "&algorithm=sha256&digits=8&period=60",
+			want:  wantTOTPSHA256,
+		},
+		{
+			name:  "uppercase scheme and type",
+			value: "OTPAUTH://TOTP/Example?secret=" + validTOTPSecret,
+			want:  wantTOTPDefault,
+		},
+		{
+			name:    "hotp rejected",
+			value:   "otpauth://hotp/Example?secret=" + validTOTPSecret,
+			wantErr: "only otpauth://totp",
+		},
+		{
+			name:    "missing secret parameter",
+			value:   "otpauth://totp/Example?issuer=Example",
+			wantErr: "missing the secret parameter",
+		},
+		{
+			name:    "secret too short",
+			value:   "JBSWY3DPEHPK3PXP",
+			wantErr: "too short",
+		},
+		{
+			name:    "not base32",
+			value:   "not-a-valid-base32-secret!!",
+			wantErr: "Base32",
+		},
+		{
+			name:    "invalid digits",
+			value:   "otpauth://totp/Example?secret=" + validTOTPSecret + "&digits=7",
+			wantErr: "digits",
+		},
+		{
+			name:    "invalid period",
+			value:   "otpauth://totp/Example?secret=" + validTOTPSecret + "&period=0",
+			wantErr: "period",
+		},
+		{
+			name:    "invalid algorithm",
+			value:   "otpauth://totp/Example?secret=" + validTOTPSecret + "&algorithm=MD5",
+			wantErr: "algorithm",
+		},
+		{
+			name:    "malformed uri",
+			value:   "otpauth://to tp/Example?secret=" + validTOTPSecret,
+			wantErr: "parse otpauth URI",
+		},
+		{
+			name:    "empty value",
+			value:   "",
+			wantErr: "empty TOTP value",
+		},
+		{
+			name:    "whitespace only",
+			value:   "   ",
+			wantErr: "empty TOTP value",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseTOTP(tt.value)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("ParseTOTP(%q) = %#v, want error containing %q", tt.value, got, tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("ParseTOTP(%q) error = %q, want it to contain %q", tt.value, err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseTOTP(%q) error = %v", tt.value, err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("ParseTOTP(%q) = %#v, want %#v", tt.value, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestTOTPRoundTripBitwarden verifies that bitwarden login.totp values (bare
+// secret or otpauth:// URI) are normalized into the identical structured
+// totp map, that URI parameters are preserved, and that malformed values are
+// skipped with a per-entry warning.
+func TestTOTPRoundTripBitwarden(t *testing.T) {
+	f := openFixture(t, "testdata/totp/bitwarden.json")
+	defer f.Close()
+
+	entries, err := (&bitwardenImporter{}).Parse(f)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	assertTOTPRoundTripCases(t, entries, NormalizePath)
+}
+
+// TestTOTPRoundTripCSV covers the same cases through the CSV otp column.
+func TestTOTPRoundTripCSV(t *testing.T) {
+	f := openFixture(t, "testdata/totp/csv.csv")
+	defer f.Close()
+
+	entries, err := NewCSV("").Parse(f)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	assertTOTPRoundTripCases(t, entries, NormalizePath)
+}
+
+// TestTOTPRoundTripOnePUX covers the same cases through 1pux OTP section
+// fields. 1Password entry paths are not normalized.
+func TestTOTPRoundTripOnePUX(t *testing.T) {
+	exportJSON, err := os.ReadFile("testdata/totp/onepux.json")
+	if err != nil {
+		t.Fatalf("read onepux fixture: %v", err)
+	}
+
+	entries, err := (&onePUXImporter{}).Parse(bytes.NewReader(onePUXZip(t, string(exportJSON))))
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	assertTOTPRoundTripCases(t, entries, func(name string) string { return name })
+}
+
+// TestTOTPRoundTripPass covers the same cases through pass otpauth:// lines.
+func TestTOTPRoundTripPass(t *testing.T) {
+	for _, tt := range []struct {
+		fixture string
+		want    map[string]any
+	}{
+		{fixture: "testdata/totp/pass-uri.txt", want: wantTOTPDefault},
+		{fixture: "testdata/totp/pass-sha256.txt", want: wantTOTPSHA256},
+	} {
+		content, err := os.ReadFile(tt.fixture)
+		if err != nil {
+			t.Fatalf("read fixture %s: %v", tt.fixture, err)
+		}
+
+		data, warnings := parsePassEntry(string(content))
+		if len(warnings) != 0 {
+			t.Fatalf("parsePassEntry(%s) warnings = %v, want none", tt.fixture, warnings)
+		}
+		assertTOTPMap(t, data, tt.want)
+		assertTOTPGenerates(t, data)
+	}
+
+	malformed, err := os.ReadFile("testdata/totp/pass-malformed.txt")
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	data, warnings := parsePassEntry(string(malformed))
+	if _, ok := data["totp"]; ok {
+		t.Fatal("malformed pass TOTP line should not produce a totp field")
+	}
+	if len(warnings) == 0 {
+		t.Fatal("malformed pass TOTP line should produce a warning")
+	}
+	if !strings.Contains(warnings[0], "totp") {
+		t.Fatalf("warning %q should mention totp", warnings[0])
+	}
+}
+
+// assertTOTPRoundTripCases asserts the shared round-trip expectations for the
+// four fixture entries (bare secret, plain URI, SHA256 URI, malformed URI).
+func assertTOTPRoundTripCases(t *testing.T, entries []ImportedEntry, pathOf func(string) string) {
+	t.Helper()
+
+	bare := findEntry(t, entries, pathOf("Bare Secret"))
+	uri := findEntry(t, entries, pathOf("Plain URI"))
+	sha := findEntry(t, entries, pathOf("SHA256 URI"))
+	mal := findEntry(t, entries, pathOf("Malformed URI"))
+
+	for _, entry := range []ImportedEntry{bare, uri, sha} {
+		if len(entry.Warnings) != 0 {
+			t.Fatalf("entry %q should have no warnings, got %v", entry.Path, entry.Warnings)
+		}
+	}
+	assertTOTPMap(t, bare.Data, wantTOTPDefault)
+	assertTOTPMap(t, uri.Data, wantTOTPDefault)
+	assertTOTPMap(t, sha.Data, wantTOTPSHA256)
+
+	// A bare Base32 secret and an equivalent otpauth:// URI must produce
+	// byte-identical vault entries.
+	bareJSON, err := json.Marshal(bare.Data["totp"])
+	if err != nil {
+		t.Fatalf("marshal bare totp: %v", err)
+	}
+	uriJSON, err := json.Marshal(uri.Data["totp"])
+	if err != nil {
+		t.Fatalf("marshal uri totp: %v", err)
+	}
+	if !bytes.Equal(bareJSON, uriJSON) {
+		t.Fatalf("bare secret and URI produced different totp data: %s vs %s", bareJSON, uriJSON)
+	}
+
+	// The structured shape validates and generates codes for every importer.
+	for _, entry := range []ImportedEntry{bare, uri, sha} {
+		if err := cryptopkg.ValidateTOTPData(entry.Data); err != nil {
+			t.Fatalf("ValidateTOTPData(%q) error = %v", entry.Path, err)
+		}
+		assertTOTPGenerates(t, entry.Data)
+	}
+
+	// Malformed values are skipped with an actionable per-entry warning.
+	if _, ok := mal.Data["totp"]; ok {
+		t.Fatal("malformed entry should not carry totp data")
+	}
+	if len(mal.Warnings) == 0 {
+		t.Fatal("malformed entry should carry a TOTP warning")
+	}
+	if !strings.Contains(mal.Warnings[0], "totp") {
+		t.Fatalf("warning %q should mention totp", mal.Warnings[0])
+	}
+}
+
+// assertTOTPMap asserts that data["totp"] is a map exactly matching want.
+func assertTOTPMap(t *testing.T, data map[string]any, want map[string]any) {
+	t.Helper()
+	got, ok := data["totp"].(map[string]any)
+	if !ok {
+		t.Fatalf("data[totp] = %#v, want map[string]any %#v", data["totp"], want)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("data[totp] = %#v, want %#v", got, want)
+	}
+}
+
+// assertTOTPGenerates verifies that the entry's totp configuration produces a
+// code with the configured digit count, i.e. the parsed parameters are the
+// ones actually used for code generation.
+func assertTOTPGenerates(t *testing.T, data map[string]any) {
+	t.Helper()
+	totp, ok := data["totp"].(map[string]any)
+	if !ok {
+		t.Fatalf("data[totp] = %#v, want map", data["totp"])
+	}
+	secret, _ := totp["secret"].(string)
+	algorithm, _ := totp["algorithm"].(string)
+	digits := int(totp["digits"].(float64))
+	period := int(totp["period"].(float64))
+
+	code, err := cryptopkg.GenerateTOTP(secret, algorithm, digits, period)
+	if err != nil {
+		t.Fatalf("GenerateTOTP(%q, %q, %d, %d) error = %v", secret, algorithm, digits, period, err)
+	}
+	if len(code.Code) != digits {
+		t.Fatalf("generated code %q has %d digits, want %d", code.Code, len(code.Code), digits)
+	}
+	for _, r := range code.Code {
+		if r < '0' || r > '9' {
+			t.Fatalf("generated code %q contains non-digit characters", code.Code)
+		}
+	}
+	if code.Period != period {
+		t.Fatalf("generated code period = %d, want %d", code.Period, period)
+	}
+}


### PR DESCRIPTION
Normalizes TOTP values across all importers: a single `otpauth://` URI parser in `internal/importer` now handles both bare Base32 secrets and full `otpauth://totp/...?secret=...&algorithm=...&digits=...&period=...` URIs, so every imported entry ends up with a structured `totp: {secret, algorithm, digits, period}` map and a bare Base32 secret.

- New `ParseTOTP` helper (`internal/importer/totp.go`) with RFC 6238 / Key URI Format defaults (SHA1, 6 digits, 30s period); invalid/malformed values are rejected with a clear per-entry message instead of writing unusable entries
- All four importers (`1password`, `bitwarden`, `pass`, `csv`) now emit the identical `map[string]any` shape — `pass` no longer stores a bare string, so `ValidateTOTPData` actually runs for every importer
- Round-trip fixtures under `internal/importer/testdata/totp/` (bare secret, plain URI, SHA256/8/60 URI, malformed URI) and fuzz coverage kept green
- Existing `GenerateTOTP` behavior verified against the fixtures

Closes #734
