### PR TITLE
refactor(cmd): finish constructor migration for root, mcp and passlint

### DIFF
--- a/cmd/device.go
+++ b/cmd/device.go
@@ -29,25 +29,40 @@ var (
 	deviceRevokeYes   bool
 )
 
-var deviceCmd = &cobra.Command{
-	Use:   "device",
-	Short: "Manage paired devices for multi-device vault access",
-	Long: `Manage paired devices that can access this vault.
+// deviceCmd is retained for API compatibility; NewCommands() uses
+// newDeviceCmd() so every call gets a fresh command.
+var deviceCmd = newDeviceCmd()
+
+func newDeviceCmd() *cobra.Command {
+	deviceCmd := &cobra.Command{
+		Use:   "device",
+		Short: "Manage paired devices for multi-device vault access",
+		Long: `Manage paired devices that can access this vault.
 
 Use 'symvault device pair' to generate a pairing token for a new device,
 and 'symvault device join' on the new device to join the vault.`,
-	Example: `  symvault device pair
+		Example: `  symvault device pair
   symvault device join ssh://user@host/path/to/vault.git <token>
   symvault device accept <token>`,
-	Annotations: map[string]string{
-		cli.JSONOutputAnnotation: "true",
-	},
+		Annotations: map[string]string{
+			cli.JSONOutputAnnotation: "true",
+		},
+	}
+	deviceCmd.GroupID = cli.GroupIDSharingSync
+	deviceCmd.AddCommand(newDevicePairCmd())
+	deviceCmd.AddCommand(newDeviceJoinCmd())
+	deviceCmd.AddCommand(newDeviceAcceptCmd())
+	deviceCmd.AddCommand(newDeviceListCmd())
+	deviceCmd.AddCommand(newDeviceRevokeCmd())
+	deviceCmd.AddCommand(newDeviceAddCmd())
+	return deviceCmd
 }
 
-var devicePairCmd = &cobra.Command{
-	Use:   "pair",
-	Short: "Generate a pairing token for a new device",
-	Long: `Generate a pairing token that another device can use to join this vault.
+func newDevicePairCmd() *cobra.Command {
+	devicePairCmd := &cobra.Command{
+		Use:   "pair",
+		Short: "Generate a pairing token for a new device",
+		Long: `Generate a pairing token that another device can use to join this vault.
 
 This saves the pairing token and this device's public key to the vault,
 commits and pushes the token file. The joining device reads this file
@@ -56,55 +71,58 @@ to obtain this device's public key for encryption.
 IMPORTANT: After the joining device submits its public key (via 'symvault device join'),
 you must run 'symvault device accept <token>' to re-encrypt all entries
 for the new device.`,
-	Example: `  symvault device pair`,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		vaultDir, err := cli.VaultPath()
-		if err != nil {
-			return err
-		}
+		Example: `  symvault device pair`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			vaultDir, err := cli.VaultPath()
+			if err != nil {
+				return err
+			}
 
-		v, err := cli.UnlockVault(vaultDir, true)
-		if err != nil {
-			return err
-		}
+			v, err := cli.UnlockVault(vaultDir, true)
+			if err != nil {
+				return err
+			}
 
-		token, err := pairing.GenerateToken()
-		if err != nil {
-			return fmt.Errorf("generate token: %w", err)
-		}
+			token, err := pairing.GenerateToken()
+			if err != nil {
+				return fmt.Errorf("generate token: %w", err)
+			}
 
-		publicKey := v.Identity.Recipient().String()
+			publicKey := v.Identity.Recipient().String()
 
-		pairingData := pairingFile{
-			Token:     string(token),
-			PublicKey: publicKey,
-			CreatedAt: time.Now().UTC(),
-		}
+			pairingData := pairingFile{
+				Token:     string(token),
+				PublicKey: publicKey,
+				CreatedAt: time.Now().UTC(),
+			}
 
-		if err := savePairingFile(vaultDir, string(token)+".json", pairingData); err != nil {
-			return fmt.Errorf("save pairing file: %w", err)
-		}
+			if err := savePairingFile(vaultDir, string(token)+".json", pairingData); err != nil {
+				return fmt.Errorf("save pairing file: %w", err)
+			}
 
-		if err := git.AutoCommitAndPush(vaultDir, fmt.Sprintf("Pairing token %s", token), v.Config.Git.AutoPush); err != nil {
-			cliout.Warnf("Warning: could not auto-commit/push: %v", err)
-		}
+			if err := git.AutoCommitAndPush(vaultDir, fmt.Sprintf("Pairing token %s", token), v.Config.Git.AutoPush); err != nil {
+				cliout.Warnf("Warning: could not auto-commit/push: %v", err)
+			}
 
-		printQuietAware("\n=== Pairing Token ===\n")
-		printQuietAware("Token: %s\n\n", token)
-		printQuietAware("This device's public key: %s\n", publicKey)
-		printQuietAware("\nOn the joining device, run:\n")
-		printQuietAware("  symvault device join <remote-url> %s\n\n", token)
-		printQuietAware("After the joining device has submitted its key, run:\n")
-		printQuietAware("  symvault device accept %s\n\n", token)
+			printQuietAware("\n=== Pairing Token ===\n")
+			printQuietAware("Token: %s\n\n", token)
+			printQuietAware("This device's public key: %s\n", publicKey)
+			printQuietAware("\nOn the joining device, run:\n")
+			printQuietAware("  symvault device join <remote-url> %s\n\n", token)
+			printQuietAware("After the joining device has submitted its key, run:\n")
+			printQuietAware("  symvault device accept %s\n\n", token)
 
-		return nil
-	},
+			return nil
+		},
+	}
+	return devicePairCmd
 }
 
-var deviceJoinCmd = &cobra.Command{
-	Use:   "join <remote-url> <token>",
-	Short: "Join an existing vault as a new device",
-	Long: `Join an existing vault from a remote git repository.
+func newDeviceJoinCmd() *cobra.Command {
+	deviceJoinCmd := &cobra.Command{
+		Use:   "join <remote-url> <token>",
+		Short: "Join an existing vault as a new device",
+		Long: `Join an existing vault from a remote git repository.
 
 Clones the vault repository, reads the pairing token file to obtain
 the existing device's public key, generates a new identity for this device,
@@ -112,307 +130,316 @@ and submits this device's public key back to the vault.
 
 After completion, the existing device must run 'symvault device accept <token>'
 to re-encrypt all entries for this new device.`,
-	Example: `  symvault device join ssh://user@host/path/to/vault.git 123456`,
-	Args:    cobra.ExactArgs(2),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		remoteURL := args[0]
-		token := strings.TrimSpace(args[1])
+		Example: `  symvault device join ssh://user@host/path/to/vault.git 123456`,
+		Args:    cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			remoteURL := args[0]
+			token := strings.TrimSpace(args[1])
 
-		if err := pairing.ValidatePairingToken(token); err != nil {
-			return fmt.Errorf("invalid pairing token: %w", err)
-		}
-
-		vaultDir, err := cli.VaultPath()
-		if err != nil {
-			return err
-		}
-
-		if vaultpkg.IsInitialized(vaultDir) {
-			return fmt.Errorf("vault already initialized at %s. Use a different --vault or remove the existing vault first", vaultDir)
-		}
-
-		cliout.Hintf("Cloning vault from %s ...", remoteURL)
-		if _, err = gogit.PlainClone(vaultDir, false, &gogit.CloneOptions{
-			URL:      remoteURL,
-			Progress: os.Stderr,
-		}); err != nil {
-			return fmt.Errorf("clone vault: %w", err)
-		}
-
-		pairingPath := filepath.Join(vaultDir, configpkg.DefaultVaultSubdir, "pairing", token+".json")
-		var pf pairingFile
-		// #nosec G304 -- pairingPath is constructed within the vault directory
-		pfData, err := vaultpkg.SafeReadFile(pairingPath)
-		if err != nil {
-			return fmt.Errorf("invalid or expired pairing token: could not read pairing file. Ensure the token is correct and the pairing device has pushed the token file: %w", err)
-		}
-		if err = json.Unmarshal(pfData, &pf); err != nil {
-			return fmt.Errorf("invalid pairing file: %w", err)
-		}
-
-		cliout.Hintf("Pairing with device (public key: %s)", truncatePubkey(pf.PublicKey))
-
-		passphrase, err := cli.ReadHiddenInput("Enter passphrase for this device (minimum 12 characters): ", nil)
-		if err != nil {
-			return fmt.Errorf("read passphrase: %w", err)
-		}
-		defer cryptopkg.Wipe(passphrase)
-		if len(passphrase) < 12 {
-			return fmt.Errorf("passphrase must be at least 12 characters")
-		}
-
-		identity, err := cryptopkg.GenerateIdentity()
-		if err != nil {
-			return fmt.Errorf("generate identity: %w", err)
-		}
-		myPubkey := identity.Recipient().String()
-
-		cfg := configpkg.Default()
-		cfg.VaultDir = vaultDir
-		cfg.Git = &configpkg.GitConfig{
-			AutoPush:         true,
-			AutoPull:         true,
-			AutoPullInterval: 10 * time.Second,
-			CommitTemplate:   "Update from Symaira Vault",
-		}
-
-		cfgPath := filepath.Join(vaultDir, "config.yaml")
-		cfgData, err := yaml.Marshal(cfg)
-		if err != nil {
-			return fmt.Errorf("marshal config: %w", err)
-		}
-		if err := os.WriteFile(cfgPath, cfgData, 0o600); err != nil {
-			return fmt.Errorf("write config: %w", err)
-		}
-
-		identityPath := filepath.Join(vaultDir, "identity.age")
-		if err := cryptopkg.SaveIdentity(identity, identityPath, passphrase, 0); err != nil {
-			return fmt.Errorf("save identity: %w", err)
-		}
-
-		recipientsPath := filepath.Join(vaultDir, "recipients.txt")
-		recipientsContent := fmt.Sprintf("# Symaira Vault vault recipients\n# Added by device join\n%s\n", pf.PublicKey)
-		if err := os.WriteFile(recipientsPath, []byte(recipientsContent), 0o600); err != nil {
-			return fmt.Errorf("write recipients: %w", err)
-		}
-
-		joinedData := joinedFile{
-			Token:     token,
-			Name:      defaultDeviceName,
-			PublicKey: myPubkey,
-			CreatedAt: time.Now().UTC(),
-		}
-		if defaultDeviceName == "" {
-			hostname, _ := os.Hostname()
-			if hostname != "" {
-				joinedData.Name = hostname
-			} else {
-				joinedData.Name = "device-" + token
+			if err := pairing.ValidatePairingToken(token); err != nil {
+				return fmt.Errorf("invalid pairing token: %w", err)
 			}
-		}
 
-		if err := savePairingFile(vaultDir, token+"-joined.json", joinedData); err != nil {
-			return fmt.Errorf("save joined file: %w", err)
-		}
+			vaultDir, err := cli.VaultPath()
+			if err != nil {
+				return err
+			}
 
-		cleanupPairingFile := filepath.Join(vaultDir, configpkg.DefaultVaultSubdir, "pairing", token+".json")
-		_ = os.Remove(cleanupPairingFile)
+			if vaultpkg.IsInitialized(vaultDir) {
+				return fmt.Errorf("vault already initialized at %s. Use a different --vault or remove the existing vault first", vaultDir)
+			}
 
-		if err := git.AutoCommitWithOptions(vaultDir, git.CommitOptions{
-			Message: fmt.Sprintf("Device join: %s (token %s)", joinedData.Name, token),
-		}); err != nil {
-			return fmt.Errorf("commit: %w", err)
-		}
+			cliout.Hintf("Cloning vault from %s ...", remoteURL)
+			if _, err = gogit.PlainClone(vaultDir, false, &gogit.CloneOptions{
+				URL:      remoteURL,
+				Progress: os.Stderr,
+			}); err != nil {
+				return fmt.Errorf("clone vault: %w", err)
+			}
 
-		cliout.Hintf("=== Join Successful ===")
-		printQuietAware("\nYour public key: %s\n", myPubkey)
-		printQuietAware("Device name: %s\n\n", joinedData.Name)
-		printQuietAware("IMPORTANT: Entries cannot be decrypted yet.\n")
-		printQuietAware("On the existing device, run:\n")
-		printQuietAware("  symvault device accept %s\n\n", token)
+			pairingPath := filepath.Join(vaultDir, configpkg.DefaultVaultSubdir, "pairing", token+".json")
+			var pf pairingFile
+			// #nosec G304 -- pairingPath is constructed within the vault directory
+			pfData, err := vaultpkg.SafeReadFile(pairingPath)
+			if err != nil {
+				return fmt.Errorf("invalid or expired pairing token: could not read pairing file. Ensure the token is correct and the pairing device has pushed the token file: %w", err)
+			}
+			if err = json.Unmarshal(pfData, &pf); err != nil {
+				return fmt.Errorf("invalid pairing file: %w", err)
+			}
 
-		if err := git.Push(vaultDir); err != nil {
-			cliout.Warnf("Warning: Could not push joined file: %v", err)
-			cliout.Hintf("Push manually with: symvault git push")
-		}
+			cliout.Hintf("Pairing with device (public key: %s)", truncatePubkey(pf.PublicKey))
 
-		return nil
-	},
+			passphrase, err := cli.ReadHiddenInput("Enter passphrase for this device (minimum 12 characters): ", nil)
+			if err != nil {
+				return fmt.Errorf("read passphrase: %w", err)
+			}
+			defer cryptopkg.Wipe(passphrase)
+			if len(passphrase) < 12 {
+				return fmt.Errorf("passphrase must be at least 12 characters")
+			}
+
+			identity, err := cryptopkg.GenerateIdentity()
+			if err != nil {
+				return fmt.Errorf("generate identity: %w", err)
+			}
+			myPubkey := identity.Recipient().String()
+
+			cfg := configpkg.Default()
+			cfg.VaultDir = vaultDir
+			cfg.Git = &configpkg.GitConfig{
+				AutoPush:         true,
+				AutoPull:         true,
+				AutoPullInterval: 10 * time.Second,
+				CommitTemplate:   "Update from Symaira Vault",
+			}
+
+			cfgPath := filepath.Join(vaultDir, "config.yaml")
+			cfgData, err := yaml.Marshal(cfg)
+			if err != nil {
+				return fmt.Errorf("marshal config: %w", err)
+			}
+			if err := os.WriteFile(cfgPath, cfgData, 0o600); err != nil {
+				return fmt.Errorf("write config: %w", err)
+			}
+
+			identityPath := filepath.Join(vaultDir, "identity.age")
+			if err := cryptopkg.SaveIdentity(identity, identityPath, passphrase, 0); err != nil {
+				return fmt.Errorf("save identity: %w", err)
+			}
+
+			recipientsPath := filepath.Join(vaultDir, "recipients.txt")
+			recipientsContent := fmt.Sprintf("# Symaira Vault vault recipients\n# Added by device join\n%s\n", pf.PublicKey)
+			if err := os.WriteFile(recipientsPath, []byte(recipientsContent), 0o600); err != nil {
+				return fmt.Errorf("write recipients: %w", err)
+			}
+
+			joinedData := joinedFile{
+				Token:     token,
+				Name:      defaultDeviceName,
+				PublicKey: myPubkey,
+				CreatedAt: time.Now().UTC(),
+			}
+			if defaultDeviceName == "" {
+				hostname, _ := os.Hostname()
+				if hostname != "" {
+					joinedData.Name = hostname
+				} else {
+					joinedData.Name = "device-" + token
+				}
+			}
+
+			if err := savePairingFile(vaultDir, token+"-joined.json", joinedData); err != nil {
+				return fmt.Errorf("save joined file: %w", err)
+			}
+
+			cleanupPairingFile := filepath.Join(vaultDir, configpkg.DefaultVaultSubdir, "pairing", token+".json")
+			_ = os.Remove(cleanupPairingFile)
+
+			if err := git.AutoCommitWithOptions(vaultDir, git.CommitOptions{
+				Message: fmt.Sprintf("Device join: %s (token %s)", joinedData.Name, token),
+			}); err != nil {
+				return fmt.Errorf("commit: %w", err)
+			}
+
+			cliout.Hintf("=== Join Successful ===")
+			printQuietAware("\nYour public key: %s\n", myPubkey)
+			printQuietAware("Device name: %s\n\n", joinedData.Name)
+			printQuietAware("IMPORTANT: Entries cannot be decrypted yet.\n")
+			printQuietAware("On the existing device, run:\n")
+			printQuietAware("  symvault device accept %s\n\n", token)
+
+			if err := git.Push(vaultDir); err != nil {
+				cliout.Warnf("Warning: Could not push joined file: %v", err)
+				cliout.Hintf("Push manually with: symvault git push")
+			}
+
+			return nil
+		},
+	}
+	deviceJoinCmd.Flags().StringVar(&defaultDeviceName, "name", "", "Name for this device (defaults to hostname)")
+	return deviceJoinCmd
 }
 
-var deviceAcceptCmd = &cobra.Command{
-	Use:   "accept <token>",
-	Short: "Accept a join request and re-encrypt entries for the new device",
-	Long: `Accept a device join request by adding the new device's public key
+func newDeviceAcceptCmd() *cobra.Command {
+	deviceAcceptCmd := &cobra.Command{
+		Use:   "accept <token>",
+		Short: "Accept a join request and re-encrypt entries for the new device",
+		Long: `Accept a device join request by adding the new device's public key
 as a recipient and re-encrypting all vault entries so the new device
 can decrypt them.`,
-	Example: `  symvault device accept 123456`,
-	Args:    cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		token := strings.TrimSpace(args[0])
+		Example: `  symvault device accept 123456`,
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			token := strings.TrimSpace(args[0])
 
-		if err := pairing.ValidatePairingToken(token); err != nil {
-			return fmt.Errorf("invalid pairing token: %w", err)
-		}
+			if err := pairing.ValidatePairingToken(token); err != nil {
+				return fmt.Errorf("invalid pairing token: %w", err)
+			}
 
-		vaultDir, err := cli.VaultPath()
-		if err != nil {
-			return err
-		}
+			vaultDir, err := cli.VaultPath()
+			if err != nil {
+				return err
+			}
 
-		v, err := cli.UnlockVault(vaultDir, true)
-		if err != nil {
-			return err
-		}
+			v, err := cli.UnlockVault(vaultDir, true)
+			if err != nil {
+				return err
+			}
 
-		joinedPath := filepath.Join(vaultDir, configpkg.DefaultVaultSubdir, "pairing", token+"-joined.json")
-		var jf joinedFile
-		// #nosec G304 -- joinedPath is constructed within the vault directory
-		jfData, err := vaultpkg.SafeReadFile(joinedPath)
-		if err != nil {
-			return fmt.Errorf("no join request found for token %s. Ensure the joining device has completed 'symvault device join' and pushed: %w", token, err)
-		}
-		if err = json.Unmarshal(jfData, &jf); err != nil {
-			return fmt.Errorf("parse joined file: %w", err)
-		}
+			joinedPath := filepath.Join(vaultDir, configpkg.DefaultVaultSubdir, "pairing", token+"-joined.json")
+			var jf joinedFile
+			// #nosec G304 -- joinedPath is constructed within the vault directory
+			jfData, err := vaultpkg.SafeReadFile(joinedPath)
+			if err != nil {
+				return fmt.Errorf("no join request found for token %s. Ensure the joining device has completed 'symvault device join' and pushed: %w", token, err)
+			}
+			if err = json.Unmarshal(jfData, &jf); err != nil {
+				return fmt.Errorf("parse joined file: %w", err)
+			}
 
-		cliout.Hintf("Accepting join from device: %s (public key: %s)", jf.Name, truncatePubkey(jf.PublicKey))
+			cliout.Hintf("Accepting join from device: %s (public key: %s)", jf.Name, truncatePubkey(jf.PublicKey))
 
-		rm := vaultpkg.NewRecipientsManager(vaultDir)
-		if err = rm.AddRecipient(jf.PublicKey); err != nil {
-			return fmt.Errorf("add recipient: %w", err)
-		}
+			rm := vaultpkg.NewRecipientsManager(vaultDir)
+			if err = rm.AddRecipient(jf.PublicKey); err != nil {
+				return fmt.Errorf("add recipient: %w", err)
+			}
 
-		allRecipients, err := v.GetAllRecipientsForEncryption()
-		if err != nil {
-			return fmt.Errorf("get recipients: %w", err)
-		}
+			allRecipients, err := v.GetAllRecipientsForEncryption()
+			if err != nil {
+				return fmt.Errorf("get recipients: %w", err)
+			}
 
-		cliout.Hintf("Re-encrypting all entries for %d recipient(s)...", len(allRecipients))
-		if err := vaultpkg.ReencryptAll(vaultDir, v.Identity, allRecipients); err != nil {
-			return fmt.Errorf("re-encrypt: %w", err)
-		}
+			cliout.Hintf("Re-encrypting all entries for %d recipient(s)...", len(allRecipients))
+			if err := vaultpkg.ReencryptAll(vaultDir, v.Identity, allRecipients); err != nil {
+				return fmt.Errorf("re-encrypt: %w", err)
+			}
 
-		_ = os.Remove(joinedPath)
+			_ = os.Remove(joinedPath)
 
-		if err := git.AutoCommitAndPush(vaultDir, fmt.Sprintf("Accept device join: %s", jf.Name), v.Config.Git.AutoPush); err != nil {
-			cliout.Warnf("Warning: could not auto-commit/push: %v", err)
-		}
+			if err := git.AutoCommitAndPush(vaultDir, fmt.Sprintf("Accept device join: %s", jf.Name), v.Config.Git.AutoPush); err != nil {
+				cliout.Warnf("Warning: could not auto-commit/push: %v", err)
+			}
 
-		printQuietAware("\n=== Pairing Complete ===\n")
-		printQuietAware("Device %q can now access all vault entries.\n\n", jf.Name)
-		printQuietAware("On the joining device, run 'symvault git pull' to fetch the re-encrypted entries.\n")
+			printQuietAware("\n=== Pairing Complete ===\n")
+			printQuietAware("Device %q can now access all vault entries.\n\n", jf.Name)
+			printQuietAware("On the joining device, run 'symvault git pull' to fetch the re-encrypted entries.\n")
 
-		return nil
-	},
+			return nil
+		},
+	}
+	return deviceAcceptCmd
 }
 
-var deviceListCmd = &cobra.Command{
-	Use:   "list",
-	Short: "List all devices",
-	Long: `List all devices registered in the vault's device registry.
+func newDeviceListCmd() *cobra.Command {
+	deviceListCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List all devices",
+		Long: `List all devices registered in the vault's device registry.
 
 Shows device name, public key (truncated), added date, and last seen time.
 Also shows recipients from recipients.txt that are not associated with
 any registered device (unmanaged recipients).`,
-	Example: `  symvault device list
+		Example: `  symvault device list
   symvault device list --output json`,
-	Annotations: map[string]string{
-		cli.JSONOutputAnnotation: "true",
-	},
-	RunE: func(cmd *cobra.Command, args []string) error {
-		vaultDir, err := cli.VaultPath()
-		if err != nil {
-			return err
-		}
-
-		dm := vaultpkg.NewDeviceManager(vaultDir)
-		devices, err := dm.ListDevices()
-		if err != nil {
-			return fmt.Errorf("list devices: %w", err)
-		}
-
-		rm := vaultpkg.NewRecipientsManager(vaultDir)
-		recipientStrs, err := rm.LoadRecipientStrings()
-		if err != nil {
-			recipientStrs = nil
-		}
-
-		deviceKeys := make(map[string]bool, len(devices))
-		for _, d := range devices {
-			deviceKeys[d.PublicKey] = true
-		}
-
-		var unmanaged []string
-		for _, r := range recipientStrs {
-			if !deviceKeys[r] {
-				unmanaged = append(unmanaged, r)
+		Annotations: map[string]string{
+			cli.JSONOutputAnnotation: "true",
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			vaultDir, err := cli.VaultPath()
+			if err != nil {
+				return err
 			}
-		}
 
-		if cli.OutputFormat == "json" || cli.OutputFormat == "yaml" {
-			type deviceOutput struct {
-				Name      string `json:"name" yaml:"name"`
-				PublicKey string `json:"public_key" yaml:"public_key"`
-				AddedAt   string `json:"added_at" yaml:"added_at"`
-				LastSeen  string `json:"last_seen,omitempty" yaml:"last_seen,omitempty"`
+			dm := vaultpkg.NewDeviceManager(vaultDir)
+			devices, err := dm.ListDevices()
+			if err != nil {
+				return fmt.Errorf("list devices: %w", err)
 			}
-			devOutput := make([]deviceOutput, 0, len(devices))
+
+			rm := vaultpkg.NewRecipientsManager(vaultDir)
+			recipientStrs, err := rm.LoadRecipientStrings()
+			if err != nil {
+				recipientStrs = nil
+			}
+
+			deviceKeys := make(map[string]bool, len(devices))
 			for _, d := range devices {
-				do := deviceOutput{
-					Name:      d.Name,
-					PublicKey: d.PublicKey,
-					AddedAt:   d.AddedAt.Format(time.RFC3339),
-				}
-				if d.LastSeen != nil {
-					do.LastSeen = d.LastSeen.Format(time.RFC3339)
-				}
-				devOutput = append(devOutput, do)
+				deviceKeys[d.PublicKey] = true
 			}
-			output := map[string]interface{}{
-				"devices": devOutput,
-				"count":   len(devices),
-			}
-			if len(unmanaged) > 0 {
-				output["unmanaged_recipients"] = unmanaged
-			}
-			return cli.PrintResult(output)
-		}
 
-		// Text output
-		if len(devices) == 0 {
-			printlnQuietAware("No devices registered.")
+			var unmanaged []string
+			for _, r := range recipientStrs {
+				if !deviceKeys[r] {
+					unmanaged = append(unmanaged, r)
+				}
+			}
+
+			if cli.OutputFormat == "json" || cli.OutputFormat == "yaml" {
+				type deviceOutput struct {
+					Name      string `json:"name" yaml:"name"`
+					PublicKey string `json:"public_key" yaml:"public_key"`
+					AddedAt   string `json:"added_at" yaml:"added_at"`
+					LastSeen  string `json:"last_seen,omitempty" yaml:"last_seen,omitempty"`
+				}
+				devOutput := make([]deviceOutput, 0, len(devices))
+				for _, d := range devices {
+					do := deviceOutput{
+						Name:      d.Name,
+						PublicKey: d.PublicKey,
+						AddedAt:   d.AddedAt.Format(time.RFC3339),
+					}
+					if d.LastSeen != nil {
+						do.LastSeen = d.LastSeen.Format(time.RFC3339)
+					}
+					devOutput = append(devOutput, do)
+				}
+				output := map[string]interface{}{
+					"devices": devOutput,
+					"count":   len(devices),
+				}
+				if len(unmanaged) > 0 {
+					output["unmanaged_recipients"] = unmanaged
+				}
+				return cli.PrintResult(output)
+			}
+
+			// Text output
+			if len(devices) == 0 {
+				printlnQuietAware("No devices registered.")
+				if len(unmanaged) > 0 {
+					printlnQuietAware("\nUnmanaged recipients in recipients.txt:")
+					for _, r := range unmanaged {
+						printlnQuietAware("  " + truncatePubkey(r))
+					}
+				}
+				return nil
+			}
+
+			printQuietAware("Devices (%d):\n\n", len(devices))
+			for _, d := range devices {
+				lastSeenStr := "never"
+				if d.LastSeen != nil {
+					lastSeenStr = d.LastSeen.Format(time.RFC3339)
+				}
+				printQuietAware("  %s\n", d.Name)
+				printQuietAware("    Public Key: %s\n", truncatePubkey(d.PublicKey))
+				printQuietAware("    Added:      %s\n", d.AddedAt.Format(time.RFC3339))
+				printQuietAware("    Last Seen:  %s\n\n", lastSeenStr)
+			}
+
 			if len(unmanaged) > 0 {
-				printlnQuietAware("\nUnmanaged recipients in recipients.txt:")
+				printlnQuietAware("Unmanaged recipients in recipients.txt:")
 				for _, r := range unmanaged {
 					printlnQuietAware("  " + truncatePubkey(r))
 				}
+				printlnQuietAware("")
 			}
+
 			return nil
-		}
-
-		printQuietAware("Devices (%d):\n\n", len(devices))
-		for _, d := range devices {
-			lastSeenStr := "never"
-			if d.LastSeen != nil {
-				lastSeenStr = d.LastSeen.Format(time.RFC3339)
-			}
-			printQuietAware("  %s\n", d.Name)
-			printQuietAware("    Public Key: %s\n", truncatePubkey(d.PublicKey))
-			printQuietAware("    Added:      %s\n", d.AddedAt.Format(time.RFC3339))
-			printQuietAware("    Last Seen:  %s\n\n", lastSeenStr)
-		}
-
-		if len(unmanaged) > 0 {
-			printlnQuietAware("Unmanaged recipients in recipients.txt:")
-			for _, r := range unmanaged {
-				printlnQuietAware("  " + truncatePubkey(r))
-			}
-			printlnQuietAware("")
-		}
-
-		return nil
-	},
+		},
+	}
+	return deviceListCmd
 }
 
 var (
@@ -420,243 +447,238 @@ var (
 	deviceAddName string
 )
 
-var deviceAddCmd = &cobra.Command{
-	Use:   "add",
-	Short: "Add this device to an existing multi-device vault",
-	Long: `Add this device to an existing multi-device vault using a pairing
+func newDeviceAddCmd() *cobra.Command {
+	deviceAddCmd := &cobra.Command{
+		Use:   "add",
+		Short: "Add this device to an existing multi-device vault",
+		Long: `Add this device to an existing multi-device vault using a pairing
 token and public key obtained via QR code from the original device.
 
 This command is used on the second device after the initial setup wizard
 shows a QR code. It creates a new local vault with its own identity,
 adds the first device's public key as a recipient, and saves a pairing
 request so the first device can accept it.`,
-	Example: `  symvault device add --pair "123456:age1..."`,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		if !deviceAddPair {
-			return fmt.Errorf("use 'symvault device add --pair <token:publickey>' to pair a device")
-		}
-		if len(args) < 1 {
-			return fmt.Errorf("missing pairing data. Usage: symvault device add --pair <token> or <token:publickey>")
-		}
-
-		raw := strings.TrimSpace(args[0])
-
-		vaultDir, err := cli.VaultPath()
-		if err != nil {
-			return err
-		}
-
-		if vaultpkg.IsInitialized(vaultDir) {
-			return fmt.Errorf("vault already initialized at %s. Use a different --vault or remove the existing vault first", vaultDir)
-		}
-
-		// Parse QR data: token or token:publicKey
-		var token, existingPubkey string
-		if idx := strings.Index(raw, ":"); idx > 0 {
-			token = raw[:idx]
-			existingPubkey = raw[idx+1:]
-		} else {
-			token = raw
-		}
-
-		if valErr := pairing.ValidatePairingToken(token); valErr != nil {
-			return fmt.Errorf("invalid pairing token: %w", valErr)
-		}
-
-		if !strings.HasPrefix(existingPubkey, "age1") || len(existingPubkey) < 50 {
-			return fmt.Errorf("invalid public key in pairing data: expected age1... format")
-		}
-
-		passphrase, err := cli.ReadHiddenInput("Enter passphrase for this device (minimum 12 characters): ", nil)
-		if err != nil {
-			return fmt.Errorf("read passphrase: %w", err)
-		}
-		defer cryptopkg.Wipe(passphrase)
-		if len(passphrase) < 12 {
-			return fmt.Errorf("passphrase must be at least 12 characters")
-		}
-
-		// Generate identity for this device
-		identity, err := cryptopkg.GenerateIdentity()
-		if err != nil {
-			return fmt.Errorf("generate identity: %w", err)
-		}
-
-		// Create vault directory structure
-		if mkdirErr := os.MkdirAll(filepath.Join(vaultDir, "entries"), 0o700); mkdirErr != nil {
-			return fmt.Errorf("create entries dir: %w", mkdirErr)
-		}
-
-		// Write config
-		cfg := configpkg.Default()
-		cfg.VaultDir = vaultDir
-		cfg.Git = &configpkg.GitConfig{
-			AutoPush:         true,
-			AutoPull:         true,
-			AutoPullInterval: 10 * time.Second,
-			CommitTemplate:   "Update from Symaira Vault",
-		}
-		cfgPath := filepath.Join(vaultDir, "config.yaml")
-		cfgData, err := yaml.Marshal(cfg)
-		if err != nil {
-			return fmt.Errorf("marshal config: %w", err)
-		}
-		if err := os.WriteFile(cfgPath, cfgData, 0o600); err != nil {
-			return fmt.Errorf("write config: %w", err)
-		}
-
-		// Save identity encrypted with passphrase
-		identityPath := filepath.Join(vaultDir, "identity.age")
-		if err := cryptopkg.SaveIdentity(identity, identityPath, passphrase, 0); err != nil {
-			return fmt.Errorf("save identity: %w", err)
-		}
-
-		// Write recipients.txt with existing device's public key
-		recipientsPath := filepath.Join(vaultDir, "recipients.txt")
-		recipientsContent := fmt.Sprintf("# Symaira Vault vault recipients\n# Added by device add --pair\n%s\n", existingPubkey)
-		if err := os.WriteFile(recipientsPath, []byte(recipientsContent), 0o600); err != nil {
-			return fmt.Errorf("write recipients: %w", err)
-		}
-
-		// Save joined file
-		joinedData := joinedFile{
-			Token:     token,
-			Name:      deviceAddName,
-			PublicKey: identity.Recipient().String(),
-			CreatedAt: time.Now().UTC(),
-		}
-		if deviceAddName == "" {
-			hostname, _ := os.Hostname()
-			if hostname != "" {
-				joinedData.Name = hostname
-			} else {
-				joinedData.Name = "device-" + token
+		Example: `  symvault device add --pair "123456:age1..."`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !deviceAddPair {
+				return fmt.Errorf("use 'symvault device add --pair <token:publickey>' to pair a device")
 			}
-		}
+			if len(args) < 1 {
+				return fmt.Errorf("missing pairing data. Usage: symvault device add --pair <token> or <token:publickey>")
+			}
 
-		if err := savePairingFile(vaultDir, token+"-joined.json", joinedData); err != nil {
-			return fmt.Errorf("save joined file: %w", err)
-		}
+			raw := strings.TrimSpace(args[0])
 
-		cliout.Hintf("=== Pairing Setup Complete ===")
-		fmt.Fprintf(os.Stderr, "Your public key: %s\n", identity.Recipient().String())
-		fmt.Fprintf(os.Stderr, "Device name: %s\n\n", joinedData.Name)
-		fmt.Fprintf(os.Stderr, "IMPORTANT: Entries cannot be decrypted yet.\n")
-		fmt.Fprintf(os.Stderr, "On the original device, run:\n")
-		fmt.Fprintf(os.Stderr, "  symvault device accept %s\n\n", token)
-		fmt.Fprintf(os.Stderr, "After accepting, pull the re-encrypted entries:\n")
-		fmt.Fprintf(os.Stderr, "  symvault git pull\n")
+			vaultDir, err := cli.VaultPath()
+			if err != nil {
+				return err
+			}
 
-		return nil
-	},
+			if vaultpkg.IsInitialized(vaultDir) {
+				return fmt.Errorf("vault already initialized at %s. Use a different --vault or remove the existing vault first", vaultDir)
+			}
+
+			// Parse QR data: token or token:publicKey
+			var token, existingPubkey string
+			if idx := strings.Index(raw, ":"); idx > 0 {
+				token = raw[:idx]
+				existingPubkey = raw[idx+1:]
+			} else {
+				token = raw
+			}
+
+			if valErr := pairing.ValidatePairingToken(token); valErr != nil {
+				return fmt.Errorf("invalid pairing token: %w", valErr)
+			}
+
+			if !strings.HasPrefix(existingPubkey, "age1") || len(existingPubkey) < 50 {
+				return fmt.Errorf("invalid public key in pairing data: expected age1... format")
+			}
+
+			passphrase, err := cli.ReadHiddenInput("Enter passphrase for this device (minimum 12 characters): ", nil)
+			if err != nil {
+				return fmt.Errorf("read passphrase: %w", err)
+			}
+			defer cryptopkg.Wipe(passphrase)
+			if len(passphrase) < 12 {
+				return fmt.Errorf("passphrase must be at least 12 characters")
+			}
+
+			// Generate identity for this device
+			identity, err := cryptopkg.GenerateIdentity()
+			if err != nil {
+				return fmt.Errorf("generate identity: %w", err)
+			}
+
+			// Create vault directory structure
+			if mkdirErr := os.MkdirAll(filepath.Join(vaultDir, "entries"), 0o700); mkdirErr != nil {
+				return fmt.Errorf("create entries dir: %w", mkdirErr)
+			}
+
+			// Write config
+			cfg := configpkg.Default()
+			cfg.VaultDir = vaultDir
+			cfg.Git = &configpkg.GitConfig{
+				AutoPush:         true,
+				AutoPull:         true,
+				AutoPullInterval: 10 * time.Second,
+				CommitTemplate:   "Update from Symaira Vault",
+			}
+			cfgPath := filepath.Join(vaultDir, "config.yaml")
+			cfgData, err := yaml.Marshal(cfg)
+			if err != nil {
+				return fmt.Errorf("marshal config: %w", err)
+			}
+			if err := os.WriteFile(cfgPath, cfgData, 0o600); err != nil {
+				return fmt.Errorf("write config: %w", err)
+			}
+
+			// Save identity encrypted with passphrase
+			identityPath := filepath.Join(vaultDir, "identity.age")
+			if err := cryptopkg.SaveIdentity(identity, identityPath, passphrase, 0); err != nil {
+				return fmt.Errorf("save identity: %w", err)
+			}
+
+			// Write recipients.txt with existing device's public key
+			recipientsPath := filepath.Join(vaultDir, "recipients.txt")
+			recipientsContent := fmt.Sprintf("# Symaira Vault vault recipients\n# Added by device add --pair\n%s\n", existingPubkey)
+			if err := os.WriteFile(recipientsPath, []byte(recipientsContent), 0o600); err != nil {
+				return fmt.Errorf("write recipients: %w", err)
+			}
+
+			// Save joined file
+			joinedData := joinedFile{
+				Token:     token,
+				Name:      deviceAddName,
+				PublicKey: identity.Recipient().String(),
+				CreatedAt: time.Now().UTC(),
+			}
+			if deviceAddName == "" {
+				hostname, _ := os.Hostname()
+				if hostname != "" {
+					joinedData.Name = hostname
+				} else {
+					joinedData.Name = "device-" + token
+				}
+			}
+
+			if err := savePairingFile(vaultDir, token+"-joined.json", joinedData); err != nil {
+				return fmt.Errorf("save joined file: %w", err)
+			}
+
+			cliout.Hintf("=== Pairing Setup Complete ===")
+			fmt.Fprintf(os.Stderr, "Your public key: %s\n", identity.Recipient().String())
+			fmt.Fprintf(os.Stderr, "Device name: %s\n\n", joinedData.Name)
+			fmt.Fprintf(os.Stderr, "IMPORTANT: Entries cannot be decrypted yet.\n")
+			fmt.Fprintf(os.Stderr, "On the original device, run:\n")
+			fmt.Fprintf(os.Stderr, "  symvault device accept %s\n\n", token)
+			fmt.Fprintf(os.Stderr, "After accepting, pull the re-encrypted entries:\n")
+			fmt.Fprintf(os.Stderr, "  symvault git pull\n")
+
+			return nil
+		},
+	}
+	deviceAddCmd.Flags().BoolVar(&deviceAddPair, "pair", false, "Pair with an existing device using QR data")
+	deviceAddCmd.Flags().StringVar(&deviceAddName, "name", "", "Name for this device (defaults to hostname)")
+	return deviceAddCmd
 }
 
-var deviceRevokeCmd = &cobra.Command{
-	Use:   "revoke <name>",
-	Short: "Revoke a device and re-encrypt all entries",
-	Long: `Revoke a device's access to the vault by removing its public key
+func newDeviceRevokeCmd() *cobra.Command {
+	deviceRevokeCmd := &cobra.Command{
+		Use:   "revoke <name>",
+		Short: "Revoke a device and re-encrypt all entries",
+		Long: `Revoke a device's access to the vault by removing its public key
 from the device registry and recipients list, then re-encrypting all
 entries so the revoked device can no longer decrypt them.
 
 WARNING: This is irreversible. The revoked device will permanently lose
 access to all vault entries.`,
-	Example: `  symvault device revoke macbook
+		Example: `  symvault device revoke macbook
   symvault device revoke macbook --yes`,
-	Args: cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		deviceName := args[0]
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			deviceName := args[0]
 
-		vaultDir, err := cli.VaultPath()
-		if err != nil {
-			return err
-		}
-
-		if !vaultpkg.IsInitialized(vaultDir) {
-			return errorspkg.NewVaultNotInitialized()
-		}
-
-		v, err := cli.UnlockVault(vaultDir, true)
-		if err != nil {
-			return err
-		}
-
-		// Find the device in the registry
-		dm := vaultpkg.NewDeviceManager(vaultDir)
-		device, err := dm.GetDevice(deviceName)
-		if err != nil {
-			return fmt.Errorf("cannot look up device: %w", err)
-		}
-		if device == nil {
-			return fmt.Errorf("device %q not found in device registry", deviceName)
-		}
-
-		// Prevent revoking the current device
-		currentPubkey := v.Identity.Recipient().String()
-		if device.PublicKey == currentPubkey {
-			return fmt.Errorf("cannot revoke the current device %q (this device's identity would be lost)", deviceName)
-		}
-
-		// Confirmation prompt unless --yes is passed
-		if !deviceRevokeYes {
-			fmt.Fprintf(os.Stderr, "This will revoke device %q and re-encrypt all entries.\nContinue? [y/N]: ", deviceName)
-			answer, readErr := bufio.NewReader(os.Stdin).ReadString('\n')
-			if readErr != nil && answer == "" {
-				return fmt.Errorf("read confirmation: %w", readErr)
+			vaultDir, err := cli.VaultPath()
+			if err != nil {
+				return err
 			}
-			if strings.ToLower(strings.TrimSpace(answer)) != "y" {
-				fmt.Fprintln(os.Stderr, "Canceled")
-				return nil
+
+			if !vaultpkg.IsInitialized(vaultDir) {
+				return errorspkg.NewVaultNotInitialized()
 			}
-		}
 
-		// Remove device from registry
-		if err = dm.RemoveDevice(deviceName); err != nil {
-			return fmt.Errorf("remove device from registry: %w", err)
-		}
-
-		// Remove device's public key from recipients
-		rm := vaultpkg.NewRecipientsManager(vaultDir)
-		if err = rm.RemoveRecipient(device.PublicKey); err != nil {
-			// Not found in recipients is acceptable — may have been manually removed
-			if !errors.Is(err, vaultpkg.ErrRecipientNotFound) {
-				return fmt.Errorf("remove recipient: %w", err)
+			v, err := cli.UnlockVault(vaultDir, true)
+			if err != nil {
+				return err
 			}
-		}
 
-		// Get remaining recipients for re-encryption
-		allRecipients, err := v.GetAllRecipientsForEncryption()
-		if err != nil {
-			return fmt.Errorf("get recipients: %w", err)
-		}
+			// Find the device in the registry
+			dm := vaultpkg.NewDeviceManager(vaultDir)
+			device, err := dm.GetDevice(deviceName)
+			if err != nil {
+				return fmt.Errorf("cannot look up device: %w", err)
+			}
+			if device == nil {
+				return fmt.Errorf("device %q not found in device registry", deviceName)
+			}
 
-		// Re-encrypt all entries without the revoked device
-		cliout.Hintf("Re-encrypting all entries for %d recipient(s)...", len(allRecipients))
-		if err := vaultpkg.ReencryptAll(vaultDir, v.Identity, allRecipients); err != nil {
-			return fmt.Errorf("re-encrypt: %w", err)
-		}
+			// Prevent revoking the current device
+			currentPubkey := v.Identity.Recipient().String()
+			if device.PublicKey == currentPubkey {
+				return fmt.Errorf("cannot revoke the current device %q (this device's identity would be lost)", deviceName)
+			}
 
-		// Auto-commit and push
-		if err := git.AutoCommitAndPush(vaultDir, fmt.Sprintf("Revoke device: %s", deviceName), v.Config.Git.AutoPush); err != nil {
-			cliout.Warnf("Warning: could not auto-commit/push: %v", err)
-		}
+			// Confirmation prompt unless --yes is passed
+			if !deviceRevokeYes {
+				fmt.Fprintf(os.Stderr, "This will revoke device %q and re-encrypt all entries.\nContinue? [y/N]: ", deviceName)
+				answer, readErr := bufio.NewReader(os.Stdin).ReadString('\n')
+				if readErr != nil && answer == "" {
+					return fmt.Errorf("read confirmation: %w", readErr)
+				}
+				if strings.ToLower(strings.TrimSpace(answer)) != "y" {
+					fmt.Fprintln(os.Stderr, "Canceled")
+					return nil
+				}
+			}
 
-		printQuietAware("\nDevice %q has been revoked and all entries re-encrypted.\n", deviceName)
-		return nil
-	},
-}
+			// Remove device from registry
+			if err = dm.RemoveDevice(deviceName); err != nil {
+				return fmt.Errorf("remove device from registry: %w", err)
+			}
 
-func init() {
-	deviceCmd.GroupID = cli.GroupIDSharingSync
-	deviceCmd.AddCommand(devicePairCmd)
-	deviceCmd.AddCommand(deviceJoinCmd)
-	deviceCmd.AddCommand(deviceAcceptCmd)
-	deviceCmd.AddCommand(deviceListCmd)
-	deviceCmd.AddCommand(deviceRevokeCmd)
-	deviceCmd.AddCommand(deviceAddCmd)
-	deviceAddCmd.Flags().BoolVar(&deviceAddPair, "pair", false, "Pair with an existing device using QR data")
-	deviceAddCmd.Flags().StringVar(&deviceAddName, "name", "", "Name for this device (defaults to hostname)")
-	deviceJoinCmd.Flags().StringVar(&defaultDeviceName, "name", "", "Name for this device (defaults to hostname)")
+			// Remove device's public key from recipients
+			rm := vaultpkg.NewRecipientsManager(vaultDir)
+			if err = rm.RemoveRecipient(device.PublicKey); err != nil {
+				// Not found in recipients is acceptable — may have been manually removed
+				if !errors.Is(err, vaultpkg.ErrRecipientNotFound) {
+					return fmt.Errorf("remove recipient: %w", err)
+				}
+			}
+
+			// Get remaining recipients for re-encryption
+			allRecipients, err := v.GetAllRecipientsForEncryption()
+			if err != nil {
+				return fmt.Errorf("get recipients: %w", err)
+			}
+
+			// Re-encrypt all entries without the revoked device
+			cliout.Hintf("Re-encrypting all entries for %d recipient(s)...", len(allRecipients))
+			if err := vaultpkg.ReencryptAll(vaultDir, v.Identity, allRecipients); err != nil {
+				return fmt.Errorf("re-encrypt: %w", err)
+			}
+
+			// Auto-commit and push
+			if err := git.AutoCommitAndPush(vaultDir, fmt.Sprintf("Revoke device: %s", deviceName), v.Config.Git.AutoPush); err != nil {
+				cliout.Warnf("Warning: could not auto-commit/push: %v", err)
+			}
+
+			printQuietAware("\nDevice %q has been revoked and all entries re-encrypted.\n", deviceName)
+			return nil
+		},
+	}
 	deviceRevokeCmd.Flags().BoolVarP(&deviceRevokeYes, "yes", "y", false, "Skip confirmation prompt")
+	return deviceRevokeCmd
 }
 
 type pairingFile struct {

--- a/cmd/device.go
+++ b/cmd/device.go
@@ -34,7 +34,7 @@ var (
 var deviceCmd = newDeviceCmd()
 
 func newDeviceCmd() *cobra.Command {
-	deviceCmd := &cobra.Command{
+	c := &cobra.Command{
 		Use:   "device",
 		Short: "Manage paired devices for multi-device vault access",
 		Long: `Manage paired devices that can access this vault.
@@ -48,14 +48,14 @@ and 'symvault device join' on the new device to join the vault.`,
 			cli.JSONOutputAnnotation: "true",
 		},
 	}
-	deviceCmd.GroupID = cli.GroupIDSharingSync
-	deviceCmd.AddCommand(newDevicePairCmd())
-	deviceCmd.AddCommand(newDeviceJoinCmd())
-	deviceCmd.AddCommand(newDeviceAcceptCmd())
-	deviceCmd.AddCommand(newDeviceListCmd())
-	deviceCmd.AddCommand(newDeviceRevokeCmd())
-	deviceCmd.AddCommand(newDeviceAddCmd())
-	return deviceCmd
+	c.GroupID = cli.GroupIDSharingSync
+	c.AddCommand(newDevicePairCmd())
+	c.AddCommand(newDeviceJoinCmd())
+	c.AddCommand(newDeviceAcceptCmd())
+	c.AddCommand(newDeviceListCmd())
+	c.AddCommand(newDeviceRevokeCmd())
+	c.AddCommand(newDeviceAddCmd())
+	return c
 }
 
 func newDevicePairCmd() *cobra.Command {

--- a/cmd/diag.go
+++ b/cmd/diag.go
@@ -13,24 +13,41 @@ import (
 	"github.com/danieljustus/symaira-vault/internal/metrics"
 )
 
-var diagCmd = &cobra.Command{
-	Use:     "diag",
-	Short:   "Diagnostic commands for Symaira Vault",
-	Example: `  symvault diag metrics`,
-	Annotations: map[string]string{
-		requiresVaultAnnotation: "false",
-	},
+func newDiagCmd() *cobra.Command {
+	diagCmd := &cobra.Command{
+		Use:     "diag",
+		Short:   "Diagnostic commands for Symaira Vault",
+		Example: `  symvault diag metrics`,
+		Annotations: map[string]string{
+			requiresVaultAnnotation: "false",
+		},
+	}
+	diagCmd.GroupID = cli.GroupIDAdministration
+	diagCmd.AddCommand(newDiagMetricsCmd())
+	return diagCmd
 }
 
-var diagMetricsCmd = &cobra.Command{
-	Use:   "metrics",
-	Short: "Print current metric values for debugging",
-	Annotations: map[string]string{
-		requiresVaultAnnotation: "false",
-	},
-	RunE: func(cmd *cobra.Command, args []string) error {
-		return printMetrics(cmd)
-	},
+// diagCmd is intentionally attached to the package-level rootCmd only:
+// NewRootCmd() does not include it, so the shipped CLI has no diag
+// command. This initializer runs after rootCmd is built (dependency
+// order) and preserves that exact tree shape.
+var _ = func() int {
+	rootCmd.AddCommand(newDiagCmd())
+	return 0
+}()
+
+func newDiagMetricsCmd() *cobra.Command {
+	diagMetricsCmd := &cobra.Command{
+		Use:   "metrics",
+		Short: "Print current metric values for debugging",
+		Annotations: map[string]string{
+			requiresVaultAnnotation: "false",
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return printMetrics(cmd)
+		},
+	}
+	return diagMetricsCmd
 }
 
 func printMetrics(cmd *cobra.Command) error {
@@ -57,10 +74,4 @@ func printMetrics(cmd *cobra.Command) error {
 
 	cmd.Print(buf.String())
 	return nil
-}
-
-func init() {
-	diagCmd.GroupID = cli.GroupIDAdministration
-	rootCmd.AddCommand(diagCmd)
-	diagCmd.AddCommand(diagMetricsCmd)
 }

--- a/cmd/doctor_test.go
+++ b/cmd/doctor_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestCmdDoctor_TextOutput(t *testing.T) {
-	rootCmd = NewRootCmd()
+	rootCmd = newPackageRootCmd()
 	vaultDir, passphrase := initVault(t)
 	setPassEnv(t, string(passphrase))
 	defer setupVaultFlag(t, vaultDir)()
@@ -35,7 +35,7 @@ func TestCmdDoctor_TextOutput(t *testing.T) {
 }
 
 func TestCmdDoctor_JSONOutput(t *testing.T) {
-	rootCmd = NewRootCmd()
+	rootCmd = newPackageRootCmd()
 	vaultDir, passphrase := initVault(t)
 	setPassEnv(t, string(passphrase))
 	defer setupVaultFlag(t, vaultDir)()
@@ -73,7 +73,7 @@ func TestCmdDoctor_JSONOutput(t *testing.T) {
 }
 
 func TestCmdDoctor_NoNetworkFlag(t *testing.T) {
-	rootCmd = NewRootCmd()
+	rootCmd = newPackageRootCmd()
 	vaultDir, passphrase := initVault(t)
 	setPassEnv(t, string(passphrase))
 	defer setupVaultFlag(t, vaultDir)()
@@ -102,7 +102,7 @@ func TestCmdDoctor_FixFlag_Registered(t *testing.T) {
 }
 
 func TestCmdDoctor_FixFlag_TextOutput(t *testing.T) {
-	rootCmd = NewRootCmd()
+	rootCmd = newPackageRootCmd()
 	vaultDir, passphrase := initVault(t)
 	setPassEnv(t, string(passphrase))
 	defer setupVaultFlag(t, vaultDir)()

--- a/cmd/dynamic.go
+++ b/cmd/dynamic.go
@@ -23,7 +23,7 @@ var (
 var dynamicCmd = newDynamicCmd()
 
 func newDynamicCmd() *cobra.Command {
-	dynamicCmd := &cobra.Command{
+	c := &cobra.Command{
 		Use:   "dynamic",
 		Short: "Generate dynamic secrets with time-limited leases",
 		Long: `Generate dynamic secrets with time-limited leases for various backends.
@@ -37,9 +37,9 @@ Supported engines:
   # Short-lived AWS STS session
   symvault dynamic generate aws-sts --role arn:aws:iam::123:role/dev --ttl 15m`,
 	}
-	dynamicCmd.AddCommand(newDynamicGenerateCmd())
-	dynamicCmd.GroupID = cli.GroupIDVault
-	return dynamicCmd
+	c.AddCommand(newDynamicGenerateCmd())
+	c.GroupID = cli.GroupIDVault
+	return c
 }
 
 func newDynamicGenerateCmd() *cobra.Command {

--- a/cmd/dynamic.go
+++ b/cmd/dynamic.go
@@ -18,64 +18,70 @@ var (
 	dynamicTTL    time.Duration
 )
 
-var dynamicCmd = &cobra.Command{
-	Use:   "dynamic",
-	Short: "Generate dynamic secrets with time-limited leases",
-	Long: `Generate dynamic secrets with time-limited leases for various backends.
+// dynamicCmd is retained for API compatibility; NewCommands() uses
+// newDynamicCmd() so every call gets a fresh command.
+var dynamicCmd = newDynamicCmd()
+
+func newDynamicCmd() *cobra.Command {
+	dynamicCmd := &cobra.Command{
+		Use:   "dynamic",
+		Short: "Generate dynamic secrets with time-limited leases",
+		Long: `Generate dynamic secrets with time-limited leases for various backends.
 
 Supported engines:
   postgres  - Create temporary PostgreSQL users with GRANT role
   aws-sts   - Generate temporary AWS STS credentials via AssumeRole`,
-	Example: `  # Generate temporary PostgreSQL credentials valid for 1h
+		Example: `  # Generate temporary PostgreSQL credentials valid for 1h
   symvault dynamic generate postgres --role analyst --ttl 1h
 
   # Short-lived AWS STS session
   symvault dynamic generate aws-sts --role arn:aws:iam::123:role/dev --ttl 15m`,
+	}
+	dynamicCmd.AddCommand(newDynamicGenerateCmd())
+	dynamicCmd.GroupID = cli.GroupIDVault
+	return dynamicCmd
 }
 
-var dynamicGenerateCmd = &cobra.Command{
-	Use:   "generate",
-	Short: "Generate a dynamic secret",
-	Example: `  # Generate a PostgreSQL secret with readonly role
+func newDynamicGenerateCmd() *cobra.Command {
+	dynamicGenerateCmd := &cobra.Command{
+		Use:   "generate",
+		Short: "Generate a dynamic secret",
+		Example: `  # Generate a PostgreSQL secret with readonly role
   symvault dynamic generate --engine postgres --role readonly --ttl 1h
 
   # Generate AWS STS credentials for a specific role
   symvault dynamic generate --engine aws-sts --role arn:aws:iam::123456789012:role/MyRole --ttl 30m`,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		return cli.WithVault(func(v *vaultpkg.Vault, vs *cli.VaultService) error {
-			ctx := context.Background()
-			mgr := dynamicsecret.NewManager(v)
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cli.WithVault(func(v *vaultpkg.Vault, vs *cli.VaultService) error {
+				ctx := context.Background()
+				mgr := dynamicsecret.NewManager(v)
 
-			req := dynamicsecret.GenerateRequest{
-				Role: dynamicRole,
-				TTL:  dynamicTTL,
-			}
+				req := dynamicsecret.GenerateRequest{
+					Role: dynamicRole,
+					TTL:  dynamicTTL,
+				}
 
-			secret, err := mgr.Generate(ctx, dynamicEngine, req)
-			if err != nil {
-				return fmt.Errorf("generate dynamic secret: %w", err)
-			}
+				secret, err := mgr.Generate(ctx, dynamicEngine, req)
+				if err != nil {
+					return fmt.Errorf("generate dynamic secret: %w", err)
+				}
 
-			result := map[string]any{
-				"lease_id":    secret.LeaseID,
-				"engine_type": secret.EngineType,
-				"expires_in":  secret.LeaseDuration.String(),
-				"created_at":  secret.CreatedAt.Format(time.RFC3339),
-				"data":        secret.Data,
-			}
+				result := map[string]any{
+					"lease_id":    secret.LeaseID,
+					"engine_type": secret.EngineType,
+					"expires_in":  secret.LeaseDuration.String(),
+					"created_at":  secret.CreatedAt.Format(time.RFC3339),
+					"data":        secret.Data,
+				}
 
-			return cli.PrintResult(result)
-		})
-	},
-}
-
-func init() {
+				return cli.PrintResult(result)
+			})
+		},
+	}
 	dynamicGenerateCmd.Flags().StringVar(&dynamicEngine, "engine", "", "Secret engine type (postgres, aws-sts)")
 	dynamicGenerateCmd.Flags().StringVar(&dynamicRole, "role", "", "Role or permission level")
 	dynamicGenerateCmd.Flags().DurationVar(&dynamicTTL, "ttl", time.Hour, "Time-to-live duration (e.g., 1h, 30m)")
 	_ = dynamicGenerateCmd.MarkFlagRequired("engine")
 	_ = dynamicGenerateCmd.MarkFlagRequired("role")
-
-	dynamicCmd.AddCommand(dynamicGenerateCmd)
-	dynamicCmd.GroupID = cli.GroupIDVault
+	return dynamicGenerateCmd
 }

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -19,11 +19,16 @@ var (
 	genQuiet   bool
 )
 
-var generateCmd = &cobra.Command{
-	Use:     "generate",
-	Aliases: []string{"gen"},
-	Short:   "Generate a secure password",
-	Example: `  # Generate a 20-character password
+// generateCmd is retained for API compatibility; NewCommands() uses
+// newGenerateCmd() so every call gets a fresh command.
+var generateCmd = newGenerateCmd()
+
+func newGenerateCmd() *cobra.Command {
+	generateCmd := &cobra.Command{
+		Use:     "generate",
+		Aliases: []string{"gen"},
+		Short:   "Generate a secure password",
+		Example: `  # Generate a 20-character password
   symvault generate --length 20
 
   # Include symbols
@@ -31,67 +36,76 @@ var generateCmd = &cobra.Command{
 
   # Generate and store
   symvault generate --store newaccount.password`,
-	Annotations: map[string]string{
-		cli.JSONOutputAnnotation: "true",
-	},
-	RunE: func(cmd *cobra.Command, args []string) error {
-		password, cleanup, err := generatePassword(genLength, genSymbols)
-		if err != nil {
-			return err
-		}
-		if cleanup != nil {
-			defer cleanup()
-		}
-
-		if genStore != "" {
-			return cli.WithVaultRaw(func(v *vaultpkg.Vault, vs *cli.VaultService) error {
-				entryPath := vaultpkg.EntryPath(v, genStore)
-				if _, err := vaultpkg.ReadEntry(v.Dir, genStore, v.Identity); err == nil {
-					if _, err := vaultpkg.MergeEntryWithRecipients(v.Dir, genStore, map[string]any{"password": password}, v.Identity); err != nil {
-						return fmt.Errorf("cannot store password: %w", err)
-					}
-				} else {
-					entry := &vaultpkg.Entry{Data: map[string]any{"password": password}, Metadata: vaultpkg.EntryMetadata{Created: time.Now().UTC(), Updated: time.Now().UTC(), Version: 0}}
-					if err := vaultpkg.WriteEntryWithRecipients(v.Dir, genStore, entry, v.Identity); err != nil {
-						return fmt.Errorf("cannot store password: %w", err)
-					}
-				}
-
-				if err := v.AutoCommitEntry(fmt.Sprintf("Generate password for %s", genStore), genStore); err != nil {
-					return fmt.Errorf("auto-commit failed: %w", err)
-				}
-
-				if cli.OutputFormat == "text" {
-					if genQuiet {
-						return nil
-					}
-					printQuietAware("Password stored at: %s\n", entryPath)
-				} else {
-					result := map[string]any{
-						"stored": true,
-						"path":   genStore,
-						"file":   entryPath,
-					}
-					if genReveal {
-						result["password"] = password
-					}
-					if err := cli.PrintResult(result); err != nil {
-						return err
-					}
-				}
-				return nil
-			})
-		}
-
-		if cli.OutputFormat == "text" {
-			printlnQuietAware(password)
-		} else {
-			if err := cli.PrintResult(map[string]interface{}{"password": password}); err != nil {
+		Annotations: map[string]string{
+			cli.JSONOutputAnnotation: "true",
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			password, cleanup, err := generatePassword(genLength, genSymbols)
+			if err != nil {
 				return err
 			}
-		}
-		return nil
-	},
+			if cleanup != nil {
+				defer cleanup()
+			}
+
+			if genStore != "" {
+				return cli.WithVaultRaw(func(v *vaultpkg.Vault, vs *cli.VaultService) error {
+					entryPath := vaultpkg.EntryPath(v, genStore)
+					if _, err := vaultpkg.ReadEntry(v.Dir, genStore, v.Identity); err == nil {
+						if _, err := vaultpkg.MergeEntryWithRecipients(v.Dir, genStore, map[string]any{"password": password}, v.Identity); err != nil {
+							return fmt.Errorf("cannot store password: %w", err)
+						}
+					} else {
+						entry := &vaultpkg.Entry{Data: map[string]any{"password": password}, Metadata: vaultpkg.EntryMetadata{Created: time.Now().UTC(), Updated: time.Now().UTC(), Version: 0}}
+						if err := vaultpkg.WriteEntryWithRecipients(v.Dir, genStore, entry, v.Identity); err != nil {
+							return fmt.Errorf("cannot store password: %w", err)
+						}
+					}
+
+					if err := v.AutoCommitEntry(fmt.Sprintf("Generate password for %s", genStore), genStore); err != nil {
+						return fmt.Errorf("auto-commit failed: %w", err)
+					}
+
+					if cli.OutputFormat == "text" {
+						if genQuiet {
+							return nil
+						}
+						printQuietAware("Password stored at: %s\n", entryPath)
+					} else {
+						result := map[string]any{
+							"stored": true,
+							"path":   genStore,
+							"file":   entryPath,
+						}
+						if genReveal {
+							result["password"] = password
+						}
+						if err := cli.PrintResult(result); err != nil {
+							return err
+						}
+					}
+					return nil
+				})
+			}
+
+			if cli.OutputFormat == "text" {
+				printlnQuietAware(password)
+			} else {
+				if err := cli.PrintResult(map[string]interface{}{"password": password}); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	}
+	generateCmd.Flags().IntVarP(&genLength, "length", "l", 20, "Password length")
+	generateCmd.Flags().BoolVarP(&genSymbols, "symbols", "s", false, "Include symbols")
+	generateCmd.Flags().StringVar(&genStore, "store", "", "Store at path (optional)")
+	generateCmd.Flags().BoolVar(&genReveal, "reveal", false, "Include generated password in output when using --store")
+	generateCmd.Flags().BoolVar(&genQuiet, "quiet", false, "Suppress success output when using --store")
+	generateCmd.AddCommand(newManpagesCmd())
+	generateCmd.GroupID = cli.GroupIDVault
+	return generateCmd
 }
 
 func generatePassword(length int, useSymbols bool) (string, func(), error) {
@@ -102,14 +116,4 @@ func generatePassword(length int, useSymbols bool) (string, func(), error) {
 		return "", func() {}, fmt.Errorf("length must be at most %d", crypto.MaxPasswordLength)
 	}
 	return crypto.GeneratePassword(length, useSymbols)
-}
-
-func init() {
-	generateCmd.Flags().IntVarP(&genLength, "length", "l", 20, "Password length")
-	generateCmd.Flags().BoolVarP(&genSymbols, "symbols", "s", false, "Include symbols")
-	generateCmd.Flags().StringVar(&genStore, "store", "", "Store at path (optional)")
-	generateCmd.Flags().BoolVar(&genReveal, "reveal", false, "Include generated password in output when using --store")
-	generateCmd.Flags().BoolVar(&genQuiet, "quiet", false, "Suppress success output when using --store")
-	generateCmd.AddCommand(manpagesCmd)
-	generateCmd.GroupID = cli.GroupIDVault
 }

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -24,7 +24,7 @@ var (
 var generateCmd = newGenerateCmd()
 
 func newGenerateCmd() *cobra.Command {
-	generateCmd := &cobra.Command{
+	c := &cobra.Command{
 		Use:     "generate",
 		Aliases: []string{"gen"},
 		Short:   "Generate a secure password",
@@ -98,14 +98,14 @@ func newGenerateCmd() *cobra.Command {
 			return nil
 		},
 	}
-	generateCmd.Flags().IntVarP(&genLength, "length", "l", 20, "Password length")
-	generateCmd.Flags().BoolVarP(&genSymbols, "symbols", "s", false, "Include symbols")
-	generateCmd.Flags().StringVar(&genStore, "store", "", "Store at path (optional)")
-	generateCmd.Flags().BoolVar(&genReveal, "reveal", false, "Include generated password in output when using --store")
-	generateCmd.Flags().BoolVar(&genQuiet, "quiet", false, "Suppress success output when using --store")
-	generateCmd.AddCommand(newManpagesCmd())
-	generateCmd.GroupID = cli.GroupIDVault
-	return generateCmd
+	c.Flags().IntVarP(&genLength, "length", "l", 20, "Password length")
+	c.Flags().BoolVarP(&genSymbols, "symbols", "s", false, "Include symbols")
+	c.Flags().StringVar(&genStore, "store", "", "Store at path (optional)")
+	c.Flags().BoolVar(&genReveal, "reveal", false, "Include generated password in output when using --store")
+	c.Flags().BoolVar(&genQuiet, "quiet", false, "Suppress success output when using --store")
+	c.AddCommand(newManpagesCmd())
+	c.GroupID = cli.GroupIDVault
+	return c
 }
 
 func generatePassword(length int, useSymbols bool) (string, func(), error) {

--- a/cmd/git.go
+++ b/cmd/git.go
@@ -16,7 +16,7 @@ import (
 var gitCmd = newGitCmd()
 
 func newGitCmd() *cobra.Command {
-	gitCmd := &cobra.Command{
+	c := &cobra.Command{
 		Use:   "git <push|pull|log> [path]",
 		Short: "Git operations on vault",
 		Example: `  # Sync with the configured remote
@@ -73,6 +73,6 @@ func newGitCmd() *cobra.Command {
 			return nil
 		},
 	}
-	gitCmd.GroupID = cli.GroupIDSharingSync
-	return gitCmd
+	c.GroupID = cli.GroupIDSharingSync
+	return c
 }

--- a/cmd/git.go
+++ b/cmd/git.go
@@ -11,64 +11,68 @@ import (
 	vaultpkg "github.com/danieljustus/symaira-vault/internal/vault"
 )
 
-var gitCmd = &cobra.Command{
-	Use:   "git <push|pull|log> [path]",
-	Short: "Git operations on vault",
-	Example: `  # Sync with the configured remote
+// gitCmd is retained for API compatibility; NewRootCmd() uses
+// newGitCmd() so every call gets a fresh command.
+var gitCmd = newGitCmd()
+
+func newGitCmd() *cobra.Command {
+	gitCmd := &cobra.Command{
+		Use:   "git <push|pull|log> [path]",
+		Short: "Git operations on vault",
+		Example: `  # Sync with the configured remote
   symvault git pull
   symvault git push
 
   # Show commit history for an entry
   symvault git log work/aws`,
-	Args: cobra.RangeArgs(1, 2),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		action := args[0]
+		Args: cobra.RangeArgs(1, 2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			action := args[0]
 
-		if action == "log" {
-			return cli.WithVaultRaw(func(v *vaultpkg.Vault, vs *cli.VaultService) error {
-				path := ""
-				if len(args) > 1 {
-					path = args[1]
-				}
-				history, err := git.Log(v.Dir, path, 0)
-				if err != nil {
-					return fmt.Errorf("cannot get log: %w", err)
-				}
-				for _, h := range history {
-					printQuietAware("%s  %s  %s\n", h.Hash[:7], h.Date.Format("2006-01-02"), h.Message)
-					printlnQuietAware("  Author: " + h.Author)
-				}
-				return nil
-			})
-		}
-
-		vaultDir, err := cli.VaultPath()
-		if err != nil {
-			return err
-		}
-		if !vaultpkg.IsInitialized(vaultDir) {
-			return errorspkg.NewVaultNotInitialized()
-		}
-
-		switch action {
-		case "push":
-			if err := git.Push(vaultDir); err != nil {
-				return fmt.Errorf("push failed: %w", err)
+			if action == "log" {
+				return cli.WithVaultRaw(func(v *vaultpkg.Vault, vs *cli.VaultService) error {
+					path := ""
+					if len(args) > 1 {
+						path = args[1]
+					}
+					history, err := git.Log(v.Dir, path, 0)
+					if err != nil {
+						return fmt.Errorf("cannot get log: %w", err)
+					}
+					for _, h := range history {
+						printQuietAware("%s  %s  %s\n", h.Hash[:7], h.Date.Format("2006-01-02"), h.Message)
+						printlnQuietAware("  Author: " + h.Author)
+					}
+					return nil
+				})
 			}
-			printlnQuietAware("Pushed to remote")
-		case "pull":
-			if err := git.Pull(vaultDir); err != nil {
-				return fmt.Errorf("pull failed: %w", err)
+
+			vaultDir, err := cli.VaultPath()
+			if err != nil {
+				return err
 			}
-			printlnQuietAware("Pulled from remote")
-		default:
-			return fmt.Errorf("unknown action: %s (use push, pull, or log)", action)
-		}
+			if !vaultpkg.IsInitialized(vaultDir) {
+				return errorspkg.NewVaultNotInitialized()
+			}
 
-		return nil
-	},
-}
+			switch action {
+			case "push":
+				if err := git.Push(vaultDir); err != nil {
+					return fmt.Errorf("push failed: %w", err)
+				}
+				printlnQuietAware("Pushed to remote")
+			case "pull":
+				if err := git.Pull(vaultDir); err != nil {
+					return fmt.Errorf("pull failed: %w", err)
+				}
+				printlnQuietAware("Pulled from remote")
+			default:
+				return fmt.Errorf("unknown action: %s (use push, pull, or log)", action)
+			}
 
-func init() {
+			return nil
+		},
+	}
 	gitCmd.GroupID = cli.GroupIDSharingSync
+	return gitCmd
 }

--- a/cmd/manpages.go
+++ b/cmd/manpages.go
@@ -10,38 +10,55 @@ import (
 	"github.com/spf13/cobra/doc"
 )
 
-var manpagesCmd = &cobra.Command{
-	Use:   "manpages <directory>",
-	Short: "Generate manual pages",
-	Example: `  # Generate man pages into ./man
+// rootForManpages carries the package-level rootCmd for the manpages
+// renderer. It exists to break Go's initialization dependency cycle:
+// rootCmd -> NewRootCmd -> newGenerateCmd -> newManpagesCmd would
+// reference rootCmd again through the RunE closure, which the
+// initializer analysis treats as a hard dependency. The assignment below
+// runs after rootCmd is initialized (dependency order) and the renderer
+// only reads it at runtime.
+var rootForManpages *cobra.Command
+
+var _ = func() int {
+	rootForManpages = rootCmd
+	return 0
+}()
+
+func newManpagesCmd() *cobra.Command {
+	manpagesCmd := &cobra.Command{
+		Use:   "manpages <directory>",
+		Short: "Generate manual pages",
+		Example: `  # Generate man pages into ./man
   symvault manpages ./man
 
   # System-wide install (requires sudo)
   sudo symvault manpages /usr/local/share/man/man1`,
-	Args: cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		dir, err := filepath.Abs(args[0])
-		if err != nil {
-			return fmt.Errorf("resolve manpage directory: %w", err)
-		}
-		if err := os.MkdirAll(dir, 0o750); err != nil {
-			return fmt.Errorf("create manpage directory: %w", err)
-		}
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			dir, err := filepath.Abs(args[0])
+			if err != nil {
+				return fmt.Errorf("resolve manpage directory: %w", err)
+			}
+			if err := os.MkdirAll(dir, 0o750); err != nil {
+				return fmt.Errorf("create manpage directory: %w", err)
+			}
 
-		header := &doc.GenManHeader{
-			Title:   strings.ToUpper(rootCmd.Name()),
-			Section: "1",
-			Manual:  "Symaira Vault Manual",
-			Source:  "Symaira Vault",
-		}
-		rootCmd.DisableAutoGenTag = true
-		if err := doc.GenManTree(rootCmd, header, dir); err != nil {
-			return fmt.Errorf("generate manpages: %w", err)
-		}
+			header := &doc.GenManHeader{
+				Title:   strings.ToUpper(rootForManpages.Name()),
+				Section: "1",
+				Manual:  "Symaira Vault Manual",
+				Source:  "Symaira Vault",
+			}
+			rootForManpages.DisableAutoGenTag = true
+			if err := doc.GenManTree(rootForManpages, header, dir); err != nil {
+				return fmt.Errorf("generate manpages: %w", err)
+			}
 
-		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Generated manpages in %s\n", dir); err != nil {
-			return fmt.Errorf("write manpage result: %w", err)
-		}
-		return nil
-	},
+			if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Generated manpages in %s\n", dir); err != nil {
+				return fmt.Errorf("write manpage result: %w", err)
+			}
+			return nil
+		},
+	}
+	return manpagesCmd
 }

--- a/cmd/mcp/agent.go
+++ b/cmd/mcp/agent.go
@@ -18,14 +18,15 @@ import (
 	"github.com/danieljustus/symaira-vault/internal/ui/cliout"
 )
 
-var agentCmd = &cobra.Command{
-	Use:   "agent",
-	Short: "Manage agent profiles",
-	Long: `Configure AI agent profiles with scoped permissions, tokens, and MCP integration.
+func newAgentCmd() *cobra.Command {
+	agentCmd := &cobra.Command{
+		Use:   "agent",
+		Short: "Manage agent profiles",
+		Long: `Configure AI agent profiles with scoped permissions, tokens, and MCP integration.
 
 Use 'symvault agent setup <name>' to create a new agent with an interactive wizard
 that guides you through security tier selection, vault path scoping, and approval mode.`,
-	Example: `  # Interactive new-agent wizard
+		Example: `  # Interactive new-agent wizard
   symvault agent setup claude-code
 
   # List configured agents
@@ -33,22 +34,39 @@ that guides you through security tier selection, vault path scoping, and approva
 
   # Issue a token for an agent
   symvault agent token new claude-code`,
+	}
+	agentCmd.AddCommand(newAgentSetupCmd())
+	agentCmd.AddCommand(newAgentAuditCmd())
+	agentCmd.AddCommand(newAgentDoctorCmd())
+	agentCmd.AddCommand(newAgentInstallCmd())
+	agentCmd.AddCommand(newAgentListCmd())
+	agentCmd.AddCommand(newAgentProfileCmd())
+	agentCmd.AddCommand(newAgentSkillCmd())
+	agentCmd.AddCommand(newAgentTokenCmd())
+	agentCmd.AddCommand(newAgentUninstallCmd())
+	agentCmd.AddCommand(newAgentUpgradeCmd())
+	agentCmd.AddCommand(newAgentWhoamiCmd())
+	agentCmd.GroupID = cli.GroupIDAgentsMCP
+	return agentCmd
 }
 
-var agentSetupCmd = &cobra.Command{
-	Use:   "setup <name>",
-	Short: "[Deprecated v4.0, removed in v4.1] Use 'symvault agent install <name>'",
-	Long: `This command was deprecated in Symaira Vault v4.0 and will be removed in v4.1.
+func newAgentSetupCmd() *cobra.Command {
+	agentSetupCmd := &cobra.Command{
+		Use:   "setup <name>",
+		Short: "[Deprecated v4.0, removed in v4.1] Use 'symvault agent install <name>'",
+		Long: `This command was deprecated in Symaira Vault v4.0 and will be removed in v4.1.
 
 Use 'symvault agent install <name>' instead to create and configure
 agent profiles interactively.`,
-	Hidden: true,
-	Args:   cobra.ArbitraryArgs,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		cliout.Warnf("This command is deprecated in v4.0. Use: symvault agent install <name>")
-		return errorspkg.NewCLIError(errorspkg.ExitNotFound,
-			"This command is deprecated in v4.0. Use: symvault agent install <name>", nil)
-	},
+		Hidden: true,
+		Args:   cobra.ArbitraryArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cliout.Warnf("This command is deprecated in v4.0. Use: symvault agent install <name>")
+			return errorspkg.NewCLIError(errorspkg.ExitNotFound,
+				"This command is deprecated in v4.0. Use: symvault agent install <name>", nil)
+		},
+	}
+	return agentSetupCmd
 }
 
 func promptApprovalMode(reader *bufio.Reader) string {
@@ -166,9 +184,4 @@ func outputAgentMCPSnippet(name, rawToken string) {
 	if err := enc.Encode(config); err != nil {
 		cliout.Errorf("Error encoding config: %v", err)
 	}
-}
-
-func init() {
-	agentCmd.AddCommand(agentSetupCmd)
-	agentCmd.GroupID = cli.GroupIDAgentsMCP
 }

--- a/cmd/mcp/agent_audit.go
+++ b/cmd/mcp/agent_audit.go
@@ -24,15 +24,16 @@ type auditFlags struct {
 
 var agentAuditFlags auditFlags
 
-var agentAuditCmd = &cobra.Command{
-	Use:   "audit <name>",
-	Short: "Show audit log for an agent",
-	Long: `Display recent audit events for a specific agent.
+func newAgentAuditCmd() *cobra.Command {
+	agentAuditCmd := &cobra.Command{
+		Use:   "audit <name>",
+		Short: "Show audit log for an agent",
+		Long: `Display recent audit events for a specific agent.
 
 Reads from the agent's dedicated audit log at ~/.symvault/audit-<name>.log
 and displays entries in table or JSON format.`,
-	Args: cobra.ExactArgs(1),
-	Example: `  # Show last 50 audit entries for an agent
+		Args: cobra.ExactArgs(1),
+		Example: `  # Show last 50 audit entries for an agent
   symvault agent audit my-agent
 
   # Show entries from the last 24 hours
@@ -43,41 +44,46 @@ and displays entries in table or JSON format.`,
 
   # Show last 100 entries
   symvault agent audit my-agent --limit 100`,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		agentName := args[0]
+		RunE: func(cmd *cobra.Command, args []string) error {
+			agentName := args[0]
 
-		vaultDir := cli.GetVaultDir()
-		logPath := filepath.Join(vaultDir, fmt.Sprintf("audit-%s.log", sanitizeAgentName(agentName)))
+			vaultDir := cli.GetVaultDir()
+			logPath := filepath.Join(vaultDir, fmt.Sprintf("audit-%s.log", sanitizeAgentName(agentName)))
 
-		entries, err := ReadAuditLog(logPath, agentAuditFlags.limit)
-		if err != nil {
-			if os.IsNotExist(err) {
-				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "No audit log found for agent %q at %s\n", agentName, logPath)
+			entries, err := ReadAuditLog(logPath, agentAuditFlags.limit)
+			if err != nil {
+				if os.IsNotExist(err) {
+					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "No audit log found for agent %q at %s\n", agentName, logPath)
+					return nil
+				}
+				return fmt.Errorf("read audit log: %w", err)
+			}
+
+			if len(entries) == 0 {
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "No audit entries found for agent %q.\n", agentName)
 				return nil
 			}
-			return fmt.Errorf("read audit log: %w", err)
-		}
 
-		if len(entries) == 0 {
-			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "No audit entries found for agent %q.\n", agentName)
-			return nil
-		}
+			entries = SinceFilter(entries, agentAuditFlags.since)
 
-		entries = SinceFilter(entries, agentAuditFlags.since)
+			if len(entries) == 0 {
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "No audit entries match the filter criteria.\n")
+				return nil
+			}
 
-		if len(entries) == 0 {
-			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "No audit entries match the filter criteria.\n")
-			return nil
-		}
-
-		switch agentAuditFlags.format {
-		case "json":
-			return printAuditJSON(cmd, entries)
-		default:
-			printAuditTable(cmd, entries)
-			return nil
-		}
-	},
+			switch agentAuditFlags.format {
+			case "json":
+				return printAuditJSON(cmd, entries)
+			default:
+				printAuditTable(cmd, entries)
+				return nil
+			}
+		},
+	}
+	agentAuditCmd.Flags().StringVar(&agentAuditFlags.since, "since", "", "Show entries since duration (e.g. 24h, 7d)")
+	agentAuditCmd.Flags().StringVar(&agentAuditFlags.format, "format", "table", "Output format (table, json)")
+	agentAuditCmd.Flags().IntVar(&agentAuditFlags.limit, "limit", 50, "Maximum number of entries to show")
+	return agentAuditCmd
 }
 
 func ReadAuditLog(path string, limit int) ([]audit.LogEntry, error) {
@@ -170,11 +176,4 @@ func printAuditJSON(cmd *cobra.Command, entries []audit.LogEntry) error {
 	enc := json.NewEncoder(cmd.OutOrStdout())
 	enc.SetIndent("", "  ")
 	return enc.Encode(entries)
-}
-
-func init() {
-	agentAuditCmd.Flags().StringVar(&agentAuditFlags.since, "since", "", "Show entries since duration (e.g. 24h, 7d)")
-	agentAuditCmd.Flags().StringVar(&agentAuditFlags.format, "format", "table", "Output format (table, json)")
-	agentAuditCmd.Flags().IntVar(&agentAuditFlags.limit, "limit", 50, "Maximum number of entries to show")
-	agentCmd.AddCommand(agentAuditCmd)
 }

--- a/cmd/mcp/agent_doctor.go
+++ b/cmd/mcp/agent_doctor.go
@@ -13,87 +13,86 @@ import (
 	configpkg "github.com/danieljustus/symaira-vault/internal/config"
 )
 
-var agentDoctorCmd = &cobra.Command{
-	Use:   "doctor <agent>",
-	Short: "Check agent integration health",
-	Long: `Run end-to-end diagnostics for an agent integration:
+func newAgentDoctorCmd() *cobra.Command {
+	agentDoctorCmd := &cobra.Command{
+		Use:   "doctor <agent>",
+		Short: "Check agent integration health",
+		Long: `Run end-to-end diagnostics for an agent integration:
   • Profile exists and is valid
   • Skill file is installed and managed by Symaira Vault
   • Skill hash matches current template (detects drift)
   • Token registry entry exists
 Reports structured results; exits 0 if all checks pass.`,
-	Args: cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		agentName := args[0]
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			agentName := args[0]
 
-		configPath := filepath.Join(cli.GetVaultDir(), "config.yaml")
-		cfg, err := configpkg.Load(configPath)
-		if err != nil {
-			return fmt.Errorf("load config: %w", err)
-		}
-
-		profile, hasProfile := cfg.Agents[agentName]
-		if !hasProfile {
-			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "\u274c No profile found for agent %q\n", agentName)
-			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "   Run: symvault agent install %s\n", agentName)
-			return fmt.Errorf("agent %q not configured", agentName)
-		}
-		profile.Normalize()
-
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "\u2713 Profile found: %s (tier=%s)\n", agentName, profile.TierValue())
-
-		targetPath := profile.SkillPathValue()
-		if targetPath == "" {
-			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "\u26a0 No skill path configured for agent %q\n", agentName)
-			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "   Run: symvault agent install %s --skill-only\n", agentName)
-			return fmt.Errorf("no skill path configured")
-		}
-
-		targetPath = expandTilde(targetPath)
-		targetPath = filepath.Clean(targetPath)
-		data, err := os.ReadFile(targetPath)
-		if err != nil {
-			if os.IsNotExist(err) {
-				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "\u274c Skill file not found: %s\n", targetPath)
-				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "   Run: symvault agent install %s --skill-only\n", agentName)
-				return fmt.Errorf("skill file not installed")
+			configPath := filepath.Join(cli.GetVaultDir(), "config.yaml")
+			cfg, err := configpkg.Load(configPath)
+			if err != nil {
+				return fmt.Errorf("load config: %w", err)
 			}
-			return fmt.Errorf("read skill file: %w", err)
-		}
 
-		manifest, err := agentskill.ParseManifest(data)
-		if err != nil {
-			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "\u26a0 Skill file exists but has no valid frontmatter\n")
-			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "   Path: %s\n", targetPath)
-			return fmt.Errorf("invalid skill file frontmatter")
-		}
+			profile, hasProfile := cfg.Agents[agentName]
+			if !hasProfile {
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "\u274c No profile found for agent %q\n", agentName)
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "   Run: symvault agent install %s\n", agentName)
+				return fmt.Errorf("agent %q not configured", agentName)
+			}
+			profile.Normalize()
 
-		if manifest.ManagedBy != agentskill.SentinelValue {
-			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "\u26a0 Skill file is not managed by Symaira Vault\n")
-			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "   Path: %s\n", targetPath)
-			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "   To overwrite: symvault agent install %s --skill-only --force\n", agentName)
-			return fmt.Errorf("unmanaged skill file")
-		}
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "\u2713 Profile found: %s (tier=%s)\n", agentName, profile.TierValue())
 
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "\u2713 Skill file is managed by Symaira Vault\n")
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "   Path:    %s\n", targetPath)
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "   Version: %s\n", manifest.ManagedVersion)
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "   Tier:    %s\n", manifest.ManagedProfileTier)
+			targetPath := profile.SkillPathValue()
+			if targetPath == "" {
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "\u26a0 No skill path configured for agent %q\n", agentName)
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "   Run: symvault agent install %s --skill-only\n", agentName)
+				return fmt.Errorf("no skill path configured")
+			}
 
-		if err := agentskill.VerifyHash(data); err != nil {
-			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "\n\u26a0 Skill version drift detected\n")
-			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "   Installed:  %s\n", manifest.ManagedVersion)
-			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "   Expected:   %s\n", cli.AppVersionStr())
-			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "   Run: symvault agent skill refresh %s\n", agentName)
-			return fmt.Errorf("skill drift detected")
-		}
+			targetPath = expandTilde(targetPath)
+			targetPath = filepath.Clean(targetPath)
+			data, err := os.ReadFile(targetPath)
+			if err != nil {
+				if os.IsNotExist(err) {
+					_, _ = fmt.Fprintf(cmd.OutOrStdout(), "\u274c Skill file not found: %s\n", targetPath)
+					_, _ = fmt.Fprintf(cmd.OutOrStdout(), "   Run: symvault agent install %s --skill-only\n", agentName)
+					return fmt.Errorf("skill file not installed")
+				}
+				return fmt.Errorf("read skill file: %w", err)
+			}
 
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "\u2713 Skill hash is current (no drift)\n")
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "\nAll checks passed for %s\n", agentName)
-		return nil
-	},
-}
+			manifest, err := agentskill.ParseManifest(data)
+			if err != nil {
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "\u26a0 Skill file exists but has no valid frontmatter\n")
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "   Path: %s\n", targetPath)
+				return fmt.Errorf("invalid skill file frontmatter")
+			}
 
-func init() {
-	agentCmd.AddCommand(agentDoctorCmd)
+			if manifest.ManagedBy != agentskill.SentinelValue {
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "\u26a0 Skill file is not managed by Symaira Vault\n")
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "   Path: %s\n", targetPath)
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "   To overwrite: symvault agent install %s --skill-only --force\n", agentName)
+				return fmt.Errorf("unmanaged skill file")
+			}
+
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "\u2713 Skill file is managed by Symaira Vault\n")
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "   Path:    %s\n", targetPath)
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "   Version: %s\n", manifest.ManagedVersion)
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "   Tier:    %s\n", manifest.ManagedProfileTier)
+
+			if err := agentskill.VerifyHash(data); err != nil {
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "\n\u26a0 Skill version drift detected\n")
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "   Installed:  %s\n", manifest.ManagedVersion)
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "   Expected:   %s\n", cli.AppVersionStr())
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "   Run: symvault agent skill refresh %s\n", agentName)
+				return fmt.Errorf("skill drift detected")
+			}
+
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "\u2713 Skill hash is current (no drift)\n")
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "\nAll checks passed for %s\n", agentName)
+			return nil
+		},
+	}
+	return agentDoctorCmd
 }

--- a/cmd/mcp/agent_install.go
+++ b/cmd/mcp/agent_install.go
@@ -44,10 +44,11 @@ type InstallResult struct {
 	BackupPath    string `json:"backup_path,omitempty" yaml:"backup_path,omitempty"`
 }
 
-var agentInstallCmd = &cobra.Command{
-	Use:   "install [name]",
-	Short: "Install and configure an AI agent for Symaira Vault",
-	Long: `Unified install command that detects an AI agent, creates a security
+func newAgentInstallCmd() *cobra.Command {
+	agentInstallCmd := &cobra.Command{
+		Use:   "install [name]",
+		Short: "Install and configure an AI agent for Symaira Vault",
+		Long: `Unified install command that detects an AI agent, creates a security
 profile in config.yaml, generates a scoped access token, injects the
 MCP server configuration into the agent's config file, and installs the
 embedded skill package — all in one step.
@@ -59,7 +60,7 @@ or "admin" tiers, an interactive terminal is required to confirm the
 security implications.
 
 Supported agents: openclaw, claude-code, hermes, codex, opencode`,
-	Example: `  # Install and configure Claude Code (auto-detect)
+		Example: `  # Install and configure Claude Code (auto-detect)
   symvault agent install claude-code
 
   # Detect all installed agents and configure each
@@ -85,24 +86,33 @@ Supported agents: openclaw, claude-code, hermes, codex, opencode`,
 
   # Structured JSON output for scripting
   symvault agent install opencode --output json`,
-	Annotations: map[string]string{
-		cli.RequiresVaultAnnotation: "false",
-		cli.JSONOutputAnnotation:    "true",
-	},
-	Args: func(cmd *cobra.Command, args []string) error {
-		autoDetect, _ := cmd.Flags().GetBool("auto-detect")
-		if autoDetect {
-			if len(args) > 0 {
-				return fmt.Errorf("cannot specify an agent name with --auto-detect")
+		Annotations: map[string]string{
+			cli.RequiresVaultAnnotation: "false",
+			cli.JSONOutputAnnotation:    "true",
+		},
+		Args: func(cmd *cobra.Command, args []string) error {
+			autoDetect, _ := cmd.Flags().GetBool("auto-detect")
+			if autoDetect {
+				if len(args) > 0 {
+					return fmt.Errorf("cannot specify an agent name with --auto-detect")
+				}
+				return nil
+			}
+			if len(args) != 1 {
+				return fmt.Errorf("requires exactly 1 argument (agent name), or use --auto-detect")
 			}
 			return nil
-		}
-		if len(args) != 1 {
-			return fmt.Errorf("requires exactly 1 argument (agent name), or use --auto-detect")
-		}
-		return nil
-	},
-	RunE: agentInstallRunE,
+		},
+		RunE: agentInstallRunE,
+	}
+	agentInstallCmd.Flags().Bool("auto-detect", false, "Detect all installed agents and configure each")
+	agentInstallCmd.Flags().String("tier", "safe", "Security tier: safe (default), standard, or admin")
+	agentInstallCmd.Flags().Bool("http", false, "Use HTTP transport with auto-generated bearer token")
+	agentInstallCmd.Flags().Bool("dry-run", false, "Preview changes without applying them")
+	agentInstallCmd.Flags().Bool("skill-only", false, "Only install the skill package, skip MCP config")
+	agentInstallCmd.Flags().Bool("config-only", false, "Only inject MCP config, skip the skill")
+	agentInstallCmd.Flags().Bool("force", false, "Overwrite existing agent profile and MCP config entries")
+	return agentInstallCmd
 }
 
 func agentInstallRunE(cmd *cobra.Command, args []string) error {
@@ -482,15 +492,4 @@ func writeInstallOutput(results []InstallResult) error {
 		}
 		return nil
 	}
-}
-
-func init() {
-	agentCmd.AddCommand(agentInstallCmd)
-	agentInstallCmd.Flags().Bool("auto-detect", false, "Detect all installed agents and configure each")
-	agentInstallCmd.Flags().String("tier", "safe", "Security tier: safe (default), standard, or admin")
-	agentInstallCmd.Flags().Bool("http", false, "Use HTTP transport with auto-generated bearer token")
-	agentInstallCmd.Flags().Bool("dry-run", false, "Preview changes without applying them")
-	agentInstallCmd.Flags().Bool("skill-only", false, "Only install the skill package, skip MCP config")
-	agentInstallCmd.Flags().Bool("config-only", false, "Only inject MCP config, skip the skill")
-	agentInstallCmd.Flags().Bool("force", false, "Overwrite existing agent profile and MCP config entries")
 }

--- a/cmd/mcp/agent_list.go
+++ b/cmd/mcp/agent_list.go
@@ -67,10 +67,11 @@ func (r AgentListResult) String() string {
 	return b.String()
 }
 
-var agentListCmd = &cobra.Command{
-	Use:   "list",
-	Short: "List all configured agents",
-	Long: `Show all installed agents with their tier, token status, and skill installation status.
+func newAgentListCmd() *cobra.Command {
+	agentListCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List all configured agents",
+		Long: `Show all installed agents with their tier, token status, and skill installation status.
 
 Output columns:
   AGENT      Agent profile name
@@ -78,89 +79,91 @@ Output columns:
   TOKEN      Token status from the registry (none, valid, invalid)
   SKILL      Skill file status (missing, installed, managed)
   LAST SEEN  Most recent token use timestamp`,
-	Example: `  # List all agents in a table
+		Example: `  # List all agents in a table
   symvault agent list
 
   # JSON output for programmatic use
   symvault agent list --output json`,
-	Annotations: map[string]string{
-		cli.RequiresVaultAnnotation: "false",
-		cli.JSONOutputAnnotation:    "true",
-	},
-	RunE: func(cmd *cobra.Command, args []string) error {
-		vaultDir := cli.GetVaultDir()
+		Annotations: map[string]string{
+			cli.RequiresVaultAnnotation: "false",
+			cli.JSONOutputAnnotation:    "true",
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			vaultDir := cli.GetVaultDir()
 
-		configPath := filepath.Join(vaultDir, "config.yaml")
-		cfg, err := configpkg.Load(configPath)
-		if err != nil {
-			return fmt.Errorf("load config: %w", err)
-		}
-
-		regPath := auth.TokenRegistryFilePath(vaultDir)
-		reg := auth.NewTokenRegistry(regPath)
-		if loadErr := reg.Load(); loadErr != nil {
-			return fmt.Errorf("load token registry: %w", loadErr)
-		}
-		allTokens := reg.List()
-
-		result := AgentListResult{
-			Agents: make([]AgentListItem, 0, len(cfg.Agents)),
-		}
-
-		names := make([]string, 0, len(cfg.Agents))
-		for name := range cfg.Agents {
-			names = append(names, name)
-		}
-		sortStrings(names)
-
-		for _, name := range names {
-			profile := cfg.Agents[name]
-			profile.Normalize()
-
-			item := AgentListItem{
-				Name: name,
-				Tier: profile.TierValue(),
+			configPath := filepath.Join(vaultDir, "config.yaml")
+			cfg, err := configpkg.Load(configPath)
+			if err != nil {
+				return fmt.Errorf("load config: %w", err)
 			}
 
-			var lastSeen time.Time
-			for _, tok := range allTokens {
-				if tok.AgentName == name && !tok.Revoked && !tok.IsExpired() {
-					item.TokenID = tok.ID
-					item.TokenValid = true
-					if tok.LastUsedAt != nil && tok.LastUsedAt.After(lastSeen) {
-						lastSeen = *tok.LastUsedAt
+			regPath := auth.TokenRegistryFilePath(vaultDir)
+			reg := auth.NewTokenRegistry(regPath)
+			if loadErr := reg.Load(); loadErr != nil {
+				return fmt.Errorf("load token registry: %w", loadErr)
+			}
+			allTokens := reg.List()
+
+			result := AgentListResult{
+				Agents: make([]AgentListItem, 0, len(cfg.Agents)),
+			}
+
+			names := make([]string, 0, len(cfg.Agents))
+			for name := range cfg.Agents {
+				names = append(names, name)
+			}
+			sortStrings(names)
+
+			for _, name := range names {
+				profile := cfg.Agents[name]
+				profile.Normalize()
+
+				item := AgentListItem{
+					Name: name,
+					Tier: profile.TierValue(),
+				}
+
+				var lastSeen time.Time
+				for _, tok := range allTokens {
+					if tok.AgentName == name && !tok.Revoked && !tok.IsExpired() {
+						item.TokenID = tok.ID
+						item.TokenValid = true
+						if tok.LastUsedAt != nil && tok.LastUsedAt.After(lastSeen) {
+							lastSeen = *tok.LastUsedAt
+						}
 					}
 				}
-			}
-			if !lastSeen.IsZero() {
-				item.LastSeen = lastSeen.Format("2006-01-02 15:04")
-			}
+				if !lastSeen.IsZero() {
+					item.LastSeen = lastSeen.Format("2006-01-02 15:04")
+				}
 
-			skillPath := profile.SkillPathValue()
-			if skillPath != "" {
-				expanded := expandTilde(skillPath)
-				expanded = filepath.Clean(expanded)
-				data, readErr := os.ReadFile(expanded)
-				if readErr == nil {
-					item.SkillInstalled = true
-					if manifest, parseErr := agentskill.ParseManifest(data); parseErr == nil && manifest.ManagedBy == agentskill.SentinelValue {
-						item.SkillManaged = true
+				skillPath := profile.SkillPathValue()
+				if skillPath != "" {
+					expanded := expandTilde(skillPath)
+					expanded = filepath.Clean(expanded)
+					data, readErr := os.ReadFile(expanded)
+					if readErr == nil {
+						item.SkillInstalled = true
+						if manifest, parseErr := agentskill.ParseManifest(data); parseErr == nil && manifest.ManagedBy == agentskill.SentinelValue {
+							item.SkillManaged = true
+						}
 					}
 				}
+
+				result.Agents = append(result.Agents, item)
 			}
+			result.Count = len(result.Agents)
 
-			result.Agents = append(result.Agents, item)
-		}
-		result.Count = len(result.Agents)
-
-		switch cli.OutputFormat {
-		case "json", "yaml":
-			return cli.PrintResult(result)
-		default:
-			cmd.Print(result.String())
-			return nil
-		}
-	},
+			switch cli.OutputFormat {
+			case "json", "yaml":
+				return cli.PrintResult(result)
+			default:
+				cmd.Print(result.String())
+				return nil
+			}
+		},
+	}
+	return agentListCmd
 }
 
 func sortStrings(s []string) {
@@ -171,8 +174,4 @@ func sortStrings(s []string) {
 			}
 		}
 	}
-}
-
-func init() {
-	agentCmd.AddCommand(agentListCmd)
 }

--- a/cmd/mcp/agent_profile.go
+++ b/cmd/mcp/agent_profile.go
@@ -16,12 +16,13 @@ import (
 	configpkg "github.com/danieljustus/symaira-vault/internal/config"
 )
 
-var agentProfileCmd = &cobra.Command{
-	Use:   "profile <name>",
-	Short: "Manage agent profiles",
-	Long:  `Show, edit, and export agent profiles.`,
-	Args:  cobra.ExactArgs(1),
-	Example: `  # Show agent profile
+func newAgentProfileCmd() *cobra.Command {
+	agentProfileCmd := &cobra.Command{
+		Use:   "profile <name>",
+		Short: "Manage agent profiles",
+		Long:  `Show, edit, and export agent profiles.`,
+		Args:  cobra.ExactArgs(1),
+		Example: `  # Show agent profile
   symvault agent profile my-agent show
 
   # Show profile as JSON
@@ -32,160 +33,176 @@ var agentProfileCmd = &cobra.Command{
 
   # Export profile as YAML to stdout
   symvault agent profile my-agent export`,
+	}
+	agentProfileCmd.AddCommand(newAgentProfileShowCmd())
+	agentProfileCmd.AddCommand(newAgentProfileEditCmd())
+	agentProfileCmd.AddCommand(newAgentProfileExportCmd())
+	return agentProfileCmd
 }
 
-var agentProfileShowCmd = &cobra.Command{
-	Use:   "show",
-	Short: "Display agent profile",
-	Long:  `Display the agent profile in YAML or JSON format.`,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		agentName := mustGetProfileAgentName(cmd)
-		output, _ := cmd.Flags().GetString("output")
+func newAgentProfileShowCmd() *cobra.Command {
+	agentProfileShowCmd := &cobra.Command{
+		Use:   "show",
+		Short: "Display agent profile",
+		Long:  `Display the agent profile in YAML or JSON format.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			agentName := mustGetProfileAgentName(cmd)
+			output, _ := cmd.Flags().GetString("output")
 
-		profile, err := loadAgentProfile(agentName)
-		if err != nil {
-			return err
-		}
+			profile, err := loadAgentProfile(agentName)
+			if err != nil {
+				return err
+			}
 
-		switch output {
-		case "json":
-			enc := json.NewEncoder(cmd.OutOrStdout())
-			enc.SetIndent("", "  ")
-			return enc.Encode(profile)
-		default:
-			enc := yaml.NewEncoder(cmd.OutOrStdout())
+			switch output {
+			case "json":
+				enc := json.NewEncoder(cmd.OutOrStdout())
+				enc.SetIndent("", "  ")
+				return enc.Encode(profile)
+			default:
+				enc := yaml.NewEncoder(cmd.OutOrStdout())
+				enc.SetIndent(2)
+				defer func() { _ = enc.Close() }()
+				return enc.Encode(profile)
+			}
+		},
+	}
+	agentProfileShowCmd.Flags().StringP("output", "o", "yaml", "Output format (yaml, json)")
+	return agentProfileShowCmd
+}
+
+func newAgentProfileEditCmd() *cobra.Command {
+	agentProfileEditCmd := &cobra.Command{
+		Use:   "edit",
+		Short: "Edit agent profile in $EDITOR",
+		Long: `Open the agent profile in your configured editor ($EDITOR or $VISUAL).
+After saving, the profile is validated and you are prompted to apply changes.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			agentName := mustGetProfileAgentName(cmd)
+
+			editor := os.Getenv("EDITOR")
+			if editor == "" {
+				editor = os.Getenv("VISUAL")
+			}
+			if editor == "" {
+				return fmt.Errorf("neither $EDITOR nor $VISUAL is set")
+			}
+
+			vaultDir := cli.GetVaultDir()
+			configPath := filepath.Join(vaultDir, "config.yaml")
+
+			data, err := os.ReadFile(filepath.Clean(configPath))
+			if err != nil {
+				return fmt.Errorf("read config: %w", err)
+			}
+
+			tmpFile, err := os.CreateTemp("", fmt.Sprintf("symaira-agent-%s-*.yaml", agentName))
+			if err != nil {
+				return fmt.Errorf("create temp file: %w", err)
+			}
+			tmpPath := tmpFile.Name()
+			defer func() { _ = os.Remove(tmpPath) }()
+
+			section, err := extractAgentSection(data, agentName)
+			if err != nil {
+				_ = tmpFile.Close()
+				return fmt.Errorf("extract agent section: %w", err)
+			}
+
+			if _, writeErr := tmpFile.Write(section); writeErr != nil {
+				_ = tmpFile.Close()
+				return fmt.Errorf("write temp file: %w", writeErr)
+			}
+			_ = tmpFile.Close()
+
+			// #nosec G204 — editor is from user's $EDITOR/$VISUAL env var; tmpPath is a controlled temp file.
+			editorCmd := exec.Command(filepath.Clean(editor), filepath.Clean(tmpPath))
+			editorCmd.Stdin = os.Stdin
+			editorCmd.Stdout = os.Stdout
+			editorCmd.Stderr = os.Stderr
+			if runErr := editorCmd.Run(); runErr != nil {
+				return fmt.Errorf("editor exited with error: %w", runErr)
+			}
+
+			editedData, err := os.ReadFile(filepath.Clean(tmpPath))
+			if err != nil {
+				return fmt.Errorf("read edited file: %w", err)
+			}
+
+			var editedProfile configpkg.AgentProfile
+			if unmarshalErr := yaml.Unmarshal(editedData, &editedProfile); unmarshalErr != nil {
+				return fmt.Errorf("invalid YAML in edited profile: %w", unmarshalErr)
+			}
+
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Edited profile for %q:\n", agentName)
+			showProfilePreview(cmd, &editedProfile)
+
+			_, _ = fmt.Fprint(cmd.ErrOrStderr(), "\nApply changes? [y/N] ")
+			var response string
+			_, _ = fmt.Scanln(&response)
+			response = strings.TrimSpace(strings.ToLower(response))
+			if response != "y" && response != "yes" {
+				_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "Changes discarded.")
+				return nil
+			}
+
+			cfg, err := configpkg.Load(configPath)
+			if err != nil {
+				return fmt.Errorf("load config: %w", err)
+			}
+
+			editedProfile.Name = agentName
+			if cfg.Agents == nil {
+				cfg.Agents = make(map[string]configpkg.AgentProfile)
+			}
+			cfg.Agents[agentName] = editedProfile
+
+			if err := cfg.SaveTo(configPath); err != nil {
+				return fmt.Errorf("save config: %w", err)
+			}
+
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Profile for %q updated.\n", agentName)
+			return nil
+		},
+	}
+	return agentProfileEditCmd
+}
+
+func newAgentProfileExportCmd() *cobra.Command {
+	agentProfileExportCmd := &cobra.Command{
+		Use:   "export",
+		Short: "Export agent profile as YAML",
+		Long: `Export the agent profile to stdout or to a file.
+Output is in YAML format by default.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			agentName := mustGetProfileAgentName(cmd)
+			outputPath, _ := cmd.Flags().GetString("output")
+
+			profile, err := loadAgentProfile(agentName)
+			if err != nil {
+				return err
+			}
+
+			var out *os.File
+			if outputPath != "" {
+				f, err := os.Create(filepath.Clean(outputPath))
+				if err != nil {
+					return fmt.Errorf("create output file: %w", err)
+				}
+				defer func() { _ = f.Close() }()
+				out = f
+			} else {
+				out = os.Stdout
+			}
+
+			enc := yaml.NewEncoder(out)
 			enc.SetIndent(2)
 			defer func() { _ = enc.Close() }()
 			return enc.Encode(profile)
-		}
-	},
-}
-
-var agentProfileEditCmd = &cobra.Command{
-	Use:   "edit",
-	Short: "Edit agent profile in $EDITOR",
-	Long: `Open the agent profile in your configured editor ($EDITOR or $VISUAL).
-After saving, the profile is validated and you are prompted to apply changes.`,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		agentName := mustGetProfileAgentName(cmd)
-
-		editor := os.Getenv("EDITOR")
-		if editor == "" {
-			editor = os.Getenv("VISUAL")
-		}
-		if editor == "" {
-			return fmt.Errorf("neither $EDITOR nor $VISUAL is set")
-		}
-
-		vaultDir := cli.GetVaultDir()
-		configPath := filepath.Join(vaultDir, "config.yaml")
-
-		data, err := os.ReadFile(filepath.Clean(configPath))
-		if err != nil {
-			return fmt.Errorf("read config: %w", err)
-		}
-
-		tmpFile, err := os.CreateTemp("", fmt.Sprintf("symaira-agent-%s-*.yaml", agentName))
-		if err != nil {
-			return fmt.Errorf("create temp file: %w", err)
-		}
-		tmpPath := tmpFile.Name()
-		defer func() { _ = os.Remove(tmpPath) }()
-
-		section, err := extractAgentSection(data, agentName)
-		if err != nil {
-			_ = tmpFile.Close()
-			return fmt.Errorf("extract agent section: %w", err)
-		}
-
-		if _, writeErr := tmpFile.Write(section); writeErr != nil {
-			_ = tmpFile.Close()
-			return fmt.Errorf("write temp file: %w", writeErr)
-		}
-		_ = tmpFile.Close()
-
-		// #nosec G204 — editor is from user's $EDITOR/$VISUAL env var; tmpPath is a controlled temp file.
-		editorCmd := exec.Command(filepath.Clean(editor), filepath.Clean(tmpPath))
-		editorCmd.Stdin = os.Stdin
-		editorCmd.Stdout = os.Stdout
-		editorCmd.Stderr = os.Stderr
-		if runErr := editorCmd.Run(); runErr != nil {
-			return fmt.Errorf("editor exited with error: %w", runErr)
-		}
-
-		editedData, err := os.ReadFile(filepath.Clean(tmpPath))
-		if err != nil {
-			return fmt.Errorf("read edited file: %w", err)
-		}
-
-		var editedProfile configpkg.AgentProfile
-		if unmarshalErr := yaml.Unmarshal(editedData, &editedProfile); unmarshalErr != nil {
-			return fmt.Errorf("invalid YAML in edited profile: %w", unmarshalErr)
-		}
-
-		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Edited profile for %q:\n", agentName)
-		showProfilePreview(cmd, &editedProfile)
-
-		_, _ = fmt.Fprint(cmd.ErrOrStderr(), "\nApply changes? [y/N] ")
-		var response string
-		_, _ = fmt.Scanln(&response)
-		response = strings.TrimSpace(strings.ToLower(response))
-		if response != "y" && response != "yes" {
-			_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "Changes discarded.")
-			return nil
-		}
-
-		cfg, err := configpkg.Load(configPath)
-		if err != nil {
-			return fmt.Errorf("load config: %w", err)
-		}
-
-		editedProfile.Name = agentName
-		if cfg.Agents == nil {
-			cfg.Agents = make(map[string]configpkg.AgentProfile)
-		}
-		cfg.Agents[agentName] = editedProfile
-
-		if err := cfg.SaveTo(configPath); err != nil {
-			return fmt.Errorf("save config: %w", err)
-		}
-
-		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Profile for %q updated.\n", agentName)
-		return nil
-	},
-}
-
-var agentProfileExportCmd = &cobra.Command{
-	Use:   "export",
-	Short: "Export agent profile as YAML",
-	Long: `Export the agent profile to stdout or to a file.
-Output is in YAML format by default.`,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		agentName := mustGetProfileAgentName(cmd)
-		outputPath, _ := cmd.Flags().GetString("output")
-
-		profile, err := loadAgentProfile(agentName)
-		if err != nil {
-			return err
-		}
-
-		var out *os.File
-		if outputPath != "" {
-			f, err := os.Create(filepath.Clean(outputPath))
-			if err != nil {
-				return fmt.Errorf("create output file: %w", err)
-			}
-			defer func() { _ = f.Close() }()
-			out = f
-		} else {
-			out = os.Stdout
-		}
-
-		enc := yaml.NewEncoder(out)
-		enc.SetIndent(2)
-		defer func() { _ = enc.Close() }()
-		return enc.Encode(profile)
-	},
+		},
+	}
+	agentProfileExportCmd.Flags().StringP("output", "o", "", "Output file path (default: stdout)")
+	return agentProfileExportCmd
 }
 
 func loadAgentProfile(agentName string) (*configpkg.AgentProfile, error) {
@@ -238,14 +255,4 @@ func showProfilePreview(cmd *cobra.Command, profile *configpkg.AgentProfile) {
 	enc.SetIndent(2)
 	defer func() { _ = enc.Close() }()
 	_ = enc.Encode(profile)
-}
-
-func init() {
-	agentProfileCmd.AddCommand(agentProfileShowCmd)
-	agentProfileCmd.AddCommand(agentProfileEditCmd)
-	agentProfileCmd.AddCommand(agentProfileExportCmd)
-	agentCmd.AddCommand(agentProfileCmd)
-
-	agentProfileShowCmd.Flags().StringP("output", "o", "yaml", "Output format (yaml, json)")
-	agentProfileExportCmd.Flags().StringP("output", "o", "", "Output file path (default: stdout)")
 }

--- a/cmd/mcp/agent_skill.go
+++ b/cmd/mcp/agent_skill.go
@@ -15,71 +15,83 @@ import (
 	configpkg "github.com/danieljustus/symaira-vault/internal/config"
 )
 
-var agentSkillCmd = &cobra.Command{
-	Use:   "skill",
-	Short: "Manage agent skill packages",
-	Long:  `Export or refresh embedded skill packages for AI agents.`,
+func newAgentSkillCmd() *cobra.Command {
+	agentSkillCmd := &cobra.Command{
+		Use:   "skill",
+		Short: "Manage agent skill packages",
+		Long:  `Export or refresh embedded skill packages for AI agents.`,
+	}
+	agentSkillCmd.AddCommand(newAgentSkillExportCmd())
+	agentSkillCmd.AddCommand(newAgentSkillRefreshCmd())
+	return agentSkillCmd
 }
 
-var agentSkillExportCmd = &cobra.Command{
-	Use:   "export <agent>",
-	Short: "Export a rendered skill package for an agent",
-	Long: `Pack the rendered skill file as a tar.gz archive for drop-in distribution.
+func newAgentSkillExportCmd() *cobra.Command {
+	agentSkillExportCmd := &cobra.Command{
+		Use:   "export <agent>",
+		Short: "Export a rendered skill package for an agent",
+		Long: `Pack the rendered skill file as a tar.gz archive for drop-in distribution.
 The archive contains the rendered skill file (SKILL.md or AGENTS.md) and an
 INSTALL.md with manual install instructions.`,
-	Args: cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		agentName := args[0]
-		outputPath, _ := cmd.Flags().GetString("output")
-		if outputPath == "" {
-			outputPath = fmt.Sprintf("symvault-%s-skill.tar.gz", agentName)
-		}
-		outputPath = filepath.Clean(outputPath)
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			agentName := args[0]
+			outputPath, _ := cmd.Flags().GetString("output")
+			if outputPath == "" {
+				outputPath = fmt.Sprintf("symvault-%s-skill.tar.gz", agentName)
+			}
+			outputPath = filepath.Clean(outputPath)
 
-		vars := buildTemplateVars(agentName)
+			vars := buildTemplateVars(agentName)
 
-		f, err := os.Create(outputPath)
-		if err != nil {
-			return fmt.Errorf("create output file: %w", err)
-		}
-		defer func() { _ = f.Close() }()
+			f, err := os.Create(outputPath)
+			if err != nil {
+				return fmt.Errorf("create output file: %w", err)
+			}
+			defer func() { _ = f.Close() }()
 
-		if err := agentskill.Export(agentName, vars, f); err != nil {
-			_ = f.Close()
-			_ = os.Remove(outputPath)
-			return fmt.Errorf("export skill: %w", err)
-		}
+			if err := agentskill.Export(agentName, vars, f); err != nil {
+				_ = f.Close()
+				_ = os.Remove(outputPath)
+				return fmt.Errorf("export skill: %w", err)
+			}
 
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Exported skill for %s to %s\n", agentName, outputPath)
-		return nil
-	},
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Exported skill for %s to %s\n", agentName, outputPath)
+			return nil
+		},
+	}
+	agentSkillExportCmd.Flags().StringP("output", "o", "", "Output file path (default: symvault-<agent>-skill.tar.gz)")
+	return agentSkillExportCmd
 }
 
-var agentSkillRefreshCmd = &cobra.Command{
-	Use:   "refresh <agent>",
-	Short: "Refresh an installed skill file in place",
-	Long: `Re-render the skill template for an agent and overwrite the installed
+func newAgentSkillRefreshCmd() *cobra.Command {
+	agentSkillRefreshCmd := &cobra.Command{
+		Use:   "refresh <agent>",
+		Short: "Refresh an installed skill file in place",
+		Long: `Re-render the skill template for an agent and overwrite the installed
 skill file if the hash has changed. Creates a backup before overwriting.`,
-	Args: cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		agentName := args[0]
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			agentName := args[0]
 
-		vars := buildTemplateVars(agentName)
+			vars := buildTemplateVars(agentName)
 
-		targetPath := getSkillTargetPath(agentName)
-		if targetPath == "" {
-			return fmt.Errorf("no skill path configured for agent %q", agentName)
-		}
+			targetPath := getSkillTargetPath(agentName)
+			if targetPath == "" {
+				return fmt.Errorf("no skill path configured for agent %q", agentName)
+			}
 
-		targetPath = expandTilde(targetPath)
+			targetPath = expandTilde(targetPath)
 
-		if err := agentskill.Refresh(agentName, targetPath, vars); err != nil {
-			return fmt.Errorf("refresh skill: %w", err)
-		}
+			if err := agentskill.Refresh(agentName, targetPath, vars); err != nil {
+				return fmt.Errorf("refresh skill: %w", err)
+			}
 
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Refreshed skill for %s at %s\n", agentName, targetPath)
-		return nil
-	},
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Refreshed skill for %s at %s\n", agentName, targetPath)
+			return nil
+		},
+	}
+	return agentSkillRefreshCmd
 }
 
 func buildTemplateVars(agentName string) agentskill.TemplateVars {
@@ -121,12 +133,4 @@ func expandTilde(path string) string {
 		return path
 	}
 	return filepath.Join(home, path[2:])
-}
-
-func init() {
-	agentSkillExportCmd.Flags().StringP("output", "o", "", "Output file path (default: symvault-<agent>-skill.tar.gz)")
-
-	agentSkillCmd.AddCommand(agentSkillExportCmd)
-	agentSkillCmd.AddCommand(agentSkillRefreshCmd)
-	agentCmd.AddCommand(agentSkillCmd)
 }

--- a/cmd/mcp/agent_token.go
+++ b/cmd/mcp/agent_token.go
@@ -12,12 +12,13 @@ import (
 	auth "github.com/danieljustus/symaira-vault/internal/mcp/auth"
 )
 
-var agentTokenCmd = &cobra.Command{
-	Use:   "token <name>",
-	Short: "Manage tokens for an agent",
-	Long:  `Create, list, revoke, and rotate scoped tokens for a specific agent.`,
-	Args:  cobra.ExactArgs(1),
-	Example: `  # Create a scoped token for an agent
+func newAgentTokenCmd() *cobra.Command {
+	agentTokenCmd := &cobra.Command{
+		Use:   "token <name>",
+		Short: "Manage tokens for an agent",
+		Long:  `Create, list, revoke, and rotate scoped tokens for a specific agent.`,
+		Args:  cobra.ExactArgs(1),
+		Example: `  # Create a scoped token for an agent
   symvault agent token my-agent new
 
   # List tokens for an agent
@@ -28,232 +29,256 @@ var agentTokenCmd = &cobra.Command{
 
   # Rotate an agent's token (revoke + create new)
   symvault agent token my-agent rotate`,
+	}
+	agentTokenCmd.AddCommand(newAgentTokenNewCmd())
+	agentTokenCmd.AddCommand(newAgentTokenListCmd())
+	agentTokenCmd.AddCommand(newAgentTokenRevokeCmd())
+	agentTokenCmd.AddCommand(newAgentTokenRotateCmd())
+	return agentTokenCmd
 }
 
-var agentTokenNewCmd = &cobra.Command{
-	Use:   "new",
-	Short: "Create a new scoped token for the agent",
-	Long: `Create a new scoped MCP token associated with the named agent.
+func newAgentTokenNewCmd() *cobra.Command {
+	agentTokenNewCmd := &cobra.Command{
+		Use:   "new",
+		Short: "Create a new scoped token for the agent",
+		Long: `Create a new scoped MCP token associated with the named agent.
 
 The raw token is printed exactly once — copy it immediately. It cannot be
 retrieved later.`,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		agentName := mustGetAgentName(cmd)
-		tools, _ := cmd.Flags().GetStringSlice("tools")
-		ttlStr, _ := cmd.Flags().GetString("ttl")
-		label, _ := cmd.Flags().GetString("label")
+		RunE: func(cmd *cobra.Command, args []string) error {
+			agentName := mustGetAgentName(cmd)
+			tools, _ := cmd.Flags().GetStringSlice("tools")
+			ttlStr, _ := cmd.Flags().GetString("ttl")
+			label, _ := cmd.Flags().GetString("label")
 
-		if len(tools) == 0 {
-			return fmt.Errorf("at least one tool must be specified (use --tools '*')")
-		}
-
-		vDir, err := cli.VaultPath()
-		if err != nil {
-			return err
-		}
-
-		ttl, err := ResolveTokenTTL(vDir, ttlStr)
-		if err != nil {
-			return err
-		}
-
-		regPath := auth.TokenRegistryFilePath(vDir)
-		reg := auth.NewTokenRegistry(regPath)
-		if loadErr := reg.Load(); loadErr != nil {
-			return fmt.Errorf("load token registry: %w", loadErr)
-		}
-
-		token, rawToken, err := reg.Create(label, tools, agentName, ttl)
-		if err != nil {
-			return fmt.Errorf("create token: %w", err)
-		}
-
-		if err := reg.Save(); err != nil {
-			return fmt.Errorf("save token registry: %w", err)
-		}
-
-		cli.PrintlnQuietAware("Token created successfully.")
-		cli.PrintQuietAware("  ID:    %s\n", token.ID)
-		cli.PrintQuietAware("  Label: %s\n", token.Label)
-		if token.AgentName != "" {
-			cli.PrintQuietAware("  Agent: %s\n", token.AgentName)
-		}
-		cli.PrintQuietAware("  Tools: %s\n", strings.Join(token.AllowedTools, ", "))
-		if token.ExpiresAt != nil {
-			cli.PrintQuietAware("  Expires: %s\n", token.ExpiresAt.Format(time.RFC3339))
-		} else {
-			cli.PrintQuietAware("  Expires: never\n")
-		}
-		cli.PrintlnQuietAware()
-		cli.PrintQuietAware("Raw token (copy now — shown once): %s\n", rawToken)
-		cli.PrintlnQuietAware()
-		cli.PrintlnQuietAware("Warning: This is the only time the raw token is displayed.")
-		cli.PrintlnQuietAware("         Store it securely — it cannot be retrieved later.")
-
-		return nil
-	},
-}
-
-var agentTokenListCmd = &cobra.Command{
-	Use:   "list",
-	Short: "List tokens for this agent",
-	Long:  `List all scoped tokens associated with the given agent name.`,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		agentName := mustGetAgentName(cmd)
-
-		vDir, err := cli.VaultPath()
-		if err != nil {
-			return err
-		}
-
-		regPath := auth.TokenRegistryFilePath(vDir)
-		reg := auth.NewTokenRegistry(regPath)
-		if err := reg.Load(); err != nil {
-			return fmt.Errorf("load token registry: %w", err)
-		}
-
-		allTokens := reg.List()
-		var tokens []*auth.ScopedToken
-		for i := range allTokens {
-			if allTokens[i].AgentName == agentName {
-				tokens = append(tokens, allTokens[i])
+			if len(tools) == 0 {
+				return fmt.Errorf("at least one tool must be specified (use --tools '*')")
 			}
-		}
 
-		if len(tokens) == 0 {
-			cli.PrintQuietAware("No tokens found for agent %q.\n", agentName)
+			vDir, err := cli.VaultPath()
+			if err != nil {
+				return err
+			}
+
+			ttl, err := ResolveTokenTTL(vDir, ttlStr)
+			if err != nil {
+				return err
+			}
+
+			regPath := auth.TokenRegistryFilePath(vDir)
+			reg := auth.NewTokenRegistry(regPath)
+			if loadErr := reg.Load(); loadErr != nil {
+				return fmt.Errorf("load token registry: %w", loadErr)
+			}
+
+			token, rawToken, err := reg.Create(label, tools, agentName, ttl)
+			if err != nil {
+				return fmt.Errorf("create token: %w", err)
+			}
+
+			if err := reg.Save(); err != nil {
+				return fmt.Errorf("save token registry: %w", err)
+			}
+
+			cli.PrintlnQuietAware("Token created successfully.")
+			cli.PrintQuietAware("  ID:    %s\n", token.ID)
+			cli.PrintQuietAware("  Label: %s\n", token.Label)
+			if token.AgentName != "" {
+				cli.PrintQuietAware("  Agent: %s\n", token.AgentName)
+			}
+			cli.PrintQuietAware("  Tools: %s\n", strings.Join(token.AllowedTools, ", "))
+			if token.ExpiresAt != nil {
+				cli.PrintQuietAware("  Expires: %s\n", token.ExpiresAt.Format(time.RFC3339))
+			} else {
+				cli.PrintQuietAware("  Expires: never\n")
+			}
+			cli.PrintlnQuietAware()
+			cli.PrintQuietAware("Raw token (copy now — shown once): %s\n", rawToken)
+			cli.PrintlnQuietAware()
+			cli.PrintlnQuietAware("Warning: This is the only time the raw token is displayed.")
+			cli.PrintlnQuietAware("         Store it securely — it cannot be retrieved later.")
+
 			return nil
-		}
-
-		cli.PrintQuietAware("%-22s %-16s %-14s %-28s %-20s %s\n", "ID", "LABEL", "AGENT", "TOOLS", "EXPIRES AT", "STATUS")
-		for i := range tokens {
-			status := "active"
-			if tokens[i].Revoked {
-				status = "revoked"
-			} else if tokens[i].IsExpired() {
-				status = "expired"
-			}
-
-			label := tokens[i].Label
-			if label == "" {
-				label = "-"
-			}
-			agent := tokens[i].AgentName
-			if agent == "" {
-				agent = "-"
-			}
-			tools := strings.Join(tokens[i].AllowedTools, ", ")
-			if len(tools) > 26 {
-				tools = tools[:23] + "..."
-			}
-			expires := "never"
-			if tokens[i].ExpiresAt != nil {
-				expires = tokens[i].ExpiresAt.Format("2006-01-02 15:04")
-			}
-
-			cli.PrintQuietAware("%-22s %-16s %-14s %-28s %-20s %s\n", tokens[i].ID, label, agent, tools, expires, status)
-		}
-
-		return nil
-	},
+		},
+	}
+	agentTokenNewCmd.Flags().StringSlice("tools", []string{"*"}, "Comma-separated allowed tools, or '*' for all")
+	agentTokenNewCmd.Flags().String("ttl", "", "Token TTL (e.g. 24h, 7d); defaults to mcp.scoped_token_ttl from config")
+	agentTokenNewCmd.Flags().String("label", "", "Human-readable label")
+	return agentTokenNewCmd
 }
 
-var agentTokenRevokeCmd = &cobra.Command{
-	Use:   "revoke <token-id>",
-	Short: "Revoke a scoped token",
-	Long:  `Revoke a scoped token by its ID. Revoked tokens are immediately invalidated.`,
-	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		tokenID := args[0]
+func newAgentTokenListCmd() *cobra.Command {
+	agentTokenListCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List tokens for this agent",
+		Long:  `List all scoped tokens associated with the given agent name.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			agentName := mustGetAgentName(cmd)
 
-		vDir, err := cli.VaultPath()
-		if err != nil {
-			return err
-		}
+			vDir, err := cli.VaultPath()
+			if err != nil {
+				return err
+			}
 
-		regPath := auth.TokenRegistryFilePath(vDir)
-		reg := auth.NewTokenRegistry(regPath)
-		if err := reg.Load(); err != nil {
-			return fmt.Errorf("load token registry: %w", err)
-		}
+			regPath := auth.TokenRegistryFilePath(vDir)
+			reg := auth.NewTokenRegistry(regPath)
+			if err := reg.Load(); err != nil {
+				return fmt.Errorf("load token registry: %w", err)
+			}
 
-		if !reg.Revoke(tokenID) {
-			return fmt.Errorf("token %q not found or already revoked", tokenID)
-		}
+			allTokens := reg.List()
+			var tokens []*auth.ScopedToken
+			for i := range allTokens {
+				if allTokens[i].AgentName == agentName {
+					tokens = append(tokens, allTokens[i])
+				}
+			}
 
-		if err := reg.Save(); err != nil {
-			return fmt.Errorf("save token registry: %w", err)
-		}
+			if len(tokens) == 0 {
+				cli.PrintQuietAware("No tokens found for agent %q.\n", agentName)
+				return nil
+			}
 
-		cli.PrintQuietAware("Token %s revoked successfully.\n", tokenID)
-		return nil
-	},
+			cli.PrintQuietAware("%-22s %-16s %-14s %-28s %-20s %s\n", "ID", "LABEL", "AGENT", "TOOLS", "EXPIRES AT", "STATUS")
+			for i := range tokens {
+				status := "active"
+				if tokens[i].Revoked {
+					status = "revoked"
+				} else if tokens[i].IsExpired() {
+					status = "expired"
+				}
+
+				label := tokens[i].Label
+				if label == "" {
+					label = "-"
+				}
+				agent := tokens[i].AgentName
+				if agent == "" {
+					agent = "-"
+				}
+				tools := strings.Join(tokens[i].AllowedTools, ", ")
+				if len(tools) > 26 {
+					tools = tools[:23] + "..."
+				}
+				expires := "never"
+				if tokens[i].ExpiresAt != nil {
+					expires = tokens[i].ExpiresAt.Format("2006-01-02 15:04")
+				}
+
+				cli.PrintQuietAware("%-22s %-16s %-14s %-28s %-20s %s\n", tokens[i].ID, label, agent, tools, expires, status)
+			}
+
+			return nil
+		},
+	}
+	return agentTokenListCmd
 }
 
-var agentTokenRotateCmd = &cobra.Command{
-	Use:   "rotate",
-	Short: "Rotate the agent's token",
-	Long: `Revoke the current token for this agent and create a new one.
+func newAgentTokenRevokeCmd() *cobra.Command {
+	agentTokenRevokeCmd := &cobra.Command{
+		Use:   "revoke <token-id>",
+		Short: "Revoke a scoped token",
+		Long:  `Revoke a scoped token by its ID. Revoked tokens are immediately invalidated.`,
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			tokenID := args[0]
+
+			vDir, err := cli.VaultPath()
+			if err != nil {
+				return err
+			}
+
+			regPath := auth.TokenRegistryFilePath(vDir)
+			reg := auth.NewTokenRegistry(regPath)
+			if err := reg.Load(); err != nil {
+				return fmt.Errorf("load token registry: %w", err)
+			}
+
+			if !reg.Revoke(tokenID) {
+				return fmt.Errorf("token %q not found or already revoked", tokenID)
+			}
+
+			if err := reg.Save(); err != nil {
+				return fmt.Errorf("save token registry: %w", err)
+			}
+
+			cli.PrintQuietAware("Token %s revoked successfully.\n", tokenID)
+			return nil
+		},
+	}
+	return agentTokenRevokeCmd
+}
+
+func newAgentTokenRotateCmd() *cobra.Command {
+	agentTokenRotateCmd := &cobra.Command{
+		Use:   "rotate",
+		Short: "Rotate the agent's token",
+		Long: `Revoke the current token for this agent and create a new one.
 The new raw token is printed exactly once.`,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		agentName := mustGetAgentName(cmd)
-		tools, _ := cmd.Flags().GetStringSlice("tools")
-		ttlStr, _ := cmd.Flags().GetString("ttl")
-		label, _ := cmd.Flags().GetString("label")
+		RunE: func(cmd *cobra.Command, args []string) error {
+			agentName := mustGetAgentName(cmd)
+			tools, _ := cmd.Flags().GetStringSlice("tools")
+			ttlStr, _ := cmd.Flags().GetString("ttl")
+			label, _ := cmd.Flags().GetString("label")
 
-		if len(tools) == 0 {
-			return fmt.Errorf("at least one tool must be specified (use --tools '*')")
-		}
-
-		vDir, err := cli.VaultPath()
-		if err != nil {
-			return err
-		}
-
-		regPath := auth.TokenRegistryFilePath(vDir)
-		reg := auth.NewTokenRegistry(regPath)
-		if loadErr := reg.Load(); loadErr != nil {
-			return fmt.Errorf("load token registry: %w", loadErr)
-		}
-
-		allTokens := reg.List()
-		for i := range allTokens {
-			if allTokens[i].AgentName == agentName && !allTokens[i].Revoked {
-				reg.Revoke(allTokens[i].ID)
+			if len(tools) == 0 {
+				return fmt.Errorf("at least one tool must be specified (use --tools '*')")
 			}
-		}
 
-		ttl, err := ResolveTokenTTL(vDir, ttlStr)
-		if err != nil {
-			return err
-		}
+			vDir, err := cli.VaultPath()
+			if err != nil {
+				return err
+			}
 
-		token, rawToken, err := reg.Create(label, tools, agentName, ttl)
-		if err != nil {
-			return fmt.Errorf("create token: %w", err)
-		}
+			regPath := auth.TokenRegistryFilePath(vDir)
+			reg := auth.NewTokenRegistry(regPath)
+			if loadErr := reg.Load(); loadErr != nil {
+				return fmt.Errorf("load token registry: %w", loadErr)
+			}
 
-		if err := reg.Save(); err != nil {
-			return fmt.Errorf("save token registry: %w", err)
-		}
+			allTokens := reg.List()
+			for i := range allTokens {
+				if allTokens[i].AgentName == agentName && !allTokens[i].Revoked {
+					reg.Revoke(allTokens[i].ID)
+				}
+			}
 
-		cli.PrintlnQuietAware("Token rotated successfully.")
-		cli.PrintQuietAware("  ID:    %s\n", token.ID)
-		cli.PrintQuietAware("  Label: %s\n", token.Label)
-		cli.PrintQuietAware("  Agent: %s\n", token.AgentName)
-		cli.PrintQuietAware("  Tools: %s\n", strings.Join(token.AllowedTools, ", "))
-		if token.ExpiresAt != nil {
-			cli.PrintQuietAware("  Expires: %s\n", token.ExpiresAt.Format(time.RFC3339))
-		} else {
-			cli.PrintQuietAware("  Expires: never\n")
-		}
-		cli.PrintlnQuietAware()
-		cli.PrintQuietAware("Raw token (copy now — shown once): %s\n", rawToken)
-		cli.PrintlnQuietAware()
-		cli.PrintlnQuietAware("Warning: This is the only time the raw token is displayed.")
+			ttl, err := ResolveTokenTTL(vDir, ttlStr)
+			if err != nil {
+				return err
+			}
 
-		return nil
-	},
+			token, rawToken, err := reg.Create(label, tools, agentName, ttl)
+			if err != nil {
+				return fmt.Errorf("create token: %w", err)
+			}
+
+			if err := reg.Save(); err != nil {
+				return fmt.Errorf("save token registry: %w", err)
+			}
+
+			cli.PrintlnQuietAware("Token rotated successfully.")
+			cli.PrintQuietAware("  ID:    %s\n", token.ID)
+			cli.PrintQuietAware("  Label: %s\n", token.Label)
+			cli.PrintQuietAware("  Agent: %s\n", token.AgentName)
+			cli.PrintQuietAware("  Tools: %s\n", strings.Join(token.AllowedTools, ", "))
+			if token.ExpiresAt != nil {
+				cli.PrintQuietAware("  Expires: %s\n", token.ExpiresAt.Format(time.RFC3339))
+			} else {
+				cli.PrintQuietAware("  Expires: never\n")
+			}
+			cli.PrintlnQuietAware()
+			cli.PrintQuietAware("Raw token (copy now — shown once): %s\n", rawToken)
+			cli.PrintlnQuietAware()
+			cli.PrintlnQuietAware("Warning: This is the only time the raw token is displayed.")
+
+			return nil
+		},
+	}
+	agentTokenRotateCmd.Flags().StringSlice("tools", []string{"*"}, "Comma-separated allowed tools, or '*' for all")
+	agentTokenRotateCmd.Flags().String("ttl", "", "Token TTL (e.g. 24h, 7d); defaults to mcp.scoped_token_ttl from config")
+	agentTokenRotateCmd.Flags().String("label", "", "Human-readable label")
+	return agentTokenRotateCmd
 }
 
 func mustGetAgentName(cmd *cobra.Command) string {
@@ -265,20 +290,4 @@ func mustGetAgentName(cmd *cobra.Command) string {
 		}
 	}
 	return "unknown"
-}
-
-func init() {
-	agentTokenCmd.AddCommand(agentTokenNewCmd)
-	agentTokenCmd.AddCommand(agentTokenListCmd)
-	agentTokenCmd.AddCommand(agentTokenRevokeCmd)
-	agentTokenCmd.AddCommand(agentTokenRotateCmd)
-	agentCmd.AddCommand(agentTokenCmd)
-
-	agentTokenNewCmd.Flags().StringSlice("tools", []string{"*"}, "Comma-separated allowed tools, or '*' for all")
-	agentTokenNewCmd.Flags().String("ttl", "", "Token TTL (e.g. 24h, 7d); defaults to mcp.scoped_token_ttl from config")
-	agentTokenNewCmd.Flags().String("label", "", "Human-readable label")
-
-	agentTokenRotateCmd.Flags().StringSlice("tools", []string{"*"}, "Comma-separated allowed tools, or '*' for all")
-	agentTokenRotateCmd.Flags().String("ttl", "", "Token TTL (e.g. 24h, 7d); defaults to mcp.scoped_token_ttl from config")
-	agentTokenRotateCmd.Flags().String("label", "", "Human-readable label")
 }

--- a/cmd/mcp/agent_uninstall.go
+++ b/cmd/mcp/agent_uninstall.go
@@ -35,10 +35,11 @@ func confirmUninstall(name string) bool {
 	return reply == "y" || reply == "yes"
 }
 
-var agentUninstallCmd = &cobra.Command{
-	Use:   "uninstall <name>",
-	Short: "Remove an agent integration",
-	Long: `Remove an agent profile, revoke all tokens, uninstall the skill file,
+func newAgentUninstallCmd() *cobra.Command {
+	agentUninstallCmd := &cobra.Command{
+		Use:   "uninstall <name>",
+		Short: "Remove an agent integration",
+		Long: `Remove an agent profile, revoke all tokens, uninstall the skill file,
 and clean up associated data.
 
 This command:
@@ -49,105 +50,102 @@ This command:
 
 Use --keep-skill to preserve the skill file and --keep-config to keep the
 agent's profile in config.yaml. Use --yes to skip the confirmation prompt.`,
-	Args: cobra.ExactArgs(1),
-	Example: `  # Interactive uninstall with confirmation
+		Args: cobra.ExactArgs(1),
+		Example: `  # Interactive uninstall with confirmation
   symvault agent uninstall hermes
 
   # Non-interactive uninstall keeping the skill file
   symvault agent uninstall claude-code --yes --keep-skill`,
-	Annotations: map[string]string{
-		cli.RequiresVaultAnnotation: "false",
-	},
-	RunE: func(cmd *cobra.Command, args []string) error {
-		agentName := args[0]
+		Annotations: map[string]string{
+			cli.RequiresVaultAnnotation: "false",
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			agentName := args[0]
 
-		vaultDir := cli.GetVaultDir()
-		configPath := filepath.Join(vaultDir, "config.yaml")
-		cfg, err := configpkg.Load(configPath)
-		if err != nil {
-			return fmt.Errorf("load config: %w", err)
-		}
-
-		profile, hasProfile := cfg.Agents[agentName]
-		if !hasProfile {
-			return fmt.Errorf("agent %q not found in config", agentName)
-		}
-		profile.Normalize()
-
-		if !agentUninstallYes && !confirmUninstall(agentName) {
-			cliout.Warnf("Uninstall canceled.")
-			return nil
-		}
-
-		if !agentUninstallKeepConfig {
-			delete(cfg.Agents, agentName)
-			if err := cfg.SaveTo(configPath); err != nil {
-				return fmt.Errorf("save config: %w", err)
+			vaultDir := cli.GetVaultDir()
+			configPath := filepath.Join(vaultDir, "config.yaml")
+			cfg, err := configpkg.Load(configPath)
+			if err != nil {
+				return fmt.Errorf("load config: %w", err)
 			}
-			cliout.Hintf("\u2713 Profile for %q removed from config", agentName)
-		} else {
-			cliout.Warnf("\u26a0 Keeping profile for %q in config (--keep-config)", agentName)
-		}
 
-		regPath := auth.TokenRegistryFilePath(vaultDir)
-		reg := auth.NewTokenRegistry(regPath)
-		revokedCount := 0
-		if loadErr := reg.Load(); loadErr == nil {
-			for _, tok := range reg.List() {
-				if tok.AgentName == agentName && !tok.Revoked {
-					reg.Revoke(tok.ID)
-					revokedCount++
+			profile, hasProfile := cfg.Agents[agentName]
+			if !hasProfile {
+				return fmt.Errorf("agent %q not found in config", agentName)
+			}
+			profile.Normalize()
+
+			if !agentUninstallYes && !confirmUninstall(agentName) {
+				cliout.Warnf("Uninstall canceled.")
+				return nil
+			}
+
+			if !agentUninstallKeepConfig {
+				delete(cfg.Agents, agentName)
+				if err := cfg.SaveTo(configPath); err != nil {
+					return fmt.Errorf("save config: %w", err)
 				}
-			}
-			if revokedCount > 0 {
-				if saveErr := reg.Save(); saveErr != nil {
-					cliout.Warnf("\u26a0 Failed to save token registry: %v", saveErr)
-				}
-			}
-		}
-		if revokedCount > 0 {
-			cliout.Hintf("\u2713 Revoked %d token(s) for %q", revokedCount, agentName)
-		}
-
-		tokenFilePath := filepath.Join(vaultDir, "mcp-tokens", agentName+".token")
-		if _, statErr := os.Stat(tokenFilePath); statErr == nil {
-			if rmErr := os.Remove(tokenFilePath); rmErr != nil {
-				cliout.Warnf("\u26a0 Failed to remove token file %s: %v", tokenFilePath, rmErr)
+				cliout.Hintf("\u2713 Profile for %q removed from config", agentName)
 			} else {
-				cliout.Hintf("\u2713 Removed token file %s", tokenFilePath)
+				cliout.Warnf("\u26a0 Keeping profile for %q in config (--keep-config)", agentName)
 			}
-		}
 
-		if !agentUninstallKeepSkill {
-			skillPath := profile.SkillPathValue()
-			if skillPath != "" {
-				expanded := expandTilde(skillPath)
-				expanded = filepath.Clean(expanded)
-				if data, readErr := os.ReadFile(expanded); readErr == nil {
-					manifest, parseErr := agentskill.ParseManifest(data)
-					if parseErr == nil && manifest.ManagedBy == agentskill.SentinelValue {
-						if rmErr := os.Remove(expanded); rmErr != nil {
-							cliout.Warnf("\u26a0 Failed to remove skill file %s: %v", expanded, rmErr)
-						} else {
-							cliout.Hintf("\u2713 Removed skill file %s", expanded)
-						}
+			regPath := auth.TokenRegistryFilePath(vaultDir)
+			reg := auth.NewTokenRegistry(regPath)
+			revokedCount := 0
+			if loadErr := reg.Load(); loadErr == nil {
+				for _, tok := range reg.List() {
+					if tok.AgentName == agentName && !tok.Revoked {
+						reg.Revoke(tok.ID)
+						revokedCount++
+					}
+				}
+				if revokedCount > 0 {
+					if saveErr := reg.Save(); saveErr != nil {
+						cliout.Warnf("\u26a0 Failed to save token registry: %v", saveErr)
 					}
 				}
 			}
-		} else {
-			cliout.Warnf("\u26a0 Keeping skill file (--keep-skill)")
-		}
+			if revokedCount > 0 {
+				cliout.Hintf("\u2713 Revoked %d token(s) for %q", revokedCount, agentName)
+			}
 
-		fmt.Fprintf(os.Stderr, "\nAgent %q has been uninstalled.\n", agentName)
-		fmt.Fprintf(os.Stderr, "Note: MCP server entries in the agent's config file (e.g. mcp.json) must be removed manually.\n")
-		return nil
-	},
-}
+			tokenFilePath := filepath.Join(vaultDir, "mcp-tokens", agentName+".token")
+			if _, statErr := os.Stat(tokenFilePath); statErr == nil {
+				if rmErr := os.Remove(tokenFilePath); rmErr != nil {
+					cliout.Warnf("\u26a0 Failed to remove token file %s: %v", tokenFilePath, rmErr)
+				} else {
+					cliout.Hintf("\u2713 Removed token file %s", tokenFilePath)
+				}
+			}
 
-func init() {
+			if !agentUninstallKeepSkill {
+				skillPath := profile.SkillPathValue()
+				if skillPath != "" {
+					expanded := expandTilde(skillPath)
+					expanded = filepath.Clean(expanded)
+					if data, readErr := os.ReadFile(expanded); readErr == nil {
+						manifest, parseErr := agentskill.ParseManifest(data)
+						if parseErr == nil && manifest.ManagedBy == agentskill.SentinelValue {
+							if rmErr := os.Remove(expanded); rmErr != nil {
+								cliout.Warnf("\u26a0 Failed to remove skill file %s: %v", expanded, rmErr)
+							} else {
+								cliout.Hintf("\u2713 Removed skill file %s", expanded)
+							}
+						}
+					}
+				}
+			} else {
+				cliout.Warnf("\u26a0 Keeping skill file (--keep-skill)")
+			}
+
+			fmt.Fprintf(os.Stderr, "\nAgent %q has been uninstalled.\n", agentName)
+			fmt.Fprintf(os.Stderr, "Note: MCP server entries in the agent's config file (e.g. mcp.json) must be removed manually.\n")
+			return nil
+		},
+	}
 	agentUninstallCmd.Flags().BoolVar(&agentUninstallKeepSkill, "keep-skill", false, "Don't remove the skill file")
 	agentUninstallCmd.Flags().BoolVar(&agentUninstallKeepConfig, "keep-config", false, "Don't modify the agent config file")
 	agentUninstallCmd.Flags().BoolVar(&agentUninstallYes, "yes", false, "Skip confirmation prompt")
-
-	agentCmd.AddCommand(agentUninstallCmd)
+	return agentUninstallCmd
 }

--- a/cmd/mcp/agent_upgrade.go
+++ b/cmd/mcp/agent_upgrade.go
@@ -191,10 +191,11 @@ func confirmUpgrade(agentName, targetTier string) bool {
 	return reply == "y" || reply == "yes"
 }
 
-var agentUpgradeCmd = &cobra.Command{
-	Use:   "upgrade <name>",
-	Short: "Upgrade an agent's security tier",
-	Long: `Show tier diff and upgrade an agent's security tier with interactive confirmation.
+func newAgentUpgradeCmd() *cobra.Command {
+	agentUpgradeCmd := &cobra.Command{
+		Use:   "upgrade <name>",
+		Short: "Upgrade an agent's security tier",
+		Long: `Show tier diff and upgrade an agent's security tier with interactive confirmation.
 
 The upgrade applies the named tier preset (safe, standard, or admin) to the
 agent profile, updating all capability fields. The legacy alias "read-only"
@@ -203,8 +204,8 @@ writing. Use --rotate-token to also rotate the agent's MCP token.
 
 The --reason flag is required when using --yes for non-interactive mode to ensure
 an audit trail.`,
-	Args: cobra.ExactArgs(1),
-	Example: `  # Interactive upgrade to admin tier with token rotation
+		Args: cobra.ExactArgs(1),
+		Example: `  # Interactive upgrade to admin tier with token rotation
   symvault agent upgrade hermes --tier admin --rotate-token
 
   # Dry-run: preview changes without writing
@@ -212,144 +213,141 @@ an audit trail.`,
 
   # Non-interactive upgrade with audit reason
   symvault agent upgrade opencode --tier standard --yes --reason "CI pipeline automation upgrade"`,
-	Annotations: map[string]string{
-		cli.RequiresVaultAnnotation: "false",
-	},
-	RunE: func(cmd *cobra.Command, args []string) error {
-		agentName := args[0]
+		Annotations: map[string]string{
+			cli.RequiresVaultAnnotation: "false",
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			agentName := args[0]
 
-		if agentUpgradeTier == "" {
-			return fmt.Errorf("--tier is required (valid: safe, standard, admin)")
-		}
-		if agentUpgradeYes && agentUpgradeReason == "" {
-			return fmt.Errorf("--reason is required when using --yes")
-		}
-
-		if !agentUpgradeValidTiers[agentUpgradeTier] {
-			return fmt.Errorf("invalid tier %q: valid values are safe, standard, admin", agentUpgradeTier)
-		}
-		agentUpgradeTier = agentUpgradeTierAlias[agentUpgradeTier]
-
-		vaultDir := cli.GetVaultDir()
-		configPath := filepath.Join(vaultDir, "config.yaml")
-		cfg, err := configpkg.Load(configPath)
-		if err != nil {
-			return fmt.Errorf("load config: %w", err)
-		}
-
-		profile, hasProfile := cfg.Agents[agentName]
-		if !hasProfile {
-			return fmt.Errorf("agent %q not found in config", agentName)
-		}
-
-		currentTier := ""
-		if profile.Tier != nil {
-			currentTier = *profile.Tier
-		}
-		if currentTier == "" {
-			currentTier = "custom"
-		}
-		if currentTier == agentUpgradeTier {
-			return fmt.Errorf("agent %q is already at tier %q", agentName, agentUpgradeTier)
-		}
-
-		oldProfile := profile
-		configpkg.ApplyTierPreset(&profile, agentUpgradeTier)
-		profile.Tier = configpkg.StrPtr(agentUpgradeTier)
-		diffs := computeTierDiff(oldProfile, profile)
-
-		fmt.Fprintf(os.Stderr, "Agent:   %s\n", agentName)
-		fmt.Fprintf(os.Stderr, "Current: %s\n", currentTier)
-		fmt.Fprintf(os.Stderr, "Target:  %s\n", agentUpgradeTier)
-		if agentUpgradeReason != "" {
-			fmt.Fprintf(os.Stderr, "Reason:  %s\n", agentUpgradeReason)
-		}
-		fmt.Fprintln(os.Stderr)
-		fmt.Fprintln(os.Stderr, "Tier changes:")
-		printTierDiff(diffs)
-		fmt.Fprintln(os.Stderr)
-
-		if agentUpgradeDryRun {
-			fmt.Fprintln(os.Stderr, "[DRY-RUN] No changes written.")
-			return nil
-		}
-
-		if !agentUpgradeNoBiometric {
-			if err := requireBiometricForUpgrade(cmd.Context(), agentName, agentUpgradeTier); err != nil {
-				return err
+			if agentUpgradeTier == "" {
+				return fmt.Errorf("--tier is required (valid: safe, standard, admin)")
 			}
-		}
-
-		if !agentUpgradeYes && !confirmUpgrade(agentName, agentUpgradeTier) {
-			fmt.Fprintln(os.Stderr, "Upgrade canceled.")
-			return nil
-		}
-
-		cfg.Agents[agentName] = profile
-		if err := cfg.SaveTo(configPath); err != nil {
-			return fmt.Errorf("save config: %w", err)
-		}
-		cliout.Hintf("\u2713 Profile for %q upgraded to %q", agentName, agentUpgradeTier)
-
-		if agentUpgradeRotate {
-			regPath := auth.TokenRegistryFilePath(vaultDir)
-			reg := auth.NewTokenRegistry(regPath)
-			if loadErr := reg.Load(); loadErr != nil {
-				return fmt.Errorf("load token registry: %w", loadErr)
+			if agentUpgradeYes && agentUpgradeReason == "" {
+				return fmt.Errorf("--reason is required when using --yes")
 			}
 
-			for _, tok := range reg.List() {
-				if tok.AgentName == agentName && !tok.Revoked {
-					reg.Revoke(tok.ID)
+			if !agentUpgradeValidTiers[agentUpgradeTier] {
+				return fmt.Errorf("invalid tier %q: valid values are safe, standard, admin", agentUpgradeTier)
+			}
+			agentUpgradeTier = agentUpgradeTierAlias[agentUpgradeTier]
+
+			vaultDir := cli.GetVaultDir()
+			configPath := filepath.Join(vaultDir, "config.yaml")
+			cfg, err := configpkg.Load(configPath)
+			if err != nil {
+				return fmt.Errorf("load config: %w", err)
+			}
+
+			profile, hasProfile := cfg.Agents[agentName]
+			if !hasProfile {
+				return fmt.Errorf("agent %q not found in config", agentName)
+			}
+
+			currentTier := ""
+			if profile.Tier != nil {
+				currentTier = *profile.Tier
+			}
+			if currentTier == "" {
+				currentTier = "custom"
+			}
+			if currentTier == agentUpgradeTier {
+				return fmt.Errorf("agent %q is already at tier %q", agentName, agentUpgradeTier)
+			}
+
+			oldProfile := profile
+			configpkg.ApplyTierPreset(&profile, agentUpgradeTier)
+			profile.Tier = configpkg.StrPtr(agentUpgradeTier)
+			diffs := computeTierDiff(oldProfile, profile)
+
+			fmt.Fprintf(os.Stderr, "Agent:   %s\n", agentName)
+			fmt.Fprintf(os.Stderr, "Current: %s\n", currentTier)
+			fmt.Fprintf(os.Stderr, "Target:  %s\n", agentUpgradeTier)
+			if agentUpgradeReason != "" {
+				fmt.Fprintf(os.Stderr, "Reason:  %s\n", agentUpgradeReason)
+			}
+			fmt.Fprintln(os.Stderr)
+			fmt.Fprintln(os.Stderr, "Tier changes:")
+			printTierDiff(diffs)
+			fmt.Fprintln(os.Stderr)
+
+			if agentUpgradeDryRun {
+				fmt.Fprintln(os.Stderr, "[DRY-RUN] No changes written.")
+				return nil
+			}
+
+			if !agentUpgradeNoBiometric {
+				if err := requireBiometricForUpgrade(cmd.Context(), agentName, agentUpgradeTier); err != nil {
+					return err
 				}
 			}
 
-			newTok, rawToken, createErr := reg.Create(
-				fmt.Sprintf("upgrade-%s-%s", agentName, agentUpgradeTier),
-				[]string{"*"},
-				agentName,
-				0,
-			)
-			if createErr != nil {
-				return fmt.Errorf("create token for %q: %w", agentName, createErr)
-			}
-			if err := reg.Save(); err != nil {
-				return fmt.Errorf("save token registry: %w", err)
+			if !agentUpgradeYes && !confirmUpgrade(agentName, agentUpgradeTier) {
+				fmt.Fprintln(os.Stderr, "Upgrade canceled.")
+				return nil
 			}
 
-			tokenPath, writeErr := writeAgentTokenFile(vaultDir, agentName, rawToken)
-			if writeErr != nil {
-				return fmt.Errorf("write token file: %w", writeErr)
+			cfg.Agents[agentName] = profile
+			if err := cfg.SaveTo(configPath); err != nil {
+				return fmt.Errorf("save config: %w", err)
 			}
-			cliout.Hintf("\u2713 Token rotated: %s (id=%s)", tokenPath, newTok.ID)
-		}
+			cliout.Hintf("\u2713 Profile for %q upgraded to %q", agentName, agentUpgradeTier)
 
-		targetPath := ""
-		if profile.SkillPath != nil {
-			targetPath = *profile.SkillPath
-		}
-		if targetPath != "" {
-			expanded := expandTilde(targetPath)
-			vars := buildTemplateVars(agentName)
-			vars.ProfileTier = agentUpgradeTier
-			if err := agentskill.Refresh(agentName, expanded, vars); err != nil {
-				cliout.Warnf("\u26a0 Skill refresh: %v", err)
-			} else {
-				cliout.Hintf("\u2713 Skill refreshed at %s", expanded)
+			if agentUpgradeRotate {
+				regPath := auth.TokenRegistryFilePath(vaultDir)
+				reg := auth.NewTokenRegistry(regPath)
+				if loadErr := reg.Load(); loadErr != nil {
+					return fmt.Errorf("load token registry: %w", loadErr)
+				}
+
+				for _, tok := range reg.List() {
+					if tok.AgentName == agentName && !tok.Revoked {
+						reg.Revoke(tok.ID)
+					}
+				}
+
+				newTok, rawToken, createErr := reg.Create(
+					fmt.Sprintf("upgrade-%s-%s", agentName, agentUpgradeTier),
+					[]string{"*"},
+					agentName,
+					0,
+				)
+				if createErr != nil {
+					return fmt.Errorf("create token for %q: %w", agentName, createErr)
+				}
+				if err := reg.Save(); err != nil {
+					return fmt.Errorf("save token registry: %w", err)
+				}
+
+				tokenPath, writeErr := writeAgentTokenFile(vaultDir, agentName, rawToken)
+				if writeErr != nil {
+					return fmt.Errorf("write token file: %w", writeErr)
+				}
+				cliout.Hintf("\u2713 Token rotated: %s (id=%s)", tokenPath, newTok.ID)
 			}
-		}
 
-		return nil
-	},
-}
+			targetPath := ""
+			if profile.SkillPath != nil {
+				targetPath = *profile.SkillPath
+			}
+			if targetPath != "" {
+				expanded := expandTilde(targetPath)
+				vars := buildTemplateVars(agentName)
+				vars.ProfileTier = agentUpgradeTier
+				if err := agentskill.Refresh(agentName, expanded, vars); err != nil {
+					cliout.Warnf("\u26a0 Skill refresh: %v", err)
+				} else {
+					cliout.Hintf("\u2713 Skill refreshed at %s", expanded)
+				}
+			}
 
-func init() {
+			return nil
+		},
+	}
 	agentUpgradeCmd.Flags().StringVar(&agentUpgradeTier, "tier", "", "Target security tier (safe, standard, admin; 'read-only' accepted as alias for 'safe')")
 	agentUpgradeCmd.Flags().BoolVar(&agentUpgradeDryRun, "dry-run", false, "Show diff without applying changes")
 	agentUpgradeCmd.Flags().BoolVar(&agentUpgradeYes, "yes", false, "Non-interactive mode (requires --reason)")
 	agentUpgradeCmd.Flags().StringVar(&agentUpgradeReason, "reason", "", "Audit reason for the upgrade (required with --yes)")
 	agentUpgradeCmd.Flags().BoolVar(&agentUpgradeRotate, "rotate-token", false, "Rotate the agent's MCP token on upgrade")
 	agentUpgradeCmd.Flags().BoolVar(&agentUpgradeNoBiometric, "no-biometric", false, "Skip biometric verification (not recommended)")
-
-	agentCmd.AddCommand(agentUpgradeCmd)
+	return agentUpgradeCmd
 }

--- a/cmd/mcp/agent_whoami.go
+++ b/cmd/mcp/agent_whoami.go
@@ -15,55 +15,59 @@ import (
 	auth "github.com/danieljustus/symaira-vault/internal/mcp/auth"
 )
 
-var agentWhoamiCmd = &cobra.Command{
-	Use:   "whoami",
-	Short: "Show current agent context",
-	Long: `Display information about the current agent profile.
+func newAgentWhoamiCmd() *cobra.Command {
+	agentWhoamiCmd := &cobra.Command{
+		Use:   "whoami",
+		Short: "Show current agent context",
+		Long: `Display information about the current agent profile.
 
 When the OPENPASS_AGENT environment variable is set, loads that agent's profile
 and shows name, tier, allowed paths, tools, quotas, and vault status.
 
 The --output json flag returns structured data matching the MCP symaira_whoami
 response format.`,
-	Example: `  # Show agent context
+		Example: `  # Show agent context
   OPENPASS_AGENT=my-agent symvault agent whoami
 
   # Show as JSON
   OPENPASS_AGENT=my-agent symvault agent whoami --output json`,
-	Annotations: map[string]string{
-		cli.RequiresVaultAnnotation: "false",
-	},
-	RunE: func(cmd *cobra.Command, args []string) error {
-		agentName := os.Getenv("OPENPASS_AGENT")
-		if agentName == "" {
-			return fmt.Errorf("OPENPASS_AGENT not set. Run without agent context or set OPENPASS_AGENT=<name>")
-		}
+		Annotations: map[string]string{
+			cli.RequiresVaultAnnotation: "false",
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			agentName := os.Getenv("OPENPASS_AGENT")
+			if agentName == "" {
+				return fmt.Errorf("OPENPASS_AGENT not set. Run without agent context or set OPENPASS_AGENT=<name>")
+			}
 
-		vaultDir := cli.GetVaultDir()
-		configPath := filepath.Join(vaultDir, "config.yaml")
-		cfg, err := configpkg.Load(configPath)
-		if err != nil {
-			return fmt.Errorf("load config: %w", err)
-		}
+			vaultDir := cli.GetVaultDir()
+			configPath := filepath.Join(vaultDir, "config.yaml")
+			cfg, err := configpkg.Load(configPath)
+			if err != nil {
+				return fmt.Errorf("load config: %w", err)
+			}
 
-		profile, ok := cfg.Agents[agentName]
-		if !ok {
-			return fmt.Errorf("agent %q not found in config", agentName)
-		}
+			profile, ok := cfg.Agents[agentName]
+			if !ok {
+				return fmt.Errorf("agent %q not found in config", agentName)
+			}
 
-		info := buildWhoamiInfo(agentName, vaultDir, &profile)
+			info := buildWhoamiInfo(agentName, vaultDir, &profile)
 
-		output, _ := cmd.Flags().GetString("output")
-		switch output {
-		case "json":
-			enc := json.NewEncoder(cmd.OutOrStdout())
-			enc.SetIndent("", "  ")
-			return enc.Encode(info)
-		default:
-			printWhoamiTable(cmd, info)
-			return nil
-		}
-	},
+			output, _ := cmd.Flags().GetString("output")
+			switch output {
+			case "json":
+				enc := json.NewEncoder(cmd.OutOrStdout())
+				enc.SetIndent("", "  ")
+				return enc.Encode(info)
+			default:
+				printWhoamiTable(cmd, info)
+				return nil
+			}
+		},
+	}
+	agentWhoamiCmd.Flags().StringP("output", "o", "text", "Output format (text, json)")
+	return agentWhoamiCmd
 }
 
 type whoamiInfo struct {
@@ -184,9 +188,4 @@ func printWhoamiTable(cmd *cobra.Command, info whoamiInfo) {
 	if info.SkillPath != "" {
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Skill:      %s\n", info.SkillPath)
 	}
-}
-
-func init() {
-	agentWhoamiCmd.Flags().StringP("output", "o", "text", "Output format (text, json)")
-	agentCmd.AddCommand(agentWhoamiCmd)
 }

--- a/cmd/mcp/commands.go
+++ b/cmd/mcp/commands.go
@@ -5,12 +5,14 @@ import (
 )
 
 // NewCommands returns all MCP and agent commands for root command assembly.
+// Each call builds a fresh command tree so consecutive calls never share
+// command objects or flag state.
 func NewCommands() []*cobra.Command {
 	return []*cobra.Command{
-		agentCmd,
-		McpConfigCmd,
-		mcpTokenRotateCmd,
-		mcpCmd,
-		ServeCmd,
+		newAgentCmd(),
+		newMcpConfigCmd(),
+		newMcpTokenRotateCmd(),
+		newMcpCmd(),
+		newServeCmd(),
 	}
 }

--- a/cmd/mcp/mcp_config.go
+++ b/cmd/mcp/mcp_config.go
@@ -26,7 +26,7 @@ import (
 var McpConfigCmd = newMcpConfigCmd()
 
 func newMcpConfigCmd() *cobra.Command {
-	McpConfigCmd := &cobra.Command{
+	c := &cobra.Command{
 		Use:   "mcp-config <agent>",
 		Short: "[Deprecated v4.0, removed in v4.1] Use 'symvault agent install <agent> --config-only'",
 		Long: `This command was deprecated in Symaira Vault v4.0 and will be removed in v4.1.
@@ -41,8 +41,8 @@ Use 'symvault agent install <agent> --config-only' to output MCP config snippets
 				"This command is deprecated in v4.0. Use: symvault agent install <agent> --config-only", nil)
 		},
 	}
-	McpConfigCmd.GroupID = cli.GroupIDAgentsMCP
-	return McpConfigCmd
+	c.GroupID = cli.GroupIDAgentsMCP
+	return c
 }
 
 func newMcpTokenRotateCmd() *cobra.Command {

--- a/cmd/mcp/mcp_config.go
+++ b/cmd/mcp/mcp_config.go
@@ -21,36 +21,48 @@ import (
 	"github.com/danieljustus/symaira-vault/internal/ui/cliout"
 )
 
-var McpConfigCmd = &cobra.Command{
-	Use:   "mcp-config <agent>",
-	Short: "[Deprecated v4.0, removed in v4.1] Use 'symvault agent install <agent> --config-only'",
-	Long: `This command was deprecated in Symaira Vault v4.0 and will be removed in v4.1.
+// McpConfigCmd is retained for API compatibility; NewCommands() uses
+// newMcpConfigCmd() so every call gets a fresh command.
+var McpConfigCmd = newMcpConfigCmd()
+
+func newMcpConfigCmd() *cobra.Command {
+	McpConfigCmd := &cobra.Command{
+		Use:   "mcp-config <agent>",
+		Short: "[Deprecated v4.0, removed in v4.1] Use 'symvault agent install <agent> --config-only'",
+		Long: `This command was deprecated in Symaira Vault v4.0 and will be removed in v4.1.
 
 Use 'symvault agent install <agent> --config-only' to output MCP config snippets.`,
-	Example: `  symvault agent install claude-code --config-only`,
-	Hidden:  true,
-	Args:    cobra.ArbitraryArgs,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		cliout.Warnf("This command is deprecated in v4.0. Use: symvault agent install <agent> --config-only")
-		return errorspkg.NewCLIError(errorspkg.ExitNotFound,
-			"This command is deprecated in v4.0. Use: symvault agent install <agent> --config-only", nil)
-	},
+		Example: `  symvault agent install claude-code --config-only`,
+		Hidden:  true,
+		Args:    cobra.ArbitraryArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cliout.Warnf("This command is deprecated in v4.0. Use: symvault agent install <agent> --config-only")
+			return errorspkg.NewCLIError(errorspkg.ExitNotFound,
+				"This command is deprecated in v4.0. Use: symvault agent install <agent> --config-only", nil)
+		},
+	}
+	McpConfigCmd.GroupID = cli.GroupIDAgentsMCP
+	return McpConfigCmd
 }
 
-var mcpTokenRotateCmd = &cobra.Command{
-	Use:   "mcp-token-rotate",
-	Short: "[Deprecated v4.0, removed in v4.1] Use 'symvault agent token <name> rotate'",
-	Long: `This command was deprecated in Symaira Vault v4.0 and will be removed in v4.1.
+func newMcpTokenRotateCmd() *cobra.Command {
+	mcpTokenRotateCmd := &cobra.Command{
+		Use:   "mcp-token-rotate",
+		Short: "[Deprecated v4.0, removed in v4.1] Use 'symvault agent token <name> rotate'",
+		Long: `This command was deprecated in Symaira Vault v4.0 and will be removed in v4.1.
 
 Token rotation is now managed per-agent via 'symvault agent token <name> rotate'.`,
-	Example: `  symvault agent token my-agent rotate`,
-	Hidden:  true,
-	Args:    cobra.ArbitraryArgs,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		cliout.Warnf("This command is deprecated in v4.0. Use: symvault agent token <name> rotate")
-		return errorspkg.NewCLIError(errorspkg.ExitNotFound,
-			"This command is deprecated in v4.0. Use: symvault agent token <name> rotate", nil)
-	},
+		Example: `  symvault agent token my-agent rotate`,
+		Hidden:  true,
+		Args:    cobra.ArbitraryArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cliout.Warnf("This command is deprecated in v4.0. Use: symvault agent token <name> rotate")
+			return errorspkg.NewCLIError(errorspkg.ExitNotFound,
+				"This command is deprecated in v4.0. Use: symvault agent token <name> rotate", nil)
+		},
+	}
+	mcpTokenRotateCmd.GroupID = cli.GroupIDAgentsMCP
+	return mcpTokenRotateCmd
 }
 
 type httpConfig struct {
@@ -311,11 +323,6 @@ func OutputAgentHTTPConfig(agentName, serverKey, displayName string, redact bool
 	enc := yaml.NewEncoder(os.Stdout)
 	defer func() { _ = enc.Close() }()
 	return enc.Encode(config)
-}
-
-func init() {
-	McpConfigCmd.GroupID = cli.GroupIDAgentsMCP
-	mcpTokenRotateCmd.GroupID = cli.GroupIDAgentsMCP
 }
 
 func OutputTokenOnly() error {

--- a/cmd/mcp/mcp_install.go
+++ b/cmd/mcp/mcp_install.go
@@ -13,20 +13,23 @@ import (
 	"github.com/danieljustus/symaira-vault/internal/ui/cliout"
 )
 
-var mcpInstallCmd = &cobra.Command{
-	Use:   "install [agent]",
-	Short: "[Deprecated v4.0, removed in v4.1] Use 'symvault agent install [agent]'",
-	Long: `This command was deprecated in Symaira Vault v4.0 and will be removed in v4.1.
+func newMcpInstallCmd() *cobra.Command {
+	mcpInstallCmd := &cobra.Command{
+		Use:   "install [agent]",
+		Short: "[Deprecated v4.0, removed in v4.1] Use 'symvault agent install [agent]'",
+		Long: `This command was deprecated in Symaira Vault v4.0 and will be removed in v4.1.
 
 Use 'symvault agent install [agent]' instead to install and configure
 AI agents with proper security profiles.`,
-	Example: `  symvault agent install [agent]`,
-	Hidden:  true,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		cliout.Warnf("This command is deprecated in v4.0. Use: symvault agent install [agent]")
-		return errorspkg.NewCLIError(errorspkg.ExitNotFound,
-			"This command is deprecated in v4.0. Use: symvault agent install [agent]", nil)
-	},
+		Example: `  symvault agent install [agent]`,
+		Hidden:  true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cliout.Warnf("This command is deprecated in v4.0. Use: symvault agent install [agent]")
+			return errorspkg.NewCLIError(errorspkg.ExitNotFound,
+				"This command is deprecated in v4.0. Use: symvault agent install [agent]", nil)
+		},
+	}
+	return mcpInstallCmd
 }
 
 func buildServerConfig(vDir, agentName string, httpMode, dryRun bool) (map[string]any, string, error) {
@@ -100,8 +103,4 @@ func buildHTTPServerConfig(vDir, agentName string, dryRun bool) (map[string]any,
 	}
 
 	return config, tokenID, nil
-}
-
-func init() {
-	mcpCmd.AddCommand(mcpInstallCmd)
 }

--- a/cmd/mcp/mcp_token.go
+++ b/cmd/mcp/mcp_token.go
@@ -35,7 +35,7 @@ now available via the 'symvault agent' command family.`,
 var McpTokenCmd = newMcpTokenCmd()
 
 func newMcpTokenCmd() *cobra.Command {
-	McpTokenCmd := &cobra.Command{
+	c := &cobra.Command{
 		Use:   "token",
 		Short: "[Deprecated v4.0, removed in v4.1] Use 'symvault agent token <name>'",
 		Long: `This command was deprecated in Symaira Vault v4.0 and will be removed in v4.1.
@@ -50,10 +50,10 @@ with subcommands new, list, revoke, and rotate.`,
 				"This command is deprecated in v4.0. Use: symvault agent token <name> new/list/revoke", nil)
 		},
 	}
-	McpTokenCmd.AddCommand(newTokenCreateCmd())
-	McpTokenCmd.AddCommand(newTokenListCmd())
-	McpTokenCmd.AddCommand(newTokenRevokeCmd())
-	return McpTokenCmd
+	c.AddCommand(newTokenCreateCmd())
+	c.AddCommand(newTokenListCmd())
+	c.AddCommand(newTokenRevokeCmd())
+	return c
 }
 
 // TokenCreateCmd is retained for API compatibility; NewCommands() uses
@@ -61,7 +61,7 @@ with subcommands new, list, revoke, and rotate.`,
 var TokenCreateCmd = newTokenCreateCmd()
 
 func newTokenCreateCmd() *cobra.Command {
-	TokenCreateCmd := &cobra.Command{
+	c := &cobra.Command{
 		Use:   "create",
 		Short: "[Deprecated v4.0, removed in v4.1] Use 'symvault agent token <name> new'",
 		Long: `This command was deprecated in Symaira Vault v4.0 and will be removed in v4.1.
@@ -74,7 +74,7 @@ Create scoped tokens via 'symvault agent token <name> new'.`,
 				"This command is deprecated in v4.0. Use: symvault agent token <name> new", nil)
 		},
 	}
-	return TokenCreateCmd
+	return c
 }
 
 func newTokenListCmd() *cobra.Command {

--- a/cmd/mcp/mcp_token.go
+++ b/cmd/mcp/mcp_token.go
@@ -13,74 +13,103 @@ import (
 	"github.com/danieljustus/symaira-vault/internal/ui/cliout"
 )
 
-var mcpCmd = &cobra.Command{
-	Use:   "mcp",
-	Short: "[Deprecated v4.0] MCP server commands — use 'symvault agent' instead",
-	Long: `MCP management commands have been replaced by the agent command group.
+func newMcpCmd() *cobra.Command {
+	mcpCmd := &cobra.Command{
+		Use:   "mcp",
+		Short: "[Deprecated v4.0] MCP server commands — use 'symvault agent' instead",
+		Long: `MCP management commands have been replaced by the agent command group.
 
 All MCP server functionality (install, configure, token management) is
 now available via the 'symvault agent' command family.`,
-	Example: `  symvault agent install claude-code`,
-	Hidden:  true,
+		Example: `  symvault agent install claude-code`,
+		Hidden:  true,
+	}
+	mcpCmd.GroupID = cli.GroupIDAgentsMCP
+	mcpCmd.AddCommand(newMcpInstallCmd())
+	mcpCmd.AddCommand(newMcpTokenCmd())
+	return mcpCmd
 }
 
-var McpTokenCmd = &cobra.Command{
-	Use:   "token",
-	Short: "[Deprecated v4.0, removed in v4.1] Use 'symvault agent token <name>'",
-	Long: `This command was deprecated in Symaira Vault v4.0 and will be removed in v4.1.
+// McpTokenCmd is retained for API compatibility; NewCommands() uses
+// newMcpTokenCmd() so every call gets a fresh command.
+var McpTokenCmd = newMcpTokenCmd()
+
+func newMcpTokenCmd() *cobra.Command {
+	McpTokenCmd := &cobra.Command{
+		Use:   "token",
+		Short: "[Deprecated v4.0, removed in v4.1] Use 'symvault agent token <name>'",
+		Long: `This command was deprecated in Symaira Vault v4.0 and will be removed in v4.1.
 
 Scoped token management is now available via 'symvault agent token <name>'
 with subcommands new, list, revoke, and rotate.`,
-	Example: `  symvault agent token my-agent new`,
-	Hidden:  true,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		cliout.Warnf("This command is deprecated in v4.0. Use: symvault agent token <name> new/list/revoke")
-		return errorspkg.NewCLIError(errorspkg.ExitNotFound,
-			"This command is deprecated in v4.0. Use: symvault agent token <name> new/list/revoke", nil)
-	},
+		Example: `  symvault agent token my-agent new`,
+		Hidden:  true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cliout.Warnf("This command is deprecated in v4.0. Use: symvault agent token <name> new/list/revoke")
+			return errorspkg.NewCLIError(errorspkg.ExitNotFound,
+				"This command is deprecated in v4.0. Use: symvault agent token <name> new/list/revoke", nil)
+		},
+	}
+	McpTokenCmd.AddCommand(newTokenCreateCmd())
+	McpTokenCmd.AddCommand(newTokenListCmd())
+	McpTokenCmd.AddCommand(newTokenRevokeCmd())
+	return McpTokenCmd
 }
 
-var TokenCreateCmd = &cobra.Command{
-	Use:   "create",
-	Short: "[Deprecated v4.0, removed in v4.1] Use 'symvault agent token <name> new'",
-	Long: `This command was deprecated in Symaira Vault v4.0 and will be removed in v4.1.
+// TokenCreateCmd is retained for API compatibility; NewCommands() uses
+// newTokenCreateCmd() so every call gets a fresh command.
+var TokenCreateCmd = newTokenCreateCmd()
+
+func newTokenCreateCmd() *cobra.Command {
+	TokenCreateCmd := &cobra.Command{
+		Use:   "create",
+		Short: "[Deprecated v4.0, removed in v4.1] Use 'symvault agent token <name> new'",
+		Long: `This command was deprecated in Symaira Vault v4.0 and will be removed in v4.1.
 
 Create scoped tokens via 'symvault agent token <name> new'.`,
-	Hidden: true,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		cliout.Warnf("This command is deprecated in v4.0. Use: symvault agent token <name> new")
-		return errorspkg.NewCLIError(errorspkg.ExitNotFound,
-			"This command is deprecated in v4.0. Use: symvault agent token <name> new", nil)
-	},
+		Hidden: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cliout.Warnf("This command is deprecated in v4.0. Use: symvault agent token <name> new")
+			return errorspkg.NewCLIError(errorspkg.ExitNotFound,
+				"This command is deprecated in v4.0. Use: symvault agent token <name> new", nil)
+		},
+	}
+	return TokenCreateCmd
 }
 
-var tokenListCmd = &cobra.Command{
-	Use:   "list",
-	Short: "[Deprecated v4.0, removed in v4.1] Use 'symvault agent token <name> list'",
-	Long: `This command was deprecated in Symaira Vault v4.0 and will be removed in v4.1.
+func newTokenListCmd() *cobra.Command {
+	tokenListCmd := &cobra.Command{
+		Use:   "list",
+		Short: "[Deprecated v4.0, removed in v4.1] Use 'symvault agent token <name> list'",
+		Long: `This command was deprecated in Symaira Vault v4.0 and will be removed in v4.1.
 
 List tokens via 'symvault agent token <name> list'.`,
-	Hidden: true,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		cliout.Warnf("This command is deprecated in v4.0. Use: symvault agent token <name> list")
-		return errorspkg.NewCLIError(errorspkg.ExitNotFound,
-			"This command is deprecated in v4.0. Use: symvault agent token <name> list", nil)
-	},
+		Hidden: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cliout.Warnf("This command is deprecated in v4.0. Use: symvault agent token <name> list")
+			return errorspkg.NewCLIError(errorspkg.ExitNotFound,
+				"This command is deprecated in v4.0. Use: symvault agent token <name> list", nil)
+		},
+	}
+	return tokenListCmd
 }
 
-var tokenRevokeCmd = &cobra.Command{
-	Use:   "revoke <token-id>",
-	Short: "[Deprecated v4.0, removed in v4.1] Use 'symvault agent token <name> revoke'",
-	Long: `This command was deprecated in Symaira Vault v4.0 and will be removed in v4.1.
+func newTokenRevokeCmd() *cobra.Command {
+	tokenRevokeCmd := &cobra.Command{
+		Use:   "revoke <token-id>",
+		Short: "[Deprecated v4.0, removed in v4.1] Use 'symvault agent token <name> revoke'",
+		Long: `This command was deprecated in Symaira Vault v4.0 and will be removed in v4.1.
 
 Revoke tokens via 'symvault agent token <name> revoke'.`,
-	Hidden: true,
-	Args:   cobra.ArbitraryArgs,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		cliout.Warnf("This command is deprecated in v4.0. Use: symvault agent token <name> revoke")
-		return errorspkg.NewCLIError(errorspkg.ExitNotFound,
-			"This command is deprecated in v4.0. Use: symvault agent token <name> revoke", nil)
-	},
+		Hidden: true,
+		Args:   cobra.ArbitraryArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cliout.Warnf("This command is deprecated in v4.0. Use: symvault agent token <name> revoke")
+			return errorspkg.NewCLIError(errorspkg.ExitNotFound,
+				"This command is deprecated in v4.0. Use: symvault agent token <name> revoke", nil)
+		},
+	}
+	return tokenRevokeCmd
 }
 
 func ResolveTokenTTL(_ string, ttlFlag string) (time.Duration, error) {
@@ -132,12 +161,4 @@ func parseDurationNumber(s string) (int, error) {
 		return 0, fmt.Errorf("negative duration")
 	}
 	return n, nil
-}
-
-func init() {
-	mcpCmd.GroupID = cli.GroupIDAgentsMCP
-	mcpCmd.AddCommand(McpTokenCmd)
-	McpTokenCmd.AddCommand(TokenCreateCmd)
-	McpTokenCmd.AddCommand(tokenListCmd)
-	McpTokenCmd.AddCommand(tokenRevokeCmd)
 }

--- a/cmd/mcp/serve.go
+++ b/cmd/mcp/serve.go
@@ -30,11 +30,16 @@ The server can run in HTTP mode or stdio mode.`,
 		config.LegacyVaultSubdir)
 }
 
-var ServeCmd = &cobra.Command{
-	Use:   "serve",
-	Short: "Start MCP server for agent access",
-	Long:  serveLongDescription(),
-	Example: `  # HTTP mode bound to localhost:8080
+// ServeCmd is retained for API compatibility; NewCommands() uses
+// newServeCmd() so every call gets a fresh command.
+var ServeCmd = newServeCmd()
+
+func newServeCmd() *cobra.Command {
+	ServeCmd := &cobra.Command{
+		Use:   "serve",
+		Short: "Start MCP server for agent access",
+		Long:  serveLongDescription(),
+		Example: `  # HTTP mode bound to localhost:8080
   symvault serve --bind 127.0.0.1 --port 8080
 
   # stdio mode for a single agent (called by MCP clients directly)
@@ -42,10 +47,8 @@ var ServeCmd = &cobra.Command{
 
   # Install as a system service (macOS launchd or systemd)
   symvault serve install`,
-	RunE: runServe,
-}
-
-func init() {
+		RunE: runServe,
+	}
 	ServeCmd.GroupID = cli.GroupIDAgentsMCP
 	ServeCmd.Flags().String("agent", "", "Agent name (required for --stdio; HTTP mode resolves agents per-request via X-Symaira-Agent header)")
 	ServeCmd.Flags().Int("port", 8080, "Server port")
@@ -55,4 +58,8 @@ func init() {
 	ServeCmd.Flags().String("tls-key", "", "TLS key file path (overrides config)")
 	ServeCmd.Flags().String("tls-ca", "", "CA certificate file path for mTLS client verification (enables mTLS)")
 	ServeCmd.Flags().Bool("allow-locked", false, "Allow the MCP server to start even when the vault is locked (stdio mode only)")
+	ServeCmd.AddCommand(newServeInstallCmd())
+	ServeCmd.AddCommand(newServeUninstallCmd())
+	ServeCmd.AddCommand(newServeStatusCmd())
+	return ServeCmd
 }

--- a/cmd/mcp/serve.go
+++ b/cmd/mcp/serve.go
@@ -35,7 +35,7 @@ The server can run in HTTP mode or stdio mode.`,
 var ServeCmd = newServeCmd()
 
 func newServeCmd() *cobra.Command {
-	ServeCmd := &cobra.Command{
+	c := &cobra.Command{
 		Use:   "serve",
 		Short: "Start MCP server for agent access",
 		Long:  serveLongDescription(),
@@ -49,17 +49,17 @@ func newServeCmd() *cobra.Command {
   symvault serve install`,
 		RunE: runServe,
 	}
-	ServeCmd.GroupID = cli.GroupIDAgentsMCP
-	ServeCmd.Flags().String("agent", "", "Agent name (required for --stdio; HTTP mode resolves agents per-request via X-Symaira-Agent header)")
-	ServeCmd.Flags().Int("port", 8080, "Server port")
-	ServeCmd.Flags().Bool("stdio", false, "Enable stdio transport (for MCP)")
-	ServeCmd.Flags().String("bind", "127.0.0.1", "Bind address for HTTP server")
-	ServeCmd.Flags().String("tls-cert", "", "TLS certificate file path (overrides config)")
-	ServeCmd.Flags().String("tls-key", "", "TLS key file path (overrides config)")
-	ServeCmd.Flags().String("tls-ca", "", "CA certificate file path for mTLS client verification (enables mTLS)")
-	ServeCmd.Flags().Bool("allow-locked", false, "Allow the MCP server to start even when the vault is locked (stdio mode only)")
-	ServeCmd.AddCommand(newServeInstallCmd())
-	ServeCmd.AddCommand(newServeUninstallCmd())
-	ServeCmd.AddCommand(newServeStatusCmd())
-	return ServeCmd
+	c.GroupID = cli.GroupIDAgentsMCP
+	c.Flags().String("agent", "", "Agent name (required for --stdio; HTTP mode resolves agents per-request via X-Symaira-Agent header)")
+	c.Flags().Int("port", 8080, "Server port")
+	c.Flags().Bool("stdio", false, "Enable stdio transport (for MCP)")
+	c.Flags().String("bind", "127.0.0.1", "Bind address for HTTP server")
+	c.Flags().String("tls-cert", "", "TLS certificate file path (overrides config)")
+	c.Flags().String("tls-key", "", "TLS key file path (overrides config)")
+	c.Flags().String("tls-ca", "", "CA certificate file path for mTLS client verification (enables mTLS)")
+	c.Flags().Bool("allow-locked", false, "Allow the MCP server to start even when the vault is locked (stdio mode only)")
+	c.AddCommand(newServeInstallCmd())
+	c.AddCommand(newServeUninstallCmd())
+	c.AddCommand(newServeStatusCmd())
+	return c
 }

--- a/cmd/mcp/serve_install.go
+++ b/cmd/mcp/serve_install.go
@@ -15,10 +15,11 @@ import (
 	"github.com/danieljustus/symaira-vault/internal/ui/cliout"
 )
 
-var serveInstallCmd = &cobra.Command{
-	Use:   "install",
-	Short: "Install MCP server as a background service",
-	Long: `Install the Symaira Vault MCP server as a system background service.
+func newServeInstallCmd() *cobra.Command {
+	serveInstallCmd := &cobra.Command{
+		Use:   "install",
+		Short: "Install MCP server as a background service",
+		Long: `Install the Symaira Vault MCP server as a system background service.
 
 On macOS, this creates a LaunchAgent plist in ~/Library/LaunchAgents/
 and loads it with launchctl. The service starts automatically on login
@@ -26,7 +27,7 @@ and stays running.
 
 On Linux, this creates a systemd user service in ~/.config/systemd/user/
 and enables it to start automatically.`,
-	Example: `  # Install as autostart service
+		Example: `  # Install as autostart service
   symvault serve install
 
   # Check status
@@ -34,35 +35,37 @@ and enables it to start automatically.`,
 
   # Remove again
   symvault serve uninstall`,
-	RunE: runServeInstall,
+		RunE: runServeInstall,
+	}
+	return serveInstallCmd
 }
 
-var serveUninstallCmd = &cobra.Command{
-	Use:   "uninstall",
-	Short: "Remove the MCP server background service",
-	Long: `Stop and remove the Symaira Vault MCP server background service.
+func newServeUninstallCmd() *cobra.Command {
+	serveUninstallCmd := &cobra.Command{
+		Use:   "uninstall",
+		Short: "Remove the MCP server background service",
+		Long: `Stop and remove the Symaira Vault MCP server background service.
 
 On macOS, this unloads the LaunchAgent and removes the plist file.
 
 On Linux, this stops and disables the systemd user service and removes
 the service file.`,
-	RunE: runServeUninstall,
+		RunE: runServeUninstall,
+	}
+	return serveUninstallCmd
 }
 
-var serveStatusCmd = &cobra.Command{
-	Use:   "status",
-	Short: "Show MCP server service status",
-	Long: `Display the current status of the Symaira Vault MCP server background service.
+func newServeStatusCmd() *cobra.Command {
+	serveStatusCmd := &cobra.Command{
+		Use:   "status",
+		Short: "Show MCP server service status",
+		Long: `Display the current status of the Symaira Vault MCP server background service.
 
 Reports whether the service is running, stopped, or not installed,
 along with the service file path, port, and vault directory.`,
-	RunE: runServeStatus,
-}
-
-func init() {
-	ServeCmd.AddCommand(serveInstallCmd)
-	ServeCmd.AddCommand(serveUninstallCmd)
-	ServeCmd.AddCommand(serveStatusCmd)
+		RunE: runServeStatus,
+	}
+	return serveStatusCmd
 }
 
 func runServeInstall(cmd *cobra.Command, args []string) error {

--- a/cmd/passlint/passlint.go
+++ b/cmd/passlint/passlint.go
@@ -11,7 +11,6 @@
 package passlint
 
 import (
-	"fmt"
 	"go/ast"
 	"go/token"
 	"go/types"
@@ -149,11 +148,4 @@ func checkBinary(pass *analysis.Pass, expr *ast.BinaryExpr) {
 // NewAnalyzer returns the passlint analyzer (convenience for embedding).
 func NewAnalyzer() *analysis.Analyzer {
 	return Analyzer
-}
-
-func init() {
-	// Ensure Analyzer is properly set up.
-	if Analyzer == nil {
-		panic(fmt.Errorf("passlint: Analyzer is nil"))
-	}
 }

--- a/cmd/policy.go
+++ b/cmd/policy.go
@@ -91,7 +91,7 @@ Example:
 var policyCmd = newPolicyCmd()
 
 func newPolicyCmd() *cobra.Command {
-	policyCmd := &cobra.Command{
+	c := &cobra.Command{
 		Use:   "policy",
 		Short: "Manage declarative policies",
 		Long: `Manage context-aware auto-approval policies for MCP tool calls.
@@ -116,12 +116,12 @@ prompted, or require biometric authentication.`,
 			requiresVaultAnnotation: "false",
 		},
 	}
-	policyCmd.AddCommand(newPolicyValidateCmd())
-	policyCmd.AddCommand(newPolicyApplyCmd())
-	policyCmd.AddCommand(newPolicyListCmd())
-	policyCmd.AddCommand(newPolicyRemoveCmd())
-	policyCmd.GroupID = cli.GroupIDAdministration
-	return policyCmd
+	c.AddCommand(newPolicyValidateCmd())
+	c.AddCommand(newPolicyApplyCmd())
+	c.AddCommand(newPolicyListCmd())
+	c.AddCommand(newPolicyRemoveCmd())
+	c.GroupID = cli.GroupIDAdministration
+	return c
 }
 
 func newPolicyApplyCmd() *cobra.Command {

--- a/cmd/policy.go
+++ b/cmd/policy.go
@@ -39,61 +39,69 @@ func safePolicyPath(policiesDir, name string) (string, error) {
 	return dest, nil
 }
 
-var policyValidateCmd = &cobra.Command{
-	Use:   "validate <file>",
-	Short: "Validate a policy file",
-	Long: `Validate a policy file for syntax and semantic errors.
+func newPolicyValidateCmd() *cobra.Command {
+	policyValidateCmd := &cobra.Command{
+		Use:   "validate <file>",
+		Short: "Validate a policy file",
+		Long: `Validate a policy file for syntax and semantic errors.
 
 Checks that the policy file has valid YAML structure, correct version,
 valid rule names, known actions, and well-formed conditions.
 
 Example:
   symvault policy validate ~/.config/symvault/policies/dev.yaml`,
-	Args: cobra.ExactArgs(1),
-	Annotations: map[string]string{
-		requiresVaultAnnotation: "false",
-	},
-	RunE: func(cmd *cobra.Command, args []string) error {
-		path := args[0]
+		Args: cobra.ExactArgs(1),
+		Annotations: map[string]string{
+			requiresVaultAnnotation: "false",
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			path := args[0]
 
-		// Expand ~ to home directory
-		if len(path) > 0 && path[0] == '~' {
-			home, err := os.UserHomeDir()
-			if err != nil {
-				return fmt.Errorf("cannot determine home directory: %w", err)
+			// Expand ~ to home directory
+			if len(path) > 0 && path[0] == '~' {
+				home, err := os.UserHomeDir()
+				if err != nil {
+					return fmt.Errorf("cannot determine home directory: %w", err)
+				}
+				path = filepath.Join(home, path[1:])
 			}
-			path = filepath.Join(home, path[1:])
-		}
 
-		p, err := policy.LoadPolicy(path)
-		if err != nil {
-			cmd.Printf("❌ Policy validation failed for %s\n", path)
-			return err
-		}
+			p, err := policy.LoadPolicy(path)
+			if err != nil {
+				cmd.Printf("❌ Policy validation failed for %s\n", path)
+				return err
+			}
 
-		cmd.Printf("✅ Policy %q is valid\n", p.Version)
-		if p.Description != "" {
-			cmd.Printf("   Description: %s\n", p.Description)
-		}
-		cmd.Printf("   Rules: %d\n", len(p.Rules))
-		for _, rule := range p.Rules {
-			cmd.Printf("   - %s (priority: %d, action: %s)\n", rule.Name, rule.Priority, rule.Action)
-		}
-		return nil
-	},
+			cmd.Printf("✅ Policy %q is valid\n", p.Version)
+			if p.Description != "" {
+				cmd.Printf("   Description: %s\n", p.Description)
+			}
+			cmd.Printf("   Rules: %d\n", len(p.Rules))
+			for _, rule := range p.Rules {
+				cmd.Printf("   - %s (priority: %d, action: %s)\n", rule.Name, rule.Priority, rule.Action)
+			}
+			return nil
+		},
+	}
+	return policyValidateCmd
 }
 
-var policyCmd = &cobra.Command{
-	Use:   "policy",
-	Short: "Manage declarative policies",
-	Long: `Manage context-aware auto-approval policies for MCP tool calls.
+// policyCmd is retained for API compatibility; NewCommands() uses
+// newPolicyCmd() so every call gets a fresh command.
+var policyCmd = newPolicyCmd()
+
+func newPolicyCmd() *cobra.Command {
+	policyCmd := &cobra.Command{
+		Use:   "policy",
+		Short: "Manage declarative policies",
+		Long: `Manage context-aware auto-approval policies for MCP tool calls.
 
 Policies are YAML files stored in the vault's "policies" directory
 (<vault>/policies). The MCP server loads policies from this same location,
 so a policy applied with "policy apply" is enforced by the server.
 They define rules for when tool calls should be allowed, denied,
 prompted, or require biometric authentication.`,
-	Example: `  # Validate a policy file before activating it
+		Example: `  # Validate a policy file before activating it
   symvault policy validate ./my-policy.yaml
 
   # Apply a policy
@@ -104,133 +112,141 @@ prompted, or require biometric authentication.`,
 
   # Remove a named policy (use the file name shown by 'policy list')
   symvault policy remove dev.yaml`,
-	Annotations: map[string]string{
-		requiresVaultAnnotation: "false",
-	},
+		Annotations: map[string]string{
+			requiresVaultAnnotation: "false",
+		},
+	}
+	policyCmd.AddCommand(newPolicyValidateCmd())
+	policyCmd.AddCommand(newPolicyApplyCmd())
+	policyCmd.AddCommand(newPolicyListCmd())
+	policyCmd.AddCommand(newPolicyRemoveCmd())
+	policyCmd.GroupID = cli.GroupIDAdministration
+	return policyCmd
 }
 
-var policyApplyCmd = &cobra.Command{
-	Use:   "apply <file>",
-	Short: "Apply a policy file to the vault",
-	Long: `Load and validate a policy file, then copy it to the vault's policies directory.
+func newPolicyApplyCmd() *cobra.Command {
+	policyApplyCmd := &cobra.Command{
+		Use:   "apply <file>",
+		Short: "Apply a policy file to the vault",
+		Long: `Load and validate a policy file, then copy it to the vault's policies directory.
 
 Example:
   symvault policy apply ~/policies/dev.yaml`,
-	Args: cobra.ExactArgs(1),
-	Annotations: map[string]string{
-		requiresVaultAnnotation: "false",
-	},
-	RunE: func(cmd *cobra.Command, args []string) error {
-		sourcePath := args[0]
-		if len(sourcePath) > 0 && sourcePath[0] == '~' {
-			home, err := os.UserHomeDir()
-			if err != nil {
-				return fmt.Errorf("cannot determine home directory: %w", err)
+		Args: cobra.ExactArgs(1),
+		Annotations: map[string]string{
+			requiresVaultAnnotation: "false",
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			sourcePath := args[0]
+			if len(sourcePath) > 0 && sourcePath[0] == '~' {
+				home, err := os.UserHomeDir()
+				if err != nil {
+					return fmt.Errorf("cannot determine home directory: %w", err)
+				}
+				sourcePath = filepath.Join(home, sourcePath[1:])
 			}
-			sourcePath = filepath.Join(home, sourcePath[1:])
-		}
 
-		p, err := policy.LoadPolicy(sourcePath)
-		if err != nil {
-			cmd.Printf("❌ Policy validation failed for %s\n", sourcePath)
-			return err
-		}
+			p, err := policy.LoadPolicy(sourcePath)
+			if err != nil {
+				cmd.Printf("❌ Policy validation failed for %s\n", sourcePath)
+				return err
+			}
 
-		vaultDir, _ := cli.VaultPath()
-		policiesDir := policy.VaultPolicyDir(vaultDir)
+			vaultDir, _ := cli.VaultPath()
+			policiesDir := policy.VaultPolicyDir(vaultDir)
 
-		destPath, err := safePolicyPath(policiesDir, filepath.Base(sourcePath))
-		if err != nil {
-			return err
-		}
+			destPath, err := safePolicyPath(policiesDir, filepath.Base(sourcePath))
+			if err != nil {
+				return err
+			}
 
-		if mkdirErr := fsutil.SafeMkdirAll(policiesDir, 0750); mkdirErr != nil {
-			return fmt.Errorf("create policies directory: %w", mkdirErr)
-		}
+			if mkdirErr := fsutil.SafeMkdirAll(policiesDir, 0750); mkdirErr != nil {
+				return fmt.Errorf("create policies directory: %w", mkdirErr)
+			}
 
-		data, err := os.ReadFile(sourcePath) //#nosec G304 -- sourcePath is validated by LoadPolicy above
-		if err != nil {
-			return fmt.Errorf("read policy file: %w", err)
-		}
+			data, err := os.ReadFile(sourcePath) //#nosec G304 -- sourcePath is validated by LoadPolicy above
+			if err != nil {
+				return fmt.Errorf("read policy file: %w", err)
+			}
 
-		if writeErr := fsutil.SafeWriteFile(destPath, data, 0640); writeErr != nil {
-			return fmt.Errorf("write policy file: %w", writeErr)
-		}
+			if writeErr := fsutil.SafeWriteFile(destPath, data, 0640); writeErr != nil {
+				return fmt.Errorf("write policy file: %w", writeErr)
+			}
 
-		cmd.Printf("✅ Policy %q applied (%d rules)\n", p.Version, len(p.Rules))
-		return nil
-	},
+			cmd.Printf("✅ Policy %q applied (%d rules)\n", p.Version, len(p.Rules))
+			return nil
+		},
+	}
+	return policyApplyCmd
 }
 
-var policyListCmd = &cobra.Command{
-	Use:   "list",
-	Short: "List all applied policies",
-	Long:  `List all policy files in the vault's policies directory.`,
-	Annotations: map[string]string{
-		requiresVaultAnnotation: "false",
-	},
-	RunE: func(cmd *cobra.Command, args []string) error {
-		vaultDir, _ := cli.VaultPath()
-		policiesDir := policy.VaultPolicyDir(vaultDir)
+func newPolicyListCmd() *cobra.Command {
+	policyListCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List all applied policies",
+		Long:  `List all policy files in the vault's policies directory.`,
+		Annotations: map[string]string{
+			requiresVaultAnnotation: "false",
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			vaultDir, _ := cli.VaultPath()
+			policiesDir := policy.VaultPolicyDir(vaultDir)
 
-		entries, err := os.ReadDir(policiesDir)
-		if err != nil {
-			if os.IsNotExist(err) {
-				cmd.Println("No policies directory found.")
+			entries, err := os.ReadDir(policiesDir)
+			if err != nil {
+				if os.IsNotExist(err) {
+					cmd.Println("No policies directory found.")
+					return nil
+				}
+				return fmt.Errorf("read policies directory: %w", err)
+			}
+
+			if len(entries) == 0 {
+				cmd.Println("No policies applied.")
 				return nil
 			}
-			return fmt.Errorf("read policies directory: %w", err)
-		}
 
-		if len(entries) == 0 {
-			cmd.Println("No policies applied.")
-			return nil
-		}
-
-		for _, entry := range entries {
-			if entry.IsDir() {
-				continue
+			for _, entry := range entries {
+				if entry.IsDir() {
+					continue
+				}
+				cmd.Printf("  - %s\n", entry.Name())
 			}
-			cmd.Printf("  - %s\n", entry.Name())
-		}
-		return nil
-	},
+			return nil
+		},
+	}
+	return policyListCmd
 }
 
-var policyRemoveCmd = &cobra.Command{
-	Use:   "remove <name>",
-	Short: "Remove an applied policy",
-	Long:  `Remove a policy file from the vault's policies directory.`,
-	Args:  cobra.ExactArgs(1),
-	Annotations: map[string]string{
-		requiresVaultAnnotation: "false",
-	},
-	RunE: func(cmd *cobra.Command, args []string) error {
-		vaultDir, _ := cli.VaultPath()
-		policiesDir := policy.VaultPolicyDir(vaultDir)
+func newPolicyRemoveCmd() *cobra.Command {
+	policyRemoveCmd := &cobra.Command{
+		Use:   "remove <name>",
+		Short: "Remove an applied policy",
+		Long:  `Remove a policy file from the vault's policies directory.`,
+		Args:  cobra.ExactArgs(1),
+		Annotations: map[string]string{
+			requiresVaultAnnotation: "false",
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			vaultDir, _ := cli.VaultPath()
+			policiesDir := policy.VaultPolicyDir(vaultDir)
 
-		policyPath, err := safePolicyPath(policiesDir, args[0])
-		if err != nil {
-			return err
-		}
+			policyPath, err := safePolicyPath(policiesDir, args[0])
+			if err != nil {
+				return err
+			}
 
-		if _, statErr := os.Stat(policyPath); os.IsNotExist(statErr) {
-			return fmt.Errorf("policy %q not found", args[0])
-		}
+			if _, statErr := os.Stat(policyPath); os.IsNotExist(statErr) {
+				return fmt.Errorf("policy %q not found", args[0])
+			}
 
-		if err := fsutil.SafeRemove(policyPath); err != nil {
-			return fmt.Errorf("remove policy: %w", err)
-		}
+			if err := fsutil.SafeRemove(policyPath); err != nil {
+				return fmt.Errorf("remove policy: %w", err)
+			}
 
-		cmd.Printf("✅ Policy %q removed\n", args[0])
-		return nil
-	},
-}
-
-func init() {
-	policyCmd.AddCommand(policyValidateCmd)
-	policyCmd.AddCommand(policyApplyCmd)
-	policyCmd.AddCommand(policyListCmd)
-	policyCmd.AddCommand(policyRemoveCmd)
-	policyCmd.GroupID = cli.GroupIDAdministration
+			cmd.Printf("✅ Policy %q removed\n", args[0])
+			return nil
+		},
+	}
+	return policyRemoveCmd
 }

--- a/cmd/policy_test.go
+++ b/cmd/policy_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestPolicyValidateCmd_Success(t *testing.T) {
-	rootCmd = NewRootCmd()
+	rootCmd = newPackageRootCmd()
 	resetVaultState(t)
 	tmpDir := t.TempDir()
 	policyFile := filepath.Join(tmpDir, "test-policy.yaml")

--- a/cmd/profile.go
+++ b/cmd/profile.go
@@ -21,7 +21,7 @@ var profileVaultPath string
 var profileCmd = newProfileCmd()
 
 func newProfileCmd() *cobra.Command {
-	profileCmd := &cobra.Command{
+	c := &cobra.Command{
 		Use:   "profile",
 		Short: "Manage vault profiles",
 		Long:  `Manage named vault profiles for switching between multiple vaults.`,
@@ -32,11 +32,11 @@ func newProfileCmd() *cobra.Command {
 			requiresVaultAnnotation: "false",
 		},
 	}
-	profileCmd.AddCommand(newProfileListCmd())
-	profileCmd.AddCommand(newProfileAddCmd())
-	profileCmd.AddCommand(newProfileUseCmd())
-	profileCmd.GroupID = cli.GroupIDAdministration
-	return profileCmd
+	c.AddCommand(newProfileListCmd())
+	c.AddCommand(newProfileAddCmd())
+	c.AddCommand(newProfileUseCmd())
+	c.GroupID = cli.GroupIDAdministration
+	return c
 }
 
 func newProfileListCmd() *cobra.Command {

--- a/cmd/profile.go
+++ b/cmd/profile.go
@@ -16,158 +16,170 @@ import (
 
 var profileVaultPath string
 
-var profileCmd = &cobra.Command{
-	Use:   "profile",
-	Short: "Manage vault profiles",
-	Long:  `Manage named vault profiles for switching between multiple vaults.`,
-	Example: `  symvault profile list
+// profileCmd is retained for API compatibility; NewRootCmd() uses
+// newProfileCmd() so every call gets a fresh command.
+var profileCmd = newProfileCmd()
+
+func newProfileCmd() *cobra.Command {
+	profileCmd := &cobra.Command{
+		Use:   "profile",
+		Short: "Manage vault profiles",
+		Long:  `Manage named vault profiles for switching between multiple vaults.`,
+		Example: `  symvault profile list
   symvault profile add work --vault ~/.symvault-work
   symvault profile use work`,
-	Annotations: map[string]string{
-		requiresVaultAnnotation: "false",
-	},
+		Annotations: map[string]string{
+			requiresVaultAnnotation: "false",
+		},
+	}
+	profileCmd.AddCommand(newProfileListCmd())
+	profileCmd.AddCommand(newProfileAddCmd())
+	profileCmd.AddCommand(newProfileUseCmd())
+	profileCmd.GroupID = cli.GroupIDAdministration
+	return profileCmd
 }
 
-var profileListCmd = &cobra.Command{
-	Use:   "list",
-	Short: "List all profiles",
-	Args:  cobra.NoArgs,
-	Annotations: map[string]string{
-		requiresVaultAnnotation: "false",
-	},
-	RunE: func(cmd *cobra.Command, args []string) error {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return errorspkg.NewCLIError(errorspkg.ExitGeneralError, "cannot determine home directory", err)
-		}
+func newProfileListCmd() *cobra.Command {
+	profileListCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List all profiles",
+		Args:  cobra.NoArgs,
+		Annotations: map[string]string{
+			requiresVaultAnnotation: "false",
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			home, err := os.UserHomeDir()
+			if err != nil {
+				return errorspkg.NewCLIError(errorspkg.ExitGeneralError, "cannot determine home directory", err)
+			}
 
-		cfg, err := configpkg.Load(filepath.Join(home, configpkg.DefaultVaultSubdir, "config.yaml"))
-		if err != nil {
-			cfg = configpkg.Default()
-		}
+			cfg, err := configpkg.Load(filepath.Join(home, configpkg.DefaultVaultSubdir, "config.yaml"))
+			if err != nil {
+				cfg = configpkg.Default()
+			}
 
-		if len(cfg.Profiles) == 0 {
-			printlnQuietAware("No profiles configured.")
-			printlnQuietAware("Use 'symvault profile add <name> --vault <path>' to create a profile.")
+			if len(cfg.Profiles) == 0 {
+				printlnQuietAware("No profiles configured.")
+				printlnQuietAware("Use 'symvault profile add <name> --vault <path>' to create a profile.")
+				return nil
+			}
+
+			w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
+			_, _ = fmt.Fprintln(w, "NAME\tVAULT PATH\tDEFAULT")
+			for name, p := range cfg.Profiles {
+				isDefault := ""
+				if name == cfg.DefaultProfile {
+					isDefault = "*"
+				}
+				vaultPath := p.VaultPath
+				if vaultPath == "" {
+					vaultPath = "(not set)"
+				}
+				_, _ = fmt.Fprintf(w, "%s\t%s\t%s\n", name, vaultPath, isDefault)
+			}
+			_ = w.Flush()
+
 			return nil
-		}
-
-		w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
-		_, _ = fmt.Fprintln(w, "NAME\tVAULT PATH\tDEFAULT")
-		for name, p := range cfg.Profiles {
-			isDefault := ""
-			if name == cfg.DefaultProfile {
-				isDefault = "*"
-			}
-			vaultPath := p.VaultPath
-			if vaultPath == "" {
-				vaultPath = "(not set)"
-			}
-			_, _ = fmt.Fprintf(w, "%s\t%s\t%s\n", name, vaultPath, isDefault)
-		}
-		_ = w.Flush()
-
-		return nil
-	},
+		},
+	}
+	return profileListCmd
 }
 
-var profileAddCmd = &cobra.Command{
-	Use:   "add <name>",
-	Short: "Add a new profile",
-	Long: `Add a new vault profile with a name and vault path.
+func newProfileAddCmd() *cobra.Command {
+	profileAddCmd := &cobra.Command{
+		Use:   "add <name>",
+		Short: "Add a new profile",
+		Long: `Add a new vault profile with a name and vault path.
 
 Example:
   symvault profile add work --vault ~/.symvault-work`,
-	Args: cobra.ExactArgs(1),
-	Annotations: map[string]string{
-		requiresVaultAnnotation: "false",
-	},
-	RunE: func(cmd *cobra.Command, args []string) error {
-		name := strings.TrimSpace(args[0])
-		if name == "" {
-			return errorspkg.NewCLIError(errorspkg.ExitGeneralError, "profile name cannot be empty", nil)
-		}
+		Args: cobra.ExactArgs(1),
+		Annotations: map[string]string{
+			requiresVaultAnnotation: "false",
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name := strings.TrimSpace(args[0])
+			if name == "" {
+				return errorspkg.NewCLIError(errorspkg.ExitGeneralError, "profile name cannot be empty", nil)
+			}
 
-		if profileVaultPath == "" {
-			return errorspkg.NewCLIError(errorspkg.ExitGeneralError, "--vault is required", nil)
-		}
+			if profileVaultPath == "" {
+				return errorspkg.NewCLIError(errorspkg.ExitGeneralError, "--vault is required", nil)
+			}
 
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return errorspkg.NewCLIError(errorspkg.ExitGeneralError, "cannot determine home directory", err)
-		}
+			home, err := os.UserHomeDir()
+			if err != nil {
+				return errorspkg.NewCLIError(errorspkg.ExitGeneralError, "cannot determine home directory", err)
+			}
 
-		configPath := filepath.Join(home, configpkg.DefaultVaultSubdir, "config.yaml")
-		cfg, err := configpkg.Load(configPath)
-		if err != nil {
-			cfg = configpkg.Default()
-		}
+			configPath := filepath.Join(home, configpkg.DefaultVaultSubdir, "config.yaml")
+			cfg, err := configpkg.Load(configPath)
+			if err != nil {
+				cfg = configpkg.Default()
+			}
 
-		if cfg.Profiles == nil {
-			cfg.Profiles = make(map[string]*configpkg.Profile)
-		}
+			if cfg.Profiles == nil {
+				cfg.Profiles = make(map[string]*configpkg.Profile)
+			}
 
-		if _, exists := cfg.Profiles[name]; exists {
-			return errorspkg.NewCLIError(errorspkg.ExitGeneralError, fmt.Sprintf("profile %q already exists", name), nil)
-		}
+			if _, exists := cfg.Profiles[name]; exists {
+				return errorspkg.NewCLIError(errorspkg.ExitGeneralError, fmt.Sprintf("profile %q already exists", name), nil)
+			}
 
-		cfg.Profiles[name] = &configpkg.Profile{VaultPath: profileVaultPath}
+			cfg.Profiles[name] = &configpkg.Profile{VaultPath: profileVaultPath}
 
-		if err := cfg.Save(); err != nil {
-			return errorspkg.NewCLIError(errorspkg.ExitGeneralError, "cannot save config", err)
-		}
+			if err := cfg.Save(); err != nil {
+				return errorspkg.NewCLIError(errorspkg.ExitGeneralError, "cannot save config", err)
+			}
 
-		printlnQuietAware(fmt.Sprintf("Profile %q added with vault %s", name, profileVaultPath))
-		return nil
-	},
+			printlnQuietAware(fmt.Sprintf("Profile %q added with vault %s", name, profileVaultPath))
+			return nil
+		},
+	}
+	profileAddCmd.Flags().StringVar(&profileVaultPath, "vault", "", "path to the vault directory (required)")
+	_ = profileAddCmd.MarkFlagRequired("vault")
+	return profileAddCmd
 }
 
-var profileUseCmd = &cobra.Command{
-	Use:   "use <name>",
-	Short: "Set the default profile",
-	Long: `Set the default profile to use when no --vault or OPENPASS_VAULT is specified.
+func newProfileUseCmd() *cobra.Command {
+	profileUseCmd := &cobra.Command{
+		Use:   "use <name>",
+		Short: "Set the default profile",
+		Long: `Set the default profile to use when no --vault or OPENPASS_VAULT is specified.
 
 Example:
   symvault profile use work`,
-	Args: cobra.ExactArgs(1),
-	Annotations: map[string]string{
-		requiresVaultAnnotation: "false",
-	},
-	RunE: func(cmd *cobra.Command, args []string) error {
-		name := strings.TrimSpace(args[0])
+		Args: cobra.ExactArgs(1),
+		Annotations: map[string]string{
+			requiresVaultAnnotation: "false",
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name := strings.TrimSpace(args[0])
 
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return errorspkg.NewCLIError(errorspkg.ExitGeneralError, "cannot determine home directory", err)
-		}
+			home, err := os.UserHomeDir()
+			if err != nil {
+				return errorspkg.NewCLIError(errorspkg.ExitGeneralError, "cannot determine home directory", err)
+			}
 
-		configPath := filepath.Join(home, configpkg.DefaultVaultSubdir, "config.yaml")
-		cfg, err := configpkg.Load(configPath)
-		if err != nil {
-			return errorspkg.NewCLIError(errorspkg.ExitGeneralError, "cannot load config", err)
-		}
+			configPath := filepath.Join(home, configpkg.DefaultVaultSubdir, "config.yaml")
+			cfg, err := configpkg.Load(configPath)
+			if err != nil {
+				return errorspkg.NewCLIError(errorspkg.ExitGeneralError, "cannot load config", err)
+			}
 
-		if _, exists := cfg.Profiles[name]; !exists {
-			return errorspkg.NewCLIError(errorspkg.ExitGeneralError, fmt.Sprintf("profile %q not found", name), nil)
-		}
+			if _, exists := cfg.Profiles[name]; !exists {
+				return errorspkg.NewCLIError(errorspkg.ExitGeneralError, fmt.Sprintf("profile %q not found", name), nil)
+			}
 
-		cfg.DefaultProfile = name
+			cfg.DefaultProfile = name
 
-		if err := cfg.Save(); err != nil {
-			return errorspkg.NewCLIError(errorspkg.ExitGeneralError, "cannot save config", err)
-		}
+			if err := cfg.Save(); err != nil {
+				return errorspkg.NewCLIError(errorspkg.ExitGeneralError, "cannot save config", err)
+			}
 
-		printlnQuietAware(fmt.Sprintf("Default profile set to %q", name))
-		return nil
-	},
-}
-
-func init() {
-	profileAddCmd.Flags().StringVar(&profileVaultPath, "vault", "", "path to the vault directory (required)")
-	_ = profileAddCmd.MarkFlagRequired("vault")
-
-	profileCmd.AddCommand(profileListCmd)
-	profileCmd.AddCommand(profileAddCmd)
-	profileCmd.AddCommand(profileUseCmd)
-	profileCmd.GroupID = cli.GroupIDAdministration
+			printlnQuietAware(fmt.Sprintf("Default profile set to %q", name))
+			return nil
+		},
+	}
+	return profileUseCmd
 }

--- a/cmd/recipients.go
+++ b/cmd/recipients.go
@@ -18,189 +18,229 @@ var (
 	reencryptAfterAdd bool
 )
 
-var recipientsCmd = &cobra.Command{
-	Use:   "recipients",
-	Short: "Manage vault recipients for multi-user encryption",
-	Long: `Manage recipients (public keys) that can decrypt vault entries.
+// recipientsCmd is retained for API compatibility; NewCommands() uses
+// newRecipientsCmd() so every call gets a fresh command.
+var recipientsCmd = newRecipientsCmd()
+
+func newRecipientsCmd() *cobra.Command {
+	recipientsCmd := &cobra.Command{
+		Use:   "recipients",
+		Short: "Manage vault recipients for multi-user encryption",
+		Long: `Manage recipients (public keys) that can decrypt vault entries.
 
 Recipients are stored in recipients.txt in the vault directory.
 Each line contains one public key in age format (starting with "age1").
 Lines starting with # are treated as comments.`,
-	Example: `  symvault recipients list              # List all recipients
+		Example: `  symvault recipients list              # List all recipients
   symvault recipients add age1...       # Add a new recipient
   symvault recipients remove age1...    # Remove a recipient`,
-	Annotations: map[string]string{
-		cli.JSONOutputAnnotation: "true",
-	},
+		Annotations: map[string]string{
+			cli.JSONOutputAnnotation: "true",
+		},
+	}
+	recipientsCmd.GroupID = cli.GroupIDVault
+	recipientsCmd.AddCommand(newRecipientsListCmd())
+	recipientsCmd.AddCommand(newRecipientsAddCmd())
+	recipientsCmd.AddCommand(newRecipientsRemoveCmd())
+	return recipientsCmd
 }
 
-var recipientsListCmd = &cobra.Command{
-	Use:     "list",
-	Short:   "List all recipients",
-	Long:    `List all recipients from the recipients.txt file.`,
-	Example: `  symvault recipients list`,
-	Annotations: map[string]string{
-		cli.JSONOutputAnnotation: "true",
-	},
-	RunE: func(cmd *cobra.Command, args []string) error {
-		vaultDir, err := cli.VaultPath()
-		if err != nil {
-			return err
-		}
+// recipientsListCmd is retained for API compatibility; NewCommands() uses
+// newRecipientsListCmd() so every call gets a fresh command.
+var recipientsListCmd = newRecipientsListCmd()
 
-		if !vaultpkg.IsInitialized(vaultDir) {
-			return errorspkg.NewVaultNotInitialized()
-		}
+func newRecipientsListCmd() *cobra.Command {
+	recipientsListCmd := &cobra.Command{
+		Use:     "list",
+		Short:   "List all recipients",
+		Long:    `List all recipients from the recipients.txt file.`,
+		Example: `  symvault recipients list`,
+		Annotations: map[string]string{
+			cli.JSONOutputAnnotation: "true",
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			vaultDir, err := cli.VaultPath()
+			if err != nil {
+				return err
+			}
 
-		rm := vaultpkg.NewRecipientsManager(vaultDir)
-		recipients, err := rm.ListRecipients()
-		if err != nil {
-			return errorspkg.ReadFailed(err, "cannot list recipients")
-		}
+			if !vaultpkg.IsInitialized(vaultDir) {
+				return errorspkg.NewVaultNotInitialized()
+			}
 
-		if len(recipients) == 0 {
+			rm := vaultpkg.NewRecipientsManager(vaultDir)
+			recipients, err := rm.ListRecipients()
+			if err != nil {
+				return errorspkg.ReadFailed(err, "cannot list recipients")
+			}
+
+			if len(recipients) == 0 {
+				if cli.OutputFormat == "text" {
+					printlnQuietAware("No recipients configured.")
+					printlnQuietAware("Use 'symvault recipients add <public-key>' to add a recipient.")
+				} else {
+					if err := cli.PrintResult(map[string]interface{}{"recipients": []string{}}); err != nil {
+						return err
+					}
+				}
+				return nil
+			}
+
 			if cli.OutputFormat == "text" {
-				printlnQuietAware("No recipients configured.")
-				printlnQuietAware("Use 'symvault recipients add <public-key>' to add a recipient.")
+				printQuietAware("Recipients (%d):\n\n", len(recipients))
+				for _, r := range recipients {
+					status := "✓"
+					if !r.Valid {
+						status = "✗"
+					}
+					printlnQuietAware("  " + status + " " + r.Normalized)
+					if !r.Valid {
+						printlnQuietAware("    Error: " + r.Error)
+					}
+				}
 			} else {
-				if err := cli.PrintResult(map[string]interface{}{"recipients": []string{}}); err != nil {
+				recipientStrings := make([]string, 0, len(recipients))
+				for _, r := range recipients {
+					recipientStrings = append(recipientStrings, r.Normalized)
+				}
+				if err := cli.PrintResult(map[string]interface{}{"recipients": recipientStrings}); err != nil {
 					return err
 				}
 			}
+
 			return nil
-		}
-
-		if cli.OutputFormat == "text" {
-			printQuietAware("Recipients (%d):\n\n", len(recipients))
-			for _, r := range recipients {
-				status := "✓"
-				if !r.Valid {
-					status = "✗"
-				}
-				printlnQuietAware("  " + status + " " + r.Normalized)
-				if !r.Valid {
-					printlnQuietAware("    Error: " + r.Error)
-				}
-			}
-		} else {
-			recipientStrings := make([]string, 0, len(recipients))
-			for _, r := range recipients {
-				recipientStrings = append(recipientStrings, r.Normalized)
-			}
-			if err := cli.PrintResult(map[string]interface{}{"recipients": recipientStrings}); err != nil {
-				return err
-			}
-		}
-
-		return nil
-	},
+		},
+	}
+	return recipientsListCmd
 }
 
-var recipientsAddCmd = &cobra.Command{
-	Use:   "add <public-key>",
-	Short: "Add a recipient",
-	Long: `Add a new recipient (public key) to the vault.
+// recipientsAddCmd is retained for API compatibility; NewCommands() uses
+// newRecipientsAddCmd() so every call gets a fresh command.
+var recipientsAddCmd = newRecipientsAddCmd()
+
+func newRecipientsAddCmd() *cobra.Command {
+	recipientsAddCmd := &cobra.Command{
+		Use:   "add <public-key>",
+		Short: "Add a recipient",
+		Long: `Add a new recipient (public key) to the vault.
 
 The public key must be a valid age public key starting with "age1".
 Once added, all new entries will be encrypted for this recipient.`,
-	Example: `  symvault recipients add age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p`,
-	Args:    cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		return cli.WithVaultRaw(func(v *vaultpkg.Vault, vs *cli.VaultService) error {
-			recipient := args[0]
+		Example: `  symvault recipients add age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p`,
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cli.WithVaultRaw(func(v *vaultpkg.Vault, vs *cli.VaultService) error {
+				recipient := args[0]
 
-			rm := vaultpkg.NewRecipientsManager(v.Dir)
-			if err := rm.AddRecipient(recipient); err != nil {
-				if errors.Is(err, vaultpkg.ErrRecipientAlreadyExists) {
-					return errorspkg.AlreadyExists("recipient already exists")
+				rm := vaultpkg.NewRecipientsManager(v.Dir)
+				if err := rm.AddRecipient(recipient); err != nil {
+					if errors.Is(err, vaultpkg.ErrRecipientAlreadyExists) {
+						return errorspkg.AlreadyExists("recipient already exists")
+					}
+					if errors.Is(err, vaultpkg.ErrInvalidRecipient) {
+						return errorspkg.InvalidInput("invalid recipient: must be a valid age public key starting with 'age1'")
+					}
+					return errorspkg.WriteFailed(err, "cannot add recipient")
 				}
-				if errors.Is(err, vaultpkg.ErrInvalidRecipient) {
-					return errorspkg.InvalidInput("invalid recipient: must be a valid age public key starting with 'age1'")
-				}
-				return errorspkg.WriteFailed(err, "cannot add recipient")
-			}
 
-			if reencryptAfterAdd {
-				recipients, err := v.GetAllRecipientsForEncryption()
-				if err != nil {
-					return fmt.Errorf("get recipients: %w", err)
+				if reencryptAfterAdd {
+					recipients, err := v.GetAllRecipientsForEncryption()
+					if err != nil {
+						return fmt.Errorf("get recipients: %w", err)
+					}
+					printQuietAware("Recipient added. Re-encrypting all entries for %d recipient(s)...\n", len(recipients))
+					if err := vaultpkg.ReencryptAll(v.Dir, v.Identity, recipients); err != nil {
+						return fmt.Errorf("re-encrypt entries: %w", err)
+					}
+					printlnQuietAware("Recipient added and all entries re-encrypted successfully.")
+				} else {
+					printlnQuietAware("Recipient added successfully.")
+					printQuietAware("Note: existing entries are not yet shared with this recipient. ")
+					printlnQuietAware("Run 'symvault recipients add <key> --reencrypt' or 'symvault auth rotate' to re-encrypt existing entries.")
 				}
-				printQuietAware("Recipient added. Re-encrypting all entries for %d recipient(s)...\n", len(recipients))
-				if err := vaultpkg.ReencryptAll(v.Dir, v.Identity, recipients); err != nil {
-					return fmt.Errorf("re-encrypt entries: %w", err)
-				}
-				printlnQuietAware("Recipient added and all entries re-encrypted successfully.")
-			} else {
-				printlnQuietAware("Recipient added successfully.")
-				printQuietAware("Note: existing entries are not yet shared with this recipient. ")
-				printlnQuietAware("Run 'symvault recipients add <key> --reencrypt' or 'symvault auth rotate' to re-encrypt existing entries.")
-			}
-			return nil
-		})
-	},
+				return nil
+			})
+		},
+	}
+	recipientsAddCmd.Flags().BoolVar(&reencryptAfterAdd, "reencrypt", false, "Re-encrypt existing entries for the new recipient")
+	return recipientsAddCmd
 }
 
-var recipientsRemoveCmd = &cobra.Command{
-	Use:     "remove <public-key>",
-	Aliases: []string{"rm"},
-	Short:   "Remove a recipient",
-	Long: `Remove a recipient (public key) from the vault.
+// recipientsRemoveCmd is retained for API compatibility; NewCommands() uses
+// newRecipientsRemoveCmd() so every call gets a fresh command.
+var recipientsRemoveCmd = newRecipientsRemoveCmd()
+
+// The compat instances mirror the pre-migration singleton topology for
+// tests that execute or mutate the package-level command vars directly:
+// the compat parent carries the compat children (replacing the fresh
+// instances the constructor added), and root.go attaches the parent to
+// the package rootCmd.
+var _ = func() int {
+	for _, c := range recipientsCmd.Commands() {
+		recipientsCmd.RemoveCommand(c)
+	}
+	recipientsCmd.AddCommand(recipientsListCmd)
+	recipientsCmd.AddCommand(recipientsAddCmd)
+	recipientsCmd.AddCommand(recipientsRemoveCmd)
+	return 0
+}()
+
+func newRecipientsRemoveCmd() *cobra.Command {
+	recipientsRemoveCmd := &cobra.Command{
+		Use:     "remove <public-key>",
+		Aliases: []string{"rm"},
+		Short:   "Remove a recipient",
+		Long: `Remove a recipient (public key) from the vault.
 
 The public key must match exactly. Use 'symvault recipients list' to see current recipients.
 
 Use --yes to skip confirmation (useful for scripts).`,
-	Example: `  symvault recipients remove age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p`,
-	Args:    cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		return cli.WithVaultRaw(func(v *vaultpkg.Vault, vs *cli.VaultService) error {
-			recipient := args[0]
+		Example: `  symvault recipients remove age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p`,
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cli.WithVaultRaw(func(v *vaultpkg.Vault, vs *cli.VaultService) error {
+				recipient := args[0]
 
-			confirmed, err := confirmInteractive(fmt.Sprintf("Remove recipient %s", recipient), confirmRemove)
-			if err != nil {
-				return err
-			}
-			if !confirmed {
-				fmt.Fprintln(os.Stderr, "Canceled")
-				return nil
-			}
-
-			rm := vaultpkg.NewRecipientsManager(v.Dir)
-			if err := rm.RemoveRecipient(recipient); err != nil {
-				if errors.Is(err, vaultpkg.ErrRecipientNotFound) {
-					return errorspkg.NotFound("recipient %q not found", recipient)
-				}
-				if errors.Is(err, vaultpkg.ErrInvalidRecipient) {
-					return errorspkg.InvalidInput("invalid recipient: must be a valid age public key starting with 'age1'")
-				}
-				return errorspkg.WriteFailed(err, "cannot remove recipient")
-			}
-
-			if noReencrypt {
-				printlnQuietAware("Recipient removed successfully.")
-				printQuietAware("Warning: existing entries are still encrypted to the removed recipient. ")
-				printlnQuietAware("Run 'symvault auth rotate' to re-encrypt all entries and fully revoke access.")
-			} else {
-				recipients, err := v.GetAllRecipientsForEncryption()
+				confirmed, err := confirmInteractive(fmt.Sprintf("Remove recipient %s", recipient), confirmRemove)
 				if err != nil {
-					return fmt.Errorf("get remaining recipients: %w", err)
+					return err
 				}
-				printQuietAware("Recipient removed. Re-encrypting %d entries for %d recipient(s)...\n", 0, len(recipients))
-				if err := vaultpkg.ReencryptAll(v.Dir, v.Identity, recipients); err != nil {
-					return fmt.Errorf("re-encrypt entries: %w", err)
+				if !confirmed {
+					fmt.Fprintln(os.Stderr, "Canceled")
+					return nil
 				}
-				printlnQuietAware("Recipient removed and all entries re-encrypted successfully.")
-			}
-			return nil
-		})
-	},
-}
 
-func init() {
-	recipientsCmd.GroupID = cli.GroupIDVault
-	recipientsCmd.AddCommand(recipientsListCmd)
-	recipientsCmd.AddCommand(recipientsAddCmd)
-	recipientsCmd.AddCommand(recipientsRemoveCmd)
-	recipientsAddCmd.Flags().BoolVar(&reencryptAfterAdd, "reencrypt", false, "Re-encrypt existing entries for the new recipient")
+				rm := vaultpkg.NewRecipientsManager(v.Dir)
+				if err := rm.RemoveRecipient(recipient); err != nil {
+					if errors.Is(err, vaultpkg.ErrRecipientNotFound) {
+						return errorspkg.NotFound("recipient %q not found", recipient)
+					}
+					if errors.Is(err, vaultpkg.ErrInvalidRecipient) {
+						return errorspkg.InvalidInput("invalid recipient: must be a valid age public key starting with 'age1'")
+					}
+					return errorspkg.WriteFailed(err, "cannot remove recipient")
+				}
+
+				if noReencrypt {
+					printlnQuietAware("Recipient removed successfully.")
+					printQuietAware("Warning: existing entries are still encrypted to the removed recipient. ")
+					printlnQuietAware("Run 'symvault auth rotate' to re-encrypt all entries and fully revoke access.")
+				} else {
+					recipients, err := v.GetAllRecipientsForEncryption()
+					if err != nil {
+						return fmt.Errorf("get remaining recipients: %w", err)
+					}
+					printQuietAware("Recipient removed. Re-encrypting %d entries for %d recipient(s)...\n", 0, len(recipients))
+					if err := vaultpkg.ReencryptAll(v.Dir, v.Identity, recipients); err != nil {
+						return fmt.Errorf("re-encrypt entries: %w", err)
+					}
+					printlnQuietAware("Recipient removed and all entries re-encrypted successfully.")
+				}
+				return nil
+			})
+		},
+	}
 	recipientsRemoveCmd.Flags().BoolVarP(&confirmRemove, "yes", "y", false, "Skip confirmation prompt")
 	recipientsRemoveCmd.Flags().BoolVar(&noReencrypt, "no-reencrypt", false, "Skip re-encrypting existing entries after removal")
+	return recipientsRemoveCmd
 }

--- a/cmd/recipients.go
+++ b/cmd/recipients.go
@@ -23,7 +23,7 @@ var (
 var recipientsCmd = newRecipientsCmd()
 
 func newRecipientsCmd() *cobra.Command {
-	recipientsCmd := &cobra.Command{
+	c := &cobra.Command{
 		Use:   "recipients",
 		Short: "Manage vault recipients for multi-user encryption",
 		Long: `Manage recipients (public keys) that can decrypt vault entries.
@@ -38,11 +38,11 @@ Lines starting with # are treated as comments.`,
 			cli.JSONOutputAnnotation: "true",
 		},
 	}
-	recipientsCmd.GroupID = cli.GroupIDVault
-	recipientsCmd.AddCommand(newRecipientsListCmd())
-	recipientsCmd.AddCommand(newRecipientsAddCmd())
-	recipientsCmd.AddCommand(newRecipientsRemoveCmd())
-	return recipientsCmd
+	c.GroupID = cli.GroupIDVault
+	c.AddCommand(newRecipientsListCmd())
+	c.AddCommand(newRecipientsAddCmd())
+	c.AddCommand(newRecipientsRemoveCmd())
+	return c
 }
 
 // recipientsListCmd is retained for API compatibility; NewCommands() uses
@@ -50,7 +50,7 @@ Lines starting with # are treated as comments.`,
 var recipientsListCmd = newRecipientsListCmd()
 
 func newRecipientsListCmd() *cobra.Command {
-	recipientsListCmd := &cobra.Command{
+	c := &cobra.Command{
 		Use:     "list",
 		Short:   "List all recipients",
 		Long:    `List all recipients from the recipients.txt file.`,
@@ -111,7 +111,7 @@ func newRecipientsListCmd() *cobra.Command {
 			return nil
 		},
 	}
-	return recipientsListCmd
+	return c
 }
 
 // recipientsAddCmd is retained for API compatibility; NewCommands() uses
@@ -119,7 +119,7 @@ func newRecipientsListCmd() *cobra.Command {
 var recipientsAddCmd = newRecipientsAddCmd()
 
 func newRecipientsAddCmd() *cobra.Command {
-	recipientsAddCmd := &cobra.Command{
+	c := &cobra.Command{
 		Use:   "add <public-key>",
 		Short: "Add a recipient",
 		Long: `Add a new recipient (public key) to the vault.
@@ -162,8 +162,8 @@ Once added, all new entries will be encrypted for this recipient.`,
 			})
 		},
 	}
-	recipientsAddCmd.Flags().BoolVar(&reencryptAfterAdd, "reencrypt", false, "Re-encrypt existing entries for the new recipient")
-	return recipientsAddCmd
+	c.Flags().BoolVar(&reencryptAfterAdd, "reencrypt", false, "Re-encrypt existing entries for the new recipient")
+	return c
 }
 
 // recipientsRemoveCmd is retained for API compatibility; NewCommands() uses
@@ -186,7 +186,7 @@ var _ = func() int {
 }()
 
 func newRecipientsRemoveCmd() *cobra.Command {
-	recipientsRemoveCmd := &cobra.Command{
+	c := &cobra.Command{
 		Use:     "remove <public-key>",
 		Aliases: []string{"rm"},
 		Short:   "Remove a recipient",
@@ -240,7 +240,7 @@ Use --yes to skip confirmation (useful for scripts).`,
 			})
 		},
 	}
-	recipientsRemoveCmd.Flags().BoolVarP(&confirmRemove, "yes", "y", false, "Skip confirmation prompt")
-	recipientsRemoveCmd.Flags().BoolVar(&noReencrypt, "no-reencrypt", false, "Skip re-encrypting existing entries after removal")
-	return recipientsRemoveCmd
+	c.Flags().BoolVarP(&confirmRemove, "yes", "y", false, "Skip confirmation prompt")
+	c.Flags().BoolVar(&noReencrypt, "no-reencrypt", false, "Skip re-encrypting existing entries after removal")
+	return c
 }

--- a/cmd/remote.go
+++ b/cmd/remote.go
@@ -23,27 +23,38 @@ var (
 	remotePushFlag bool
 )
 
-var remoteCmd = &cobra.Command{
-	Use:   "remote",
-	Short: "Manage git remote for vault sync",
-	Long: `Manage the git remote used for synchronizing the vault.
+// remoteCmd is retained for API compatibility; NewCommands() uses
+// newRemoteCmd() so every call gets a fresh command.
+var remoteCmd = newRemoteCmd()
+
+func newRemoteCmd() *cobra.Command {
+	remoteCmd := &cobra.Command{
+		Use:   "remote",
+		Short: "Manage git remote for vault sync",
+		Long: `Manage the git remote used for synchronizing the vault.
 
 Use 'symvault remote init <ssh-target>' to configure a remote git repository
 for vault synchronization. The vault must be initialized first.`,
-	Example: `  symvault remote init hermes@macmini
+		Example: `  symvault remote init hermes@macmini
   symvault remote init user@host:/custom/path.git
   symvault remote init hermes@macmini --push
   symvault remote status`,
-	Annotations: map[string]string{
-		requiresVaultAnnotation:  "false",
-		cli.JSONOutputAnnotation: "true",
-	},
+		Annotations: map[string]string{
+			requiresVaultAnnotation:  "false",
+			cli.JSONOutputAnnotation: "true",
+		},
+	}
+	remoteCmd.GroupID = cli.GroupIDSharingSync
+	remoteCmd.AddCommand(newRemoteInitCmd())
+	remoteCmd.AddCommand(newRemoteStatusCmd())
+	return remoteCmd
 }
 
-var remoteInitCmd = &cobra.Command{
-	Use:   "init <ssh-target>",
-	Short: "Initialize git remote for the vault",
-	Long: `Configure a remote git repository for vault synchronization.
+func newRemoteInitCmd() *cobra.Command {
+	remoteInitCmd := &cobra.Command{
+		Use:   "init <ssh-target>",
+		Short: "Initialize git remote for the vault",
+		Long: `Configure a remote git repository for vault synchronization.
 
 The ssh-target can be in these formats:
   user@host           - bare repo at ~/symvault-remote.git on remote
@@ -57,34 +68,32 @@ Flags:
   --push   - Push the vault to the remote after setup
 
 This command also enables git.auto_push in your Symaira Vault config.`,
-	Example: `  symvault remote init hermes@macmini
+		Example: `  symvault remote init hermes@macmini
   symvault remote init dev@server:/srv/git/symvault.git --name upstream
   symvault remote init hermes@macmini --push`,
-	Args: cobra.ExactArgs(1),
-	Annotations: map[string]string{
-		requiresVaultAnnotation: "false",
-	},
-	RunE: runRemoteInit,
-}
-
-var remoteStatusCmd = &cobra.Command{
-	Use:   "status",
-	Short: "Show remote sync configuration",
-	Long:  `Display the current git remote configuration and sync status for the vault.`,
-	Annotations: map[string]string{
-		requiresVaultAnnotation: "false",
-	},
-	RunE: runRemoteStatus,
-}
-
-func init() {
-	remoteCmd.GroupID = cli.GroupIDSharingSync
-	remoteCmd.AddCommand(remoteInitCmd)
-	remoteCmd.AddCommand(remoteStatusCmd)
-
+		Args: cobra.ExactArgs(1),
+		Annotations: map[string]string{
+			requiresVaultAnnotation: "false",
+		},
+		RunE: runRemoteInit,
+	}
 	remoteInitCmd.Flags().StringVarP(&remoteName, "name", "n", "origin", "Remote name")
 	remoteInitCmd.Flags().StringVarP(&remotePath, "path", "p", "", "Custom bare repo path on remote (default: ~/symvault-remote.git)")
 	remoteInitCmd.Flags().BoolVar(&remotePushFlag, "push", false, "Push vault to remote after setup")
+	return remoteInitCmd
+}
+
+func newRemoteStatusCmd() *cobra.Command {
+	remoteStatusCmd := &cobra.Command{
+		Use:   "status",
+		Short: "Show remote sync configuration",
+		Long:  `Display the current git remote configuration and sync status for the vault.`,
+		Annotations: map[string]string{
+			requiresVaultAnnotation: "false",
+		},
+		RunE: runRemoteStatus,
+	}
+	return remoteStatusCmd
 }
 
 func runRemoteInit(cmd *cobra.Command, args []string) error {

--- a/cmd/remote.go
+++ b/cmd/remote.go
@@ -28,7 +28,7 @@ var (
 var remoteCmd = newRemoteCmd()
 
 func newRemoteCmd() *cobra.Command {
-	remoteCmd := &cobra.Command{
+	c := &cobra.Command{
 		Use:   "remote",
 		Short: "Manage git remote for vault sync",
 		Long: `Manage the git remote used for synchronizing the vault.
@@ -44,10 +44,10 @@ for vault synchronization. The vault must be initialized first.`,
 			cli.JSONOutputAnnotation: "true",
 		},
 	}
-	remoteCmd.GroupID = cli.GroupIDSharingSync
-	remoteCmd.AddCommand(newRemoteInitCmd())
-	remoteCmd.AddCommand(newRemoteStatusCmd())
-	return remoteCmd
+	c.GroupID = cli.GroupIDSharingSync
+	c.AddCommand(newRemoteInitCmd())
+	c.AddCommand(newRemoteStatusCmd())
+	return c
 }
 
 func newRemoteInitCmd() *cobra.Command {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,7 +25,34 @@ var (
 // rootCmd is the package-level root used by production code.
 // Tests that modify command state should use a fresh NewRootCmd() for
 // isolation.
-var rootCmd = NewRootCmd()
+var rootCmd = newPackageRootCmd()
+
+// newPackageRootCmd builds the package-level root tree: a fresh
+// NewRootCmd() tree whose top-level commands are replaced by the
+// package-level compat instances (deviceCmd, generateCmd, mcp.ServeCmd,
+// ...). This mirrors the pre-migration singleton topology for tests that
+// execute or mutate package-level command vars directly (for example
+// recipientsAddCmd.Execute() or resets of mcpcmd.ServeCmd flags): the
+// executed commands are the same objects the tests mutate. Fresh
+// NewRootCmd() calls are unaffected and remain fully independent trees.
+func newPackageRootCmd() *cobra.Command {
+	root := NewRootCmd()
+	compat := []*cobra.Command{
+		deviceCmd, dynamicCmd, generateCmd, gitCmd, policyCmd, profileCmd,
+		recipientsCmd, remoteCmd, runCmd, shareCmd, syncCmd, templateCmd, uiCmd,
+		mcp.ServeCmd,
+	}
+	for _, c := range root.Commands() {
+		for _, compatCmd := range compat {
+			if c.Name() == compatCmd.Name() {
+				root.RemoveCommand(c)
+				break
+			}
+		}
+	}
+	root.AddCommand(compat...)
+	return root
+}
 
 // NewRootCmd returns a fully assembled root command tree containing all
 // subpackages and top-level commands without relying on init() side effects.
@@ -41,19 +68,19 @@ func NewRootCmd() *cobra.Command {
 
 	// Add top-level commands in cmd/
 	root.AddCommand(
-		deviceCmd,
-		dynamicCmd,
-		generateCmd,
-		gitCmd,
-		policyCmd,
-		profileCmd,
-		recipientsCmd,
-		remoteCmd,
-		runCmd,
-		shareCmd,
-		syncCmd,
-		templateCmd,
-		uiCmd,
+		newDeviceCmd(),
+		newDynamicCmd(),
+		newGenerateCmd(),
+		newGitCmd(),
+		newPolicyCmd(),
+		newProfileCmd(),
+		newRecipientsCmd(),
+		newRemoteCmd(),
+		newRunCmd(),
+		newShareCmd(),
+		newSyncCmd(),
+		newTemplateCmd(),
+		newUiCmd(),
 	)
 
 	return root

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -80,7 +80,7 @@ func NewRootCmd() *cobra.Command {
 		newShareCmd(),
 		newSyncCmd(),
 		newTemplateCmd(),
-		newUiCmd(),
+		newUICmd(),
 	)
 
 	return root

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -226,7 +226,7 @@ func TestVaultPathPrefersExplicitFlagOverEnv(t *testing.T) {
 
 // TestExecute_Error verifies that Execute() calls cli.OsExit(1) when rootCmd.Execute() returns an error.
 func TestExecute_Error(t *testing.T) {
-	rootCmd = NewRootCmd()
+	rootCmd = newPackageRootCmd()
 	var exitCode int
 
 	// Save and restore original cli.OsExit

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -28,7 +28,7 @@ var (
 var runCmd = newRunCmd()
 
 func newRunCmd() *cobra.Command {
-	runCmd := &cobra.Command{
+	c := &cobra.Command{
 		Use:   "run [flags] -- <command> [args...]",
 		Short: "Run a command with secrets injected as environment variables",
 		Long:  "Executes a command with vault secrets injected as environment variables. Use --env NAME=path.field to map secrets.",
@@ -112,13 +112,13 @@ func newRunCmd() *cobra.Command {
 			})
 		},
 	}
-	runCmd.Flags().StringArrayVarP(&runEnvFlags, "env", "e", nil, "Environment variable mapping (NAME=path.field)")
-	runCmd.Flags().StringArrayVarP(&runEnvFiles, "env-file", "f", nil, "File with env variable mappings (NAME=path.field), one per line")
-	runCmd.Flags().StringArrayVar(&runPassthrough, "passthrough", nil, "Parent env var names to pass through to the child process (comma-separated)")
-	runCmd.Flags().StringVarP(&runWorkingDir, "working-dir", "C", "", "Working directory for the command")
-	runCmd.Flags().DurationVarP(&runTimeout, "timeout", "t", 0, "Timeout for the command (e.g., 30s)")
-	runCmd.GroupID = cli.GroupIDVault
-	return runCmd
+	c.Flags().StringArrayVarP(&runEnvFlags, "env", "e", nil, "Environment variable mapping (NAME=path.field)")
+	c.Flags().StringArrayVarP(&runEnvFiles, "env-file", "f", nil, "File with env variable mappings (NAME=path.field), one per line")
+	c.Flags().StringArrayVar(&runPassthrough, "passthrough", nil, "Parent env var names to pass through to the child process (comma-separated)")
+	c.Flags().StringVarP(&runWorkingDir, "working-dir", "C", "", "Working directory for the command")
+	c.Flags().DurationVarP(&runTimeout, "timeout", "t", 0, "Timeout for the command (e.g., 30s)")
+	c.GroupID = cli.GroupIDVault
+	return c
 }
 
 // parseEnvFile reads an env file and returns a map of env var names to secret references.

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -23,11 +23,16 @@ var (
 	runTimeout     time.Duration
 )
 
-var runCmd = &cobra.Command{
-	Use:   "run [flags] -- <command> [args...]",
-	Short: "Run a command with secrets injected as environment variables",
-	Long:  "Executes a command with vault secrets injected as environment variables. Use --env NAME=path.field to map secrets.",
-	Example: `  # Inject AWS_SECRET_ACCESS_KEY from vault entry "work/aws.secret"
+// runCmd is retained for API compatibility; NewRootCmd() uses
+// newRunCmd() so every call gets a fresh command.
+var runCmd = newRunCmd()
+
+func newRunCmd() *cobra.Command {
+	runCmd := &cobra.Command{
+		Use:   "run [flags] -- <command> [args...]",
+		Short: "Run a command with secrets injected as environment variables",
+		Long:  "Executes a command with vault secrets injected as environment variables. Use --env NAME=path.field to map secrets.",
+		Example: `  # Inject AWS_SECRET_ACCESS_KEY from vault entry "work/aws.secret"
   symvault run --env AWS_SECRET_ACCESS_KEY=work/aws.secret -- aws s3 ls
 
   # Multiple secrets from env file
@@ -41,71 +46,79 @@ var runCmd = &cobra.Command{
     --env DB_PASS=prod/db.password \
     --env API_TOKEN=stripe.token \
     --workdir /tmp/job -- ./deploy.sh`,
-	Args: cobra.MinimumNArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		return cli.WithVault(func(v *vaultpkg.Vault, vs *cli.VaultService) error {
-			// Parse --env flags: each is "ENV_NAME=path.field"
-			envMap := make(map[string]string)
-			for _, envFlag := range runEnvFlags {
-				parts := strings.SplitN(envFlag, "=", 2)
-				if len(parts) != 2 {
-					return fmt.Errorf("invalid --env format: %q (expected NAME=path.field)", envFlag)
-				}
-				envName := parts[0]
-				secretRef := parts[1]
-
-				value, resolveErr := secrets.ResolveSecretRef(v, secretRef)
-				if resolveErr != nil {
-					return resolveErr
-				}
-				envMap[envName] = value
-			}
-
-			// Parse --env-file flags: each file contains "ENV_NAME=path.field" lines
-			for _, envFilePath := range runEnvFiles {
-				parsed, parseErr := parseEnvFile(envFilePath)
-				if parseErr != nil {
-					return parseErr
-				}
-				for envName, secretRef := range parsed {
-					if _, exists := envMap[envName]; exists {
-						return fmt.Errorf("duplicate env var %q: defined in both --env and --env-file (or in multiple --env-file)", envName)
+		Args: cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cli.WithVault(func(v *vaultpkg.Vault, vs *cli.VaultService) error {
+				// Parse --env flags: each is "ENV_NAME=path.field"
+				envMap := make(map[string]string)
+				for _, envFlag := range runEnvFlags {
+					parts := strings.SplitN(envFlag, "=", 2)
+					if len(parts) != 2 {
+						return fmt.Errorf("invalid --env format: %q (expected NAME=path.field)", envFlag)
 					}
+					envName := parts[0]
+					secretRef := parts[1]
+
 					value, resolveErr := secrets.ResolveSecretRef(v, secretRef)
 					if resolveErr != nil {
 						return resolveErr
 					}
 					envMap[envName] = value
 				}
-			}
 
-			// args contains the command and its arguments (everything after --)
-			result, err := secrets.RunCommand(secrets.RunOptions{
-				Command:     args,
-				Env:         envMap,
-				Passthrough: runPassthrough,
-				WorkingDir:  runWorkingDir,
-				Timeout:     runTimeout,
+				// Parse --env-file flags: each file contains "ENV_NAME=path.field" lines
+				for _, envFilePath := range runEnvFiles {
+					parsed, parseErr := parseEnvFile(envFilePath)
+					if parseErr != nil {
+						return parseErr
+					}
+					for envName, secretRef := range parsed {
+						if _, exists := envMap[envName]; exists {
+							return fmt.Errorf("duplicate env var %q: defined in both --env and --env-file (or in multiple --env-file)", envName)
+						}
+						value, resolveErr := secrets.ResolveSecretRef(v, secretRef)
+						if resolveErr != nil {
+							return resolveErr
+						}
+						envMap[envName] = value
+					}
+				}
+
+				// args contains the command and its arguments (everything after --)
+				result, err := secrets.RunCommand(secrets.RunOptions{
+					Command:     args,
+					Env:         envMap,
+					Passthrough: runPassthrough,
+					WorkingDir:  runWorkingDir,
+					Timeout:     runTimeout,
+				})
+				if err != nil {
+					return err
+				}
+
+				// Print stdout/stderr
+				if result.Stdout != "" {
+					_, _ = fmt.Print(result.Stdout)
+				}
+				if result.Stderr != "" {
+					_, _ = fmt.Fprint(os.Stderr, result.Stderr)
+				}
+
+				if result.ExitCode != 0 {
+					return errorspkg.NewCLIError(errorspkg.ExitGeneralError, fmt.Sprintf("command exited with code %d", result.ExitCode), nil)
+				}
+
+				return nil
 			})
-			if err != nil {
-				return err
-			}
-
-			// Print stdout/stderr
-			if result.Stdout != "" {
-				_, _ = fmt.Print(result.Stdout)
-			}
-			if result.Stderr != "" {
-				_, _ = fmt.Fprint(os.Stderr, result.Stderr)
-			}
-
-			if result.ExitCode != 0 {
-				return errorspkg.NewCLIError(errorspkg.ExitGeneralError, fmt.Sprintf("command exited with code %d", result.ExitCode), nil)
-			}
-
-			return nil
-		})
-	},
+		},
+	}
+	runCmd.Flags().StringArrayVarP(&runEnvFlags, "env", "e", nil, "Environment variable mapping (NAME=path.field)")
+	runCmd.Flags().StringArrayVarP(&runEnvFiles, "env-file", "f", nil, "File with env variable mappings (NAME=path.field), one per line")
+	runCmd.Flags().StringArrayVar(&runPassthrough, "passthrough", nil, "Parent env var names to pass through to the child process (comma-separated)")
+	runCmd.Flags().StringVarP(&runWorkingDir, "working-dir", "C", "", "Working directory for the command")
+	runCmd.Flags().DurationVarP(&runTimeout, "timeout", "t", 0, "Timeout for the command (e.g., 30s)")
+	runCmd.GroupID = cli.GroupIDVault
+	return runCmd
 }
 
 // parseEnvFile reads an env file and returns a map of env var names to secret references.
@@ -142,13 +155,4 @@ func parseEnvFile(path string) (map[string]string, error) {
 		return nil, fmt.Errorf("read env file %q: %w", path, err)
 	}
 	return result, nil
-}
-
-func init() {
-	runCmd.Flags().StringArrayVarP(&runEnvFlags, "env", "e", nil, "Environment variable mapping (NAME=path.field)")
-	runCmd.Flags().StringArrayVarP(&runEnvFiles, "env-file", "f", nil, "File with env variable mappings (NAME=path.field), one per line")
-	runCmd.Flags().StringArrayVar(&runPassthrough, "passthrough", nil, "Parent env var names to pass through to the child process (comma-separated)")
-	runCmd.Flags().StringVarP(&runWorkingDir, "working-dir", "C", "", "Working directory for the command")
-	runCmd.Flags().DurationVarP(&runTimeout, "timeout", "t", 0, "Timeout for the command (e.g., 30s)")
-	runCmd.GroupID = cli.GroupIDVault
 }

--- a/cmd/share.go
+++ b/cmd/share.go
@@ -12,11 +12,16 @@ import (
 	"github.com/danieljustus/symaira-vault/internal/vault/taint"
 )
 
-var shareCmd = &cobra.Command{
-	Use:   "share",
-	Short: "Manage secret sharing between agents",
-	Long:  "List and revoke secret share grants between MCP agents.",
-	Example: `  # List all pending share requests
+// shareCmd is retained for API compatibility; NewRootCmd() uses
+// newShareCmd() so every call gets a fresh command.
+var shareCmd = newShareCmd()
+
+func newShareCmd() *cobra.Command {
+	shareCmd := &cobra.Command{
+		Use:   "share",
+		Short: "Manage secret sharing between agents",
+		Long:  "List and revoke secret share grants between MCP agents.",
+		Example: `  # List all pending share requests
   symvault share list --status pending
 
   # Revoke a grant by ID
@@ -24,15 +29,21 @@ var shareCmd = &cobra.Command{
 
   # JSON output for tooling
   symvault share list --output json`,
-	Annotations: map[string]string{
-		cli.JSONOutputAnnotation: "true",
-	},
+		Annotations: map[string]string{
+			cli.JSONOutputAnnotation: "true",
+		},
+	}
+	shareCmd.GroupID = cli.GroupIDSharingSync
+	shareCmd.AddCommand(newShareListCmd())
+	shareCmd.AddCommand(newShareRevokeCmd())
+	return shareCmd
 }
 
-var shareListCmd = &cobra.Command{
-	Use:   "list",
-	Short: "List share grants",
-	Long: `List all share grants with optional filtering by status, agent, or path.
+func newShareListCmd() *cobra.Command {
+	shareListCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List share grants",
+		Long: `List all share grants with optional filtering by status, agent, or path.
 
 Examples:
   symvault share list
@@ -41,123 +52,121 @@ Examples:
   symvault share list --to agent-b
   symvault share list --path github.password
   symvault share list --output json`,
-	Annotations: map[string]string{
-		cli.JSONOutputAnnotation: "true",
-	},
-	RunE: func(cmd *cobra.Command, args []string) error {
-		vDir, err := cli.VaultPath()
-		if err != nil {
-			return err
-		}
-
-		store := server.NewShareStore(server.ShareStoreFilePath(vDir))
-		if err := store.Load(); err != nil {
-			return fmt.Errorf("load share store: %w", err)
-		}
-
-		statusStr, _ := cmd.Flags().GetString("status")
-		from, _ := cmd.Flags().GetString("from")
-		to, _ := cmd.Flags().GetString("to")
-		path, _ := cmd.Flags().GetString("path")
-
-		var filter mcp.ShareFilter
-		if statusStr != "" {
-			s := mcp.ShareStatus(statusStr)
-			filter.Status = &s
-		}
-		if from != "" {
-			filter.FromAgent = from
-		}
-		if to != "" {
-			filter.ToAgent = to
-		}
-		if path != "" {
-			filter.SecretPath = path
-		}
-
-		grants := store.List(filter)
-
-		if cli.OutputFormat != "text" {
-			if err := cli.PrintResult(grants); err != nil {
+		Annotations: map[string]string{
+			cli.JSONOutputAnnotation: "true",
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			vDir, err := cli.VaultPath()
+			if err != nil {
 				return err
 			}
-			return nil
-		}
 
-		if len(grants) == 0 {
-			printlnQuietAware("No share grants found.")
-			return nil
-		}
-
-		hasFilter := statusStr != "" || from != "" || to != "" || path != ""
-
-		printQuietAware("%-22s %-18s %-18s %-28s %-8s %-10s %-16s %s\n",
-			"ID", "FROM", "TO", "PATH", "FIELD", "STATUS", "CREATED", "EXPIRES")
-		for _, g := range grants {
-			status := string(g.Status)
-			if g.IsExpired() {
-				status = "expired"
+			store := server.NewShareStore(server.ShareStoreFilePath(vDir))
+			if err := store.Load(); err != nil {
+				return fmt.Errorf("load share store: %w", err)
 			}
 
-			field := g.SecretField
-			if field == "" {
-				field = "-"
+			statusStr, _ := cmd.Flags().GetString("status")
+			from, _ := cmd.Flags().GetString("from")
+			to, _ := cmd.Flags().GetString("to")
+			path, _ := cmd.Flags().GetString("path")
+
+			var filter mcp.ShareFilter
+			if statusStr != "" {
+				s := mcp.ShareStatus(statusStr)
+				filter.Status = &s
+			}
+			if from != "" {
+				filter.FromAgent = from
+			}
+			if to != "" {
+				filter.ToAgent = to
+			}
+			if path != "" {
+				filter.SecretPath = path
 			}
 
-			expires := "never"
-			if g.ExpiresAt != nil {
-				expires = g.ExpiresAt.Format("2006-01-02 15:04")
+			grants := store.List(filter)
+
+			if cli.OutputFormat != "text" {
+				if err := cli.PrintResult(grants); err != nil {
+					return err
+				}
+				return nil
 			}
+
+			if len(grants) == 0 {
+				printlnQuietAware("No share grants found.")
+				return nil
+			}
+
+			hasFilter := statusStr != "" || from != "" || to != "" || path != ""
 
 			printQuietAware("%-22s %-18s %-18s %-28s %-8s %-10s %-16s %s\n",
-				g.ID, g.FromAgent, g.ToAgent, render.ForTerminal(taint.Wrap(g.SecretPath, taint.Provenance{Source: "cli.path"})), field, status,
-				g.CreatedAt.Format("2006-01-02 15:04"), expires)
-		}
+				"ID", "FROM", "TO", "PATH", "FIELD", "STATUS", "CREATED", "EXPIRES")
+			for _, g := range grants {
+				status := string(g.Status)
+				if g.IsExpired() {
+					status = "expired"
+				}
 
-		if hasFilter {
-			printQuietAware("\n%d grant(s) match the current filter.\n", len(grants))
-		} else {
-			printQuietAware("\n%d grant(s) total.\n", len(grants))
-		}
+				field := g.SecretField
+				if field == "" {
+					field = "-"
+				}
 
-		return nil
-	},
-}
+				expires := "never"
+				if g.ExpiresAt != nil {
+					expires = g.ExpiresAt.Format("2006-01-02 15:04")
+				}
 
-var shareRevokeCmd = &cobra.Command{
-	Use:   "revoke <grant-id>",
-	Short: "Revoke a share grant",
-	Long:  "Revoke an active share grant, immediately removing the recipient's access to the shared secret.",
-	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		grantID := args[0]
+				printQuietAware("%-22s %-18s %-18s %-28s %-8s %-10s %-16s %s\n",
+					g.ID, g.FromAgent, g.ToAgent, render.ForTerminal(taint.Wrap(g.SecretPath, taint.Provenance{Source: "cli.path"})), field, status,
+					g.CreatedAt.Format("2006-01-02 15:04"), expires)
+			}
 
-		vDir, err := cli.VaultPath()
-		if err != nil {
-			return err
-		}
+			if hasFilter {
+				printQuietAware("\n%d grant(s) match the current filter.\n", len(grants))
+			} else {
+				printQuietAware("\n%d grant(s) total.\n", len(grants))
+			}
 
-		store := server.NewShareStore(server.ShareStoreFilePath(vDir))
-		if err := store.Load(); err != nil {
-			return fmt.Errorf("load share store: %w", err)
-		}
-
-		if err := store.Revoke(grantID); err != nil {
-			return fmt.Errorf("revoke share grant: %w", err)
-		}
-
-		printQuietAware("Share grant %s revoked successfully.\n", grantID)
-		return nil
-	},
-}
-
-func init() {
-	shareCmd.GroupID = cli.GroupIDSharingSync
-	shareCmd.AddCommand(shareListCmd)
-	shareCmd.AddCommand(shareRevokeCmd)
-
+			return nil
+		},
+	}
 	shareListCmd.Flags().String("status", "", "Filter by status (pending, approved, revoked, expired, rejected)")
 	shareListCmd.Flags().String("from", "", "Filter by source agent")
 	shareListCmd.Flags().String("to", "", "Filter by target agent")
 	shareListCmd.Flags().String("path", "", "Filter by secret path")
+	return shareListCmd
+}
+
+func newShareRevokeCmd() *cobra.Command {
+	shareRevokeCmd := &cobra.Command{
+		Use:   "revoke <grant-id>",
+		Short: "Revoke a share grant",
+		Long:  "Revoke an active share grant, immediately removing the recipient's access to the shared secret.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			grantID := args[0]
+
+			vDir, err := cli.VaultPath()
+			if err != nil {
+				return err
+			}
+
+			store := server.NewShareStore(server.ShareStoreFilePath(vDir))
+			if err := store.Load(); err != nil {
+				return fmt.Errorf("load share store: %w", err)
+			}
+
+			if err := store.Revoke(grantID); err != nil {
+				return fmt.Errorf("revoke share grant: %w", err)
+			}
+
+			printQuietAware("Share grant %s revoked successfully.\n", grantID)
+			return nil
+		},
+	}
+	return shareRevokeCmd
 }

--- a/cmd/share.go
+++ b/cmd/share.go
@@ -17,7 +17,7 @@ import (
 var shareCmd = newShareCmd()
 
 func newShareCmd() *cobra.Command {
-	shareCmd := &cobra.Command{
+	c := &cobra.Command{
 		Use:   "share",
 		Short: "Manage secret sharing between agents",
 		Long:  "List and revoke secret share grants between MCP agents.",
@@ -33,10 +33,10 @@ func newShareCmd() *cobra.Command {
 			cli.JSONOutputAnnotation: "true",
 		},
 	}
-	shareCmd.GroupID = cli.GroupIDSharingSync
-	shareCmd.AddCommand(newShareListCmd())
-	shareCmd.AddCommand(newShareRevokeCmd())
-	return shareCmd
+	c.GroupID = cli.GroupIDSharingSync
+	c.AddCommand(newShareListCmd())
+	c.AddCommand(newShareRevokeCmd())
+	return c
 }
 
 func newShareListCmd() *cobra.Command {

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -22,7 +22,7 @@ var syncForce bool
 var syncCmd = newSyncCmd()
 
 func newSyncCmd() *cobra.Command {
-	syncCmd := &cobra.Command{
+	c := &cobra.Command{
 		Use:   "sync",
 		Short: "Sync vault with remote (pull + optional push)",
 		Long:  "Pulls changes from the remote git repository and optionally pushes local changes.",
@@ -99,10 +99,10 @@ func newSyncCmd() *cobra.Command {
 			return nil
 		},
 	}
-	syncCmd.Flags().BoolVarP(&syncPush, "push", "p", false, "also push after pull")
-	syncCmd.Flags().BoolVarP(&syncForce, "force", "f", false, "force pull (reset local changes)")
-	syncCmd.GroupID = cli.GroupIDSharingSync
-	return syncCmd
+	c.Flags().BoolVarP(&syncPush, "push", "p", false, "also push after pull")
+	c.Flags().BoolVarP(&syncForce, "force", "f", false, "force pull (reset local changes)")
+	c.GroupID = cli.GroupIDSharingSync
+	return c
 }
 
 func isOfflineErr(err error) bool {

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -17,11 +17,16 @@ import (
 var syncPush bool
 var syncForce bool
 
-var syncCmd = &cobra.Command{
-	Use:   "sync",
-	Short: "Sync vault with remote (pull + optional push)",
-	Long:  "Pulls changes from the remote git repository and optionally pushes local changes.",
-	Example: `  # Pull only
+// syncCmd is retained for API compatibility; NewRootCmd() uses
+// newSyncCmd() so every call gets a fresh command.
+var syncCmd = newSyncCmd()
+
+func newSyncCmd() *cobra.Command {
+	syncCmd := &cobra.Command{
+		Use:   "sync",
+		Short: "Sync vault with remote (pull + optional push)",
+		Long:  "Pulls changes from the remote git repository and optionally pushes local changes.",
+		Example: `  # Pull only
   symvault sync
 
   # Pull and push
@@ -29,76 +34,75 @@ var syncCmd = &cobra.Command{
 
   # Force pull (reset local changes)
   symvault sync --force`,
-	Args: cobra.NoArgs,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		vaultDir, err := cli.VaultPath()
-		if err != nil {
-			return err
-		}
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			vaultDir, err := cli.VaultPath()
+			if err != nil {
+				return err
+			}
 
-		if !vaultpkg.IsInitialized(vaultDir) {
-			return errorspkg.NewVaultNotInitialized()
-		}
+			if !vaultpkg.IsInitialized(vaultDir) {
+				return errorspkg.NewVaultNotInitialized()
+			}
 
-		hasRemote, _ := git.HasRemote(vaultDir, "origin")
-		if !hasRemote {
-			printlnQuietAware("No remote configured. Skipping sync.")
-			return nil
-		}
-
-		result := git.Sync(vaultDir, syncPush)
-
-		if result.Skipped {
-			printlnQuietAware("No remote configured. Skipping sync.")
-			return nil
-		}
-
-		if result.Error != nil {
-			if isOfflineErr(result.Error) {
-				printlnQuietAware("Warning: could not reach remote — offline")
+			hasRemote, _ := git.HasRemote(vaultDir, "origin")
+			if !hasRemote {
+				printlnQuietAware("No remote configured. Skipping sync.")
 				return nil
 			}
-			return fmt.Errorf("sync failed: %w", result.Error)
-		}
 
-		if result.Success {
-			printlnQuietAware("Pulled from remote")
-			if err := git.SetLastSyncTime(vaultDir); err != nil {
-				cliout.Warnf("Warning: could not record sync time: %v", err)
+			result := git.Sync(vaultDir, syncPush)
+
+			if result.Skipped {
+				printlnQuietAware("No remote configured. Skipping sync.")
+				return nil
 			}
 
-			hostname, _ := os.Hostname()
-			if err := git.ResolveConflicts(vaultDir, hostname); err != nil {
-				cliout.Warnf("Warning: conflict resolution failed: %v", err)
+			if result.Error != nil {
+				if isOfflineErr(result.Error) {
+					printlnQuietAware("Warning: could not reach remote — offline")
+					return nil
+				}
+				return fmt.Errorf("sync failed: %w", result.Error)
 			}
-		} else {
-			printlnQuietAware("Already up to date")
-		}
 
-		if result.PushDone {
-			if result.PushSuccess {
-				printlnQuietAware("Pushed to remote")
+			if result.Success {
+				printlnQuietAware("Pulled from remote")
+				if err := git.SetLastSyncTime(vaultDir); err != nil {
+					cliout.Warnf("Warning: could not record sync time: %v", err)
+				}
+
+				hostname, _ := os.Hostname()
+				if err := git.ResolveConflicts(vaultDir, hostname); err != nil {
+					cliout.Warnf("Warning: conflict resolution failed: %v", err)
+				}
 			} else {
-				printlnQuietAware("Push skipped or failed")
+				printlnQuietAware("Already up to date")
 			}
-		}
 
-		conflictFiles := findConflictFiles(vaultDir)
-		if len(conflictFiles) > 0 {
-			cliout.Warnf("Warning: %d conflict file(s) created:", len(conflictFiles))
-			for _, f := range conflictFiles {
-				cliout.Warnf("  %s", f)
+			if result.PushDone {
+				if result.PushSuccess {
+					printlnQuietAware("Pushed to remote")
+				} else {
+					printlnQuietAware("Push skipped or failed")
+				}
 			}
-		}
 
-		return nil
-	},
-}
+			conflictFiles := findConflictFiles(vaultDir)
+			if len(conflictFiles) > 0 {
+				cliout.Warnf("Warning: %d conflict file(s) created:", len(conflictFiles))
+				for _, f := range conflictFiles {
+					cliout.Warnf("  %s", f)
+				}
+			}
 
-func init() {
+			return nil
+		},
+	}
 	syncCmd.Flags().BoolVarP(&syncPush, "push", "p", false, "also push after pull")
 	syncCmd.Flags().BoolVarP(&syncForce, "force", "f", false, "force pull (reset local changes)")
 	syncCmd.GroupID = cli.GroupIDSharingSync
+	return syncCmd
 }
 
 func isOfflineErr(err error) bool {

--- a/cmd/template.go
+++ b/cmd/template.go
@@ -22,10 +22,15 @@ var (
 	templatePrefix string
 )
 
-var templateCmd = &cobra.Command{
-	Use:   "template",
-	Short: "Generate configuration files from templates",
-	Long: `Generate configuration files from built-in or custom templates.
+// templateCmd is retained for API compatibility; NewCommands() uses
+// newTemplateCmd() so every call gets a fresh command.
+var templateCmd = newTemplateCmd()
+
+func newTemplateCmd() *cobra.Command {
+	templateCmd := &cobra.Command{
+		Use:   "template",
+		Short: "Generate configuration files from templates",
+		Long: `Generate configuration files from built-in or custom templates.
 
 Supported template types:
   env             - Environment variable file
@@ -33,30 +38,35 @@ Supported template types:
   k8s-secret      - Kubernetes Secret manifest
   github-actions  - GitHub Actions workflow secrets
   terraform       - Terraform variable definitions`,
-	Example: `  # Generate a .env file from the work/* entries
+		Example: `  # Generate a .env file from the work/* entries
   symvault template generate env --prefix work/ > .env
 
   # K8s Secret manifest
   symvault template generate k8s-secret --name prod-secrets prod/*`,
-	Annotations: map[string]string{
-		cli.JSONOutputAnnotation: "true",
-	},
+		Annotations: map[string]string{
+			cli.JSONOutputAnnotation: "true",
+		},
+	}
+	templateCmd.AddCommand(newTemplateGenerateCmd())
+	templateCmd.GroupID = cli.GroupIDVault
+	return templateCmd
 }
 
-var templateGenerateCmd = &cobra.Command{
-	Use:   "generate [KEY=ref ...]",
-	Short: "Generate a configuration file from a template",
-	Annotations: map[string]string{
-		cli.JSONOutputAnnotation: "true",
-	},
-	Long: `Generate a configuration file from a template.
+func newTemplateGenerateCmd() *cobra.Command {
+	templateGenerateCmd := &cobra.Command{
+		Use:   "generate [KEY=ref ...]",
+		Short: "Generate a configuration file from a template",
+		Annotations: map[string]string{
+			cli.JSONOutputAnnotation: "true",
+		},
+		Long: `Generate a configuration file from a template.
 
 Refs can be specified as positional KEY=ref arguments or via --prefix to
 automatically select entries matching a vault path prefix. Each ref is a
 vault entry path with an optional dot-separated field (e.g. db.password).
 When --prefix is used without positional args, all matching entries are
 included with the entry basename as the key.`,
-	Example: `  # Generate .env file from specific vault secrets
+		Example: `  # Generate .env file from specific vault secrets
   symvault template generate --type env DB_PASS=prod/db.password API_KEY=stripe.token
 
   # Generate .env from all entries under work/
@@ -67,88 +77,84 @@ included with the entry basename as the key.`,
 
   # Dry-run to preview without real values
   symvault template generate --type env --prefix work/ --dry-run`,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		return cli.WithVault(func(v *vaultpkg.Vault, vs *cli.VaultService) error {
-			ctx := context.Background()
-			engine := template.NewEngine(v)
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cli.WithVault(func(v *vaultpkg.Vault, vs *cli.VaultService) error {
+				ctx := context.Background()
+				engine := template.NewEngine(v)
 
-			refs := make(map[string]string)
+				refs := make(map[string]string)
 
-			if templatePrefix != "" {
-				entries, listErr := vaultpkg.List(v.Dir, templatePrefix, v.Identity)
-				if listErr != nil {
-					return fmt.Errorf("list entries with prefix %q: %w", templatePrefix, listErr)
-				}
-				for _, entryPath := range entries {
-					entry, readErr := vaultpkg.ReadEntry(v.Dir, entryPath, v.Identity)
-					if readErr != nil {
-						return fmt.Errorf("read entry %q: %w", entryPath, readErr)
+				if templatePrefix != "" {
+					entries, listErr := vaultpkg.List(v.Dir, templatePrefix, v.Identity)
+					if listErr != nil {
+						return fmt.Errorf("list entries with prefix %q: %w", templatePrefix, listErr)
 					}
-					for field := range entry.Data {
-						basename := entryPath
-						if idx := strings.LastIndex(entryPath, "/"); idx >= 0 {
-							basename = entryPath[idx+1:]
+					for _, entryPath := range entries {
+						entry, readErr := vaultpkg.ReadEntry(v.Dir, entryPath, v.Identity)
+						if readErr != nil {
+							return fmt.Errorf("read entry %q: %w", entryPath, readErr)
 						}
-						key := basename + "." + field
-						refs[key] = entryPath + "." + field
+						for field := range entry.Data {
+							basename := entryPath
+							if idx := strings.LastIndex(entryPath, "/"); idx >= 0 {
+								basename = entryPath[idx+1:]
+							}
+							key := basename + "." + field
+							refs[key] = entryPath + "." + field
+						}
 					}
 				}
-			}
 
-			for _, arg := range args {
-				parts := strings.SplitN(arg, "=", 2)
-				if len(parts) != 2 {
-					return fmt.Errorf("invalid ref format: %q (expected KEY=path[.field])", arg)
+				for _, arg := range args {
+					parts := strings.SplitN(arg, "=", 2)
+					if len(parts) != 2 {
+						return fmt.Errorf("invalid ref format: %q (expected KEY=path[.field])", arg)
+					}
+					key := parts[0]
+					ref := parts[1]
+					if key == "" || ref == "" {
+						return fmt.Errorf("empty key or ref in: %q", arg)
+					}
+					refs[key] = ref
 				}
-				key := parts[0]
-				ref := parts[1]
-				if key == "" || ref == "" {
-					return fmt.Errorf("empty key or ref in: %q", arg)
+
+				if len(refs) == 0 {
+					return fmt.Errorf("no secret references provided: use positional KEY=ref arguments or --prefix")
 				}
-				refs[key] = ref
-			}
 
-			if len(refs) == 0 {
-				return fmt.Errorf("no secret references provided: use positional KEY=ref arguments or --prefix")
-			}
+				customDir := os.ExpandEnv("$HOME/.config/symvault/templates")
+				_ = engine.LoadCustomTemplates(customDir)
 
-			customDir := os.ExpandEnv("$HOME/.config/symvault/templates")
-			_ = engine.LoadCustomTemplates(customDir)
-
-			output, err := engine.Render(ctx, templateType, templateName, refs, templateDryRun)
-			if err != nil {
-				return fmt.Errorf("render template: %w", err)
-			}
-
-			if templateOutput != "" {
-				if err := os.WriteFile(templateOutput, []byte(output), 0600); err != nil {
-					return fmt.Errorf("write output file: %w", err)
+				output, err := engine.Render(ctx, templateType, templateName, refs, templateDryRun)
+				if err != nil {
+					return fmt.Errorf("render template: %w", err)
 				}
-				if cli.OutputFormat == "text" {
-					fmt.Printf("Template written to: %s\n", templateOutput)
-				} else {
-					return cli.PrintResult(map[string]interface{}{
-						"output_path": templateOutput,
-						"dry_run":     templateDryRun,
-					})
+
+				if templateOutput != "" {
+					if err := os.WriteFile(templateOutput, []byte(output), 0600); err != nil {
+						return fmt.Errorf("write output file: %w", err)
+					}
+					if cli.OutputFormat == "text" {
+						fmt.Printf("Template written to: %s\n", templateOutput)
+					} else {
+						return cli.PrintResult(map[string]interface{}{
+							"output_path": templateOutput,
+							"dry_run":     templateDryRun,
+						})
+					}
+					return nil
 				}
+
+				fmt.Println(output)
 				return nil
-			}
-
-			fmt.Println(output)
-			return nil
-		})
-	},
-}
-
-func init() {
+			})
+		},
+	}
 	templateGenerateCmd.Flags().StringVar(&templateType, "type", "", "Template type (env, docker-compose, k8s-secret, github-actions, terraform)")
 	templateGenerateCmd.Flags().StringVar(&templateOutput, "output", "", "Output file path (optional)")
 	templateGenerateCmd.Flags().BoolVar(&templateDryRun, "dry-run", false, "Show template with masked values")
 	templateGenerateCmd.Flags().StringVar(&templateName, "name", "app", "Name of the resource being generated")
 	templateGenerateCmd.Flags().StringVar(&templatePrefix, "prefix", "", "Vault path prefix to auto-select entries (e.g. work/)")
 	_ = templateGenerateCmd.MarkFlagRequired("type")
-
-	templateCmd.AddCommand(templateGenerateCmd)
-	templateCmd.GroupID = cli.GroupIDVault
+	return templateGenerateCmd
 }

--- a/cmd/template.go
+++ b/cmd/template.go
@@ -27,7 +27,7 @@ var (
 var templateCmd = newTemplateCmd()
 
 func newTemplateCmd() *cobra.Command {
-	templateCmd := &cobra.Command{
+	c := &cobra.Command{
 		Use:   "template",
 		Short: "Generate configuration files from templates",
 		Long: `Generate configuration files from built-in or custom templates.
@@ -47,9 +47,9 @@ Supported template types:
 			cli.JSONOutputAnnotation: "true",
 		},
 	}
-	templateCmd.AddCommand(newTemplateGenerateCmd())
-	templateCmd.GroupID = cli.GroupIDVault
-	return templateCmd
+	c.AddCommand(newTemplateGenerateCmd())
+	c.GroupID = cli.GroupIDVault
+	return c
 }
 
 func newTemplateGenerateCmd() *cobra.Command {

--- a/cmd/ui.go
+++ b/cmd/ui.go
@@ -14,10 +14,15 @@ import (
 var uiPrintKeybindings bool
 var uiExperimental bool
 
-var uiCmd = &cobra.Command{
-	Use:   "ui",
-	Short: "Launch the interactive terminal UI",
-	Long: `Launches the interactive terminal UI for browsing and managing the vault.
+// uiCmd is retained for API compatibility; NewCommands() uses
+// newUiCmd() so every call gets a fresh command.
+var uiCmd = newUiCmd()
+
+func newUiCmd() *cobra.Command {
+	uiCmd := &cobra.Command{
+		Use:   "ui",
+		Short: "Launch the interactive terminal UI",
+		Long: `Launches the interactive terminal UI for browsing and managing the vault.
 
 Inside the TUI:
   ↑/↓ or j/k   move
@@ -29,35 +34,32 @@ Inside the TUI:
   g            generate password for selected entry
   ?            toggle full keybinding help
   q or Ctrl+C  quit`,
-	Example: `  # Launch the TUI
+		Example: `  # Launch the TUI
   symvault ui
 
   # Combined with a specific profile
   symvault ui --profile work`,
-	Args: cobra.NoArgs,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		if uiPrintKeybindings {
-			tbl := cliout.NewTable("Key", "Action")
-			for _, b := range ui.Keybindings() {
-				tbl.AddRow(b.Key, b.Action)
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if uiPrintKeybindings {
+				tbl := cliout.NewTable("Key", "Action")
+				for _, b := range ui.Keybindings() {
+					tbl.AddRow(b.Key, b.Action)
+				}
+				fmt.Print(tbl.Render())
+				return nil
 			}
-			fmt.Print(tbl.Render())
-			return nil
-		}
-		return cli.WithVault(func(v *vaultpkg.Vault, vs *cli.VaultService) error {
-			if err := ui.Run(v); err != nil {
-				return fmt.Errorf("ui failed: %w", err)
-			}
+			return cli.WithVault(func(v *vaultpkg.Vault, vs *cli.VaultService) error {
+				if err := ui.Run(v); err != nil {
+					return fmt.Errorf("ui failed: %w", err)
+				}
 
-			return nil
-		})
-	},
-}
-
-func init() {
+				return nil
+			})
+		},
+	}
 	uiCmd.Flags().BoolVar(&uiPrintKeybindings, "print-keybindings", false, "Print the TUI keybinding reference and exit")
-	// --experimental is kept as a no-op for backward compatibility with scripts
-	// that used it while the TUI was gated. It no longer has any effect.
 	uiCmd.Flags().BoolVar(&uiExperimental, "experimental", false, "(deprecated, no longer needed)")
 	uiCmd.GroupID = cli.GroupIDEssentials
+	return uiCmd
 }

--- a/cmd/ui.go
+++ b/cmd/ui.go
@@ -15,11 +15,11 @@ var uiPrintKeybindings bool
 var uiExperimental bool
 
 // uiCmd is retained for API compatibility; NewCommands() uses
-// newUiCmd() so every call gets a fresh command.
-var uiCmd = newUiCmd()
+// newUICmd() so every call gets a fresh command.
+var uiCmd = newUICmd()
 
-func newUiCmd() *cobra.Command {
-	uiCmd := &cobra.Command{
+func newUICmd() *cobra.Command {
+	c := &cobra.Command{
 		Use:   "ui",
 		Short: "Launch the interactive terminal UI",
 		Long: `Launches the interactive terminal UI for browsing and managing the vault.
@@ -58,8 +58,8 @@ Inside the TUI:
 			})
 		},
 	}
-	uiCmd.Flags().BoolVar(&uiPrintKeybindings, "print-keybindings", false, "Print the TUI keybinding reference and exit")
-	uiCmd.Flags().BoolVar(&uiExperimental, "experimental", false, "(deprecated, no longer needed)")
-	uiCmd.GroupID = cli.GroupIDEssentials
-	return uiCmd
+	c.Flags().BoolVar(&uiPrintKeybindings, "print-keybindings", false, "Print the TUI keybinding reference and exit")
+	c.Flags().BoolVar(&uiExperimental, "experimental", false, "(deprecated, no longer needed)")
+	c.GroupID = cli.GroupIDEssentials
+	return c
 }

--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -71,7 +71,7 @@ func setVersionInfoForTest(t *testing.T, version string) {
 }
 
 func TestUpdateCheckCommandReportsAvailableUpdate(t *testing.T) {
-	rootCmd = NewRootCmd()
+	rootCmd = newPackageRootCmd()
 	buf := prepareRootCommandOutput(t)
 	setVersionInfoForTest(t, "1.0.0")
 
@@ -109,7 +109,7 @@ func TestUpdateCheckCommandReportsAvailableUpdate(t *testing.T) {
 }
 
 func TestUpdateCheckCommandReportsUpToDate(t *testing.T) {
-	rootCmd = NewRootCmd()
+	rootCmd = newPackageRootCmd()
 	buf := prepareRootCommandOutput(t)
 	setVersionInfoForTest(t, "1.0.0")
 
@@ -135,7 +135,7 @@ func TestUpdateCheckCommandReportsUpToDate(t *testing.T) {
 }
 
 func TestUpdateCheckCommandHandlesNonReleaseBuild(t *testing.T) {
-	rootCmd = NewRootCmd()
+	rootCmd = newPackageRootCmd()
 	buf := prepareRootCommandOutput(t)
 	setVersionInfoForTest(t, "dev")
 
@@ -181,7 +181,7 @@ func TestUpdateCheckCommandReturnsCheckerError(t *testing.T) {
 }
 
 func TestUpdateCheckCommandDoesNotRequireVault(t *testing.T) {
-	rootCmd = NewRootCmd()
+	rootCmd = newPackageRootCmd()
 	buf := prepareRootCommandOutput(t)
 	setVersionInfoForTest(t, "dev")
 	setUpdateCheckerForTest(t, &stubUpdateChecker{
@@ -225,7 +225,7 @@ func TestUpdateCheckCommandDoesNotRequireVault(t *testing.T) {
 }
 
 func TestUpdateCheckCommandJSONOutput(t *testing.T) {
-	rootCmd = NewRootCmd()
+	rootCmd = newPackageRootCmd()
 	buf := prepareRootCommandOutput(t)
 	setVersionInfoForTest(t, "1.0.0")
 
@@ -263,7 +263,7 @@ func TestUpdateCheckCommandJSONOutput(t *testing.T) {
 }
 
 func TestUpdateCheckCommandJSONOutputNoUpdate(t *testing.T) {
-	rootCmd = NewRootCmd()
+	rootCmd = newPackageRootCmd()
 	buf := prepareRootCommandOutput(t)
 	setVersionInfoForTest(t, "1.0.0")
 


### PR DESCRIPTION
Second and final part of the CLI constructor migration (issue #744): the root package, `cmd/mcp` and `cmd/passlint`.

- **cmd/mcp**: all 16 `init()` bodies converted to `newXxxCmd()` constructors with inline flag registration and child wiring; `NewCommands()` now returns fresh trees
- **top-level cmd package**: every singleton command var converted to a constructor; `NewRootCmd()` is now a pure builder returning fully independent trees (regression tests in `root_cmd_test.go` cover independence, path uniqueness and the golden tree)
- **cmd/passlint**: removed the redundant `init()` nil-guard
- **Compat layer**: the package-level `rootCmd` (and the per-test reassignments) are built by `newPackageRootCmd()`, which swaps the package-level compat instances into a fresh tree — tests that execute or mutate package vars directly (`recipientsAddCmd.Execute()`, `mcpcmd.ServeCmd` flag resets, `admin.DoctorCmd`) keep working exactly as before the migration
- **Init-cycle fix**: the manpages renderer references the package root through a small indirection var (`rootForManpages`) — a direct reference would create `rootCmd -> NewRootCmd -> newGenerateCmd -> newManpagesCmd -> rootCmd` and fail at compile time
- Verified: `go build ./...`, `go vet`, `gofmt -l` clean, full `go test ./cmd/...` suite green (357s run, including the serve/recipients/generate command tests)

Closes #744
