### PR TITLE
refactor(cmd): complete CLI constructor migration — NewCommands() returns fresh trees

### DIFF
--- a/cmd/admin/audit.go
+++ b/cmd/admin/audit.go
@@ -25,15 +25,20 @@ var (
 	AuditFailed bool
 )
 
-var AuditCmd = &cobra.Command{
-	Use:   "audit",
-	Short: "View MCP audit logs",
-	Long: `View audit logs of MCP tool invocations.
+// AuditCmd is retained for API compatibility; NewCommands() uses
+// newAuditCmd() instead so every call gets a fresh command.
+var AuditCmd = newAuditCmd()
+
+func newAuditCmd() *cobra.Command {
+	auditCmd := &cobra.Command{
+		Use:   "audit",
+		Short: "View MCP audit logs",
+		Long: `View audit logs of MCP tool invocations.
 
 By default shows the last 20 entries. Use --tail to change the number of entries.
 Use --json for machine-readable output. Use --agent to filter by agent name.
 Use --since to filter by time (e.g. "1h", "24h", "7d").`,
-	Example: `  # Last 20 audit entries
+		Example: `  # Last 20 audit entries
   symvault audit
 
   # Last 100 entries, JSON format
@@ -41,23 +46,67 @@ Use --since to filter by time (e.g. "1h", "24h", "7d").`,
 
   # Failed invocations in the last day from a specific agent
   symvault audit --agent claude-code --since 24h --failed`,
-	Annotations: map[string]string{
-		cli.RequiresVaultAnnotation: "false",
-	},
-	RunE: func(cmd *cobra.Command, args []string) error {
-		entries, err := LoadAuditEntries(AuditAgent, AuditTail)
-		if err != nil {
-			return err
-		}
+		Annotations: map[string]string{
+			cli.RequiresVaultAnnotation: "false",
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			entries, err := LoadAuditEntries(AuditAgent, AuditTail)
+			if err != nil {
+				return err
+			}
 
-		entries = FilterAuditEntries(entries, AuditSince, AuditFailed)
+			entries = FilterAuditEntries(entries, AuditSince, AuditFailed)
 
-		if cli.WantJSONOutput(auditJSON) {
-			return OutputAuditJSON(cmd, entries)
-		}
+			if cli.WantJSONOutput(auditJSON) {
+				return OutputAuditJSON(cmd, entries)
+			}
 
-		return OutputAuditTable(cmd, entries)
-	},
+			return OutputAuditTable(cmd, entries)
+		},
+	}
+
+	auditCmd.Flags().IntVarP(&AuditTail, "tail", "n", 20, "Number of entries to show")
+	auditCmd.Flags().BoolVarP(&auditJSON, "json", "j", false, "Output as JSON (deprecated: use --output=json)")
+	auditCmd.Flags().StringVarP(&AuditAgent, "agent", "a", "default", "Agent name to filter by")
+	auditCmd.Flags().StringVarP(&AuditSince, "since", "s", "", "Show entries since duration (e.g. 1h, 24h, 7d)")
+	auditCmd.Flags().BoolVar(&AuditFailed, "failed", false, "Show only failed entries")
+	auditCmd.AddCommand(newRotateKeyCmd())
+	auditCmd.AddCommand(newAuditExportCmd())
+	auditCmd.GroupID = cli.GroupIDAdministration
+	return auditCmd
+}
+
+func newRotateKeyCmd() *cobra.Command {
+	rotateKeyCmd := &cobra.Command{
+		Use:   "rotate-key",
+		Short: "Rotate the audit log HMAC key",
+		Long: `Generate a new HMAC key for audit log integrity and archive the current key.
+
+The old key is archived to a timestamped file (audit-hmac-key.rotated.YYYY-MM-DD)
+in the vault directory. A new audit log file is started with the new key.`,
+		Annotations: map[string]string{
+			cli.RequiresVaultAnnotation: "true",
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			vaultDir, err := cli.VaultPath()
+			if err != nil {
+				return err
+			}
+
+			ks := audit.NewKeystore(vaultDir, nil)
+			newKey, archivePath, err := ks.RotateKey()
+			if err != nil {
+				return fmt.Errorf("rotate HMAC key: %w", err)
+			}
+
+			cmd.Printf("HMAC key rotated successfully.\n")
+			cmd.Printf("New key: %x (first 4 bytes)\n", newKey[:4])
+			cmd.Printf("Old key archived to: %s\n", archivePath)
+			cmd.Printf("A new audit log will be started on the next audit write.\n")
+			return nil
+		},
+	}
+	return rotateKeyCmd
 }
 
 func AuditLogPath(agent string) (string, error) {
@@ -208,44 +257,4 @@ func OutputAuditTable(cmd *cobra.Command, entries []audit.LogEntry) error {
 
 	cmd.Printf("\nTotal: %d entries\n", len(entries))
 	return nil
-}
-
-func init() {
-	AuditCmd.Flags().IntVarP(&AuditTail, "tail", "n", 20, "Number of entries to show")
-	AuditCmd.Flags().BoolVarP(&auditJSON, "json", "j", false, "Output as JSON (deprecated: use --output=json)")
-	AuditCmd.Flags().StringVarP(&AuditAgent, "agent", "a", "default", "Agent name to filter by")
-	AuditCmd.Flags().StringVarP(&AuditSince, "since", "s", "", "Show entries since duration (e.g. 1h, 24h, 7d)")
-	AuditCmd.Flags().BoolVar(&AuditFailed, "failed", false, "Show only failed entries")
-	AuditCmd.AddCommand(rotateKeyCmd)
-	AuditCmd.GroupID = cli.GroupIDAdministration
-}
-
-var rotateKeyCmd = &cobra.Command{
-	Use:   "rotate-key",
-	Short: "Rotate the audit log HMAC key",
-	Long: `Generate a new HMAC key for audit log integrity and archive the current key.
-
-The old key is archived to a timestamped file (audit-hmac-key.rotated.YYYY-MM-DD)
-in the vault directory. A new audit log file is started with the new key.`,
-	Annotations: map[string]string{
-		cli.RequiresVaultAnnotation: "true",
-	},
-	RunE: func(cmd *cobra.Command, args []string) error {
-		vaultDir, err := cli.VaultPath()
-		if err != nil {
-			return err
-		}
-
-		ks := audit.NewKeystore(vaultDir, nil)
-		newKey, archivePath, err := ks.RotateKey()
-		if err != nil {
-			return fmt.Errorf("rotate HMAC key: %w", err)
-		}
-
-		cmd.Printf("HMAC key rotated successfully.\n")
-		cmd.Printf("New key: %x (first 4 bytes)\n", newKey[:4])
-		cmd.Printf("Old key archived to: %s\n", archivePath)
-		cmd.Printf("A new audit log will be started on the next audit write.\n")
-		return nil
-	},
 }

--- a/cmd/admin/audit_export.go
+++ b/cmd/admin/audit_export.go
@@ -24,14 +24,15 @@ var (
 	auditExportRedactPaths bool
 )
 
-var auditExportCmd = &cobra.Command{
-	Use:   "export",
-	Short: "Export audit evidence for auditor or incident-response bundles",
-	Long: `Export local audit evidence without exposing secret values.
+func newAuditExportCmd() *cobra.Command {
+	auditExportCmd := &cobra.Command{
+		Use:   "export",
+		Short: "Export audit evidence for auditor or incident-response bundles",
+		Long: `Export local audit evidence without exposing secret values.
 
 Supports JSON and table output. Filter by time range, agent, and action.
 Optionally verify HMAC integrity and redact vault paths.`,
-	Example: `  # Export all audit entries as JSON
+		Example: `  # Export all audit entries as JSON
   symvault audit export --format json
 
   # Export last 7 days to a file
@@ -45,66 +46,77 @@ Optionally verify HMAC integrity and redact vault paths.`,
 
   # Filter by agent and action
   symvault audit export --agent claude-code --action get_entry`,
-	Annotations: map[string]string{
-		cli.RequiresVaultAnnotation: "false",
-	},
-	RunE: func(cmd *cobra.Command, args []string) (retErr error) {
-		vaultDir, _ := cli.VaultPath()
+		Annotations: map[string]string{
+			cli.RequiresVaultAnnotation: "false",
+		},
+		RunE: func(cmd *cobra.Command, args []string) (retErr error) {
+			vaultDir, _ := cli.VaultPath()
 
-		opts := audit.ExportOptions{
-			Agent:       auditExportAgent,
-			Action:      auditExportAction,
-			Since:       auditExportSince,
-			FailedOnly:  auditExportFailed,
-			RedactPaths: auditExportRedactPaths,
-			VerifyHMAC:  auditExportVerifyHMAC,
-		}
-
-		if opts.VerifyHMAC && vaultDir != "" {
-			ks := audit.NewKeystore(vaultDir, nil)
-			key, err := ks.LoadOrCreateHMACKey()
-			if err != nil {
-				return fmt.Errorf("load HMAC key: %w", err)
-			}
-			opts.HMACKey = key
-		}
-
-		if opts.Action != "" {
-			opts.Action = strings.TrimSpace(opts.Action)
-		}
-
-		if auditExportOutput != "" {
-			cleanPath := filepath.Clean(auditExportOutput)
-			dir := filepath.Dir(cleanPath)
-			if err := os.MkdirAll(dir, 0o700); err != nil {
-				return fmt.Errorf("create output directory: %w", err)
+			opts := audit.ExportOptions{
+				Agent:       auditExportAgent,
+				Action:      auditExportAction,
+				Since:       auditExportSince,
+				FailedOnly:  auditExportFailed,
+				RedactPaths: auditExportRedactPaths,
+				VerifyHMAC:  auditExportVerifyHMAC,
 			}
 
-			out, err := fsutil.CreateSensitiveOutput(cleanPath)
-			if err != nil {
-				return fmt.Errorf("create output file: %w", err)
-			}
-			defer func() {
-				if closeErr := out.Close(); closeErr != nil && retErr == nil {
-					retErr = fmt.Errorf("close output file: %w", closeErr)
+			if opts.VerifyHMAC && vaultDir != "" {
+				ks := audit.NewKeystore(vaultDir, nil)
+				key, err := ks.LoadOrCreateHMACKey()
+				if err != nil {
+					return fmt.Errorf("load HMAC key: %w", err)
 				}
-			}()
+				opts.HMACKey = key
+			}
 
-			result, err := audit.ExportAuditLog(opts, out, auditExportFormat)
+			if opts.Action != "" {
+				opts.Action = strings.TrimSpace(opts.Action)
+			}
+
+			if auditExportOutput != "" {
+				cleanPath := filepath.Clean(auditExportOutput)
+				dir := filepath.Dir(cleanPath)
+				if err := os.MkdirAll(dir, 0o700); err != nil {
+					return fmt.Errorf("create output directory: %w", err)
+				}
+
+				out, err := fsutil.CreateSensitiveOutput(cleanPath)
+				if err != nil {
+					return fmt.Errorf("create output file: %w", err)
+				}
+				defer func() {
+					if closeErr := out.Close(); closeErr != nil && retErr == nil {
+						retErr = fmt.Errorf("close output file: %w", closeErr)
+					}
+				}()
+
+				result, err := audit.ExportAuditLog(opts, out, auditExportFormat)
+				if err != nil {
+					return err
+				}
+				printExportSummary(cmd, result)
+				return nil
+			}
+
+			result, err := audit.ExportAuditLog(opts, cmd.OutOrStdout(), auditExportFormat)
 			if err != nil {
 				return err
 			}
 			printExportSummary(cmd, result)
 			return nil
-		}
+		},
+	}
 
-		result, err := audit.ExportAuditLog(opts, cmd.OutOrStdout(), auditExportFormat)
-		if err != nil {
-			return err
-		}
-		printExportSummary(cmd, result)
-		return nil
-	},
+	auditExportCmd.Flags().StringVar(&auditExportAgent, "agent", "", "Agent name to filter by (default: all agents)")
+	auditExportCmd.Flags().StringVar(&auditExportAction, "action", "", "Action type to filter by (e.g. get_entry, set_entry)")
+	auditExportCmd.Flags().StringVar(&auditExportSince, "since", "", "Export entries since duration (e.g. 1h, 24h, 7d)")
+	auditExportCmd.Flags().BoolVar(&auditExportFailed, "failed", false, "Export only failed entries")
+	auditExportCmd.Flags().StringVarP(&auditExportOutput, "output", "o", "", "Output file path (default: stdout)")
+	auditExportCmd.Flags().StringVar(&auditExportFormat, "format", "json", "Output format: json or table")
+	auditExportCmd.Flags().BoolVar(&auditExportVerifyHMAC, "verify-hmac", false, "Verify HMAC integrity of exported entries")
+	auditExportCmd.Flags().BoolVar(&auditExportRedactPaths, "redact-paths", false, "Redact vault paths in exported entries")
+	return auditExportCmd
 }
 
 func printExportSummary(cmd *cobra.Command, result *audit.ExportResult) {
@@ -117,16 +129,4 @@ func printExportSummary(cmd *cobra.Command, result *audit.ExportResult) {
 			result.Verified, result.Legacy, result.Tampered)
 	}
 	cmd.Println()
-}
-
-func init() {
-	auditExportCmd.Flags().StringVar(&auditExportAgent, "agent", "", "Agent name to filter by (default: all agents)")
-	auditExportCmd.Flags().StringVar(&auditExportAction, "action", "", "Action type to filter by (e.g. get_entry, set_entry)")
-	auditExportCmd.Flags().StringVar(&auditExportSince, "since", "", "Export entries since duration (e.g. 1h, 24h, 7d)")
-	auditExportCmd.Flags().BoolVar(&auditExportFailed, "failed", false, "Export only failed entries")
-	auditExportCmd.Flags().StringVarP(&auditExportOutput, "output", "o", "", "Output file path (default: stdout)")
-	auditExportCmd.Flags().StringVar(&auditExportFormat, "format", "json", "Output format: json or table")
-	auditExportCmd.Flags().BoolVar(&auditExportVerifyHMAC, "verify-hmac", false, "Verify HMAC integrity of exported entries")
-	auditExportCmd.Flags().BoolVar(&auditExportRedactPaths, "redact-paths", false, "Redact vault paths in exported entries")
-	AuditCmd.AddCommand(auditExportCmd)
 }

--- a/cmd/admin/backup.go
+++ b/cmd/admin/backup.go
@@ -28,41 +28,46 @@ var (
 
 var BackupExcludeGit bool
 
-var backupCmd = &cobra.Command{
-	Use:   "backup <archive-path>",
-	Short: "Create a backup archive of the vault",
-	Long: `Create a compressed archive (.tar.gz) of the current vault.
+func newBackupCmd() *cobra.Command {
+	backupCmd := &cobra.Command{
+		Use:   "backup <archive-path>",
+		Short: "Create a backup archive of the vault",
+		Long: `Create a compressed archive (.tar.gz) of the current vault.
 
 The backup includes all vault files: identity.age, config.yaml, entries/, and mcp-token.
 Use --exclude-git to omit the .git/ directory from the backup.`,
-	Example: `  # Full backup to a tarball
+		Example: `  # Full backup to a tarball
   symvault backup ~/symvault-2026-05-17.tar.gz
 
   # Skip the Git history (smaller archive)
   symvault backup --exclude-git ~/symvault.tar.gz`,
-	Args: cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		vaultDir, err := cli.VaultPath()
-		if err != nil {
-			return err
-		}
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			vaultDir, err := cli.VaultPath()
+			if err != nil {
+				return err
+			}
 
-		if !vaultpkg.IsInitialized(vaultDir) {
-			return errorspkg.NewVaultNotInitialized()
-		}
+			if !vaultpkg.IsInitialized(vaultDir) {
+				return errorspkg.NewVaultNotInitialized()
+			}
 
-		archivePath := args[0]
-		if !strings.HasSuffix(archivePath, ".tar.gz") {
-			archivePath += ".tar.gz"
-		}
+			archivePath := args[0]
+			if !strings.HasSuffix(archivePath, ".tar.gz") {
+				archivePath += ".tar.gz"
+			}
 
-		if err := CreateBackup(vaultDir, archivePath, BackupExcludeGit); err != nil {
-			return fmt.Errorf("backup failed: %w", err)
-		}
+			if err := CreateBackup(vaultDir, archivePath, BackupExcludeGit); err != nil {
+				return fmt.Errorf("backup failed: %w", err)
+			}
 
-		cli.PrintQuietAware("Backup created: %s\n", archivePath)
-		return nil
-	},
+			cli.PrintQuietAware("Backup created: %s\n", archivePath)
+			return nil
+		},
+	}
+	backupCmd.Flags().BoolVar(&BackupExcludeGit, "exclude-git", false, "Exclude .git/ directory from backup")
+	backupCmd.GroupID = cli.GroupIDSharingSync
+	return backupCmd
 }
 
 func CreateBackup(vaultDir, archivePath string, excludeGit bool) (retErr error) {
@@ -134,42 +139,46 @@ func CreateBackup(vaultDir, archivePath string, excludeGit bool) (retErr error) 
 	})
 }
 
-var restoreCmd = &cobra.Command{
-	Use:   "restore <archive-path>",
-	Short: "Restore vault from a backup archive",
-	Long: `Restore a vault from a previously created backup archive (.tar.gz).
+func newRestoreCmd() *cobra.Command {
+	restoreCmd := &cobra.Command{
+		Use:   "restore <archive-path>",
+		Short: "Restore vault from a backup archive",
+		Long: `Restore a vault from a previously created backup archive (.tar.gz).
 
 The archive is extracted into the current vault directory. If the vault directory
 does not exist, it will be created. After extraction, the vault is verified
 to ensure all expected files are present.`,
-	Example: `  # Restore into the default vault directory
+		Example: `  # Restore into the default vault directory
   symvault restore ~/symvault-2026-05-17.tar.gz
 
   # Restore into a custom location
   symvault --vault ~/restored restore archive.tar.gz`,
-	Args: cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		vaultDir, err := cli.VaultPath()
-		if err != nil {
-			return err
-		}
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			vaultDir, err := cli.VaultPath()
+			if err != nil {
+				return err
+			}
 
-		archivePath := args[0]
-		if _, err := os.Stat(archivePath); err != nil {
-			return fmt.Errorf("archive not found: %w", err)
-		}
+			archivePath := args[0]
+			if _, err := os.Stat(archivePath); err != nil {
+				return fmt.Errorf("archive not found: %w", err)
+			}
 
-		if err := RestoreBackup(archivePath, vaultDir); err != nil {
-			return fmt.Errorf("restore failed: %w", err)
-		}
+			if err := RestoreBackup(archivePath, vaultDir); err != nil {
+				return fmt.Errorf("restore failed: %w", err)
+			}
 
-		if !vaultpkg.IsInitialized(vaultDir) {
-			return errorspkg.NewVaultNotInitialized()
-		}
+			if !vaultpkg.IsInitialized(vaultDir) {
+				return errorspkg.NewVaultNotInitialized()
+			}
 
-		cli.PrintQuietAware("Vault restored to: %s\n", vaultDir)
-		return nil
-	},
+			cli.PrintQuietAware("Vault restored to: %s\n", vaultDir)
+			return nil
+		},
+	}
+	restoreCmd.GroupID = cli.GroupIDSharingSync
+	return restoreCmd
 }
 
 func RestoreBackup(archivePath, vaultDir string) error {
@@ -313,10 +322,4 @@ func ComputeSHA256(path string) (string, error) {
 		return "", err
 	}
 	return fmt.Sprintf("%x", h.Sum(nil)), nil
-}
-
-func init() {
-	backupCmd.Flags().BoolVar(&BackupExcludeGit, "exclude-git", false, "Exclude .git/ directory from backup")
-	backupCmd.GroupID = cli.GroupIDSharingSync
-	restoreCmd.GroupID = cli.GroupIDSharingSync
 }

--- a/cmd/admin/commands.go
+++ b/cmd/admin/commands.go
@@ -5,20 +5,22 @@ import (
 )
 
 // NewCommands returns all administration commands for root command assembly.
+// Each call builds a fresh command tree so consecutive calls never share
+// command objects or flag state.
 func NewCommands() []*cobra.Command {
 	return []*cobra.Command{
-		AuditCmd,
-		backupCmd,
-		restoreCmd,
-		configCmd,
-		DoctorCmd,
-		exportCmd,
-		importCmd,
-		initCmd,
-		MigrateCmd,
-		setupCmd,
-		startupProfileCmd,
-		UpdateCmd,
-		verifyCmd,
+		newAuditCmd(),
+		newBackupCmd(),
+		newRestoreCmd(),
+		newConfigCmd(),
+		newDoctorCmd(),
+		newExportCmd(),
+		newImportCmd(),
+		newInitCmd(),
+		newMigrateCmd(),
+		newSetupCmd(),
+		newStartupProfileCmd(),
+		newUpdateCmd(),
+		newVerifyCmd(),
 	}
 }

--- a/cmd/admin/config.go
+++ b/cmd/admin/config.go
@@ -20,11 +20,12 @@ var (
 	ConfigValidateFix  bool
 )
 
-var configCmd = &cobra.Command{
-	Use:   "config",
-	Short: "Manage Symaira Vault configuration",
-	Long:  `Manage Symaira Vault configuration including validation, profiles, and key-value editing.`,
-	Example: `  # Validate the default config file
+func newConfigCmd() *cobra.Command {
+	configCmd := &cobra.Command{
+		Use:   "config",
+		Short: "Manage Symaira Vault configuration",
+		Long:  `Manage Symaira Vault configuration including validation, profiles, and key-value editing.`,
+		Example: `  # Validate the default config file
   symvault config validate
 
   # Validate a specific file
@@ -41,125 +42,137 @@ var configCmd = &cobra.Command{
 
   # JSON output
   symvault config get vaultDir --output json`,
-	Annotations: map[string]string{
-		cli.RequiresVaultAnnotation: "false",
-		cli.JSONOutputAnnotation:    "true",
-	},
+		Annotations: map[string]string{
+			cli.RequiresVaultAnnotation: "false",
+			cli.JSONOutputAnnotation:    "true",
+		},
+	}
+	configCmd.AddCommand(newConfigValidateCmd())
+	configCmd.AddCommand(newConfigGetCmd())
+	configCmd.AddCommand(newConfigSetCmd())
+	configCmd.AddCommand(newConfigListCmd())
+	configCmd.GroupID = cli.GroupIDAdministration
+	return configCmd
 }
 
-var configValidateCmd = &cobra.Command{
-	Use:   "validate [path]",
-	Short: "Validate the configuration file",
-	Long: `Validate the Symaira Vault configuration file for schema errors.
+func newConfigValidateCmd() *cobra.Command {
+	configValidateCmd := &cobra.Command{
+		Use:   "validate [path]",
+		Short: "Validate the configuration file",
+		Long: `Validate the Symaira Vault configuration file for schema errors.
 
 If no path is given, validates the default config at ~/.symvault/config.yaml.
 
 When --fix is supplied, validation failures and recoverable load errors trigger
 an interactive repair flow: deterministic defaults are offered for fields that
 have safe replacements, and a manual $EDITOR session is offered as a fall-back.`,
-	Args: cobra.MaximumNArgs(1),
-	Annotations: map[string]string{
-		cli.RequiresVaultAnnotation: "false",
-	},
-	RunE: func(cmd *cobra.Command, args []string) error {
-		var path string
-		if len(args) > 0 {
-			path = args[0]
-		} else {
-			home, err := os.UserHomeDir()
-			if err != nil {
-				return errorspkg.NewCLIError(errorspkg.ExitGeneralError, "cannot determine home directory", err)
-			}
-			path = filepath.Join(home, configpkg.DefaultVaultSubdir, "config.yaml")
-		}
-
-		cfg, err := configpkg.Load(path)
-		jsonOut := cli.WantJSONOutput(ConfigValidateJSON)
-		if err != nil {
-			if ConfigValidateFix && cli.IsTerminalFunc(int(os.Stdin.Fd())) {
-				fixed, fixErr := cli.InteractiveFixConfig(path, err, nil, nil)
-				if fixErr != nil {
-					return errorspkg.NewCLIError(errorspkg.ExitConfigError, "config fix failed", fixErr)
+		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{
+			cli.RequiresVaultAnnotation: "false",
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var path string
+			if len(args) > 0 {
+				path = args[0]
+			} else {
+				home, err := os.UserHomeDir()
+				if err != nil {
+					return errorspkg.NewCLIError(errorspkg.ExitGeneralError, "cannot determine home directory", err)
 				}
-				if fixed != nil {
-					cli.PrintlnQuietAware("Configuration repaired successfully.")
-					cfg = fixed
+				path = filepath.Join(home, configpkg.DefaultVaultSubdir, "config.yaml")
+			}
+
+			cfg, err := configpkg.Load(path)
+			jsonOut := cli.WantJSONOutput(ConfigValidateJSON)
+			if err != nil {
+				if ConfigValidateFix && cli.IsTerminalFunc(int(os.Stdin.Fd())) {
+					fixed, fixErr := cli.InteractiveFixConfig(path, err, nil, nil)
+					if fixErr != nil {
+						return errorspkg.NewCLIError(errorspkg.ExitConfigError, "config fix failed", fixErr)
+					}
+					if fixed != nil {
+						cli.PrintlnQuietAware("Configuration repaired successfully.")
+						cfg = fixed
+						goto revalidate
+					}
+					// User edited the file in $EDITOR; reload and re-validate.
+					newCfg, reloadErr := configpkg.Load(path)
+					if reloadErr != nil {
+						return errorspkg.NewCLIError(errorspkg.ExitConfigError, "config still invalid after manual edit", reloadErr)
+					}
+					cfg = newCfg
 					goto revalidate
 				}
-				// User edited the file in $EDITOR; reload and re-validate.
-				newCfg, reloadErr := configpkg.Load(path)
-				if reloadErr != nil {
-					return errorspkg.NewCLIError(errorspkg.ExitConfigError, "config still invalid after manual edit", reloadErr)
+				if jsonOut {
+					cli.PrintJSON(map[string]interface{}{
+						"valid": false,
+						"error": err.Error(),
+					})
+					return errorspkg.NewCLIError(errorspkg.ExitConfigError, "config load failed", err)
 				}
-				cfg = newCfg
-				goto revalidate
+				return errorspkg.NewCLIError(errorspkg.ExitConfigError, fmt.Sprintf("cannot load config from %s: %v", path, err), err)
 			}
-			if jsonOut {
-				cli.PrintJSON(map[string]interface{}{
-					"valid": false,
-					"error": err.Error(),
-				})
-				return errorspkg.NewCLIError(errorspkg.ExitConfigError, "config load failed", err)
-			}
-			return errorspkg.NewCLIError(errorspkg.ExitConfigError, fmt.Sprintf("cannot load config from %s: %v", path, err), err)
-		}
 
-	revalidate:
-		if valErr := cfg.Validate(); valErr != nil {
-			if ConfigValidateFix && cli.IsTerminalFunc(int(os.Stdin.Fd())) {
-				fixed, fixErr := cli.InteractiveFixConfig(path, nil, cfg, valErr)
-				if fixErr != nil {
-					return errorspkg.NewCLIError(errorspkg.ExitConfigError, "config fix failed", fixErr)
-				}
-				if fixed != nil {
-					cli.PrintlnQuietAware("Configuration repaired successfully.")
-					cfg = fixed
-					if valErr2 := cfg.Validate(); valErr2 != nil {
-						return errorspkg.NewCLIError(errorspkg.ExitConfigError, "config still invalid after auto-fix", valErr2)
+		revalidate:
+			if valErr := cfg.Validate(); valErr != nil {
+				if ConfigValidateFix && cli.IsTerminalFunc(int(os.Stdin.Fd())) {
+					fixed, fixErr := cli.InteractiveFixConfig(path, nil, cfg, valErr)
+					if fixErr != nil {
+						return errorspkg.NewCLIError(errorspkg.ExitConfigError, "config fix failed", fixErr)
 					}
+					if fixed != nil {
+						cli.PrintlnQuietAware("Configuration repaired successfully.")
+						cfg = fixed
+						if valErr2 := cfg.Validate(); valErr2 != nil {
+							return errorspkg.NewCLIError(errorspkg.ExitConfigError, "config still invalid after auto-fix", valErr2)
+						}
+						goto ok
+					}
+					// User edited the file in $EDITOR; reload and re-validate.
+					newCfg, reloadErr := configpkg.Load(path)
+					if reloadErr != nil {
+						return errorspkg.NewCLIError(errorspkg.ExitConfigError, "config still invalid after manual edit", reloadErr)
+					}
+					if valErr2 := newCfg.Validate(); valErr2 != nil {
+						return errorspkg.NewCLIError(errorspkg.ExitConfigError, "config still invalid after manual edit", valErr2)
+					}
+					cli.PrintlnQuietAware("Configuration repaired successfully.")
+					cfg = newCfg
 					goto ok
 				}
-				// User edited the file in $EDITOR; reload and re-validate.
-				newCfg, reloadErr := configpkg.Load(path)
-				if reloadErr != nil {
-					return errorspkg.NewCLIError(errorspkg.ExitConfigError, "config still invalid after manual edit", reloadErr)
+				if jsonOut {
+					cli.PrintJSON(map[string]interface{}{
+						"valid":  false,
+						"errors": strings.Split(valErr.Error(), "\n"),
+					})
+					return errorspkg.NewCLIError(errorspkg.ExitConfigError, "config validation failed", valErr)
 				}
-				if valErr2 := newCfg.Validate(); valErr2 != nil {
-					return errorspkg.NewCLIError(errorspkg.ExitConfigError, "config still invalid after manual edit", valErr2)
+				cli.PrintlnQuietAware(fmt.Sprintf("Configuration is invalid (%s):", path))
+				for _, line := range strings.Split(valErr.Error(), "\n") {
+					if line != "" {
+						cli.PrintlnQuietAware("  ✗ " + line)
+					}
 				}
-				cli.PrintlnQuietAware("Configuration repaired successfully.")
-				cfg = newCfg
-				goto ok
-			}
-			if jsonOut {
-				cli.PrintJSON(map[string]interface{}{
-					"valid":  false,
-					"errors": strings.Split(valErr.Error(), "\n"),
-				})
 				return errorspkg.NewCLIError(errorspkg.ExitConfigError, "config validation failed", valErr)
 			}
-			cli.PrintlnQuietAware(fmt.Sprintf("Configuration is invalid (%s):", path))
-			for _, line := range strings.Split(valErr.Error(), "\n") {
-				if line != "" {
-					cli.PrintlnQuietAware("  ✗ " + line)
-				}
+
+		ok:
+
+			if jsonOut {
+				cli.PrintJSON(map[string]interface{}{
+					"valid": true,
+					"path":  path,
+				})
+				return nil
 			}
-			return errorspkg.NewCLIError(errorspkg.ExitConfigError, "config validation failed", valErr)
-		}
 
-	ok:
-
-		if jsonOut {
-			cli.PrintJSON(map[string]interface{}{
-				"valid": true,
-				"path":  path,
-			})
+			cli.PrintlnQuietAware(fmt.Sprintf("Configuration is valid (%s)", path))
 			return nil
-		}
-
-		cli.PrintlnQuietAware(fmt.Sprintf("Configuration is valid (%s)", path))
-		return nil
-	},
+		},
+	}
+	configValidateCmd.Flags().BoolVar(&ConfigValidateJSON, "json", false, "output validation result as JSON (deprecated: use --output=json)")
+	configValidateCmd.Flags().BoolVar(&ConfigValidateFix, "fix", false, "interactively repair validation errors (requires a TTY)")
+	return configValidateCmd
 }
 
 func resolveConfigPath(_ []string) string {
@@ -187,51 +200,56 @@ func ConfigKeyCompletionFunc(_ *cobra.Command, _ []string, toComplete string) ([
 	return matches, cobra.ShellCompDirectiveNoFileComp
 }
 
-var configGetCmd = &cobra.Command{
-	Use:   "get <dotted.path>",
-	Short: "Get a configuration value",
-	Long: `Get the value of a configuration key using dotted path notation.
+func newConfigGetCmd() *cobra.Command {
+	configGetCmd := &cobra.Command{
+		Use:   "get <dotted.path>",
+		Short: "Get a configuration value",
+		Long: `Get the value of a configuration key using dotted path notation.
 
 Examples:
   symvault config get vaultDir
   symvault config get agents.claude-code.canWrite
   symvault config get mcp.port`,
-	Args:              cobra.ExactArgs(1),
-	ValidArgsFunction: ConfigKeyCompletionFunc,
-	Annotations: map[string]string{
-		cli.RequiresVaultAnnotation: "false",
-		cli.JSONOutputAnnotation:    "true",
-	},
-	RunE: func(cmd *cobra.Command, args []string) error {
-		path := resolveConfigPath(args)
-		if path == "" {
-			return errorspkg.NewCLIError(errorspkg.ExitGeneralError, "cannot determine config file path", nil)
-		}
-		key := args[0]
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: ConfigKeyCompletionFunc,
+		Annotations: map[string]string{
+			cli.RequiresVaultAnnotation: "false",
+			cli.JSONOutputAnnotation:    "true",
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			path := resolveConfigPath(args)
+			if path == "" {
+				return errorspkg.NewCLIError(errorspkg.ExitGeneralError, "cannot determine config file path", nil)
+			}
+			key := args[0]
 
-		root, err := configpkg.LoadConfigNode(path)
-		if err != nil {
-			return errorspkg.NewCLIError(errorspkg.ExitConfigError, fmt.Sprintf("cannot load config: %v", err), err)
-		}
+			root, err := configpkg.LoadConfigNode(path)
+			if err != nil {
+				return errorspkg.NewCLIError(errorspkg.ExitConfigError, fmt.Sprintf("cannot load config: %v", err), err)
+			}
 
-		node, err := configpkg.GetConfigValue(root, key)
-		if err != nil {
-			return errorspkg.NewCLIError(errorspkg.ExitConfigError, fmt.Sprintf("key %q not found", key), err)
-		}
+			node, err := configpkg.GetConfigValue(root, key)
+			if err != nil {
+				return errorspkg.NewCLIError(errorspkg.ExitConfigError, fmt.Sprintf("key %q not found", key), err)
+			}
 
-		val := configpkg.NodeToString(node)
-		if cli.OutputFormat == "json" {
-			return cli.PrintResult(map[string]string{key: val})
-		}
-		cli.PrintlnQuietAware(val)
-		return nil
-	},
+			val := configpkg.NodeToString(node)
+			if cli.OutputFormat == "json" {
+				return cli.PrintResult(map[string]string{key: val})
+			}
+			cli.PrintlnQuietAware(val)
+			return nil
+		},
+	}
+	configGetCmd.Flags().StringVar(&ConfigFile, "file", "", "path to config file (default: ~/.symvault/config.yaml)")
+	return configGetCmd
 }
 
-var configSetCmd = &cobra.Command{
-	Use:   "set <dotted.path> <value>",
-	Short: "Set a configuration value",
-	Long: `Set the value of a configuration key using dotted path notation.
+func newConfigSetCmd() *cobra.Command {
+	configSetCmd := &cobra.Command{
+		Use:   "set <dotted.path> <value>",
+		Short: "Set a configuration value",
+		Long: `Set the value of a configuration key using dotted path notation.
 The value is automatically parsed as YAML to infer types: true/false for booleans,
 numbers for integers, and quoted strings for text.
 
@@ -240,77 +258,69 @@ Examples:
   symvault config set agents.claude-code.canWrite true
   symvault config set mcp.port 9090
   symvault config set clipboard.auto_clear_duration 60`,
-	Args:              cobra.ExactArgs(2),
-	ValidArgsFunction: ConfigKeyCompletionFunc,
-	Annotations: map[string]string{
-		cli.RequiresVaultAnnotation: "false",
-	},
-	RunE: func(cmd *cobra.Command, args []string) error {
-		path := resolveConfigPath(args)
-		if path == "" {
-			return errorspkg.NewCLIError(errorspkg.ExitGeneralError, "cannot determine config file path", nil)
-		}
-		key := args[0]
-		value := args[1]
+		Args:              cobra.ExactArgs(2),
+		ValidArgsFunction: ConfigKeyCompletionFunc,
+		Annotations: map[string]string{
+			cli.RequiresVaultAnnotation: "false",
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			path := resolveConfigPath(args)
+			if path == "" {
+				return errorspkg.NewCLIError(errorspkg.ExitGeneralError, "cannot determine config file path", nil)
+			}
+			key := args[0]
+			value := args[1]
 
-		root, err := configpkg.LoadConfigNode(path)
-		if err != nil {
-			return errorspkg.NewCLIError(errorspkg.ExitConfigError, fmt.Sprintf("cannot load config: %v", err), err)
-		}
+			root, err := configpkg.LoadConfigNode(path)
+			if err != nil {
+				return errorspkg.NewCLIError(errorspkg.ExitConfigError, fmt.Sprintf("cannot load config: %v", err), err)
+			}
 
-		if err := configpkg.SetConfigValue(root, key, value); err != nil {
-			return errorspkg.NewCLIError(errorspkg.ExitConfigError, fmt.Sprintf("cannot set %q: %v", key, err), err)
-		}
+			if err := configpkg.SetConfigValue(root, key, value); err != nil {
+				return errorspkg.NewCLIError(errorspkg.ExitConfigError, fmt.Sprintf("cannot set %q: %v", key, err), err)
+			}
 
-		if err := configpkg.SaveConfigNode(path, root); err != nil {
-			return errorspkg.NewCLIError(errorspkg.ExitConfigError, fmt.Sprintf("cannot write config: %v", err), err)
-		}
+			if err := configpkg.SaveConfigNode(path, root); err != nil {
+				return errorspkg.NewCLIError(errorspkg.ExitConfigError, fmt.Sprintf("cannot write config: %v", err), err)
+			}
 
-		if _, loadErr := configpkg.Load(path); loadErr != nil {
-			return errorspkg.NewCLIError(errorspkg.ExitConfigError, fmt.Sprintf("config is invalid after update: %v", loadErr), loadErr)
-		}
+			if _, loadErr := configpkg.Load(path); loadErr != nil {
+				return errorspkg.NewCLIError(errorspkg.ExitConfigError, fmt.Sprintf("config is invalid after update: %v", loadErr), loadErr)
+			}
 
-		cli.PrintlnQuietAware(fmt.Sprintf("Set %s = %s", key, value))
-		return nil
-	},
+			cli.PrintlnQuietAware(fmt.Sprintf("Set %s = %s", key, value))
+			return nil
+		},
+	}
+	configSetCmd.Flags().StringVar(&ConfigFile, "file", "", "path to config file (default: ~/.symvault/config.yaml)")
+	return configSetCmd
 }
 
-var configListCmd = &cobra.Command{
-	Use:   "list",
-	Short: "Show all configuration values",
-	Long: `Display the entire Symaira Vault configuration in YAML format.
+func newConfigListCmd() *cobra.Command {
+	configListCmd := &cobra.Command{
+		Use:   "list",
+		Short: "Show all configuration values",
+		Long: `Display the entire Symaira Vault configuration in YAML format.
 
 This shows the raw config file contents as-is.`,
-	Args: cobra.NoArgs,
-	Annotations: map[string]string{
-		cli.RequiresVaultAnnotation: "false",
-	},
-	RunE: func(cmd *cobra.Command, args []string) error {
-		path := resolveConfigPath(args)
-		if path == "" {
-			return errorspkg.NewCLIError(errorspkg.ExitGeneralError, "cannot determine config file path", nil)
-		}
+		Args: cobra.NoArgs,
+		Annotations: map[string]string{
+			cli.RequiresVaultAnnotation: "false",
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			path := resolveConfigPath(args)
+			if path == "" {
+				return errorspkg.NewCLIError(errorspkg.ExitGeneralError, "cannot determine config file path", nil)
+			}
 
-		raw, err := os.ReadFile(filepath.Clean(path))
-		if err != nil {
-			return errorspkg.NewCLIError(errorspkg.ExitConfigError, fmt.Sprintf("cannot load config: %v", err), err)
-		}
-		cli.PrintQuietAware("%s", string(raw))
-		return nil
-	},
-}
-
-func init() {
-	configValidateCmd.Flags().BoolVar(&ConfigValidateJSON, "json", false, "output validation result as JSON (deprecated: use --output=json)")
-	configValidateCmd.Flags().BoolVar(&ConfigValidateFix, "fix", false, "interactively repair validation errors (requires a TTY)")
-
-	configGetCmd.Flags().StringVar(&ConfigFile, "file", "", "path to config file (default: ~/.symvault/config.yaml)")
-	configSetCmd.Flags().StringVar(&ConfigFile, "file", "", "path to config file (default: ~/.symvault/config.yaml)")
+			raw, err := os.ReadFile(filepath.Clean(path))
+			if err != nil {
+				return errorspkg.NewCLIError(errorspkg.ExitConfigError, fmt.Sprintf("cannot load config: %v", err), err)
+			}
+			cli.PrintQuietAware("%s", string(raw))
+			return nil
+		},
+	}
 	configListCmd.Flags().StringVar(&ConfigFile, "file", "", "path to config file (default: ~/.symvault/config.yaml)")
-
-	configCmd.AddCommand(configValidateCmd)
-	configCmd.AddCommand(configGetCmd)
-	configCmd.AddCommand(configSetCmd)
-	configCmd.AddCommand(configListCmd)
-	configCmd.GroupID = cli.GroupIDAdministration
+	return configListCmd
 }

--- a/cmd/admin/doctor.go
+++ b/cmd/admin/doctor.go
@@ -25,17 +25,22 @@ var (
 	DoctorQuick     bool
 )
 
-var DoctorCmd = &cobra.Command{
-	Use:   "doctor",
-	Short: "Check vault health and configuration",
-	Long: `Run a series of health checks on the current vault and report their status.
+// DoctorCmd is retained for API compatibility; NewCommands() uses
+// newDoctorCmd() so every call gets a fresh command.
+var DoctorCmd = newDoctorCmd()
+
+func newDoctorCmd() *cobra.Command {
+	DoctorCmd := &cobra.Command{
+		Use:   "doctor",
+		Short: "Check vault health and configuration",
+		Long: `Run a series of health checks on the current vault and report their status.
 
 Output modes:
   --text (default): colored output, one line per check
   --json:           machine-readable JSON (suitable for CI/monitoring)
 
 Use --no-network to skip checks that require network access (git remote reachability, update check).`,
-	Example: `  # Full health check
+		Example: `  # Full health check
   symvault doctor
 
   # JSON output, no network
@@ -47,63 +52,74 @@ Use --no-network to skip checks that require network access (git remote reachabi
   # Auto-fix what's safe to fix (with dry-run first)
   symvault doctor --fix-dry-run
   symvault doctor --fix`,
-	Annotations: map[string]string{
-		cli.RequiresVaultAnnotation: "false",
-	},
-	RunE: func(cmd *cobra.Command, args []string) error {
-		vaultDir := cli.GetVaultDir()
-		opts := health.Options{
-			NoNetwork: DoctorNoNetwork,
-			Quick:     DoctorQuick,
-			Version:   cli.AppVersion,
-			Only:      DoctorOnly,
-			Exclude:   DoctorExclude,
-		}
-		results := health.RunChecks(vaultDir, opts)
+		Annotations: map[string]string{
+			cli.RequiresVaultAnnotation: "false",
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			vaultDir := cli.GetVaultDir()
+			opts := health.Options{
+				NoNetwork: DoctorNoNetwork,
+				Quick:     DoctorQuick,
+				Version:   cli.AppVersion,
+				Only:      DoctorOnly,
+				Exclude:   DoctorExclude,
+			}
+			results := health.RunChecks(vaultDir, opts)
 
-		// Fix ordering: --fix runs first to patch results (changing their Status),
-		// then Score() evaluates the final state. This ensures the score reflects
-		// any repairs that were applied. --fix-dry-run logs intent without changes.
-		if DoctorFix {
-			for i := range results {
-				r := &results[i]
-				if r.Fixable && r.Status != health.StatusOK && r.Fix != nil {
-					if DoctorFixDryRun {
-						cmd.Printf("Would fix %s: %s\n", r.ID, r.Message)
-						continue
-					}
-					if err := r.Fix(); err != nil {
-						r.Message = "fix failed: " + err.Error()
-					} else {
-						r.Fixed = true
-						r.Status = health.StatusOK
-						r.Message = "fixed — " + r.Message
+			// Fix ordering: --fix runs first to patch results (changing their Status),
+			// then Score() evaluates the final state. This ensures the score reflects
+			// any repairs that were applied. --fix-dry-run logs intent without changes.
+			if DoctorFix {
+				for i := range results {
+					r := &results[i]
+					if r.Fixable && r.Status != health.StatusOK && r.Fix != nil {
+						if DoctorFixDryRun {
+							cmd.Printf("Would fix %s: %s\n", r.ID, r.Message)
+							continue
+						}
+						if err := r.Fix(); err != nil {
+							r.Message = "fix failed: " + err.Error()
+						} else {
+							r.Fixed = true
+							r.Status = health.StatusOK
+							r.Message = "fixed — " + r.Message
+						}
 					}
 				}
 			}
-		}
 
-		if cli.WantJSONOutput(DoctorJSON) {
-			if err := outputDoctorJSON(cmd, vaultDir, results); err != nil {
-				return err
+			if cli.WantJSONOutput(DoctorJSON) {
+				if err := outputDoctorJSON(cmd, vaultDir, results); err != nil {
+					return err
+				}
+			} else {
+				if err := outputDoctorText(cmd, vaultDir, results); err != nil {
+					return err
+				}
 			}
-		} else {
-			if err := outputDoctorText(cmd, vaultDir, results); err != nil {
-				return err
-			}
-		}
 
-		if DoctorStrict {
-			_, warn, fail := health.Score(results)
-			if fail > 0 {
-				return errorspkg.NewCLIError(errorspkg.ExitDoctorFail, fmt.Sprintf("%d check(s) failed", fail), nil)
+			if DoctorStrict {
+				_, warn, fail := health.Score(results)
+				if fail > 0 {
+					return errorspkg.NewCLIError(errorspkg.ExitDoctorFail, fmt.Sprintf("%d check(s) failed", fail), nil)
+				}
+				if warn > 0 {
+					return errorspkg.NewCLIError(errorspkg.ExitDoctorWarn, fmt.Sprintf("%d warning(s)", warn), nil)
+				}
 			}
-			if warn > 0 {
-				return errorspkg.NewCLIError(errorspkg.ExitDoctorWarn, fmt.Sprintf("%d warning(s)", warn), nil)
-			}
-		}
-		return nil
-	},
+			return nil
+		},
+	}
+	DoctorCmd.GroupID = cli.GroupIDEssentials
+	DoctorCmd.Flags().BoolVar(&DoctorJSON, "json", false, "Output in JSON format (deprecated: use --output=json)")
+	DoctorCmd.Flags().BoolVar(&DoctorNoNetwork, "no-network", false, "Skip network-dependent checks")
+	DoctorCmd.Flags().BoolVar(&DoctorStrict, "strict", false, "Return non-zero exit code for warnings (7) or failures (8)")
+	DoctorCmd.Flags().StringSliceVar(&DoctorOnly, "only", nil, "Only run checks matching these glob patterns (comma-separated, e.g. vault.*)")
+	DoctorCmd.Flags().StringSliceVar(&DoctorExclude, "exclude", nil, "Skip checks matching these glob patterns (comma-separated)")
+	DoctorCmd.Flags().BoolVar(&DoctorFix, "fix", false, "auto-repair safe issues (permissions, gitignore, git init)")
+	DoctorCmd.Flags().BoolVar(&DoctorFixDryRun, "fix-dry-run", false, "Log what --fix would do without modifying anything")
+	DoctorCmd.Flags().BoolVar(&DoctorQuick, "quick", false, "Skip slow checks (scrypt benchmark, update check)")
+	return DoctorCmd
 }
 
 func outputDoctorText(cmd *cobra.Command, vaultDir string, results []health.Result) error {
@@ -184,16 +200,4 @@ func outputDoctorJSON(cmd *cobra.Command, vaultDir string, results []health.Resu
 	enc := json.NewEncoder(cmd.OutOrStdout())
 	enc.SetIndent("", "  ")
 	return enc.Encode(out)
-}
-
-func init() {
-	DoctorCmd.GroupID = cli.GroupIDEssentials
-	DoctorCmd.Flags().BoolVar(&DoctorJSON, "json", false, "Output in JSON format (deprecated: use --output=json)")
-	DoctorCmd.Flags().BoolVar(&DoctorNoNetwork, "no-network", false, "Skip network-dependent checks")
-	DoctorCmd.Flags().BoolVar(&DoctorStrict, "strict", false, "Return non-zero exit code for warnings (7) or failures (8)")
-	DoctorCmd.Flags().StringSliceVar(&DoctorOnly, "only", nil, "Only run checks matching these glob patterns (comma-separated, e.g. vault.*)")
-	DoctorCmd.Flags().StringSliceVar(&DoctorExclude, "exclude", nil, "Skip checks matching these glob patterns (comma-separated)")
-	DoctorCmd.Flags().BoolVar(&DoctorFix, "fix", false, "auto-repair safe issues (permissions, gitignore, git init)")
-	DoctorCmd.Flags().BoolVar(&DoctorFixDryRun, "fix-dry-run", false, "Log what --fix would do without modifying anything")
-	DoctorCmd.Flags().BoolVar(&DoctorQuick, "quick", false, "Skip slow checks (scrypt benchmark, update check)")
 }

--- a/cmd/admin/export.go
+++ b/cmd/admin/export.go
@@ -32,11 +32,12 @@ var (
 // cli.ConfirmInteractive's shared implementation.
 var confirmExport = cli.ConfirmInteractive
 
-var exportCmd = &cobra.Command{
-	Use:   "export",
-	Short: "Export vault entries to CSV or JSON",
-	Long:  "Exports all vault entries in CSV or JSON format for portability and backup.",
-	Example: `  # Export all entries as JSON
+func newExportCmd() *cobra.Command {
+	exportCmd := &cobra.Command{
+		Use:   "export",
+		Short: "Export vault entries to CSV or JSON",
+		Long:  "Exports all vault entries in CSV or JSON format for portability and backup.",
+		Example: `  # Export all entries as JSON
   symvault export --format json
 
   # Export as CSV to a file
@@ -44,171 +45,170 @@ var exportCmd = &cobra.Command{
 
   # Export with field mapping (rename columns)
   symvault export --format csv --mapping "path=title,username=user,password=secret"`,
-	Args: cobra.NoArgs,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		format := exporter.Format(ExportFormat)
-		if !isSupportedExportFormat(format) {
-			return errorspkg.NewCLIError(errorspkg.ExitGeneralError, fmt.Sprintf("unsupported export format: %s", ExportFormat), nil)
-		}
-
-		mapping, err := importer.ParseMapping(ExportMapping)
-		if err != nil {
-			return errorspkg.NewCLIError(errorspkg.ExitGeneralError, "invalid mapping", err)
-		}
-
-		const warningMsg = "WARNING: Vault export produces unencrypted output. All secrets will be in plaintext."
-		if ExportYes {
-			// Scripting mode: respect --quiet suppression via cliout.
-			cliout.Warnf(warningMsg)
-		} else {
-			// Interactive mode: always show, even in quiet — user must see before confirming.
-			fmt.Fprintln(os.Stderr, warningMsg)
-		}
-
-		confirmed, err := confirmExport("Export all vault entries as plaintext?", ExportYes)
-		if err != nil {
-			return errorspkg.NewCLIError(errorspkg.ExitGeneralError, "export confirmation failed", err)
-		}
-		if !confirmed {
-			fmt.Fprintln(os.Stderr, "Export canceled.")
-			return nil
-		}
-
-		return cli.WithVault(func(v *vaultpkg.Vault, vs *cli.VaultService) (retErr error) {
-			entries, err := vs.ListEntries("")
-			if err != nil {
-				return fmt.Errorf("list entries: %w", err)
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			format := exporter.Format(ExportFormat)
+			if !isSupportedExportFormat(format) {
+				return errorspkg.NewCLIError(errorspkg.ExitGeneralError, fmt.Sprintf("unsupported export format: %s", ExportFormat), nil)
 			}
 
-			if len(entries) == 0 {
-				cli.PrintQuietAware("No entries found in vault.\n")
+			mapping, err := importer.ParseMapping(ExportMapping)
+			if err != nil {
+				return errorspkg.NewCLIError(errorspkg.ExitGeneralError, "invalid mapping", err)
+			}
+
+			const warningMsg = "WARNING: Vault export produces unencrypted output. All secrets will be in plaintext."
+			if ExportYes {
+				// Scripting mode: respect --quiet suppression via cliout.
+				cliout.Warnf(warningMsg)
+			} else {
+				// Interactive mode: always show, even in quiet — user must see before confirming.
+				fmt.Fprintln(os.Stderr, warningMsg)
+			}
+
+			confirmed, err := confirmExport("Export all vault entries as plaintext?", ExportYes)
+			if err != nil {
+				return errorspkg.NewCLIError(errorspkg.ExitGeneralError, "export confirmation failed", err)
+			}
+			if !confirmed {
+				fmt.Fprintln(os.Stderr, "Export canceled.")
 				return nil
 			}
 
-			out, createErr := fsutil.CreateSensitiveOutput(ExportOutput)
-			if createErr != nil {
-				return errorspkg.NewCLIError(errorspkg.ExitGeneralError, "create output file", createErr)
-			}
-			defer func() {
-				if closeErr := out.Close(); closeErr != nil && retErr == nil {
-					retErr = errorspkg.NewCLIError(errorspkg.ExitGeneralError, "close output file", closeErr)
+			return cli.WithVault(func(v *vaultpkg.Vault, vs *cli.VaultService) (retErr error) {
+				entries, err := vs.ListEntries("")
+				if err != nil {
+					return fmt.Errorf("list entries: %w", err)
 				}
-			}()
 
-			workers := 0
-			if v.Config != nil && v.Config.Vault != nil {
-				workers = v.Config.Vault.SearchWorkers
-			}
-			maxWorkers := vaultpkg.SearchWorkerCount(workers)
+				if len(entries) == 0 {
+					cli.PrintQuietAware("No entries found in vault.\n")
+					return nil
+				}
 
-			entryChan := make(chan struct {
-				index int
-				path  string
-			}, len(entries))
-			resultChan := make(chan exportResult, len(entries))
+				out, createErr := fsutil.CreateSensitiveOutput(ExportOutput)
+				if createErr != nil {
+					return errorspkg.NewCLIError(errorspkg.ExitGeneralError, "create output file", createErr)
+				}
+				defer func() {
+					if closeErr := out.Close(); closeErr != nil && retErr == nil {
+						retErr = errorspkg.NewCLIError(errorspkg.ExitGeneralError, "close output file", closeErr)
+					}
+				}()
 
-			done := make(chan struct{})
-			var cancelOnce sync.Once
-			cancel := func() { cancelOnce.Do(func() { close(done) }) }
+				workers := 0
+				if v.Config != nil && v.Config.Vault != nil {
+					workers = v.Config.Vault.SearchWorkers
+				}
+				maxWorkers := vaultpkg.SearchWorkerCount(workers)
 
-			var wg sync.WaitGroup
-			for i := 0; i < maxWorkers; i++ {
-				wg.Add(1)
+				entryChan := make(chan struct {
+					index int
+					path  string
+				}, len(entries))
+				resultChan := make(chan exportResult, len(entries))
+
+				done := make(chan struct{})
+				var cancelOnce sync.Once
+				cancel := func() { cancelOnce.Do(func() { close(done) }) }
+
+				var wg sync.WaitGroup
+				for i := 0; i < maxWorkers; i++ {
+					wg.Add(1)
+					go func() {
+						defer wg.Done()
+						for item := range entryChan {
+							select {
+							case <-done:
+								return
+							default:
+							}
+							entry, readErr := vs.GetEntry(item.path)
+							if readErr != nil {
+								resultChan <- exportResult{
+									index: item.index,
+									err:   fmt.Errorf("read entry %s: %w", item.path, readErr),
+								}
+								cancel()
+								return
+							}
+							resultChan <- exportResult{
+								index: item.index,
+								entry: exporter.ExportEntry{
+									Path: item.path,
+									Data: entry.Data,
+								},
+							}
+						}
+					}()
+				}
+
 				go func() {
-					defer wg.Done()
-					for item := range entryChan {
+					defer close(entryChan)
+					for i, path := range entries {
 						select {
 						case <-done:
 							return
-						default:
-						}
-						entry, readErr := vs.GetEntry(item.path)
-						if readErr != nil {
-							resultChan <- exportResult{
-								index: item.index,
-								err:   fmt.Errorf("read entry %s: %w", item.path, readErr),
-							}
-							cancel()
-							return
-						}
-						resultChan <- exportResult{
-							index: item.index,
-							entry: exporter.ExportEntry{
-								Path: item.path,
-								Data: entry.Data,
-							},
+						case entryChan <- struct {
+							index int
+							path  string
+						}{index: i, path: path}:
 						}
 					}
 				}()
-			}
 
-			go func() {
-				defer close(entryChan)
-				for i, path := range entries {
-					select {
-					case <-done:
-						return
-					case entryChan <- struct {
-						index int
-						path  string
-					}{index: i, path: path}:
+				go func() {
+					wg.Wait()
+					close(resultChan)
+				}()
+
+				if format == exporter.FormatJSON {
+					if err := exportJSONStreaming(out, resultChan, mapping); err != nil {
+						return errorspkg.NewCLIError(errorspkg.ExitGeneralError, "export entries", err)
+					}
+				} else {
+					exportEntries := make([]exporter.ExportEntry, len(entries))
+					for result := range resultChan {
+						if result.err != nil {
+							return result.err
+						}
+						exportEntries[result.index] = result.entry
+					}
+
+					exp, expErr := newExporter(format)
+					if expErr != nil {
+						return errorspkg.NewCLIError(errorspkg.ExitGeneralError, "create exporter", expErr)
+					}
+					if err := exp.Export(out, exportEntries, mapping); err != nil {
+						return errorspkg.NewCLIError(errorspkg.ExitGeneralError, "export entries", err)
 					}
 				}
-			}()
 
-			go func() {
-				wg.Wait()
-				close(resultChan)
-			}()
-
-			if format == exporter.FormatJSON {
-				if err := exportJSONStreaming(out, resultChan, mapping); err != nil {
-					return errorspkg.NewCLIError(errorspkg.ExitGeneralError, "export entries", err)
-				}
-			} else {
-				exportEntries := make([]exporter.ExportEntry, len(entries))
-				for result := range resultChan {
-					if result.err != nil {
-						return result.err
+				if auditLog, auditErr := audit.New("symvault", v.Dir, v.Identity); auditErr == nil {
+					if logErr := auditLog.LogEntry(audit.LogEntry{
+						Action:    "export",
+						OK:        true,
+						Timestamp: time.Now().UTC().Format(time.RFC3339),
+					}); logErr != nil {
+						cliout.Warnf("Warning: audit log write failed: %v", logErr)
 					}
-					exportEntries[result.index] = result.entry
+					if closeErr := auditLog.Close(); closeErr != nil {
+						cliout.Warnf("Warning: audit log close failed: %v", closeErr)
+					}
 				}
 
-				exp, expErr := newExporter(format)
-				if expErr != nil {
-					return errorspkg.NewCLIError(errorspkg.ExitGeneralError, "create exporter", expErr)
-				}
-				if err := exp.Export(out, exportEntries, mapping); err != nil {
-					return errorspkg.NewCLIError(errorspkg.ExitGeneralError, "export entries", err)
-				}
-			}
-
-			if auditLog, auditErr := audit.New("symvault", v.Dir, v.Identity); auditErr == nil {
-				if logErr := auditLog.LogEntry(audit.LogEntry{
-					Action:    "export",
-					OK:        true,
-					Timestamp: time.Now().UTC().Format(time.RFC3339),
-				}); logErr != nil {
-					cliout.Warnf("Warning: audit log write failed: %v", logErr)
-				}
-				if closeErr := auditLog.Close(); closeErr != nil {
-					cliout.Warnf("Warning: audit log close failed: %v", closeErr)
-				}
-			}
-
-			cli.PrintQuietAware("Exported %d entries\n", len(entries))
-			return nil
-		})
-	},
-}
-
-func init() {
+				cli.PrintQuietAware("Exported %d entries\n", len(entries))
+				return nil
+			})
+		},
+	}
 	exportCmd.Flags().StringVar(&ExportFormat, "format", "", "Export format: csv or json (required)")
 	exportCmd.Flags().StringVar(&ExportMapping, "mapping", "", "Column mapping (format: vault_field=output_header,...)")
 	exportCmd.Flags().StringVar(&ExportOutput, "output", "", "Output file path (default: stdout)")
 	exportCmd.Flags().BoolVarP(&ExportYes, "yes", "y", false, "Skip confirmation prompt")
 	_ = exportCmd.MarkFlagRequired("format") //nolint:errcheck
 	exportCmd.GroupID = cli.GroupIDSharingSync
+	return exportCmd
 }
 
 func isSupportedExportFormat(format exporter.Format) bool {

--- a/cmd/admin/import.go
+++ b/cmd/admin/import.go
@@ -30,10 +30,11 @@ var (
 	ImportFormat       string
 )
 
-var importCmd = &cobra.Command{
-	Use:   "import <source>",
-	Short: "Import entries from another password manager",
-	Long: `Imports password entries from another password manager.
+func newImportCmd() *cobra.Command {
+	importCmd := &cobra.Command{
+		Use:   "import <source>",
+		Short: "Import entries from another password manager",
+		Long: `Imports password entries from another password manager.
 
 When --format is not specified, the format is auto-detected from the input file extension:
   .csv  → CSV format
@@ -41,7 +42,7 @@ When --format is not specified, the format is auto-detected from the input file 
   .yaml/.yml → YAML format
 
 Use --format to override auto-detection or when the file extension does not match the actual format.`,
-	Example: `  # Auto-detect format from file extension
+		Example: `  # Auto-detect format from file extension
   symvault import bw-export.json --dry-run
 
   # Explicitly specify format (overrides auto-detection)
@@ -52,143 +53,141 @@ Use --format to override auto-detection or when the file extension does not matc
 
   # Auto-detect CSV from .csv extension
   symvault import data.csv --overwrite`,
-	Args: cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		sourcePath := args[0]
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			sourcePath := args[0]
 
-		var format importer.Format
-		if ImportFormat != "" {
-			format = importer.Format(strings.ToLower(strings.TrimSpace(ImportFormat)))
-		} else {
-			var err error
-			format, err = detectFormatFromExt(sourcePath)
-			if err != nil {
-				return errorspkg.NewCLIError(errorspkg.ExitGeneralError, err.Error(), nil)
-			}
-		}
-		if !isSupportedImportFormat(format) {
-			return errorspkg.NewCLIError(errorspkg.ExitGeneralError, fmt.Sprintf("unsupported import format: %s", format), nil)
-		}
-
-		if ImportSkipExisting && ImportOverwrite {
-			return errorspkg.NewCLIError(errorspkg.ExitGeneralError, "--skip-existing and --overwrite cannot be used together", nil)
-		}
-
-		if ImportQuarantine && ImportPrefix != "" {
-			return errorspkg.NewCLIError(errorspkg.ExitGeneralError, "--quarantine and --prefix cannot be used together", nil)
-		}
-
-		options := importer.ImportOptions{
-			DryRun:       ImportDryRun,
-			Prefix:       strings.Trim(ImportPrefix, "/"),
-			SkipExisting: ImportSkipExisting,
-			Overwrite:    ImportOverwrite,
-			Mapping:      ImportMapping,
-		}
-
-		if ImportQuarantine {
-			importID := generateImportID()
-			options.Prefix = "quarantine/" + importID
-			cli.PrintQuietAware("Quarantine import ID: %s\n", importID)
-		}
-
-		if _, err := importer.ParseMapping(options.Mapping); err != nil {
-			return errorspkg.NewCLIError(errorspkg.ExitGeneralError, "invalid CSV mapping", err)
-		}
-
-		source, err := os.Open(sourcePath) // #nosec G304 -- import source path is user-provided CLI argument
-		if err != nil {
-			return errorspkg.NewCLIError(errorspkg.ExitGeneralError, "open import source", err)
-		}
-		defer func() { _ = source.Close() }()
-
-		fi, err := source.Stat()
-		if err != nil {
-			return errorspkg.NewCLIError(errorspkg.ExitGeneralError, "stat import source", err)
-		}
-		if fi.Size() > importer.MaxImportSize {
-			return errorspkg.NewCLIError(errorspkg.ExitGeneralError,
-				fmt.Sprintf("import source exceeds maximum size of %d bytes", importer.MaxImportSize), nil)
-		}
-
-		imp, err := newImporter(format, options)
-		if err != nil {
-			return errorspkg.NewCLIError(errorspkg.ExitGeneralError, "create importer", err)
-		}
-
-		entries, err := imp.Parse(source)
-		if err != nil {
-			return errorspkg.NewCLIError(errorspkg.ExitGeneralError, "parse import source", err)
-		}
-
-		return cli.WithVault(func(v *vaultpkg.Vault, vs *cli.VaultService) error {
-			// Batch mode: the write loop below would otherwise trigger a full
-			// decrypt/re-encrypt/persist of the search index per entry (O(N²)
-			// total). Suspend defers index maintenance; the deferred Resume
-			// performs exactly one rebuild — even when the import fails midway —
-			// and invalidates the index explicitly if that rebuild fails, so the
-			// index is never left silently stale.
-			if !options.DryRun {
-				vaultpkg.SuspendSearchIndex(v.Dir)
-				defer func() {
-					if err := vaultpkg.ResumeSearchIndex(v.Dir, v.Identity); err != nil {
-						cli.PrintQuietAware("Warning: search index rebuild failed after import; the index was invalidated and will be rebuilt on the next search: %v\n", err)
-					}
-				}()
-			}
-
-			imported, skipped := 0, 0
-			for _, entry := range entries {
-				entryPath := importEntryPath(options.Prefix, entry.Path)
-				if entryPath == "" {
-					skipped++
-					cli.PrintQuietAware("Skipped entry with empty path\n")
-					continue
-				}
-
-				exists, err := importEntryExists(vs, entryPath)
+			var format importer.Format
+			if ImportFormat != "" {
+				format = importer.Format(strings.ToLower(strings.TrimSpace(ImportFormat)))
+			} else {
+				var err error
+				format, err = detectFormatFromExt(sourcePath)
 				if err != nil {
-					return fmt.Errorf("cannot check entry: %w", err)
+					return errorspkg.NewCLIError(errorspkg.ExitGeneralError, err.Error(), nil)
 				}
-
-				if exists && options.SkipExisting {
-					skipped++
-					cli.PrintQuietAware("Skipped existing: %s\n", entryPath)
-					continue
-				}
-
-				if options.DryRun {
-					cli.PrintQuietAware("Would import: %s\n", entryPath)
-					imported++
-					continue
-				}
-
-				if exists && options.Overwrite {
-					if err := vs.DeleteEntry(entryPath); err != nil {
-						return fmt.Errorf("cannot overwrite entry: %w", err)
-					}
-				}
-
-				record := vaultpkg.WriteRecord{Action: "import"}
-				if err := vs.SetFieldsWithProvenance(entryPath, entry.Data, record); err != nil {
-					return fmt.Errorf("cannot write entry: %w", err)
-				}
-				if entry.SecretMetadata != nil {
-					if err := vs.SetSecretMetadata(entryPath, *entry.SecretMetadata); err != nil {
-						return fmt.Errorf("cannot set secret metadata: %w", err)
-					}
-				}
-				cli.PrintQuietAware("Imported: %s\n", entryPath)
-				imported++
+			}
+			if !isSupportedImportFormat(format) {
+				return errorspkg.NewCLIError(errorspkg.ExitGeneralError, fmt.Sprintf("unsupported import format: %s", format), nil)
 			}
 
-			cli.PrintQuietAware("Import summary: %d imported, %d skipped\n", imported, skipped)
-			return nil
-		})
-	},
-}
+			if ImportSkipExisting && ImportOverwrite {
+				return errorspkg.NewCLIError(errorspkg.ExitGeneralError, "--skip-existing and --overwrite cannot be used together", nil)
+			}
 
-func init() {
+			if ImportQuarantine && ImportPrefix != "" {
+				return errorspkg.NewCLIError(errorspkg.ExitGeneralError, "--quarantine and --prefix cannot be used together", nil)
+			}
+
+			options := importer.ImportOptions{
+				DryRun:       ImportDryRun,
+				Prefix:       strings.Trim(ImportPrefix, "/"),
+				SkipExisting: ImportSkipExisting,
+				Overwrite:    ImportOverwrite,
+				Mapping:      ImportMapping,
+			}
+
+			if ImportQuarantine {
+				importID := generateImportID()
+				options.Prefix = "quarantine/" + importID
+				cli.PrintQuietAware("Quarantine import ID: %s\n", importID)
+			}
+
+			if _, err := importer.ParseMapping(options.Mapping); err != nil {
+				return errorspkg.NewCLIError(errorspkg.ExitGeneralError, "invalid CSV mapping", err)
+			}
+
+			source, err := os.Open(sourcePath) // #nosec G304 -- import source path is user-provided CLI argument
+			if err != nil {
+				return errorspkg.NewCLIError(errorspkg.ExitGeneralError, "open import source", err)
+			}
+			defer func() { _ = source.Close() }()
+
+			fi, err := source.Stat()
+			if err != nil {
+				return errorspkg.NewCLIError(errorspkg.ExitGeneralError, "stat import source", err)
+			}
+			if fi.Size() > importer.MaxImportSize {
+				return errorspkg.NewCLIError(errorspkg.ExitGeneralError,
+					fmt.Sprintf("import source exceeds maximum size of %d bytes", importer.MaxImportSize), nil)
+			}
+
+			imp, err := newImporter(format, options)
+			if err != nil {
+				return errorspkg.NewCLIError(errorspkg.ExitGeneralError, "create importer", err)
+			}
+
+			entries, err := imp.Parse(source)
+			if err != nil {
+				return errorspkg.NewCLIError(errorspkg.ExitGeneralError, "parse import source", err)
+			}
+
+			return cli.WithVault(func(v *vaultpkg.Vault, vs *cli.VaultService) error {
+				// Batch mode: the write loop below would otherwise trigger a full
+				// decrypt/re-encrypt/persist of the search index per entry (O(N²)
+				// total). Suspend defers index maintenance; the deferred Resume
+				// performs exactly one rebuild — even when the import fails midway —
+				// and invalidates the index explicitly if that rebuild fails, so the
+				// index is never left silently stale.
+				if !options.DryRun {
+					vaultpkg.SuspendSearchIndex(v.Dir)
+					defer func() {
+						if err := vaultpkg.ResumeSearchIndex(v.Dir, v.Identity); err != nil {
+							cli.PrintQuietAware("Warning: search index rebuild failed after import; the index was invalidated and will be rebuilt on the next search: %v\n", err)
+						}
+					}()
+				}
+
+				imported, skipped := 0, 0
+				for _, entry := range entries {
+					entryPath := importEntryPath(options.Prefix, entry.Path)
+					if entryPath == "" {
+						skipped++
+						cli.PrintQuietAware("Skipped entry with empty path\n")
+						continue
+					}
+
+					exists, err := importEntryExists(vs, entryPath)
+					if err != nil {
+						return fmt.Errorf("cannot check entry: %w", err)
+					}
+
+					if exists && options.SkipExisting {
+						skipped++
+						cli.PrintQuietAware("Skipped existing: %s\n", entryPath)
+						continue
+					}
+
+					if options.DryRun {
+						cli.PrintQuietAware("Would import: %s\n", entryPath)
+						imported++
+						continue
+					}
+
+					if exists && options.Overwrite {
+						if err := vs.DeleteEntry(entryPath); err != nil {
+							return fmt.Errorf("cannot overwrite entry: %w", err)
+						}
+					}
+
+					record := vaultpkg.WriteRecord{Action: "import"}
+					if err := vs.SetFieldsWithProvenance(entryPath, entry.Data, record); err != nil {
+						return fmt.Errorf("cannot write entry: %w", err)
+					}
+					if entry.SecretMetadata != nil {
+						if err := vs.SetSecretMetadata(entryPath, *entry.SecretMetadata); err != nil {
+							return fmt.Errorf("cannot set secret metadata: %w", err)
+						}
+					}
+					cli.PrintQuietAware("Imported: %s\n", entryPath)
+					imported++
+				}
+
+				cli.PrintQuietAware("Import summary: %d imported, %d skipped\n", imported, skipped)
+				return nil
+			})
+		},
+	}
 	importCmd.Flags().BoolVar(&ImportDryRun, "dry-run", false, "Parse import source without writing entries")
 	importCmd.Flags().StringVar(&ImportPrefix, "prefix", "", "Prepend path to all imported entries")
 	importCmd.Flags().BoolVar(&ImportSkipExisting, "skip-existing", false, "Skip entries that already exist")
@@ -197,6 +196,8 @@ func init() {
 	importCmd.Flags().BoolVar(&ImportQuarantine, "quarantine", false, "Import entries into quarantine/<import-id>/ for human review before agent access")
 	importCmd.Flags().StringVar(&ImportFormat, "format", "", "Import format (auto-detected from file extension when omitted)")
 	importCmd.GroupID = cli.GroupIDSharingSync
+	importCmd.AddCommand(newImportReviewCmd())
+	return importCmd
 }
 
 func isSupportedImportFormat(format importer.Format) bool {
@@ -270,109 +271,114 @@ func importEntryExists(vs *cli.VaultService, entryPath string) (bool, error) {
 
 var ReviewPromoteOverwrite bool
 
-var importReviewCmd = &cobra.Command{
-	Use:   "review",
-	Short: "Review and manage quarantined imports",
+func newImportReviewCmd() *cobra.Command {
+	importReviewCmd := &cobra.Command{
+		Use:   "review",
+		Short: "Review and manage quarantined imports",
+	}
+	importReviewCmd.AddCommand(newImportReviewListCmd())
+	importReviewCmd.AddCommand(newImportReviewPromoteCmd())
+	return importReviewCmd
 }
 
-var importReviewListCmd = &cobra.Command{
-	Use:   "list",
-	Short: "List quarantined import batches",
-	Args:  cobra.NoArgs,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		return cli.WithVault(func(v *vaultpkg.Vault, vs *cli.VaultService) error {
-			entries, err := vs.ListEntries("quarantine/")
-			if err != nil {
-				return fmt.Errorf("list quarantine: %w", err)
-			}
-			// Group by import-id (path format: quarantine/<import-id>/<rest>)
-			batches := make(map[string]int)
-			for _, e := range entries {
-				parts := strings.SplitN(strings.TrimPrefix(e, "quarantine/"), "/", 2)
-				if len(parts) > 0 && parts[0] != "" {
-					batches[parts[0]]++
+func newImportReviewListCmd() *cobra.Command {
+	importReviewListCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List quarantined import batches",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cli.WithVault(func(v *vaultpkg.Vault, vs *cli.VaultService) error {
+				entries, err := vs.ListEntries("quarantine/")
+				if err != nil {
+					return fmt.Errorf("list quarantine: %w", err)
 				}
-			}
-			if len(batches) == 0 {
-				cli.PrintQuietAware("No quarantined imports found.\n")
+				// Group by import-id (path format: quarantine/<import-id>/<rest>)
+				batches := make(map[string]int)
+				for _, e := range entries {
+					parts := strings.SplitN(strings.TrimPrefix(e, "quarantine/"), "/", 2)
+					if len(parts) > 0 && parts[0] != "" {
+						batches[parts[0]]++
+					}
+				}
+				if len(batches) == 0 {
+					cli.PrintQuietAware("No quarantined imports found.\n")
+					return nil
+				}
+				ids := make([]string, 0, len(batches))
+				for id := range batches {
+					ids = append(ids, id)
+				}
+				sort.Strings(ids)
+				for _, id := range ids {
+					cli.PrintQuietAware("%s  (%d entries)\n", id, batches[id])
+				}
 				return nil
-			}
-			ids := make([]string, 0, len(batches))
-			for id := range batches {
-				ids = append(ids, id)
-			}
-			sort.Strings(ids)
-			for _, id := range ids {
-				cli.PrintQuietAware("%s  (%d entries)\n", id, batches[id])
-			}
-			return nil
-		})
-	},
+			})
+		},
+	}
+	return importReviewListCmd
 }
 
-var importReviewPromoteCmd = &cobra.Command{
-	Use:   "promote <import-id>",
-	Short: "Promote quarantined entries to their final vault paths",
-	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		importID := args[0]
-		quarantinePrefix := "quarantine/" + importID + "/"
-		return cli.WithVault(func(v *vaultpkg.Vault, vs *cli.VaultService) error {
-			entries, err := vs.ListEntries(quarantinePrefix)
-			if err != nil {
-				return fmt.Errorf("list quarantine batch: %w", err)
-			}
-			if len(entries) == 0 {
-				return fmt.Errorf("no quarantined entries found for import-id %q", importID)
-			}
-			hadError := false
-			for _, entryPath := range entries {
-				destPath := strings.TrimPrefix(entryPath, quarantinePrefix)
-				if destPath == "" {
-					continue
+func newImportReviewPromoteCmd() *cobra.Command {
+	importReviewPromoteCmd := &cobra.Command{
+		Use:   "promote <import-id>",
+		Short: "Promote quarantined entries to their final vault paths",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			importID := args[0]
+			quarantinePrefix := "quarantine/" + importID + "/"
+			return cli.WithVault(func(v *vaultpkg.Vault, vs *cli.VaultService) error {
+				entries, err := vs.ListEntries(quarantinePrefix)
+				if err != nil {
+					return fmt.Errorf("list quarantine batch: %w", err)
 				}
-				// Check if destination already exists
-				exists, existsErr := importEntryExists(vs, destPath)
-				if existsErr != nil {
-					cli.PrintQuietAware("Warning: cannot check destination %s: %v\n", destPath, existsErr)
-					hadError = true
-					continue
+				if len(entries) == 0 {
+					return fmt.Errorf("no quarantined entries found for import-id %q", importID)
 				}
-				if exists && !ReviewPromoteOverwrite {
-					cli.PrintQuietAware("Warning: skipping %s — destination already exists (use --overwrite)\n", destPath)
-					hadError = true
-					continue
+				hadError := false
+				for _, entryPath := range entries {
+					destPath := strings.TrimPrefix(entryPath, quarantinePrefix)
+					if destPath == "" {
+						continue
+					}
+					// Check if destination already exists
+					exists, existsErr := importEntryExists(vs, destPath)
+					if existsErr != nil {
+						cli.PrintQuietAware("Warning: cannot check destination %s: %v\n", destPath, existsErr)
+						hadError = true
+						continue
+					}
+					if exists && !ReviewPromoteOverwrite {
+						cli.PrintQuietAware("Warning: skipping %s — destination already exists (use --overwrite)\n", destPath)
+						hadError = true
+						continue
+					}
+					// Read source entry
+					entry, readErr := vs.GetEntry(entryPath)
+					if readErr != nil {
+						cli.PrintQuietAware("Warning: failed to read %s: %v\n", entryPath, readErr)
+						hadError = true
+						continue
+					}
+					// Write to destination
+					if writeErr := vs.WriteEntry(destPath, entry); writeErr != nil {
+						cli.PrintQuietAware("Warning: failed to write %s: %v\n", destPath, writeErr)
+						hadError = true
+						continue
+					}
+					if deleteErr := vs.DeleteEntry(entryPath); deleteErr != nil {
+						cli.PrintQuietAware("Warning: failed to delete quarantine entry %s: %v\n", entryPath, deleteErr)
+						// Don't set hadError — promote succeeded
+					}
+					cli.PrintQuietAware("Promoted: %s\n", destPath)
 				}
-				// Read source entry
-				entry, readErr := vs.GetEntry(entryPath)
-				if readErr != nil {
-					cli.PrintQuietAware("Warning: failed to read %s: %v\n", entryPath, readErr)
-					hadError = true
-					continue
+				if hadError {
+					return fmt.Errorf("some entries could not be promoted")
 				}
-				// Write to destination
-				if writeErr := vs.WriteEntry(destPath, entry); writeErr != nil {
-					cli.PrintQuietAware("Warning: failed to write %s: %v\n", destPath, writeErr)
-					hadError = true
-					continue
-				}
-				if deleteErr := vs.DeleteEntry(entryPath); deleteErr != nil {
-					cli.PrintQuietAware("Warning: failed to delete quarantine entry %s: %v\n", entryPath, deleteErr)
-					// Don't set hadError — promote succeeded
-				}
-				cli.PrintQuietAware("Promoted: %s\n", destPath)
-			}
-			if hadError {
-				return fmt.Errorf("some entries could not be promoted")
-			}
-			return nil
-		})
-	},
-}
-
-func init() {
+				return nil
+			})
+		},
+	}
 	importReviewPromoteCmd.Flags().BoolVar(&ReviewPromoteOverwrite, "overwrite", false, "Overwrite existing entries at destination")
-	importReviewCmd.AddCommand(importReviewListCmd)
-	importReviewCmd.AddCommand(importReviewPromoteCmd)
-	importCmd.AddCommand(importReviewCmd)
+	return importReviewPromoteCmd
 }

--- a/cmd/admin/init.go
+++ b/cmd/admin/init.go
@@ -22,11 +22,12 @@ import (
 
 var initAuthMethod string
 
-var initCmd = &cobra.Command{
-	Use:   "init [vault-dir]",
-	Short: "Initialize a new password vault",
-	Long:  "Creates a new vault directory with identity and configuration.",
-	Example: `  # Initialize default vault
+func newInitCmd() *cobra.Command {
+	initCmd := &cobra.Command{
+		Use:   "init [vault-dir]",
+		Short: "Initialize a new password vault",
+		Long:  "Creates a new vault directory with identity and configuration.",
+		Example: `  # Initialize default vault
   symvault init
 
   # Initialize with specific auth method
@@ -34,105 +35,109 @@ var initCmd = &cobra.Command{
 
   # Initialize custom vault directory
   symvault init ~/my-vault`,
-	Args: cobra.MaximumNArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		if !term.IsTerminal(int(os.Stdin.Fd())) && !cli.HasCachedEnvPassphrase() {
-			return fmt.Errorf("init requires a TTY or SYMVAULT_PASSPHRASE/OPENPASS_PASSPHRASE env var; use `symvault setup` for interactive initialization")
-		}
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !term.IsTerminal(int(os.Stdin.Fd())) && !cli.HasCachedEnvPassphrase() {
+				return fmt.Errorf("init requires a TTY or SYMVAULT_PASSPHRASE/OPENPASS_PASSPHRASE env var; use `symvault setup` for interactive initialization")
+			}
 
-		var (
-			vaultDir string
-			err      error
-		)
-		if len(args) > 0 {
-			vaultDir, err = cli.ExpandVaultDir(args[0])
-		} else {
-			vaultDir, err = cli.VaultPath()
-		}
-		if err != nil {
-			return err
-		}
-
-		if _, statErr := os.Stat(filepath.Join(vaultDir, "config.yaml")); statErr == nil {
-			return errorspkg.NewCLIError(errorspkg.ExitGeneralError, fmt.Sprintf("vault already initialized at %s", vaultDir), nil)
-		} else if !os.IsNotExist(statErr) {
-			return fmt.Errorf("cannot check vault directory: %w", statErr)
-		}
-
-		if mkdirErr := os.MkdirAll(vaultDir, 0o700); mkdirErr != nil {
-			return fmt.Errorf("cannot create vault directory: %w", mkdirErr)
-		}
-
-		var passphrase []byte
-		if cached := cli.ConsumeCachedEnvPassphrase(); len(cached) > 0 {
-			passphrase = cached
-		} else {
-			passphrase, err = cli.ReadHiddenInput("Enter passphrase for vault identity (minimum 12 characters): ", nil)
+			var (
+				vaultDir string
+				err      error
+			)
+			if len(args) > 0 {
+				vaultDir, err = cli.ExpandVaultDir(args[0])
+			} else {
+				vaultDir, err = cli.VaultPath()
+			}
 			if err != nil {
-				return fmt.Errorf("cannot read passphrase: %w", err)
+				return err
 			}
-		}
-		defer cryptopkg.Wipe(passphrase)
-		if len(passphrase) < 12 {
-			return fmt.Errorf("passphrase must be at least 12 characters")
-		}
-		authMethod, err := resolveInitAuthMethod(initAuthMethod)
-		if err != nil {
-			return err
-		}
 
-		cfg := config.Default()
-		cfg.VaultDir = vaultDir
-		// A non-nil Vault section is required for InitWithPassphrase to take
-		// the argon2id path (see internal/vault/vault.go); without it, new
-		// vaults would silently fall back to legacy scrypt.
-		cfg.Vault = &config.VaultConfig{
-			SearchIndex:     true,
-			AutoHealZeroKey: true,
-		}
-		if authErr := cfg.SetAuthMethod(authMethod); authErr != nil {
-			return authErr
-		}
-		cfg.DefaultAgent = "cli"
-		cfg.Agents = map[string]config.AgentProfile{
-			"cli": {
-				Name:            "cli",
-				AllowedPaths:    []string{"*"},
-				CanWrite:        config.BoolPtr(true),
-				RequireApproval: config.BoolPtr(false),
-			},
-		}
-
-		// Initialize Git config with defaults (auto-push enabled)
-		cfg.Git = &config.GitConfig{
-			AutoPush:       true,
-			CommitTemplate: "Update from Symaira Vault",
-		}
-
-		identity, err := vaultpkg.InitWithPassphrase(vaultDir, passphrase, cfg)
-		if err != nil {
-			return fmt.Errorf("cannot initialize vault: %w", err)
-		}
-
-		if err := git.Init(vaultDir); err != nil {
-			return fmt.Errorf("cannot initialize git: %w", err)
-		}
-
-		if err := git.CreateGitignore(vaultDir); err != nil {
-			return fmt.Errorf("cannot create .gitignore: %w", err)
-		}
-		if authMethod == config.AuthMethodTouchID {
-			if err := session.SaveBiometricPassphrase(context.Background(), vaultDir, passphrase); err != nil {
-				return fmt.Errorf("cannot configure Touch ID unlock: %w", err)
+			if _, statErr := os.Stat(filepath.Join(vaultDir, "config.yaml")); statErr == nil {
+				return errorspkg.NewCLIError(errorspkg.ExitGeneralError, fmt.Sprintf("vault already initialized at %s", vaultDir), nil)
+			} else if !os.IsNotExist(statErr) {
+				return fmt.Errorf("cannot check vault directory: %w", statErr)
 			}
-			cli.PrintQuietAware("Touch ID unlock enabled\n")
-		}
 
-		cli.PrintQuietAware("Vault initialized at %s\n", vaultDir)
-		cli.PrintQuietAware("Public key: %s\n", identity.Recipient().String())
-		printPostInitHints(vaultDir)
-		return nil
-	},
+			if mkdirErr := os.MkdirAll(vaultDir, 0o700); mkdirErr != nil {
+				return fmt.Errorf("cannot create vault directory: %w", mkdirErr)
+			}
+
+			var passphrase []byte
+			if cached := cli.ConsumeCachedEnvPassphrase(); len(cached) > 0 {
+				passphrase = cached
+			} else {
+				passphrase, err = cli.ReadHiddenInput("Enter passphrase for vault identity (minimum 12 characters): ", nil)
+				if err != nil {
+					return fmt.Errorf("cannot read passphrase: %w", err)
+				}
+			}
+			defer cryptopkg.Wipe(passphrase)
+			if len(passphrase) < 12 {
+				return fmt.Errorf("passphrase must be at least 12 characters")
+			}
+			authMethod, err := resolveInitAuthMethod(initAuthMethod)
+			if err != nil {
+				return err
+			}
+
+			cfg := config.Default()
+			cfg.VaultDir = vaultDir
+			// A non-nil Vault section is required for InitWithPassphrase to take
+			// the argon2id path (see internal/vault/vault.go); without it, new
+			// vaults would silently fall back to legacy scrypt.
+			cfg.Vault = &config.VaultConfig{
+				SearchIndex:     true,
+				AutoHealZeroKey: true,
+			}
+			if authErr := cfg.SetAuthMethod(authMethod); authErr != nil {
+				return authErr
+			}
+			cfg.DefaultAgent = "cli"
+			cfg.Agents = map[string]config.AgentProfile{
+				"cli": {
+					Name:            "cli",
+					AllowedPaths:    []string{"*"},
+					CanWrite:        config.BoolPtr(true),
+					RequireApproval: config.BoolPtr(false),
+				},
+			}
+
+			// Initialize Git config with defaults (auto-push enabled)
+			cfg.Git = &config.GitConfig{
+				AutoPush:       true,
+				CommitTemplate: "Update from Symaira Vault",
+			}
+
+			identity, err := vaultpkg.InitWithPassphrase(vaultDir, passphrase, cfg)
+			if err != nil {
+				return fmt.Errorf("cannot initialize vault: %w", err)
+			}
+
+			if err := git.Init(vaultDir); err != nil {
+				return fmt.Errorf("cannot initialize git: %w", err)
+			}
+
+			if err := git.CreateGitignore(vaultDir); err != nil {
+				return fmt.Errorf("cannot create .gitignore: %w", err)
+			}
+			if authMethod == config.AuthMethodTouchID {
+				if err := session.SaveBiometricPassphrase(context.Background(), vaultDir, passphrase); err != nil {
+					return fmt.Errorf("cannot configure Touch ID unlock: %w", err)
+				}
+				cli.PrintQuietAware("Touch ID unlock enabled\n")
+			}
+
+			cli.PrintQuietAware("Vault initialized at %s\n", vaultDir)
+			cli.PrintQuietAware("Public key: %s\n", identity.Recipient().String())
+			printPostInitHints(vaultDir)
+			return nil
+		},
+	}
+	initCmd.GroupID = cli.GroupIDEssentials
+	initCmd.Flags().StringVar(&initAuthMethod, "auth", "ask", "unlock method for this vault (ask, passphrase, touchid)")
+	return initCmd
 }
 
 func printPostInitHints(vaultDir string) {
@@ -153,11 +158,6 @@ func printPostInitHints(vaultDir string) {
 	cli.PrintlnQuietAware("     https://github.com/danieljustus/symaira-vault/blob/main/config.yaml.example")
 	cli.PrintlnQuietAware("")
 	cli.PrintlnQuietAware("Tip: 'symvault --help' lists all commands. Use 'symvault <cmd> --help' for details.")
-}
-
-func init() {
-	initCmd.GroupID = cli.GroupIDEssentials
-	initCmd.Flags().StringVar(&initAuthMethod, "auth", "ask", "unlock method for this vault (ask, passphrase, touchid)")
 }
 
 func resolveInitAuthMethod(method string) (string, error) {

--- a/cmd/admin/migrate.go
+++ b/cmd/admin/migrate.go
@@ -22,18 +22,31 @@ var (
 	MigrateV4DryRun bool
 )
 
-var MigrateCmd = &cobra.Command{
-	Use:   "migrate",
-	Short: "Vault migration commands",
-	Example: `  # Pseudonymise on-disk paths (one-way)
+// MigrateCmd is retained for API compatibility; NewCommands() uses
+// newMigrateCmd() so every call gets a fresh command.
+var MigrateCmd = newMigrateCmd()
+
+func newMigrateCmd() *cobra.Command {
+	MigrateCmd := &cobra.Command{
+		Use:   "migrate",
+		Short: "Vault migration commands",
+		Example: `  # Pseudonymise on-disk paths (one-way)
   symvault migrate pseudonymize --dry-run
   symvault migrate pseudonymize`,
+	}
+	MigrateCmd.AddCommand(newMigratePseudonymizeCmd())
+	MigrateCmd.AddCommand(newMigrateKDFCmd())
+	MigrateCmd.AddCommand(newMigrateV4Cmd())
+	MigrateCmd.AddCommand(newMigrateSessionCmd())
+	MigrateCmd.GroupID = cli.GroupIDAdministration
+	return MigrateCmd
 }
 
-var migratePseudonymizeCmd = &cobra.Command{
-	Use:   "pseudonymize",
-	Short: "Migrate vault entries to pseudonymized storage paths",
-	Long: `Migrate vault entries to pseudonymized storage paths.
+func newMigratePseudonymizeCmd() *cobra.Command {
+	migratePseudonymizeCmd := &cobra.Command{
+		Use:   "pseudonymize",
+		Short: "Migrate vault entries to pseudonymized storage paths",
+		Long: `Migrate vault entries to pseudonymized storage paths.
 
 WARNING: This rewrites every entry in the vault. Make a backup first.
 Each entry is read, re-encrypted with its plaintext path stored inside
@@ -42,36 +55,39 @@ entries/. The old plaintext-named files are removed.
 
 After migration, enable pseudonymize_paths in your vault config.yaml
 to write new entries to pseudonymized paths.`,
-	Example: `  symvault migrate pseudonymize`,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		vaultDir, err := cli.VaultPath()
-		if err != nil {
-			return err
-		}
+		Example: `  symvault migrate pseudonymize`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			vaultDir, err := cli.VaultPath()
+			if err != nil {
+				return err
+			}
 
-		if !vaultpkg.IsInitialized(vaultDir) {
-			return errorspkg.NewVaultNotInitialized()
-		}
+			if !vaultpkg.IsInitialized(vaultDir) {
+				return errorspkg.NewVaultNotInitialized()
+			}
 
-		v, err := cli.UnlockVault(vaultDir, true)
-		if err != nil {
-			return err
-		}
+			v, err := cli.UnlockVault(vaultDir, true)
+			if err != nil {
+				return err
+			}
 
-		confirmed, err := cli.ConfirmInteractive(
-			"Migrate all entries to pseudonymized paths. Make a backup first",
-			MigrateYes,
-		)
-		if err != nil {
-			return err
-		}
-		if !confirmed {
-			fmt.Fprintln(os.Stderr, "Canceled")
-			return nil
-		}
+			confirmed, err := cli.ConfirmInteractive(
+				"Migrate all entries to pseudonymized paths. Make a backup first",
+				MigrateYes,
+			)
+			if err != nil {
+				return err
+			}
+			if !confirmed {
+				fmt.Fprintln(os.Stderr, "Canceled")
+				return nil
+			}
 
-		return runPseudonymizeMigration(v)
-	},
+			return runPseudonymizeMigration(v)
+		},
+	}
+	migratePseudonymizeCmd.Flags().BoolVarP(&MigrateYes, "yes", "y", false, "Skip confirmation prompt")
+	return migratePseudonymizeCmd
 }
 
 func runPseudonymizeMigration(v *vaultpkg.Vault) error {
@@ -135,10 +151,11 @@ func runPseudonymizeMigration(v *vaultpkg.Vault) error {
 	return nil
 }
 
-var migrateV4Cmd = &cobra.Command{
-	Use:   "v4",
-	Short: "Migrate agent profiles and config to v4.0 format",
-	Long: `Migrate agent profiles to the v4.0 format by assigning tier fields.
+func newMigrateV4Cmd() *cobra.Command {
+	migrateV4Cmd := &cobra.Command{
+		Use:   "v4",
+		Short: "Migrate agent profiles and config to v4.0 format",
+		Long: `Migrate agent profiles to the v4.0 format by assigning tier fields.
 
 Agent profiles without a tier field are automatically assigned a tier based
 on their existing capabilities:
@@ -152,100 +169,105 @@ before any changes are written.
 
 This migration is idempotent — running it multiple times is safe for
 profiles that already have a tier field.`,
-	Example: `  symvault migrate v4
+		Example: `  symvault migrate v4
   symvault migrate v4 --dry-run
   symvault migrate v4 --yes`,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		vaultDir, err := cli.VaultPath()
-		if err != nil {
-			return err
-		}
-
-		cfg, err := configpkg.Load(filepath.Join(vaultDir, "config.yaml"))
-		if err != nil {
-			return fmt.Errorf("load config: %w", err)
-		}
-
-		type pendingTier struct {
-			name string
-			tier string
-		}
-		var pending []pendingTier
-
-		for name, profile := range cfg.Agents {
-			if profile.Tier != nil && *profile.Tier != "" {
-				continue
+		RunE: func(cmd *cobra.Command, args []string) error {
+			vaultDir, err := cli.VaultPath()
+			if err != nil {
+				return err
 			}
-			var tier string
-			switch {
-			case profile.CanRunCommands != nil && *profile.CanRunCommands:
-				tier = "admin"
-			case profile.CanWrite != nil && *profile.CanWrite:
-				tier = "standard"
-			default:
-				tier = "safe"
+
+			cfg, err := configpkg.Load(filepath.Join(vaultDir, "config.yaml"))
+			if err != nil {
+				return fmt.Errorf("load config: %w", err)
 			}
-			pending = append(pending, pendingTier{name: name, tier: tier})
-		}
 
-		if len(pending) == 0 {
-			cli.PrintlnQuietAware("All profiles already have tier fields.")
+			type pendingTier struct {
+				name string
+				tier string
+			}
+			var pending []pendingTier
+
+			for name, profile := range cfg.Agents {
+				if profile.Tier != nil && *profile.Tier != "" {
+					continue
+				}
+				var tier string
+				switch {
+				case profile.CanRunCommands != nil && *profile.CanRunCommands:
+					tier = "admin"
+				case profile.CanWrite != nil && *profile.CanWrite:
+					tier = "standard"
+				default:
+					tier = "safe"
+				}
+				pending = append(pending, pendingTier{name: name, tier: tier})
+			}
+
+			if len(pending) == 0 {
+				cli.PrintlnQuietAware("All profiles already have tier fields.")
+				return nil
+			}
+
+			cli.PrintlnQuietAware(fmt.Sprintf("Found %d agent profile(s) without tier fields:", len(pending)))
+			for _, p := range pending {
+				cli.PrintlnQuietAware(fmt.Sprintf("  %s → %s", p.name, p.tier))
+			}
+
+			if MigrateV4DryRun {
+				cli.PrintlnQuietAware("Dry-run: no changes written.")
+				return nil
+			}
+
+			confirmed, err := cli.ConfirmInteractive(
+				"Migrate agent profiles to v4.0 format",
+				MigrateYes,
+			)
+			if err != nil {
+				return err
+			}
+			if !confirmed {
+				fmt.Fprintln(os.Stderr, "Canceled")
+				return nil
+			}
+
+			// Backup original config
+			configPath := filepath.Join(vaultDir, "config.yaml")
+			backupPath := filepath.Join(vaultDir, fmt.Sprintf("config.yaml.v3-backup-%d", time.Now().Unix()))
+			input, err := os.ReadFile(filepath.Clean(configPath))
+			if err != nil {
+				return fmt.Errorf("read config for backup: %w", err)
+			}
+			if err := os.WriteFile(backupPath, input, 0o600); err != nil {
+				return fmt.Errorf("write backup: %w", err)
+			}
+			cli.PrintlnQuietAware(fmt.Sprintf("Backup created: %s", backupPath))
+
+			for _, p := range pending {
+				profile := cfg.Agents[p.name]
+				profile.Tier = configpkg.StrPtr(p.tier)
+				cfg.Agents[p.name] = profile
+			}
+
+			if err := cfg.SaveTo(configPath); err != nil {
+				return fmt.Errorf("save migrated config: %w", err)
+			}
+
+			cli.PrintlnQuietAware(fmt.Sprintf("Migrated %d agent profile(s) to v4.0 format.", len(pending)))
 			return nil
-		}
-
-		cli.PrintlnQuietAware(fmt.Sprintf("Found %d agent profile(s) without tier fields:", len(pending)))
-		for _, p := range pending {
-			cli.PrintlnQuietAware(fmt.Sprintf("  %s → %s", p.name, p.tier))
-		}
-
-		if MigrateV4DryRun {
-			cli.PrintlnQuietAware("Dry-run: no changes written.")
-			return nil
-		}
-
-		confirmed, err := cli.ConfirmInteractive(
-			"Migrate agent profiles to v4.0 format",
-			MigrateYes,
-		)
-		if err != nil {
-			return err
-		}
-		if !confirmed {
-			fmt.Fprintln(os.Stderr, "Canceled")
-			return nil
-		}
-
-		// Backup original config
-		configPath := filepath.Join(vaultDir, "config.yaml")
-		backupPath := filepath.Join(vaultDir, fmt.Sprintf("config.yaml.v3-backup-%d", time.Now().Unix()))
-		input, err := os.ReadFile(filepath.Clean(configPath))
-		if err != nil {
-			return fmt.Errorf("read config for backup: %w", err)
-		}
-		if err := os.WriteFile(backupPath, input, 0o600); err != nil {
-			return fmt.Errorf("write backup: %w", err)
-		}
-		cli.PrintlnQuietAware(fmt.Sprintf("Backup created: %s", backupPath))
-
-		for _, p := range pending {
-			profile := cfg.Agents[p.name]
-			profile.Tier = configpkg.StrPtr(p.tier)
-			cfg.Agents[p.name] = profile
-		}
-
-		if err := cfg.SaveTo(configPath); err != nil {
-			return fmt.Errorf("save migrated config: %w", err)
-		}
-
-		cli.PrintlnQuietAware(fmt.Sprintf("Migrated %d agent profile(s) to v4.0 format.", len(pending)))
-		return nil
-	},
+		},
+	}
+	migrateV4Cmd.Flags().BoolVarP(&MigrateYes, "yes", "y", false, "Skip confirmation prompt")
+	migrateV4Cmd.Flags().BoolVar(&MigrateV4DryRun, "dry-run", false, "Preview changes without writing")
+	return migrateV4Cmd
 }
 
-var migrateKDFCmd = &cobra.Command{
-	Use:   "kdf",
-	Short: "Migrate the vault identity from scrypt to argon2id",
-	Long: `Migrate the vault identity's key derivation function from the legacy
+func newMigrateKDFCmd() *cobra.Command {
+	migrateKDFCmd := &cobra.Command{
+		Use:   "kdf",
+		Short: "Migrate the vault identity from scrypt to argon2id",
+		Long: `Migrate the vault identity's key derivation function from the legacy
 scrypt KDF to argon2id.
 
 Argon2id is the industry standard for password hashing and provides stronger
@@ -262,84 +284,87 @@ file is decrypt-verified before the migration is considered done. On any
 failure the original identity.age is restored automatically. Changing
 config.yaml's scrypt_work_factor alone does not perform this migration —
 only this command (or auto_migrate_kdf) re-encrypts identity.age.`,
-	Example: `  symvault migrate kdf
+		Example: `  symvault migrate kdf
   symvault migrate kdf --yes`,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		vaultDir := cli.GetVaultDir()
-		identityPath := filepath.Join(vaultDir, "identity.age")
-		raw, err := os.ReadFile(identityPath) // #nosec G304 -- fixed filename under the resolved vault dir
-		if err != nil {
-			return fmt.Errorf("read vault identity (%s): %w", identityPath, err)
-		}
+		RunE: func(cmd *cobra.Command, args []string) error {
+			vaultDir := cli.GetVaultDir()
+			identityPath := filepath.Join(vaultDir, "identity.age")
+			raw, err := os.ReadFile(identityPath) // #nosec G304 -- fixed filename under the resolved vault dir
+			if err != nil {
+				return fmt.Errorf("read vault identity (%s): %w", identityPath, err)
+			}
 
-		switch cryptopkg.DetectEncryptedIdentityFormat(raw) {
-		case "argon2id":
-			fmt.Println("✓ Your vault identity is already protected with argon2id.")
-			fmt.Println("No migration is needed.")
-			return nil
-		case "scrypt":
-			// handled below
-		default:
-			fmt.Println("Could not determine the vault identity's key derivation function.")
-			fmt.Println("Run 'symvault doctor' for a full diagnosis.")
-			return nil
-		}
+			switch cryptopkg.DetectEncryptedIdentityFormat(raw) {
+			case "argon2id":
+				fmt.Println("✓ Your vault identity is already protected with argon2id.")
+				fmt.Println("No migration is needed.")
+				return nil
+			case "scrypt":
+				// handled below
+			default:
+				fmt.Println("Could not determine the vault identity's key derivation function.")
+				fmt.Println("Run 'symvault doctor' for a full diagnosis.")
+				return nil
+			}
 
-		fmt.Println("Your vault identity is currently protected with scrypt.")
+			fmt.Println("Your vault identity is currently protected with scrypt.")
 
-		// Unlock (which needs the passphrase) before the confirmation prompt,
-		// not after: ConfirmInteractive reads through a buffered os.Stdin
-		// reader that is free to consume more than the "y\n" line, which
-		// would silently steal bytes a later raw passphrase read expects.
-		// This also fails fast on a wrong passphrase before asking the user
-		// to confirm a migration that couldn't proceed anyway.
-		passphrase, err := cli.ReadHiddenInput("Passphrase: ", nil)
-		if err != nil {
-			return fmt.Errorf("read passphrase: %w", err)
-		}
-		defer cryptopkg.Wipe(passphrase)
+			// Unlock (which needs the passphrase) before the confirmation prompt,
+			// not after: ConfirmInteractive reads through a buffered os.Stdin
+			// reader that is free to consume more than the "y\n" line, which
+			// would silently steal bytes a later raw passphrase read expects.
+			// This also fails fast on a wrong passphrase before asking the user
+			// to confirm a migration that couldn't proceed anyway.
+			passphrase, err := cli.ReadHiddenInput("Passphrase: ", nil)
+			if err != nil {
+				return fmt.Errorf("read passphrase: %w", err)
+			}
+			defer cryptopkg.Wipe(passphrase)
 
-		v, err := vaultpkg.OpenWithPassphrase(vaultDir, passphrase)
-		if err != nil {
-			return fmt.Errorf("unlock vault: %w", err)
-		}
+			v, err := vaultpkg.OpenWithPassphrase(vaultDir, passphrase)
+			if err != nil {
+				return fmt.Errorf("unlock vault: %w", err)
+			}
 
-		// OpenWithPassphrase already migrates when vault.auto_migrate_kdf is
-		// set — v.NeedsMigration is only true when it left the file as scrypt
-		// (auto-migrate off, or a prior attempt failed). When auto-migrate
-		// already did the work, report that instead of asking for a
-		// confirmation the open call has already acted on.
-		if !v.NeedsMigration {
-			fmt.Println("✓ Migrated automatically on unlock (vault.auto_migrate_kdf is enabled).")
+			// OpenWithPassphrase already migrates when vault.auto_migrate_kdf is
+			// set — v.NeedsMigration is only true when it left the file as scrypt
+			// (auto-migrate off, or a prior attempt failed). When auto-migrate
+			// already did the work, report that instead of asking for a
+			// confirmation the open call has already acted on.
+			if !v.NeedsMigration {
+				fmt.Println("✓ Migrated automatically on unlock (vault.auto_migrate_kdf is enabled).")
+				fmt.Println("The previous identity.age was backed up to identity.age.bak.")
+				return nil
+			}
+
+			confirmed, err := cli.ConfirmInteractive(
+				"Migrate the vault identity to argon2id now (identity.age is backed up to identity.age.bak first)",
+				MigrateYes,
+			)
+			if err != nil {
+				return err
+			}
+			if !confirmed {
+				fmt.Fprintln(os.Stderr, "Canceled")
+				return nil
+			}
+
+			if err := vaultpkg.MigrateKDF(vaultDir, v.Identity, passphrase, v); err != nil {
+				return fmt.Errorf("migrate kdf: %w", err)
+			}
+
+			raw2, readErr := os.ReadFile(identityPath) // #nosec G304 -- fixed filename under the resolved vault dir
+			if readErr != nil || cryptopkg.DetectEncryptedIdentityFormat(raw2) != "argon2id" {
+				return fmt.Errorf("migration did not complete — identity.age was restored to its original form; run `symvault doctor` for details")
+			}
+
+			fmt.Println("✓ Migrated vault identity to argon2id.")
 			fmt.Println("The previous identity.age was backed up to identity.age.bak.")
 			return nil
-		}
-
-		confirmed, err := cli.ConfirmInteractive(
-			"Migrate the vault identity to argon2id now (identity.age is backed up to identity.age.bak first)",
-			MigrateYes,
-		)
-		if err != nil {
-			return err
-		}
-		if !confirmed {
-			fmt.Fprintln(os.Stderr, "Canceled")
-			return nil
-		}
-
-		if err := vaultpkg.MigrateKDF(vaultDir, v.Identity, passphrase, v); err != nil {
-			return fmt.Errorf("migrate kdf: %w", err)
-		}
-
-		raw2, readErr := os.ReadFile(identityPath) // #nosec G304 -- fixed filename under the resolved vault dir
-		if readErr != nil || cryptopkg.DetectEncryptedIdentityFormat(raw2) != "argon2id" {
-			return fmt.Errorf("migration did not complete — identity.age was restored to its original form; run `symvault doctor` for details")
-		}
-
-		fmt.Println("✓ Migrated vault identity to argon2id.")
-		fmt.Println("The previous identity.age was backed up to identity.age.bak.")
-		return nil
-	},
+		},
+	}
+	migrateKDFCmd.Flags().BoolVarP(&MigrateYes, "yes", "y", false, "Skip confirmation prompt")
+	return migrateKDFCmd
 }
 
 func enablePseudonymizeConfig(vaultDir string) error {
@@ -357,15 +382,4 @@ func enablePseudonymizeConfig(vaultDir string) error {
 		return fmt.Errorf("save config: %w", err)
 	}
 	return nil
-}
-
-func init() {
-	MigrateCmd.AddCommand(migratePseudonymizeCmd)
-	migratePseudonymizeCmd.Flags().BoolVarP(&MigrateYes, "yes", "y", false, "Skip confirmation prompt")
-	MigrateCmd.AddCommand(migrateKDFCmd)
-	migrateKDFCmd.Flags().BoolVarP(&MigrateYes, "yes", "y", false, "Skip confirmation prompt")
-	MigrateCmd.AddCommand(migrateV4Cmd)
-	migrateV4Cmd.Flags().BoolVarP(&MigrateYes, "yes", "y", false, "Skip confirmation prompt")
-	migrateV4Cmd.Flags().BoolVar(&MigrateV4DryRun, "dry-run", false, "Preview changes without writing")
-	MigrateCmd.GroupID = cli.GroupIDAdministration
 }

--- a/cmd/admin/migrate_session.go
+++ b/cmd/admin/migrate_session.go
@@ -9,10 +9,11 @@ import (
 	"github.com/danieljustus/symaira-vault/internal/session"
 )
 
-var migrateSessionCmd = &cobra.Command{
-	Use:   "session",
-	Short: "Upgrade a cached session from the legacy plaintext format to encrypted",
-	Long: `Upgrade a cached session from the legacy plaintext format to the
+func newMigrateSessionCmd() *cobra.Command {
+	migrateSessionCmd := &cobra.Command{
+		Use:   "session",
+		Short: "Upgrade a cached session from the legacy plaintext format to encrypted",
+		Long: `Upgrade a cached session from the legacy plaintext format to the
 encrypted form that uses a randomly generated wrap key.
 
 Earlier versions of Symaira Vault stored cached passphrases in plaintext
@@ -23,45 +24,43 @@ upgrade the cached entry.
 The migration is a no-op when the session is already in the encrypted
 format. The vault directory defaults to the value of --vault (or the
 $SYMVAULT_VAULT environment variable).`,
-	Example: `  symvault migrate session
+		Example: `  symvault migrate session
   symvault migrate session --vault ~/.symvault
   symvault migrate session --dry-run`,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		vaultDir, err := cli.VaultPath()
-		if err != nil {
-			return err
-		}
+		RunE: func(cmd *cobra.Command, args []string) error {
+			vaultDir, err := cli.VaultPath()
+			if err != nil {
+				return err
+			}
 
-		mgr := session.DefaultManager()
-		legacy, err := mgr.HasLegacyPlaintextSession(vaultDir)
-		if err != nil {
-			return fmt.Errorf("inspect session: %w", err)
-		}
-		if !legacy {
-			cli.PrintlnQuietAware("No legacy plaintext session found. Nothing to migrate.")
+			mgr := session.DefaultManager()
+			legacy, err := mgr.HasLegacyPlaintextSession(vaultDir)
+			if err != nil {
+				return fmt.Errorf("inspect session: %w", err)
+			}
+			if !legacy {
+				cli.PrintlnQuietAware("No legacy plaintext session found. Nothing to migrate.")
+				return nil
+			}
+
+			if MigrateV4DryRun {
+				cli.PrintlnQuietAware("Dry-run: legacy plaintext session detected. Re-run without --dry-run to upgrade.")
+				return nil
+			}
+
+			upgraded, err := mgr.MigrateSession(vaultDir)
+			if err != nil {
+				return fmt.Errorf("migrate session: %w", err)
+			}
+			if !upgraded {
+				cli.PrintlnQuietAware("No legacy plaintext session found. Nothing to migrate.")
+				return nil
+			}
+
+			cli.PrintlnQuietAware("Session upgraded. The cached passphrase is now stored encrypted in the OS keyring.")
 			return nil
-		}
-
-		if MigrateV4DryRun {
-			cli.PrintlnQuietAware("Dry-run: legacy plaintext session detected. Re-run without --dry-run to upgrade.")
-			return nil
-		}
-
-		upgraded, err := mgr.MigrateSession(vaultDir)
-		if err != nil {
-			return fmt.Errorf("migrate session: %w", err)
-		}
-		if !upgraded {
-			cli.PrintlnQuietAware("No legacy plaintext session found. Nothing to migrate.")
-			return nil
-		}
-
-		cli.PrintlnQuietAware("Session upgraded. The cached passphrase is now stored encrypted in the OS keyring.")
-		return nil
-	},
-}
-
-func init() {
+		},
+	}
 	migrateSessionCmd.Flags().BoolVar(&MigrateV4DryRun, "dry-run", false, "Preview the migration without writing")
-	MigrateCmd.AddCommand(migrateSessionCmd)
+	return migrateSessionCmd
 }

--- a/cmd/admin/setup.go
+++ b/cmd/admin/setup.go
@@ -15,10 +15,11 @@ import (
 var setupKeepOnError bool
 var setupNoResume bool
 
-var setupCmd = &cobra.Command{
-	Use:   "setup",
-	Short: "Interactive setup wizard for Symaira Vault",
-	Long: `Launch the interactive setup wizard to initialize or re-configure your vault.
+func newSetupCmd() *cobra.Command {
+	setupCmd := &cobra.Command{
+		Use:   "setup",
+		Short: "Interactive setup wizard for Symaira Vault",
+		Long: `Launch the interactive setup wizard to initialize or re-configure your vault.
 
 The wizard guides you through:
   • Vault directory and passphrase
@@ -31,7 +32,7 @@ The wizard guides you through:
   • Profile name
 
 For non-interactive environments (CI, scripts), use 'symvault init' instead.`,
-	Example: `  # Run the wizard (resumes from saved state if available)
+		Example: `  # Run the wizard (resumes from saved state if available)
   symvault setup
 
   # Restart from scratch
@@ -39,22 +40,21 @@ For non-interactive environments (CI, scripts), use 'symvault init' instead.`,
 
   # Keep partial vault artifacts on error for debugging
   symvault setup --keep-on-error`,
-	Annotations: map[string]string{
-		cli.RequiresVaultAnnotation: "false",
-	},
-	RunE: func(cmd *cobra.Command, args []string) error {
-		// WIZ-15: Non-TTY guard.
-		if !term.IsTerminal(int(os.Stdin.Fd())) {
-			return fmt.Errorf("setup needs a TTY; use `symvault init` for non-interactive vault initialization")
-		}
+		Annotations: map[string]string{
+			cli.RequiresVaultAnnotation: "false",
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// WIZ-15: Non-TTY guard.
+			if !term.IsTerminal(int(os.Stdin.Fd())) {
+				return fmt.Errorf("setup needs a TTY; use `symvault init` for non-interactive vault initialization")
+			}
 
-		vaultDir := cli.GetVaultDir()
-		return wizard.Run(vaultDir, setupKeepOnError, setupNoResume)
-	},
-}
-
-func init() {
+			vaultDir := cli.GetVaultDir()
+			return wizard.Run(vaultDir, setupKeepOnError, setupNoResume)
+		},
+	}
 	setupCmd.Flags().BoolVar(&setupKeepOnError, "keep-on-error", false, "do not rollback vault init artifacts when subsequent steps fail")
 	setupCmd.Flags().BoolVar(&setupNoResume, "no-resume", false, "disable setup resume after abort")
 	setupCmd.GroupID = cli.GroupIDEssentials
+	return setupCmd
 }

--- a/cmd/admin/startup_profile.go
+++ b/cmd/admin/startup_profile.go
@@ -23,17 +23,18 @@ var (
 	startupProfileTraceFile string
 )
 
-var startupProfileCmd = &cobra.Command{
-	Use:   "startup-profile",
-	Short: "Measure and report CLI startup time",
-	Long: `Measure CLI startup time by re-executing the binary multiple times.
+func newStartupProfileCmd() *cobra.Command {
+	startupProfileCmd := &cobra.Command{
+		Use:   "startup-profile",
+		Short: "Measure and report CLI startup time",
+		Long: `Measure CLI startup time by re-executing the binary multiple times.
 
 Reports min, max, average, and p95 startup times across N iterations.
 The measurement covers Go runtime init, all init() functions, cobra
 command tree setup, flag parsing, and the PersistentPreRunE hook.
 
 Use --trace to generate a runtime/trace file analyzable with 'go tool trace'.`,
-	Example: `  # Measure startup time (default 10 iterations)
+		Example: `  # Measure startup time (default 10 iterations)
   symvault startup-profile
 
   # Measure with 50 iterations
@@ -41,17 +42,16 @@ Use --trace to generate a runtime/trace file analyzable with 'go tool trace'.`,
 
   # Generate a runtime trace for detailed analysis
   symvault startup-profile --trace startup.trace`,
-	Annotations: map[string]string{
-		cli.RequiresVaultAnnotation: "false",
-	},
-	RunE: runStartupProfile,
-}
-
-func init() {
+		Annotations: map[string]string{
+			cli.RequiresVaultAnnotation: "false",
+		},
+		RunE: runStartupProfile,
+	}
 	startupProfileCmd.Flags().IntVarP(&startupProfileCount, "count", "n", 10, "number of benchmark iterations")
 	startupProfileCmd.Flags().IntVar(&startupProfileTopN, "top", 5, "show top N slowest phases in trace breakdown")
 	startupProfileCmd.Flags().StringVar(&startupProfileTraceFile, "trace", "", "write a runtime trace file (viewable with 'go tool trace')")
 	startupProfileCmd.GroupID = cli.GroupIDAdministration
+	return startupProfileCmd
 }
 
 const envProfileChild = "SYMVAULT_STARTUP_PROFILE_CHILD"

--- a/cmd/admin/update.go
+++ b/cmd/admin/update.go
@@ -59,17 +59,28 @@ var (
 
 var errUpdateAvailable = errorspkg.NewCLIError(errorspkg.ExitUpdateAvailable, "update available", nil)
 
-var UpdateCmd = &cobra.Command{
-	Use:     "update",
-	Short:   "Check for Symaira Vault updates",
-	Example: `  symvault update check`,
-	Args:    cobra.NoArgs,
-	Annotations: map[string]string{
-		cli.RequiresVaultAnnotation: "false",
-	},
-	RunE: func(cmd *cobra.Command, args []string) error {
-		return cmd.Help()
-	},
+// UpdateCmd is retained for API compatibility; NewCommands() uses
+// newUpdateCmd() so every call gets a fresh command.
+var UpdateCmd = newUpdateCmd()
+
+func newUpdateCmd() *cobra.Command {
+	UpdateCmd := &cobra.Command{
+		Use:     "update",
+		Short:   "Check for Symaira Vault updates",
+		Example: `  symvault update check`,
+		Args:    cobra.NoArgs,
+		Annotations: map[string]string{
+			cli.RequiresVaultAnnotation: "false",
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+	UpdateCmd.AddCommand(newUpdateCheckCmd())
+	UpdateCmd.AddCommand(newUpdateApplyCmd())
+	UpdateCmd.AddCommand(newUpdateInfoCmd())
+	UpdateCmd.GroupID = cli.GroupIDAdministration
+	return UpdateCmd
 }
 
 type updateCheckJSONOutput struct {
@@ -80,69 +91,79 @@ type updateCheckJSONOutput struct {
 	UpdateAvailable bool   `json:"update_available"`
 }
 
-var UpdateCheckCmd = &cobra.Command{
-	Use:   "check",
-	Short: "Check GitHub for a newer Symaira Vault release",
-	Args:  cobra.NoArgs,
-	Annotations: map[string]string{
-		cli.RequiresVaultAnnotation: "false",
-	},
-	SilenceUsage:  true,
-	SilenceErrors: true,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		checker := UpdateCheckerFactory()
-		result, err := checker.CheckWithForce(cmd.Context(), cli.AppVersion, UpdateCheckForce)
-		if err != nil {
-			return fmt.Errorf("check for updates: %w", err)
-		}
+// UpdateCheckCmd is retained for API compatibility; NewCommands() uses
+// newUpdateCheckCmd() so every call gets a fresh command.
+var UpdateCheckCmd = newUpdateCheckCmd()
 
-		if cli.WantJSONOutput(UpdateCheckJSON) {
-			output := updateCheckJSONOutput{
-				CurrentVersion:  result.CurrentVersion,
-				LatestVersion:   result.LatestVersion,
-				ReleaseURL:      result.ReleaseURL,
-				Checkable:       result.Checkable,
-				UpdateAvailable: result.UpdateAvailable,
+func newUpdateCheckCmd() *cobra.Command {
+	UpdateCheckCmd := &cobra.Command{
+		Use:   "check",
+		Short: "Check GitHub for a newer Symaira Vault release",
+		Args:  cobra.NoArgs,
+		Annotations: map[string]string{
+			cli.RequiresVaultAnnotation: "false",
+		},
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			checker := UpdateCheckerFactory()
+			result, err := checker.CheckWithForce(cmd.Context(), cli.AppVersion, UpdateCheckForce)
+			if err != nil {
+				return fmt.Errorf("check for updates: %w", err)
 			}
-			encoder := json.NewEncoder(cmd.OutOrStdout())
-			encoder.SetIndent("", "  ")
-			if err := encoder.Encode(output); err != nil {
-				return fmt.Errorf("encode JSON output: %w", err)
+
+			if cli.WantJSONOutput(UpdateCheckJSON) {
+				output := updateCheckJSONOutput{
+					CurrentVersion:  result.CurrentVersion,
+					LatestVersion:   result.LatestVersion,
+					ReleaseURL:      result.ReleaseURL,
+					Checkable:       result.Checkable,
+					UpdateAvailable: result.UpdateAvailable,
+				}
+				encoder := json.NewEncoder(cmd.OutOrStdout())
+				encoder.SetIndent("", "  ")
+				if err := encoder.Encode(output); err != nil {
+					return fmt.Errorf("encode JSON output: %w", err)
+				}
+				if result.UpdateAvailable {
+					return errUpdateAvailable
+				}
+				return nil
 			}
+
+			if UpdateCheckQuiet {
+				if result.UpdateAvailable {
+					return errUpdateAvailable
+				}
+				return nil
+			}
+
+			if !result.Checkable {
+				cmd.Printf("Update checks are only available for stable release builds. Current version: %s\n", result.CurrentVersion)
+				return nil
+			}
+
 			if result.UpdateAvailable {
+				cmd.Printf("Update available: %s -> %s\n", result.CurrentVersion, result.LatestVersion)
+				if result.ReleaseURL != "" {
+					cmd.Printf("Download: %s\n", result.ReleaseURL)
+				}
 				return errUpdateAvailable
 			}
-			return nil
-		}
 
-		if UpdateCheckQuiet {
-			if result.UpdateAvailable {
-				return errUpdateAvailable
+			if result.CurrentVersion == result.LatestVersion {
+				cmd.Printf("Symaira Vault is up to date (%s).\n", result.CurrentVersion)
+				return nil
 			}
+
+			cmd.Printf("No newer stable release found. Current version: %s. Latest published stable release: %s.\n", result.CurrentVersion, result.LatestVersion)
 			return nil
-		}
-
-		if !result.Checkable {
-			cmd.Printf("Update checks are only available for stable release builds. Current version: %s\n", result.CurrentVersion)
-			return nil
-		}
-
-		if result.UpdateAvailable {
-			cmd.Printf("Update available: %s -> %s\n", result.CurrentVersion, result.LatestVersion)
-			if result.ReleaseURL != "" {
-				cmd.Printf("Download: %s\n", result.ReleaseURL)
-			}
-			return errUpdateAvailable
-		}
-
-		if result.CurrentVersion == result.LatestVersion {
-			cmd.Printf("Symaira Vault is up to date (%s).\n", result.CurrentVersion)
-			return nil
-		}
-
-		cmd.Printf("No newer stable release found. Current version: %s. Latest published stable release: %s.\n", result.CurrentVersion, result.LatestVersion)
-		return nil
-	},
+		},
+	}
+	UpdateCheckCmd.Flags().BoolVar(&UpdateCheckJSON, "json", false, "output update check result as JSON (deprecated: use --output=json)")
+	UpdateCheckCmd.Flags().BoolVar(&UpdateCheckQuiet, "quiet", false, "suppress non-essential output (exit code 1 if update available)")
+	UpdateCheckCmd.Flags().BoolVar(&UpdateCheckForce, "force", false, "bypass cache and force a fresh check")
+	return UpdateCheckCmd
 }
 
 type updateApplyJSONOutput struct {
@@ -163,37 +184,102 @@ type updateInfoJSONOutput struct {
 	IsLegacyBinary      bool   `json:"is_legacy_binary"`
 }
 
-var updateApplyCmd = &cobra.Command{
-	Use:   "apply",
-	Short: "Apply the latest Symaira Vault self-update",
-	Long: `Downloads, verifies, and applies the latest Symaira Vault release.
+func newUpdateApplyCmd() *cobra.Command {
+	updateApplyCmd := &cobra.Command{
+		Use:   "apply",
+		Short: "Apply the latest Symaira Vault self-update",
+		Long: `Downloads, verifies, and applies the latest Symaira Vault release.
 
 Supports direct-download installations only. When run via Homebrew, go install,
 or a package manager, self-update is disabled and guidance is shown instead.`,
-	Args: cobra.NoArgs,
-	Annotations: map[string]string{
-		cli.RequiresVaultAnnotation: "false",
-	},
-	SilenceUsage:  true,
-	SilenceErrors: true,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		if updateApplyDryRun {
-			checker := UpdateCheckerFactory()
-			result, err := checker.CheckWithForce(cmd.Context(), cli.AppVersion, UpdateApplyForce)
+		Args: cobra.NoArgs,
+		Annotations: map[string]string{
+			cli.RequiresVaultAnnotation: "false",
+		},
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if updateApplyDryRun {
+				checker := UpdateCheckerFactory()
+				result, err := checker.CheckWithForce(cmd.Context(), cli.AppVersion, UpdateApplyForce)
+				if err != nil {
+					return fmt.Errorf("check for updates: %w", err)
+				}
+
+				if cli.WantJSONOutput(updateApplyJSON) {
+					output := updateApplyJSONOutput{
+						OldVersion: result.CurrentVersion,
+						BinaryPath: "",
+						DryRun:     true,
+					}
+					if result.UpdateAvailable {
+						output.NewVersion = result.LatestVersion
+					} else {
+						output.NewVersion = result.CurrentVersion
+					}
+					encoder := json.NewEncoder(cmd.OutOrStdout())
+					encoder.SetIndent("", "  ")
+					if err := encoder.Encode(output); err != nil {
+						return fmt.Errorf("encode JSON output: %w", err)
+					}
+					return nil
+				}
+
+				if !result.Checkable {
+					cmd.Printf("Update checks are only available for stable release builds. Current version: %s\n", result.CurrentVersion)
+					return nil
+				}
+
+				if result.UpdateAvailable {
+					cmd.Printf("Update available: %s -> %s (use --dry-run to preview)\n", result.CurrentVersion, result.LatestVersion)
+				} else {
+					cmd.Printf("Symaira Vault is up to date (%s).\n", result.CurrentVersion)
+				}
+				return nil
+			}
+
+			info, err := updatepkg.Info()
+			if err == nil && info.IsLegacyBinary {
+				cmd.PrintErrln("Warning: You are running the legacy 'openpass' binary.")
+				cmd.PrintErrln("This will be updated to 'symvault' and a compatibility symlink will be created.")
+				cmd.PrintErrln("Consider updating your scripts and aliases to use 'symvault' instead.")
+				cmd.PrintErrln()
+			}
+
+			applyResult, err := updatepkg.Apply(cmd.Context(), cli.AppVersion, UpdateApplyForce, false)
 			if err != nil {
-				return fmt.Errorf("check for updates: %w", err)
+				var unsupported *updatepkg.ErrUnsupportedMethod
+				if errors.As(err, &unsupported) {
+					guidance := unsupported.Guidance
+					if info.IsLegacyBinary {
+						guidance = installmethod.LegacyGuidance(info.Method)
+					}
+					if cli.WantJSONOutput(updateApplyJSON) {
+						encoder := json.NewEncoder(cmd.OutOrStdout())
+						encoder.SetIndent("", "  ")
+						if encodeErr := encoder.Encode(map[string]string{
+							"error":    err.Error(),
+							"guidance": guidance,
+						}); encodeErr != nil {
+							_ = encodeErr
+						}
+					} else {
+						cmd.PrintErrln("Error: " + err.Error())
+						cmd.PrintErrln("Guidance: " + guidance)
+					}
+					return errorspkg.NewCLIError(errorspkg.ExitNotFound, "self-update not supported", err)
+				}
+				return fmt.Errorf("apply update: %w", err)
 			}
 
 			if cli.WantJSONOutput(updateApplyJSON) {
 				output := updateApplyJSONOutput{
-					OldVersion: result.CurrentVersion,
-					BinaryPath: "",
-					DryRun:     true,
-				}
-				if result.UpdateAvailable {
-					output.NewVersion = result.LatestVersion
-				} else {
-					output.NewVersion = result.CurrentVersion
+					Method:            string(applyResult.Method),
+					OldVersion:        applyResult.OldVersion,
+					NewVersion:        applyResult.NewVersion,
+					BackupPath:        applyResult.BackupPath,
+					BinaryPath:        applyResult.BinaryPath,
+					LegacySymlinkPath: applyResult.LegacySymlinkPath,
 				}
 				encoder := json.NewEncoder(cmd.OutOrStdout())
 				encoder.SetIndent("", "  ")
@@ -203,150 +289,78 @@ or a package manager, self-update is disabled and guidance is shown instead.`,
 				return nil
 			}
 
-			if !result.Checkable {
-				cmd.Printf("Update checks are only available for stable release builds. Current version: %s\n", result.CurrentVersion)
+			if applyResult.OldVersion == applyResult.NewVersion {
+				cmd.Printf("Symaira Vault is already up to date (%s).\n", applyResult.NewVersion)
 				return nil
 			}
 
-			if result.UpdateAvailable {
-				cmd.Printf("Update available: %s -> %s (use --dry-run to preview)\n", result.CurrentVersion, result.LatestVersion)
-			} else {
-				cmd.Printf("Symaira Vault is up to date (%s).\n", result.CurrentVersion)
+			cmd.Printf("Updated Symaira Vault: %s -> %s\n", applyResult.OldVersion, applyResult.NewVersion)
+			cmd.Printf("Installation method: %s\n", applyResult.Method)
+			cmd.Printf("Binary: %s\n", applyResult.BinaryPath)
+			if applyResult.BackupPath != "" {
+				cmd.Printf("Backup saved to: %s\n", applyResult.BackupPath)
+			}
+			if applyResult.LegacySymlinkPath != "" {
+				cmd.Printf("Legacy symlink created: %s\n", applyResult.LegacySymlinkPath)
+				cmd.Printf("You can still use 'openpass' during the transition period.\n")
 			}
 			return nil
-		}
-
-		info, err := updatepkg.Info()
-		if err == nil && info.IsLegacyBinary {
-			cmd.PrintErrln("Warning: You are running the legacy 'openpass' binary.")
-			cmd.PrintErrln("This will be updated to 'symvault' and a compatibility symlink will be created.")
-			cmd.PrintErrln("Consider updating your scripts and aliases to use 'symvault' instead.")
-			cmd.PrintErrln()
-		}
-
-		applyResult, err := updatepkg.Apply(cmd.Context(), cli.AppVersion, UpdateApplyForce, false)
-		if err != nil {
-			var unsupported *updatepkg.ErrUnsupportedMethod
-			if errors.As(err, &unsupported) {
-				guidance := unsupported.Guidance
-				if info.IsLegacyBinary {
-					guidance = installmethod.LegacyGuidance(info.Method)
-				}
-				if cli.WantJSONOutput(updateApplyJSON) {
-					encoder := json.NewEncoder(cmd.OutOrStdout())
-					encoder.SetIndent("", "  ")
-					if encodeErr := encoder.Encode(map[string]string{
-						"error":    err.Error(),
-						"guidance": guidance,
-					}); encodeErr != nil {
-						_ = encodeErr
-					}
-				} else {
-					cmd.PrintErrln("Error: " + err.Error())
-					cmd.PrintErrln("Guidance: " + guidance)
-				}
-				return errorspkg.NewCLIError(errorspkg.ExitNotFound, "self-update not supported", err)
-			}
-			return fmt.Errorf("apply update: %w", err)
-		}
-
-		if cli.WantJSONOutput(updateApplyJSON) {
-			output := updateApplyJSONOutput{
-				Method:            string(applyResult.Method),
-				OldVersion:        applyResult.OldVersion,
-				NewVersion:        applyResult.NewVersion,
-				BackupPath:        applyResult.BackupPath,
-				BinaryPath:        applyResult.BinaryPath,
-				LegacySymlinkPath: applyResult.LegacySymlinkPath,
-			}
-			encoder := json.NewEncoder(cmd.OutOrStdout())
-			encoder.SetIndent("", "  ")
-			if err := encoder.Encode(output); err != nil {
-				return fmt.Errorf("encode JSON output: %w", err)
-			}
-			return nil
-		}
-
-		if applyResult.OldVersion == applyResult.NewVersion {
-			cmd.Printf("Symaira Vault is already up to date (%s).\n", applyResult.NewVersion)
-			return nil
-		}
-
-		cmd.Printf("Updated Symaira Vault: %s -> %s\n", applyResult.OldVersion, applyResult.NewVersion)
-		cmd.Printf("Installation method: %s\n", applyResult.Method)
-		cmd.Printf("Binary: %s\n", applyResult.BinaryPath)
-		if applyResult.BackupPath != "" {
-			cmd.Printf("Backup saved to: %s\n", applyResult.BackupPath)
-		}
-		if applyResult.LegacySymlinkPath != "" {
-			cmd.Printf("Legacy symlink created: %s\n", applyResult.LegacySymlinkPath)
-			cmd.Printf("You can still use 'openpass' during the transition period.\n")
-		}
-		return nil
-	},
-}
-
-var updateInfoCmd = &cobra.Command{
-	Use:   "info",
-	Short: "Show Symaira Vault installation method info",
-	Long: `Detects how Symaira Vault was installed and shows whether self-update
-is supported, along with upgrade guidance for the detected method.`,
-	Args: cobra.NoArgs,
-	Annotations: map[string]string{
-		cli.RequiresVaultAnnotation: "false",
-	},
-	SilenceUsage:  true,
-	SilenceErrors: true,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		info, err := updatepkg.Info()
-		if err != nil {
-			return fmt.Errorf("update info: %w", err)
-		}
-
-		if cli.WantJSONOutput(updateInfoJSON) {
-			output := updateInfoJSONOutput{
-				Method:              string(info.Method),
-				BinaryPath:          info.BinaryPath,
-				SelfUpdateSupported: info.SelfUpdateSupported,
-				Guidance:            info.Guidance,
-				IsLegacyBinary:      info.IsLegacyBinary,
-			}
-			encoder := json.NewEncoder(cmd.OutOrStdout())
-			encoder.SetIndent("", "  ")
-			if err := encoder.Encode(output); err != nil {
-				return fmt.Errorf("encode JSON output: %w", err)
-			}
-			return nil
-		}
-
-		cmd.Printf("Installation method: %s\n", info.Method)
-		cmd.Printf("Binary path: %s\n", info.BinaryPath)
-		if info.SelfUpdateSupported {
-			cmd.Println("Self-update: supported")
-		} else {
-			cmd.Println("Self-update: not supported")
-		}
-		if info.IsLegacyBinary {
-			cmd.Println("Binary: legacy (openpass)")
-		}
-		cmd.Printf("Guidance: %s\n", info.Guidance)
-		return nil
-	},
-}
-
-func init() {
-	UpdateCheckCmd.Flags().BoolVar(&UpdateCheckJSON, "json", false, "output update check result as JSON (deprecated: use --output=json)")
-	UpdateCheckCmd.Flags().BoolVar(&UpdateCheckQuiet, "quiet", false, "suppress non-essential output (exit code 1 if update available)")
-	UpdateCheckCmd.Flags().BoolVar(&UpdateCheckForce, "force", false, "bypass cache and force a fresh check")
-
+		},
+	}
 	updateApplyCmd.Flags().BoolVar(&UpdateApplyForce, "force", false, "bypass cache and force a fresh check")
 	updateApplyCmd.Flags().BoolVar(&updateApplyDryRun, "dry-run", false, "preview update without applying")
 	updateApplyCmd.Flags().BoolVar(&updateApplyJSON, "json", false, "output apply result as JSON (deprecated: use --output=json)")
+	return updateApplyCmd
+}
 
+func newUpdateInfoCmd() *cobra.Command {
+	updateInfoCmd := &cobra.Command{
+		Use:   "info",
+		Short: "Show Symaira Vault installation method info",
+		Long: `Detects how Symaira Vault was installed and shows whether self-update
+is supported, along with upgrade guidance for the detected method.`,
+		Args: cobra.NoArgs,
+		Annotations: map[string]string{
+			cli.RequiresVaultAnnotation: "false",
+		},
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			info, err := updatepkg.Info()
+			if err != nil {
+				return fmt.Errorf("update info: %w", err)
+			}
+
+			if cli.WantJSONOutput(updateInfoJSON) {
+				output := updateInfoJSONOutput{
+					Method:              string(info.Method),
+					BinaryPath:          info.BinaryPath,
+					SelfUpdateSupported: info.SelfUpdateSupported,
+					Guidance:            info.Guidance,
+					IsLegacyBinary:      info.IsLegacyBinary,
+				}
+				encoder := json.NewEncoder(cmd.OutOrStdout())
+				encoder.SetIndent("", "  ")
+				if err := encoder.Encode(output); err != nil {
+					return fmt.Errorf("encode JSON output: %w", err)
+				}
+				return nil
+			}
+
+			cmd.Printf("Installation method: %s\n", info.Method)
+			cmd.Printf("Binary path: %s\n", info.BinaryPath)
+			if info.SelfUpdateSupported {
+				cmd.Println("Self-update: supported")
+			} else {
+				cmd.Println("Self-update: not supported")
+			}
+			if info.IsLegacyBinary {
+				cmd.Println("Binary: legacy (openpass)")
+			}
+			cmd.Printf("Guidance: %s\n", info.Guidance)
+			return nil
+		},
+	}
 	updateInfoCmd.Flags().BoolVar(&updateInfoJSON, "json", false, "output info as JSON (deprecated: use --output=json)")
-
-	UpdateCmd.AddCommand(UpdateCheckCmd)
-	UpdateCmd.AddCommand(updateApplyCmd)
-	UpdateCmd.AddCommand(updateInfoCmd)
-	UpdateCmd.GroupID = cli.GroupIDAdministration
+	return updateInfoCmd
 }

--- a/cmd/admin/verify.go
+++ b/cmd/admin/verify.go
@@ -16,17 +16,18 @@ var (
 	verifyRebuildOnly bool
 )
 
-var verifyCmd = &cobra.Command{
-	Use:   "verify",
-	Short: "Verify vault entry integrity against manifest",
-	Long: `Verify that all vault entries match their recorded manifest hashes.
+func newVerifyCmd() *cobra.Command {
+	verifyCmd := &cobra.Command{
+		Use:   "verify",
+		Short: "Verify vault entry integrity against manifest",
+		Long: `Verify that all vault entries match their recorded manifest hashes.
 This detects tampered or corrupted entry files.
 
 Use --rebuild to regenerate the manifest from the on-disk .age files (use
 this when entries have been added out-of-band, e.g. via git sync, and the
 manifest has not been updated). Use --rebuild-only to skip the integrity
 check and only rebuild.`,
-	Example: `  # Verify manifest matches on-disk entries
+		Example: `  # Verify manifest matches on-disk entries
   symvault verify
 
   # Rebuild the manifest from on-disk entries (fixes "unknown" entries from sync)
@@ -37,63 +38,62 @@ check and only rebuild.`,
 
   # As part of a scripted health check
   symvault verify || echo "Manifest mismatch — investigate"`,
-	Annotations: map[string]string{
-		cli.RequiresVaultAnnotation: "true",
-	},
-	RunE: func(cmd *cobra.Command, args []string) error {
-		return cli.WithVaultRaw(func(v *vaultpkg.Vault, vs *cli.VaultService) error {
-			if verifyRebuild || verifyRebuildOnly {
-				if err := vaultpkg.RebuildManifest(v.Dir, v.Identity); err != nil {
-					return fmt.Errorf("rebuild manifest: %w", err)
+		Annotations: map[string]string{
+			cli.RequiresVaultAnnotation: "true",
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cli.WithVaultRaw(func(v *vaultpkg.Vault, vs *cli.VaultService) error {
+				if verifyRebuild || verifyRebuildOnly {
+					if err := vaultpkg.RebuildManifest(v.Dir, v.Identity); err != nil {
+						return fmt.Errorf("rebuild manifest: %w", err)
+					}
+					cmd.Println("Manifest rebuilt from on-disk entries.")
+					if verifyRebuildOnly {
+						return nil
+					}
 				}
-				cmd.Println("Manifest rebuilt from on-disk entries.")
-				if verifyRebuildOnly {
-					return nil
-				}
-			}
 
-			result, err := vaultpkg.VerifyManifestIntegrity(v.Dir, v.Identity)
-			if err != nil {
-				if os.IsNotExist(err) {
-					cmd.Println("No manifest found. Run `symvault verify --rebuild` to create one from on-disk entries.")
-					return nil
+				result, err := vaultpkg.VerifyManifestIntegrity(v.Dir, v.Identity)
+				if err != nil {
+					if os.IsNotExist(err) {
+						cmd.Println("No manifest found. Run `symvault verify --rebuild` to create one from on-disk entries.")
+						return nil
+					}
+					return err
 				}
-				return err
-			}
 
-			cmd.Printf("Manifest verification: %d entries match, %d missing, %d tampered, %d unknown\n",
-				result.OK, len(result.Missing), len(result.Tampered), len(result.Unknown))
+				cmd.Printf("Manifest verification: %d entries match, %d missing, %d tampered, %d unknown\n",
+					result.OK, len(result.Missing), len(result.Tampered), len(result.Unknown))
 
-			if len(result.Missing) > 0 {
-				cmd.Println("\nMissing entries:")
-				for _, p := range result.Missing {
-					cmd.Printf("  - %s\n", p)
+				if len(result.Missing) > 0 {
+					cmd.Println("\nMissing entries:")
+					for _, p := range result.Missing {
+						cmd.Printf("  - %s\n", p)
+					}
 				}
-			}
-			if len(result.Tampered) > 0 {
-				cmd.Println("\nTampered entries:")
-				for _, p := range result.Tampered {
-					cmd.Printf("  - %s (hash mismatch)\n", p)
+				if len(result.Tampered) > 0 {
+					cmd.Println("\nTampered entries:")
+					for _, p := range result.Tampered {
+						cmd.Printf("  - %s (hash mismatch)\n", p)
+					}
 				}
-			}
-			if len(result.Unknown) > 0 {
-				cmd.Println("\nUnknown entries (not in manifest):")
-				for _, p := range result.Unknown {
-					cmd.Printf("  - %s\n", p)
+				if len(result.Unknown) > 0 {
+					cmd.Println("\nUnknown entries (not in manifest):")
+					for _, p := range result.Unknown {
+						cmd.Printf("  - %s\n", p)
+					}
+					cmd.Println("\nHint: run `symvault verify --rebuild` to add these entries to the manifest.")
 				}
-				cmd.Println("\nHint: run `symvault verify --rebuild` to add these entries to the manifest.")
-			}
 
-			if len(result.Tampered) > 0 {
-				return fmt.Errorf("manifest integrity check failed: %d tampered entries", len(result.Tampered))
-			}
-			return nil
-		})
-	},
-}
-
-func init() {
+				if len(result.Tampered) > 0 {
+					return fmt.Errorf("manifest integrity check failed: %d tampered entries", len(result.Tampered))
+				}
+				return nil
+			})
+		},
+	}
 	verifyCmd.GroupID = cli.GroupIDAdministration
 	verifyCmd.Flags().BoolVar(&verifyRebuild, "rebuild", false, "Rebuild the manifest from on-disk entries after the integrity check")
 	verifyCmd.Flags().BoolVar(&verifyRebuildOnly, "rebuild-only", false, "Rebuild the manifest and skip the integrity check")
+	return verifyCmd
 }

--- a/cmd/auth/auth.go
+++ b/cmd/auth/auth.go
@@ -20,10 +20,20 @@ import (
 
 var AuthStatusJSON bool
 
-var AuthCmd = &cobra.Command{
-	Use:   "auth",
-	Short: "Manage vault unlock authentication",
-	Example: `  # Check current auth status (passphrase vs Touch ID)
+// AuthCmd is retained for API compatibility; the assembled tree built by
+// NewCommands() uses newAuthCmd() instead so every call gets a fresh tree.
+var AuthCmd = newAuthCmd()
+
+// AuthStatusCmd and AuthSetCmd are retained for API compatibility.
+var AuthStatusCmd = newAuthStatusCmd()
+
+var AuthSetCmd = newAuthSetCmd()
+
+func newAuthCmd() *cobra.Command {
+	authCmd := &cobra.Command{
+		Use:   "auth",
+		Short: "Manage vault unlock authentication",
+		Example: `  # Check current auth status (passphrase vs Touch ID)
   symvault auth status
 
   # Enable Touch ID (macOS)
@@ -31,111 +41,120 @@ var AuthCmd = &cobra.Command{
 
   # Switch back to passphrase-only
   symvault auth set passphrase`,
+	}
+
+	authCmd.GroupID = cli.GroupIDAuthAccess
+	authCmd.AddCommand(newAuthStatusCmd())
+	authCmd.AddCommand(newAuthSetCmd())
+	authCmd.AddCommand(newRotatePassphraseCmd())
+	return authCmd
 }
 
-var AuthStatusCmd = &cobra.Command{
-	Use:   "status",
-	Short: "Show vault unlock authentication status",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		_, _ = cmd, args
-		vaultDir, cfg, err := loadAuthConfig()
-		if err != nil {
-			return err
-		}
-		method := cfg.EffectiveAuthMethod()
-		cache := session.GetCacheStatus()
-		keyringHealth := "available"
-		if !cache.Persistent {
-			keyringHealth = "unavailable"
-		}
-		payload := map[string]any{
-			"vault":            vaultDir,
-			"method":           method,
-			"touchIDAvailable": session.BiometricAvailable(),
-			"cache":            cache,
-			"keyringHealth":    keyringHealth,
-		}
-		if cli.WantJSONOutput(AuthStatusJSON) {
-			printer, err := cli.NewPrinter("json")
+func newAuthStatusCmd() *cobra.Command {
+	authStatusCmd := &cobra.Command{
+		Use:   "status",
+		Short: "Show vault unlock authentication status",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			_, _ = cmd, args
+			vaultDir, cfg, err := loadAuthConfig()
 			if err != nil {
 				return err
 			}
-			return printer.Print(payload)
-		}
-		cli.PrintlnQuietAware("Vault: " + vaultDir)
-		cli.PrintlnQuietAware("Auth method: " + method)
-		cli.PrintlnQuietAware(fmt.Sprintf("Touch ID available: %t", payload["touchIDAvailable"]))
-		cli.PrintlnQuietAware(fmt.Sprintf("Session cache: %s (persistent: %t)", cache.Backend, cache.Persistent))
-		cli.PrintlnQuietAware("Keyring health: " + keyringHealth)
-		return nil
-	},
+			method := cfg.EffectiveAuthMethod()
+			cache := session.GetCacheStatus()
+			keyringHealth := "available"
+			if !cache.Persistent {
+				keyringHealth = "unavailable"
+			}
+			payload := map[string]any{
+				"vault":            vaultDir,
+				"method":           method,
+				"touchIDAvailable": session.BiometricAvailable(),
+				"cache":            cache,
+				"keyringHealth":    keyringHealth,
+			}
+			if cli.WantJSONOutput(AuthStatusJSON) {
+				printer, err := cli.NewPrinter("json")
+				if err != nil {
+					return err
+				}
+				return printer.Print(payload)
+			}
+			cli.PrintlnQuietAware("Vault: " + vaultDir)
+			cli.PrintlnQuietAware("Auth method: " + method)
+			cli.PrintlnQuietAware(fmt.Sprintf("Touch ID available: %t", payload["touchIDAvailable"]))
+			cli.PrintlnQuietAware(fmt.Sprintf("Session cache: %s (persistent: %t)", cache.Backend, cache.Persistent))
+			cli.PrintlnQuietAware("Keyring health: " + keyringHealth)
+			return nil
+		},
+	}
+
+	authStatusCmd.Flags().BoolVar(&AuthStatusJSON, "json", false, "output auth status as JSON (deprecated: use --output=json)")
+	return authStatusCmd
 }
 
-var AuthSetCmd = &cobra.Command{
-	Use:   "set passphrase|touchid",
-	Short: "Set the vault unlock authentication method",
-	Args: func(cmd *cobra.Command, args []string) error {
-		if len(args) != 1 {
-			_ = cmd.Help()
-			return fmt.Errorf("set requires exactly 1 argument: passphrase or touchid")
-		}
-		return nil
-	},
-	RunE: func(cmd *cobra.Command, args []string) error {
-		_, _ = cmd, args
-		method, err := configpkg.NormalizeAuthMethod(args[0])
-		if err != nil {
-			return err
-		}
-		vaultDir, cfg, err := loadAuthConfig()
-		if err != nil {
-			return err
-		}
-
-		switch method {
-		case configpkg.AuthMethodPassphrase:
-			if err := cfg.SetAuthMethod(configpkg.AuthMethodPassphrase); err != nil {
-				return err
+func newAuthSetCmd() *cobra.Command {
+	authSetCmd := &cobra.Command{
+		Use:   "set passphrase|touchid",
+		Short: "Set the vault unlock authentication method",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 1 {
+				_ = cmd.Help()
+				return fmt.Errorf("set requires exactly 1 argument: passphrase or touchid")
 			}
-			if err := cfg.SaveTo(filepath.Join(vaultDir, "config.yaml")); err != nil {
-				return fmt.Errorf("save config: %w", err)
-			}
-			if err := session.ClearBiometricPassphrase(vaultDir); err != nil {
-				cliout.Warnf("Warning: could not remove Touch ID unlock item: %v", err)
-			}
-			cli.PrintlnQuietAware("Auth method set to passphrase")
 			return nil
-		case configpkg.AuthMethodTouchID:
-			if !session.BiometricAvailable() {
-				return fmt.Errorf("touch ID is not available in this Symaira Vault build or on this Mac")
-			}
-			passphrase, err := passphraseForBiometricSetup(vaultDir)
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			_, _ = cmd, args
+			method, err := configpkg.NormalizeAuthMethod(args[0])
 			if err != nil {
 				return err
 			}
-			defer cryptopkg.Wipe(passphrase)
-			if err := session.SaveBiometricPassphrase(context.Background(), vaultDir, passphrase); err != nil {
-				return fmt.Errorf("save Touch ID unlock item: %w", err)
-			}
-			if err := cfg.SetAuthMethod(configpkg.AuthMethodTouchID); err != nil {
+			vaultDir, cfg, err := loadAuthConfig()
+			if err != nil {
 				return err
 			}
-			if err := cfg.SaveTo(filepath.Join(vaultDir, "config.yaml")); err != nil {
-				return fmt.Errorf("save config: %w", err)
-			}
-			cli.PrintlnQuietAware("Auth method set to touchid")
-			return nil
-		default:
-			return fmt.Errorf("unsupported auth method %q", method)
-		}
-	},
-}
 
-func init() {
-	AuthStatusCmd.Flags().BoolVar(&AuthStatusJSON, "json", false, "output auth status as JSON (deprecated: use --output=json)")
-	AuthCmd.AddCommand(AuthStatusCmd)
-	AuthCmd.AddCommand(AuthSetCmd)
-	AuthCmd.GroupID = cli.GroupIDAuthAccess
+			switch method {
+			case configpkg.AuthMethodPassphrase:
+				if err := cfg.SetAuthMethod(configpkg.AuthMethodPassphrase); err != nil {
+					return err
+				}
+				if err := cfg.SaveTo(filepath.Join(vaultDir, "config.yaml")); err != nil {
+					return fmt.Errorf("save config: %w", err)
+				}
+				if err := session.ClearBiometricPassphrase(vaultDir); err != nil {
+					cliout.Warnf("Warning: could not remove Touch ID unlock item: %v", err)
+				}
+				cli.PrintlnQuietAware("Auth method set to passphrase")
+				return nil
+			case configpkg.AuthMethodTouchID:
+				if !session.BiometricAvailable() {
+					return fmt.Errorf("touch ID is not available in this Symaira Vault build or on this Mac")
+				}
+				passphrase, err := passphraseForBiometricSetup(vaultDir)
+				if err != nil {
+					return err
+				}
+				defer cryptopkg.Wipe(passphrase)
+				if err := session.SaveBiometricPassphrase(context.Background(), vaultDir, passphrase); err != nil {
+					return fmt.Errorf("save Touch ID unlock item: %w", err)
+				}
+				if err := cfg.SetAuthMethod(configpkg.AuthMethodTouchID); err != nil {
+					return err
+				}
+				if err := cfg.SaveTo(filepath.Join(vaultDir, "config.yaml")); err != nil {
+					return fmt.Errorf("save config: %w", err)
+				}
+				cli.PrintlnQuietAware("Auth method set to touchid")
+				return nil
+			default:
+				return fmt.Errorf("unsupported auth method %q", method)
+			}
+		},
+	}
+
+	return authSetCmd
 }
 
 func loadAuthConfig() (string, *configpkg.Config, error) {

--- a/cmd/auth/auth_rotate.go
+++ b/cmd/auth/auth_rotate.go
@@ -25,125 +25,125 @@ import (
 var rotateReencrypt bool
 var rotateYes bool
 
-var rotatePassphraseCmd = &cobra.Command{
-	Use:   "rotate-passphrase",
-	Short: "Change the vault master passphrase",
-	Long: `Change the vault's master passphrase without re-initializing the vault.
+func newRotatePassphraseCmd() *cobra.Command {
+	rotatePassphraseCmd := &cobra.Command{
+		Use:   "rotate-passphrase",
+		Short: "Change the vault master passphrase",
+		Long: `Change the vault's master passphrase without re-initializing the vault.
 The X25519 key pair stays the same — only the passphrase protecting it is changed.
 Optionally re-encrypts all entries with the new passphrase.`,
-	Example: `  # Change the passphrase only
+		Example: `  # Change the passphrase only
   symvault rotate-passphrase
 
   # Change passphrase AND re-encrypt all entries (slow but clean)
   symvault rotate-passphrase --reencrypt`,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		_, _ = cmd, args
-		vaultDir, cfg, err := loadAuthConfig()
-		if err != nil {
-			return err
-		}
-
-		oldPassphrase, err := cli.ReadHiddenInput("Current passphrase: ", nil)
-		if err != nil {
-			return fmt.Errorf("cannot read current passphrase: %w", err)
-		}
-		defer cryptopkg.Wipe(oldPassphrase)
-
-		v, err := vaultpkg.OpenWithPassphrase(vaultDir, oldPassphrase)
-		if err != nil {
-			return fmt.Errorf("current passphrase is incorrect: %w", err)
-		}
-
-		newPassphrase, err := cli.ReadHiddenInput("New passphrase (minimum 12 characters): ", nil)
-		if err != nil {
-			return fmt.Errorf("cannot read new passphrase: %w", err)
-		}
-		defer cryptopkg.Wipe(newPassphrase)
-
-		if len(newPassphrase) < 12 {
-			return fmt.Errorf("passphrase must be at least 12 characters")
-		}
-
-		confirmation, err := cli.ReadHiddenInput("Confirm new passphrase: ", nil)
-		if err != nil {
-			return fmt.Errorf("cannot read confirmation: %w", err)
-		}
-		defer cryptopkg.Wipe(confirmation)
-
-		if string(newPassphrase) != string(confirmation) {
-			return fmt.Errorf("passphrases do not match")
-		}
-
-		if string(oldPassphrase) == string(newPassphrase) {
-			return fmt.Errorf("new passphrase must be different from the current passphrase")
-		}
-
-		if !rotateYes {
-			fmt.Fprintf(os.Stderr, "Change vault passphrase? (y/N): ")
-			answer, readErr := bufio.NewReader(os.Stdin).ReadString('\n')
-			if readErr != nil && answer == "" {
-				return fmt.Errorf("read confirmation: %w", readErr)
+		RunE: func(cmd *cobra.Command, args []string) error {
+			_, _ = cmd, args
+			vaultDir, cfg, err := loadAuthConfig()
+			if err != nil {
+				return err
 			}
-			if strings.ToLower(strings.TrimSpace(answer)) != "y" {
-				fmt.Fprintln(os.Stderr, "Canceled")
-				return nil
+
+			oldPassphrase, err := cli.ReadHiddenInput("Current passphrase: ", nil)
+			if err != nil {
+				return fmt.Errorf("cannot read current passphrase: %w", err)
 			}
-		}
+			defer cryptopkg.Wipe(oldPassphrase)
 
-		newPassphraseForEnc := make([]byte, len(newPassphrase))
-		copy(newPassphraseForEnc, newPassphrase)
-		defer cryptopkg.Wipe(newPassphraseForEnc)
-
-		if err := cryptopkg.SaveIdentity(v.Identity, filepath.Join(vaultDir, "identity.age"), newPassphraseForEnc, 0); err != nil {
-			return fmt.Errorf("save identity with new passphrase: %w", err)
-		}
-
-		if rotateReencrypt {
-			recipients, recErr := v.GetAllRecipientsForEncryption()
-			if recErr != nil {
-				return fmt.Errorf("get recipients for re-encryption: %w", recErr)
+			v, err := vaultpkg.OpenWithPassphrase(vaultDir, oldPassphrase)
+			if err != nil {
+				return fmt.Errorf("current passphrase is incorrect: %w", err)
 			}
-			if recErr := vaultpkg.ReencryptAll(vaultDir, v.Identity, recipients); recErr != nil {
-				return fmt.Errorf("re-encrypt entries: %w", recErr)
+
+			newPassphrase, err := cli.ReadHiddenInput("New passphrase (minimum 12 characters): ", nil)
+			if err != nil {
+				return fmt.Errorf("cannot read new passphrase: %w", err)
 			}
-		}
+			defer cryptopkg.Wipe(newPassphrase)
 
-		ttl := cli.ConfiguredSessionTTL(v, 0)
-		if cacheErr := cli.SessionSavePassphrase(vaultDir, newPassphrase, ttl); cacheErr != nil {
-			cliout.Warnf("Warning: could not update session cache: %v", cacheErr)
-		}
-		_ = cli.SessionSaveIdentity(vaultDir, v.Identity.String(), ttl)
-
-		if cfg.EffectiveAuthMethod() == configpkg.AuthMethodTouchID {
-			if bioErr := session.SaveBiometricPassphrase(context.Background(), vaultDir, newPassphrase); bioErr != nil {
-				cliout.Warnf("Warning: could not update Touch ID unlock: %v", bioErr)
+			if len(newPassphrase) < 12 {
+				return fmt.Errorf("passphrase must be at least 12 characters")
 			}
-		}
 
-		cfg.Vault.LastRotated = time.Now().UTC()
-		if saveErr := cfg.SaveTo(filepath.Join(vaultDir, "config.yaml")); saveErr != nil {
-			return fmt.Errorf("save config: %w", saveErr)
-		}
-
-		if commitErr := v.AutoCommit("Rotate vault passphrase"); commitErr != nil {
-			cliout.Warnf("Warning: git auto-commit failed: %v", commitErr)
-		}
-
-		auditLog, auditErr := audit.New("symvault", vaultDir, v.Identity)
-		if auditErr == nil {
-			if err := auditLog.LogEntry(audit.LogEntry{Action: "rotate-passphrase", OK: true, Timestamp: time.Now().UTC().Format(time.RFC3339)}); err != nil {
-				cliout.Warnf("Warning: audit log write failed: %v", err)
+			confirmation, err := cli.ReadHiddenInput("Confirm new passphrase: ", nil)
+			if err != nil {
+				return fmt.Errorf("cannot read confirmation: %w", err)
 			}
-			_ = auditLog.Close()
-		}
+			defer cryptopkg.Wipe(confirmation)
 
-		cli.PrintlnQuietAware("Passphrase rotated successfully.")
-		return nil
-	},
-}
+			if string(newPassphrase) != string(confirmation) {
+				return fmt.Errorf("passphrases do not match")
+			}
 
-func init() {
+			if string(oldPassphrase) == string(newPassphrase) {
+				return fmt.Errorf("new passphrase must be different from the current passphrase")
+			}
+
+			if !rotateYes {
+				fmt.Fprintf(os.Stderr, "Change vault passphrase? (y/N): ")
+				answer, readErr := bufio.NewReader(os.Stdin).ReadString('\n')
+				if readErr != nil && answer == "" {
+					return fmt.Errorf("read confirmation: %w", readErr)
+				}
+				if strings.ToLower(strings.TrimSpace(answer)) != "y" {
+					fmt.Fprintln(os.Stderr, "Canceled")
+					return nil
+				}
+			}
+
+			newPassphraseForEnc := make([]byte, len(newPassphrase))
+			copy(newPassphraseForEnc, newPassphrase)
+			defer cryptopkg.Wipe(newPassphraseForEnc)
+
+			if err := cryptopkg.SaveIdentity(v.Identity, filepath.Join(vaultDir, "identity.age"), newPassphraseForEnc, 0); err != nil {
+				return fmt.Errorf("save identity with new passphrase: %w", err)
+			}
+
+			if rotateReencrypt {
+				recipients, recErr := v.GetAllRecipientsForEncryption()
+				if recErr != nil {
+					return fmt.Errorf("get recipients for re-encryption: %w", recErr)
+				}
+				if recErr := vaultpkg.ReencryptAll(vaultDir, v.Identity, recipients); recErr != nil {
+					return fmt.Errorf("re-encrypt entries: %w", recErr)
+				}
+			}
+
+			ttl := cli.ConfiguredSessionTTL(v, 0)
+			if cacheErr := cli.SessionSavePassphrase(vaultDir, newPassphrase, ttl); cacheErr != nil {
+				cliout.Warnf("Warning: could not update session cache: %v", cacheErr)
+			}
+			_ = cli.SessionSaveIdentity(vaultDir, v.Identity.String(), ttl)
+
+			if cfg.EffectiveAuthMethod() == configpkg.AuthMethodTouchID {
+				if bioErr := session.SaveBiometricPassphrase(context.Background(), vaultDir, newPassphrase); bioErr != nil {
+					cliout.Warnf("Warning: could not update Touch ID unlock: %v", bioErr)
+				}
+			}
+
+			cfg.Vault.LastRotated = time.Now().UTC()
+			if saveErr := cfg.SaveTo(filepath.Join(vaultDir, "config.yaml")); saveErr != nil {
+				return fmt.Errorf("save config: %w", saveErr)
+			}
+
+			if commitErr := v.AutoCommit("Rotate vault passphrase"); commitErr != nil {
+				cliout.Warnf("Warning: git auto-commit failed: %v", commitErr)
+			}
+
+			auditLog, auditErr := audit.New("symvault", vaultDir, v.Identity)
+			if auditErr == nil {
+				if err := auditLog.LogEntry(audit.LogEntry{Action: "rotate-passphrase", OK: true, Timestamp: time.Now().UTC().Format(time.RFC3339)}); err != nil {
+					cliout.Warnf("Warning: audit log write failed: %v", err)
+				}
+				_ = auditLog.Close()
+			}
+
+			cli.PrintlnQuietAware("Passphrase rotated successfully.")
+			return nil
+		},
+	}
+
 	rotatePassphraseCmd.Flags().BoolVar(&rotateReencrypt, "reencrypt", true, "Re-encrypt all entries")
 	rotatePassphraseCmd.Flags().BoolVarP(&rotateYes, "yes", "y", false, "Skip confirmation prompt")
-	AuthCmd.AddCommand(rotatePassphraseCmd)
+	return rotatePassphraseCmd
 }

--- a/cmd/auth/commands.go
+++ b/cmd/auth/commands.go
@@ -5,10 +5,12 @@ import (
 )
 
 // NewCommands returns all authentication commands for root command assembly.
+// Each call builds a fresh command tree so consecutive calls never share
+// command objects or flag state.
 func NewCommands() []*cobra.Command {
 	return []*cobra.Command{
-		AuthCmd,
-		lockCmd,
-		AuthUnlockCmd,
+		newAuthCmd(),
+		newLockCmd(),
+		newAuthUnlockCmd(),
 	}
 }

--- a/cmd/auth/commands_test.go
+++ b/cmd/auth/commands_test.go
@@ -1,0 +1,53 @@
+package auth
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// TestNewCommands_FreshTrees guards the constructor migration (#744): every
+// NewCommands() call must return a freshly built tree, so consecutive calls
+// never share command objects, parent/child pointers, or flag state.
+func TestNewCommands_FreshTrees(t *testing.T) {
+	first := NewCommands()
+	second := NewCommands()
+
+	if len(first) != 3 || len(second) != 3 {
+		t.Fatalf("NewCommands() returned %d and %d commands, want 3 (auth, lock, unlock)", len(first), len(second))
+	}
+
+	seen := map[string]*cobra.Command{}
+	for i, secondCmd := range second {
+		firstCmd := first[i]
+		if firstCmd == secondCmd {
+			t.Fatalf("command %q is shared between NewCommands() calls", secondCmd.Name())
+		}
+		if prev, ok := seen[secondCmd.Name()]; ok && prev == secondCmd {
+			t.Fatalf("duplicate command %q in NewCommands() result", secondCmd.Name())
+		}
+		seen[secondCmd.Name()] = secondCmd
+	}
+
+	// The auth parent must expose all three children on every fresh tree.
+	authCmd := second[0]
+	if authCmd.Name() != "auth" {
+		t.Fatalf("first command = %q, want %q", authCmd.Name(), "auth")
+	}
+	children := authCmd.Commands()
+	if len(children) != 3 {
+		t.Fatalf("auth command has %d children, want 3 (status, set, rotate-passphrase)", len(children))
+	}
+	childNames := map[string]bool{}
+	for _, c := range children {
+		if c.Parent() != authCmd {
+			t.Fatalf("child %q is not parented to the fresh auth command", c.Name())
+		}
+		childNames[c.Name()] = true
+	}
+	for _, want := range []string{"status", "set", "rotate-passphrase"} {
+		if !childNames[want] {
+			t.Errorf("auth command missing child %q", want)
+		}
+	}
+}

--- a/cmd/auth/lock.go
+++ b/cmd/auth/lock.go
@@ -13,30 +13,31 @@ import (
 	vaultpkg "github.com/danieljustus/symaira-vault/internal/vault"
 )
 
-var lockCmd = &cobra.Command{
-	Use:   "lock",
-	Short: "Lock the vault (clear session)",
-	Example: `  # Lock the vault (clear session)
+func newLockCmd() *cobra.Command {
+	lockCmd := &cobra.Command{
+		Use:   "lock",
+		Short: "Lock the vault (clear session)",
+		Example: `  # Lock the vault (clear session)
   symvault lock`,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		vaultDir, err := cli.VaultPath()
-		if err != nil {
-			return err
-		}
+		RunE: func(cmd *cobra.Command, args []string) error {
+			vaultDir, err := cli.VaultPath()
+			if err != nil {
+				return err
+			}
 
-		if !vaultpkg.IsInitialized(vaultDir) {
-			return errorspkg.NewVaultNotInitialized()
-		}
+			if !vaultpkg.IsInitialized(vaultDir) {
+				return errorspkg.NewVaultNotInitialized()
+			}
 
-		if err := session.ClearSession(vaultDir); err != nil {
-			return errorspkg.NewCLIError(errorspkg.ExitGeneralError, "cannot clear session", err)
-		}
+			if err := session.ClearSession(vaultDir); err != nil {
+				return errorspkg.NewCLIError(errorspkg.ExitGeneralError, "cannot clear session", err)
+			}
 
-		fmt.Fprintln(os.Stderr, "Vault locked")
-		return nil
-	},
-}
+			fmt.Fprintln(os.Stderr, "Vault locked")
+			return nil
+		},
+	}
 
-func init() {
 	lockCmd.GroupID = cli.GroupIDAuthAccess
+	return lockCmd
 }

--- a/cmd/auth/unlock.go
+++ b/cmd/auth/unlock.go
@@ -14,10 +14,15 @@ import (
 	vaultpkg "github.com/danieljustus/symaira-vault/internal/vault"
 )
 
-var AuthUnlockCmd = &cobra.Command{
-	Use:   "unlock",
-	Short: "Unlock the vault and cache the passphrase",
-	Long: `Unlock the vault by validating the passphrase and caching it in the
+// AuthUnlockCmd is retained for API compatibility; NewCommands() uses
+// newAuthUnlockCmd() instead so every call gets a fresh command.
+var AuthUnlockCmd = newAuthUnlockCmd()
+
+func newAuthUnlockCmd() *cobra.Command {
+	authUnlockCmd := &cobra.Command{
+		Use:   "unlock",
+		Short: "Unlock the vault and cache the passphrase",
+		Long: `Unlock the vault by validating the passphrase and caching it in the
 OS keyring. This allows MCP servers to start without interactive prompts.
 
 Use --check to verify if an active session exists without prompting.
@@ -28,7 +33,7 @@ explicitly allowed via SYMVAULT_ALLOW_ENV_PASSPHRASE=1 or
 security.allow_env_passphrase: true in config.yaml — the passphrase variable
 alone is ignored (default-deny). It should NOT be used on shared machines
 (visible in process listings).`,
-	Example: `  # Unlock the vault
+		Example: `  # Unlock the vault
   symvault unlock
 
   # Check if session is active
@@ -36,50 +41,50 @@ alone is ignored (default-deny). It should NOT be used on shared machines
 
   # Unlock with custom TTL
   symvault unlock --ttl 30m`,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		check, _ := cmd.Flags().GetBool("check")
-		ttl, _ := cmd.Flags().GetDuration("ttl")
-		ttlFlag := cmd.Flags().Lookup("ttl")
-		ttlOverride := time.Duration(0)
-		if ttlFlag != nil && ttlFlag.Changed {
-			ttlOverride = ttl
-		}
-
-		vaultDir, err := cli.VaultPath()
-		if err != nil {
-			return err
-		}
-
-		if !vaultpkg.IsInitialized(vaultDir) {
-			return errorspkg.NewVaultNotInitialized()
-		}
-
-		if check {
-			if cli.SessionIsExpired(vaultDir) {
-				cmd.SilenceUsage = true
-				return errorspkg.NewCLIError(errorspkg.ExitLocked, "no active session", errorspkg.ErrVaultLocked)
+		RunE: func(cmd *cobra.Command, args []string) error {
+			check, _ := cmd.Flags().GetBool("check")
+			ttl, _ := cmd.Flags().GetDuration("ttl")
+			ttlFlag := cmd.Flags().Lookup("ttl")
+			ttlOverride := time.Duration(0)
+			if ttlFlag != nil && ttlFlag.Changed {
+				ttlOverride = ttl
 			}
-			fmt.Fprintln(os.Stderr, "Session active")
+
+			vaultDir, err := cli.VaultPath()
+			if err != nil {
+				return err
+			}
+
+			if !vaultpkg.IsInitialized(vaultDir) {
+				return errorspkg.NewVaultNotInitialized()
+			}
+
+			if check {
+				if cli.SessionIsExpired(vaultDir) {
+					cmd.SilenceUsage = true
+					return errorspkg.NewCLIError(errorspkg.ExitLocked, "no active session", errorspkg.ErrVaultLocked)
+				}
+				fmt.Fprintln(os.Stderr, "Session active")
+				return nil
+			}
+
+			v, effectiveTTL, err := cli.UnlockVaultWithTTL(vaultDir, true, ttlOverride, true)
+			if err != nil {
+				return err
+			}
+			_ = v
+
+			if status := cli.SessionGetCacheStatus(); !status.Persistent {
+				return errorspkg.NewCLIError(errorspkg.ExitLocked, "session cache is memory-only; 'symvault unlock' cannot unlock future serve processes. Start serve with OPENPASS_PASSPHRASE or use a build with OS keyring support", nil)
+			}
+
+			cliout.Hintf("Vault unlocked (session TTL: %s)", effectiveTTL)
 			return nil
-		}
+		},
+	}
 
-		v, effectiveTTL, err := cli.UnlockVaultWithTTL(vaultDir, true, ttlOverride, true)
-		if err != nil {
-			return err
-		}
-		_ = v
-
-		if status := cli.SessionGetCacheStatus(); !status.Persistent {
-			return errorspkg.NewCLIError(errorspkg.ExitLocked, "session cache is memory-only; 'symvault unlock' cannot unlock future serve processes. Start serve with OPENPASS_PASSPHRASE or use a build with OS keyring support", nil)
-		}
-
-		cliout.Hintf("Vault unlocked (session TTL: %s)", effectiveTTL)
-		return nil
-	},
-}
-
-func init() {
-	AuthUnlockCmd.GroupID = cli.GroupIDAuthAccess
-	AuthUnlockCmd.Flags().Duration("ttl", cli.DefaultSessionTTL(), "Session duration (overrides config sessionTimeout)")
-	AuthUnlockCmd.Flags().Bool("check", false, "Check if session is active (exit 0 = active, exit 1 = expired)")
+	authUnlockCmd.GroupID = cli.GroupIDAuthAccess
+	authUnlockCmd.Flags().Duration("ttl", cli.DefaultSessionTTL(), "Session duration (overrides config sessionTimeout)")
+	authUnlockCmd.Flags().Bool("check", false, "Check if session is active (exit 0 = active, exit 1 = expired)")
+	return authUnlockCmd
 }

--- a/cmd/file/add.go
+++ b/cmd/file/add.go
@@ -29,16 +29,26 @@ var (
 	AddShred   bool
 )
 
-var addCmd = &cobra.Command{
-	Use:   "add <path>",
-	Short: "Attach a certificate/key file to a vault entry",
-	Long: `Reads a file from disk, base64-encodes it, and stores it in the named
+// newAddCmd builds the `file add` command and registers its flags inline.
+func newAddCmd() *cobra.Command {
+	addCmd := &cobra.Command{
+		Use:   "add <path>",
+		Short: "Attach a certificate/key file to a vault entry",
+		Long: `Reads a file from disk, base64-encodes it, and stores it in the named
 vault entry's field, recording sha256, original filename and size as
 attachment metadata. Creates the entry if it does not exist, or merges the
 field into an existing entry.`,
-	Example: `  symvault file add elster/cert --field cert_p12 --from ~/Downloads/elster.pfx --shred`,
-	Args:    cobra.ExactArgs(1),
-	RunE:    runFileAdd,
+		Example: `  symvault file add elster/cert --field cert_p12 --from ~/Downloads/elster.pfx --shred`,
+		Args:    cobra.ExactArgs(1),
+		RunE:    runFileAdd,
+	}
+
+	addCmd.Flags().StringVar(&AddField, "field", "", "Data field name to store the attachment under (required)")
+	addCmd.Flags().StringVar(&AddFrom, "from", "", "Path to the source file to attach (required)")
+	addCmd.Flags().StringVar(&AddType, "type", string(vaultpkg.SecretTypeCertificate), "Secret type to set on the entry if not already set")
+	addCmd.Flags().Int64Var(&AddMaxSize, "max-size", DefaultMaxAttachmentSize, "Maximum source file size in bytes")
+	addCmd.Flags().BoolVar(&AddShred, "shred", false, "Best-effort overwrite and remove the source file after a successful attach")
+	return addCmd
 }
 
 func runFileAdd(cmd *cobra.Command, args []string) error {
@@ -121,13 +131,4 @@ func runFileAdd(cmd *cobra.Command, args []string) error {
 		}
 		return nil
 	})
-}
-
-func init() {
-	addCmd.Flags().StringVar(&AddField, "field", "", "Data field name to store the attachment under (required)")
-	addCmd.Flags().StringVar(&AddFrom, "from", "", "Path to the source file to attach (required)")
-	addCmd.Flags().StringVar(&AddType, "type", string(vaultpkg.SecretTypeCertificate), "Secret type to set on the entry if not already set")
-	addCmd.Flags().Int64Var(&AddMaxSize, "max-size", DefaultMaxAttachmentSize, "Maximum source file size in bytes")
-	addCmd.Flags().BoolVar(&AddShred, "shred", false, "Best-effort overwrite and remove the source file after a successful attach")
-	fileCmd.AddCommand(addCmd)
 }

--- a/cmd/file/commands.go
+++ b/cmd/file/commands.go
@@ -5,8 +5,10 @@ import (
 )
 
 // NewCommands returns all file attachment commands for root command assembly.
+// Each call builds a fresh command tree so consecutive calls never share
+// command objects or flag state.
 func NewCommands() []*cobra.Command {
 	return []*cobra.Command{
-		fileCmd,
+		newFileCmd(),
 	}
 }

--- a/cmd/file/commands_test.go
+++ b/cmd/file/commands_test.go
@@ -1,0 +1,45 @@
+package file
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// TestNewCommands_FreshTrees guards the constructor migration (#744): every
+// NewCommands() call must return a freshly built tree, so consecutive calls
+// never share command objects, parent/child pointers, or flag state.
+func TestNewCommands_FreshTrees(t *testing.T) {
+	first := NewCommands()
+	second := NewCommands()
+
+	if len(first) != 1 || len(second) != 1 {
+		t.Fatalf("NewCommands() returned %d and %d commands, want 1 each", len(first), len(second))
+	}
+
+	fileA, fileB := first[0], second[0]
+	if fileA == fileB {
+		t.Fatal("two NewCommands() calls returned the same file command object")
+	}
+
+	childrenA := fileA.Commands()
+	childrenB := fileB.Commands()
+	if len(childrenA) != 3 || len(childrenB) != 3 {
+		t.Fatalf("file command has %d and %d children, want 3 (add, get, use)", len(childrenA), len(childrenB))
+	}
+
+	seen := map[string]*cobra.Command{}
+	for i, childB := range childrenB {
+		childA := childrenA[i]
+		if childA == childB {
+			t.Fatalf("child %q is shared between NewCommands() calls", childB.Name())
+		}
+		if childB.Parent() != fileB {
+			t.Fatalf("child %q is not parented to the fresh file command", childB.Name())
+		}
+		if prev, ok := seen[childB.Name()]; ok && prev == childB {
+			t.Fatalf("duplicate child %q in tree", childB.Name())
+		}
+		seen[childB.Name()] = childB
+	}
+}

--- a/cmd/file/file.go
+++ b/cmd/file/file.go
@@ -8,17 +8,23 @@ import (
 	cli "github.com/danieljustus/symaira-vault/internal/cli"
 )
 
-var fileCmd = &cobra.Command{
-	Use:   "file",
-	Short: "Store, export, and consume file attachments in the vault",
-	Long: `Store, export, and consume binary file attachments (e.g. a PKCS#12
+// newFileCmd builds the file parent command with freshly constructed
+// children, so every NewCommands() call returns an isolated tree.
+func newFileCmd() *cobra.Command {
+	fileCmd := &cobra.Command{
+		Use:   "file",
+		Short: "Store, export, and consume file attachments in the vault",
+		Long: `Store, export, and consume binary file attachments (e.g. a PKCS#12
 certificate) through vault entries. Content is base64-encoded at rest, with
 sha256, original filename and size recorded as attachment metadata.`,
-	Example: `  symvault file add elster/cert --field cert_p12 --from ~/elster.pfx --shred
+		Example: `  symvault file add elster/cert --field cert_p12 --from ~/elster.pfx --shred
   symvault file get elster/cert#cert_p12 --out ~/elster.pfx
   symvault file use elster/cert -- java -jar elstertool.jar --cert $SYMVAULT_FILE_CERT_P12`,
-}
+	}
 
-func init() {
 	fileCmd.GroupID = cli.GroupIDVault
+	fileCmd.AddCommand(newAddCmd())
+	fileCmd.AddCommand(newGetCmd())
+	fileCmd.AddCommand(newUseCmd())
+	return fileCmd
 }

--- a/cmd/file/get.go
+++ b/cmd/file/get.go
@@ -18,15 +18,22 @@ var (
 	GetOut   string
 )
 
-var getCmd = &cobra.Command{
-	Use:   "get <path>[#field]",
-	Short: "Export a stored file attachment to disk",
-	Long: `Decodes a vault entry's attachment field back to its original binary
+// newGetCmd builds the `file get` command and registers its flags inline.
+func newGetCmd() *cobra.Command {
+	getCmd := &cobra.Command{
+		Use:   "get <path>[#field]",
+		Short: "Export a stored file attachment to disk",
+		Long: `Decodes a vault entry's attachment field back to its original binary
 content and writes it to the given output path. Use path#field, or --field,
 to select the field when an entry has more than one attachment.`,
-	Example: `  symvault file get elster/cert#cert_p12 --out ~/elster.pfx`,
-	Args:    cobra.ExactArgs(1),
-	RunE:    runFileGet,
+		Example: `  symvault file get elster/cert#cert_p12 --out ~/elster.pfx`,
+		Args:    cobra.ExactArgs(1),
+		RunE:    runFileGet,
+	}
+
+	getCmd.Flags().StringVar(&GetField, "field", "", "Data field to export (auto-detected when the entry has exactly one attachment)")
+	getCmd.Flags().StringVar(&GetOut, "out", "", "Output file path (required)")
+	return getCmd
 }
 
 func runFileGet(cmd *cobra.Command, args []string) error {
@@ -76,10 +83,4 @@ func runFileGet(cmd *cobra.Command, args []string) error {
 		cli.PrintQuietAware("Exported %s#%s to %s (%d bytes)\n", path, resolvedField, GetOut, len(content))
 		return nil
 	})
-}
-
-func init() {
-	getCmd.Flags().StringVar(&GetField, "field", "", "Data field to export (auto-detected when the entry has exactly one attachment)")
-	getCmd.Flags().StringVar(&GetOut, "out", "", "Output file path (required)")
-	fileCmd.AddCommand(getCmd)
 }

--- a/cmd/file/use.go
+++ b/cmd/file/use.go
@@ -21,16 +21,24 @@ var (
 	UseTimeout time.Duration
 )
 
-var useCmd = &cobra.Command{
-	Use:   "use <path>[#field] -- <command> [args...]",
-	Short: "Run a command with a stored file attachment materialized to an ephemeral path",
-	Long: `Decodes a vault entry's attachment field back to its original binary
+// newUseCmd builds the `file use` command and registers its flags inline.
+func newUseCmd() *cobra.Command {
+	useCmd := &cobra.Command{
+		Use:   "use <path>[#field] -- <command> [args...]",
+		Short: "Run a command with a stored file attachment materialized to an ephemeral path",
+		Long: `Decodes a vault entry's attachment field back to its original binary
 content, writes it to a private ephemeral file for the lifetime of the given
 command, exposes it as $SYMVAULT_FILE_<NAME>, and shreds it afterward — the
 CLI twin of the MCP run_command "files" map.`,
-	Example: `  symvault file use elster/cert -- java -jar elstertool.jar --cert $SYMVAULT_FILE_CERT_P12`,
-	Args:    cobra.MinimumNArgs(2),
-	RunE:    runFileUse,
+		Example: `  symvault file use elster/cert -- java -jar elstertool.jar --cert $SYMVAULT_FILE_CERT_P12`,
+		Args:    cobra.MinimumNArgs(2),
+		RunE:    runFileUse,
+	}
+
+	useCmd.Flags().StringVar(&UseField, "field", "", "Data field to materialize (auto-detected when the entry has exactly one attachment)")
+	useCmd.Flags().StringVar(&UseAs, "as", "", "Name exposed as $SYMVAULT_FILE_<NAME> (defaults to the uppercased field name)")
+	useCmd.Flags().DurationVarP(&UseTimeout, "timeout", "t", 0, "Timeout for the command (e.g., 30s)")
+	return useCmd
 }
 
 func runFileUse(cmd *cobra.Command, args []string) error {
@@ -90,11 +98,4 @@ func runFileUse(cmd *cobra.Command, args []string) error {
 		}
 		return nil
 	})
-}
-
-func init() {
-	useCmd.Flags().StringVar(&UseField, "field", "", "Data field to materialize (auto-detected when the entry has exactly one attachment)")
-	useCmd.Flags().StringVar(&UseAs, "as", "", "Name exposed as $SYMVAULT_FILE_<NAME> (defaults to the uppercased field name)")
-	useCmd.Flags().DurationVarP(&UseTimeout, "timeout", "t", 0, "Timeout for the command (e.g., 30s)")
-	fileCmd.AddCommand(useCmd)
 }


### PR DESCRIPTION
Completes the CLI constructor migration (issue #722 follow-up): the four subpackages' `NewCommands()` now build **fresh** command trees instead of returning `init()`-mutated package singletons.

- `cmd/file`, `cmd/auth`, `cmd/admin`: singleton `var XxxCmd = &cobra.Command{...}` declarations converted to `func newXxxCmd() *cobra.Command` constructors; flag registration and child `AddCommand` wiring moved out of `func init()` into the constructors
- `cmd/crud` was already migrated and is unchanged
- Exported compat vars (`AuditCmd`, `DoctorCmd`, `MigrateCmd`, `UpdateCmd`, `UpdateCheckCmd`) are retained for existing tests
- Two consecutive `NewRootCmd()` calls now return fully independent trees; regression tests added in `cmd/file` and `cmd/auth` assert fresh construction
- No CLI-visible behavior change; verified with `go build ./...`, `go vet ./cmd/...`, and the full `go test ./cmd/...` suite (all green)

Issue #744 is tracked across two PRs: this one migrates the subpackages; a follow-up PR migrates the remaining root-package commands (`cmd/mcp`, `cmd/passlint`, top-level `cmd/*`) and completes the issue.
