### PR TITLE
feat(importer): built-in CSV profiles for Apple Passwords, Chrome and Firefox

### DIFF
--- a/cmd/admin/import.go
+++ b/cmd/admin/import.go
@@ -2,6 +2,7 @@ package admin
 
 import (
 	"crypto/rand"
+	"encoding/csv"
 	"errors"
 	"fmt"
 	"os"
@@ -41,15 +42,24 @@ When --format is not specified, the format is auto-detected from the input file 
   .json → JSON format
   .yaml/.yml → YAML format
 
-Use --format to override auto-detection or when the file extension does not match the actual format.`,
+CSV files are additionally header-sniffed: exports from Apple Passwords
+(iCloud Keychain), Chrome/Chromium and Firefox are recognized from their
+header row and mapped with a built-in profile. Use --format apple, --format
+chrome or --format firefox to select a profile explicitly. Use --format to
+override auto-detection or when the file extension does not match the actual
+format.`,
+
 		Example: `  # Auto-detect format from file extension
   symvault import bw-export.json --dry-run
 
-  # Explicitly specify format (overrides auto-detection)
+  # Auto-detect the CSV profile from the header row (Apple Passwords, Chrome, Firefox)
+  symvault import passwords.csv --dry-run
+
+  # Explicitly specify a format (overrides auto-detection)
   symvault import bitwarden bw-export.json --dry-run
 
-  # Import 1Password CSV under a prefix, skipping entries that already exist
-  symvault import export.csv --format 1password --prefix work/ --skip-existing
+  # Import a Firefox export under a prefix, skipping entries that already exist
+  symvault import logins.csv --format firefox --prefix work/ --skip-existing
 
   # Auto-detect CSV from .csv extension
   symvault import data.csv --overwrite`,
@@ -69,6 +79,19 @@ Use --format to override auto-detection or when the file extension does not matc
 			}
 			if !isSupportedImportFormat(format) {
 				return errorspkg.NewCLIError(errorspkg.ExitGeneralError, fmt.Sprintf("unsupported import format: %s", format), nil)
+			}
+
+			// Sniff .csv files: match the header row against the built-in CSV
+			// profiles (Apple Passwords, Chrome/Chromium, Firefox) before falling
+			// back to the generic CSV mapping.
+			if format == importer.FormatCSV && ImportFormat == "" {
+				format = sniffOrKeepCSV(format, sourcePath)
+			}
+
+			// Dry-run reports the resolved format and the CSV mapping in effect,
+			// so a user can verify the profile before writing anything.
+			if err := reportDryRunImport(format); err != nil {
+				return err
 			}
 
 			if ImportSkipExisting && ImportOverwrite {
@@ -138,51 +161,10 @@ Use --format to override auto-detection or when the file extension does not matc
 					}()
 				}
 
-				imported, skipped := 0, 0
-				for _, entry := range entries {
-					entryPath := importEntryPath(options.Prefix, entry.Path)
-					if entryPath == "" {
-						skipped++
-						cli.PrintQuietAware("Skipped entry with empty path\n")
-						continue
-					}
-
-					exists, err := importEntryExists(vs, entryPath)
-					if err != nil {
-						return fmt.Errorf("cannot check entry: %w", err)
-					}
-
-					if exists && options.SkipExisting {
-						skipped++
-						cli.PrintQuietAware("Skipped existing: %s\n", entryPath)
-						continue
-					}
-
-					if options.DryRun {
-						cli.PrintQuietAware("Would import: %s\n", entryPath)
-						imported++
-						continue
-					}
-
-					if exists && options.Overwrite {
-						if err := vs.DeleteEntry(entryPath); err != nil {
-							return fmt.Errorf("cannot overwrite entry: %w", err)
-						}
-					}
-
-					record := vaultpkg.WriteRecord{Action: "import"}
-					if err := vs.SetFieldsWithProvenance(entryPath, entry.Data, record); err != nil {
-						return fmt.Errorf("cannot write entry: %w", err)
-					}
-					if entry.SecretMetadata != nil {
-						if err := vs.SetSecretMetadata(entryPath, *entry.SecretMetadata); err != nil {
-							return fmt.Errorf("cannot set secret metadata: %w", err)
-						}
-					}
-					cli.PrintQuietAware("Imported: %s\n", entryPath)
-					imported++
+				imported, skipped, err := importEntries(vs, entries, options)
+				if err != nil {
+					return err
 				}
-
 				cli.PrintQuietAware("Import summary: %d imported, %d skipped\n", imported, skipped)
 				return nil
 			})
@@ -202,11 +184,68 @@ Use --format to override auto-detection or when the file extension does not matc
 
 func isSupportedImportFormat(format importer.Format) bool {
 	switch format {
-	case importer.Format1Password, importer.FormatBitwarden, importer.FormatPass, importer.FormatCSV:
+	case importer.Format1Password, importer.FormatBitwarden, importer.FormatPass, importer.FormatCSV,
+		importer.FormatApple, importer.FormatChrome, importer.FormatFirefox:
 		return true
 	default:
 		return false
 	}
+}
+
+// reportDryRunImport prints the resolved format and, for CSV imports, the
+// field→column mapping in effect, so a user can verify the profile before
+// writing anything.
+func reportDryRunImport(format importer.Format) error {
+	if !ImportDryRun {
+		return nil
+	}
+	cli.PrintQuietAware("Import format: %s\n", format)
+	if !importer.IsCSVFormat(format) {
+		return nil
+	}
+	effective, err := importer.CSVEffectiveMapping(format, ImportMapping)
+	if err != nil {
+		return errorspkg.NewCLIError(errorspkg.ExitGeneralError, "invalid CSV mapping", err)
+	}
+	mappingParts := make([]string, 0, len(effective))
+	for field, column := range effective {
+		mappingParts = append(mappingParts, field+"="+column)
+	}
+	sort.Strings(mappingParts)
+	cli.PrintQuietAware("CSV mapping: %s\n", strings.Join(mappingParts, ", "))
+	return nil
+}
+
+// sniffOrKeepCSV sniffs a .csv source against the built-in CSV profiles and
+// returns the detected profile format, or the original format when the header
+// matches none. It announces a detected profile on stdout.
+func sniffOrKeepCSV(format importer.Format, sourcePath string) importer.Format {
+	profile := sniffCSVProfile(sourcePath)
+	if profile == importer.FormatCSV {
+		return format
+	}
+	if p, ok := importer.CSVProfileFor(profile); ok {
+		cli.PrintQuietAware("Detected %s CSV export from header row\n", p.Name)
+	}
+	return profile
+}
+
+// sniffCSVProfile reads the header row of a CSV file and returns the
+// built-in profile it matches, or FormatCSV when no profile matches.
+func sniffCSVProfile(sourcePath string) importer.Format {
+	f, err := os.Open(sourcePath) // #nosec G304 -- import source path is user-provided CLI argument
+	if err != nil {
+		return importer.FormatCSV
+	}
+	defer func() { _ = f.Close() }()
+
+	reader := csv.NewReader(f)
+	reader.FieldsPerRecord = -1
+	header, err := reader.Read()
+	if err != nil {
+		return importer.FormatCSV
+	}
+	return importer.DetectCSVProfile(header)
 }
 
 // detectFormatFromExt derives the import format from the file extension.
@@ -226,10 +265,63 @@ func detectFormatFromExt(filename string) (importer.Format, error) {
 }
 
 func newImporter(format importer.Format, options importer.ImportOptions) (importer.Importer, error) {
-	if format == importer.FormatCSV {
-		return importer.NewCSV(options.Mapping), nil
+	if importer.IsCSVFormat(format) {
+		if format == importer.FormatCSV {
+			return importer.NewCSV(options.Mapping), nil
+		}
+		return importer.NewCSVProfile(format, options.Mapping)
 	}
 	return importer.New(format)
+}
+
+// importEntries writes the parsed entries into the vault, applying the
+// import options (prefix, skip-existing, overwrite, dry-run) per entry. It
+// returns the number of imported and skipped entries.
+func importEntries(vs *cli.VaultService, entries []importer.ImportedEntry, options importer.ImportOptions) (imported, skipped int, err error) {
+	for _, entry := range entries {
+		entryPath := importEntryPath(options.Prefix, entry.Path)
+		if entryPath == "" {
+			skipped++
+			cli.PrintQuietAware("Skipped entry with empty path\n")
+			continue
+		}
+
+		exists, err := importEntryExists(vs, entryPath)
+		if err != nil {
+			return 0, 0, fmt.Errorf("cannot check entry: %w", err)
+		}
+
+		if exists && options.SkipExisting {
+			skipped++
+			cli.PrintQuietAware("Skipped existing: %s\n", entryPath)
+			continue
+		}
+
+		if options.DryRun {
+			cli.PrintQuietAware("Would import: %s\n", entryPath)
+			imported++
+			continue
+		}
+
+		if exists && options.Overwrite {
+			if err := vs.DeleteEntry(entryPath); err != nil {
+				return 0, 0, fmt.Errorf("cannot overwrite entry: %w", err)
+			}
+		}
+
+		record := vaultpkg.WriteRecord{Action: "import"}
+		if err := vs.SetFieldsWithProvenance(entryPath, entry.Data, record); err != nil {
+			return 0, 0, fmt.Errorf("cannot write entry: %w", err)
+		}
+		if entry.SecretMetadata != nil {
+			if err := vs.SetSecretMetadata(entryPath, *entry.SecretMetadata); err != nil {
+				return 0, 0, fmt.Errorf("cannot set secret metadata: %w", err)
+			}
+		}
+		cli.PrintQuietAware("Imported: %s\n", entryPath)
+		imported++
+	}
+	return imported, skipped, nil
 }
 
 func importEntryPath(prefix, entryPath string) string {

--- a/cmd/admin/import_test.go
+++ b/cmd/admin/import_test.go
@@ -71,6 +71,9 @@ func TestIsSupportedImportFormat(t *testing.T) {
 		{importer.Format1Password, true},
 		{importer.FormatBitwarden, true},
 		{importer.FormatPass, true},
+		{importer.FormatApple, true},
+		{importer.FormatChrome, true},
+		{importer.FormatFirefox, true},
 		{"json", false},
 		{"yaml", false},
 		{"unknown", false},
@@ -80,6 +83,43 @@ func TestIsSupportedImportFormat(t *testing.T) {
 		t.Run(string(tt.format), func(t *testing.T) {
 			if got := isSupportedImportFormat(tt.format); got != tt.want {
 				t.Errorf("isSupportedImportFormat(%q) = %v, want %v", tt.format, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSniffCSVProfile(t *testing.T) {
+	tmpDir := t.TempDir()
+	writeCSV := func(name, content string) string {
+		t.Helper()
+		p := filepath.Join(tmpDir, name)
+		if err := os.WriteFile(p, []byte(content), 0o600); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+		return p
+	}
+
+	tests := []struct {
+		name    string
+		content string
+		want    importer.Format
+	}{
+		{"apple", "Title,URL,Username,Password,Notes,OTPAuth\nExample,https://example.com,u,p,n,otpauth://totp/x?secret=JBSWY3DPEHPK3PXPJBSWY3DPEHPK3PXP\n", importer.FormatApple},
+		{"chrome", "name,url,username,password,note\nExample,https://example.com,u,p,n\n", importer.FormatChrome},
+		{"firefox", "url,username,password,httpRealm,formActionOrigin,guid,timeCreated,timeLastUsed,timePasswordChanged\nhttps://example.com,u,p,,https://example.com,{00000000-0000-0000-0000-000000000001},1735689600000,1735776000000,1735776000000\n", importer.FormatFirefox},
+		{"generic", "title,username,password,url,notes\nExample,u,p,https://example.com,n\n", importer.FormatCSV},
+		{"empty file", "", importer.FormatCSV},
+		{"missing file", "", importer.FormatCSV},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(tmpDir, "does-not-exist.csv")
+			if tt.name != "missing file" {
+				path = writeCSV(tt.name+".csv", tt.content)
+			}
+			if got := sniffCSVProfile(path); got != tt.want {
+				t.Errorf("sniffCSVProfile(%q) = %q, want %q", path, got, tt.want)
 			}
 		})
 	}

--- a/internal/importer/csv.go
+++ b/internal/importer/csv.go
@@ -10,6 +10,7 @@ import (
 
 type csvImporter struct {
 	mapping string
+	profile *CSVProfile
 }
 
 // NewCSV creates a CSV importer with an optional field-to-column mapping.
@@ -30,11 +31,14 @@ func (i *csvImporter) Parse(r io.Reader) ([]ImportedEntry, error) {
 	}
 
 	columnIndex := csvColumnIndex(header)
-	mapping, err := csvMapping(i.mapping)
+	mapping, err := csvMapping(i.mapping, i.profile)
 	if err != nil {
 		return nil, err
 	}
 
+	// Profile imports de-duplicate paths so every entry lands on a unique
+	// vault path (colliding entries would otherwise fail or overwrite).
+	usedPaths := make(map[string]bool)
 	var entries []ImportedEntry
 	for {
 		row, err := reader.Read()
@@ -58,7 +62,9 @@ func (i *csvImporter) Parse(r io.Reader) ([]ImportedEntry, error) {
 
 			switch field {
 			case "title", "path":
-				entry.Path = NormalizePath(value)
+				if entry.Path == "" && value != "" {
+					entry.Path = NormalizePath(value)
+				}
 			case "otp", "totp.secret":
 				if value != "" {
 					totp, err := ParseTOTP(value)
@@ -73,19 +79,35 @@ func (i *csvImporter) Parse(r io.Reader) ([]ImportedEntry, error) {
 			}
 		}
 
+		// Sources without a title column (Firefox) — and rows whose title is
+		// empty (Chrome) — derive the entry path from the URL host.
+		if entry.Path == "" && i.profile != nil && i.profile.PathFromURL {
+			if urlValue, ok := csvValue(row, columnIndex, i.profile.URLColumn); ok {
+				if host := hostFromURL(urlValue); host != "" {
+					entry.Path = NormalizePath(strings.ToLower(host))
+				}
+			}
+		}
+		if i.profile != nil {
+			entry.Path = uniquePath(usedPaths, entry.Path)
+		}
+
 		entries = append(entries, entry)
 	}
 
 	return entries, nil
 }
 
-func csvMapping(mapping string) (map[string]string, error) {
-	parsed, err := ParseMapping(mapping)
-	if err != nil {
-		return nil, fmt.Errorf("parse csv mapping: %w", err)
-	}
-	if parsed != nil {
+func csvMapping(userMapping string, profile *CSVProfile) (map[string]string, error) {
+	if userMapping != "" {
+		parsed, err := ParseMapping(userMapping)
+		if err != nil {
+			return nil, fmt.Errorf("parse csv mapping: %w", err)
+		}
 		return parsed, nil
+	}
+	if profile != nil {
+		return profile.Mapping, nil
 	}
 	return map[string]string{
 		"title":    "title",

--- a/internal/importer/csv_profiles.go
+++ b/internal/importer/csv_profiles.go
@@ -1,0 +1,225 @@
+package importer
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Canonical (lowercase) CSV column names and vault field names used by the
+// built-in profiles. They are declared once so header sniffing, profile
+// mappings and path derivation share a single vocabulary.
+const (
+	csvColTitle            = "title"
+	csvColURL              = "url"
+	csvColUsername         = "username"
+	csvColPassword         = "password"
+	csvColNotes            = "notes"
+	csvColOTPAuth          = "otpauth"
+	csvColName             = "name"
+	csvColNote             = "note"
+	csvColHTTPRealm        = "httprealm"
+	csvColFormActionOrigin = "formactionorigin"
+	csvColGUID             = "guid"
+	csvColTimeCreated      = "timecreated"
+)
+
+// CSVProfile is a built-in CSV import profile: the field→column mapping for
+// a well-known password-manager export, selected with --format or detected
+// from the header row.
+type CSVProfile struct {
+	// Format is the --format value that selects this profile.
+	Format Format
+	// Name is the human-readable source name, shown in status output.
+	Name string
+	// Mapping maps vault fields to CSV columns.
+	Mapping map[string]string
+	// URLColumn is the CSV column holding the login URL, used to derive
+	// entry paths when the source has no usable title column.
+	URLColumn string
+	// PathFromURL derives the entry path from the URL host when the row has
+	// no title (Firefox always; Chrome when the name column is empty).
+	PathFromURL bool
+	// Required lists the header columns (lowercase) that must all be present
+	// for header sniffing to select this profile.
+	Required []string
+}
+
+// csvProfileApple matches the Apple Passwords / iCloud Keychain CSV export
+// (System Settings → Passwords → ⋯ → Export Passwords):
+//
+//	Title,URL,Username,Password,Notes,OTPAuth
+var csvProfileApple = CSVProfile{
+	Format:    FormatApple,
+	Name:      "Apple Passwords (iCloud Keychain)",
+	URLColumn: csvColURL,
+	Mapping: map[string]string{
+		"title":    "Title",
+		"url":      "URL",
+		"username": "Username",
+		"password": "Password",
+		"notes":    "Notes",
+		"otp":      "OTPAuth",
+	},
+	Required: []string{csvColTitle, csvColURL, csvColUsername, csvColPassword, csvColOTPAuth},
+}
+
+// csvProfileChrome matches the Chrome / Chromium (Edge, Brave, Opera, ...)
+// CSV export (chrome://password-manager/passwords → Export):
+//
+//	name,url,username,password,note
+var csvProfileChrome = CSVProfile{
+	Format:      FormatChrome,
+	Name:        "Chrome / Chromium",
+	URLColumn:   csvColURL,
+	PathFromURL: true, // Chrome rows can have an empty name; fall back to the URL host.
+	Mapping: map[string]string{
+		"title":    "name",
+		"url":      "url",
+		"username": "username",
+		"password": "password",
+		"notes":    "note",
+	},
+	Required: []string{csvColName, csvColURL, csvColUsername, csvColPassword, csvColNote},
+}
+
+// csvProfileFirefox matches the Firefox CSV export
+// (about:logins → ⋯ → Export Logins):
+//
+//	url,username,password,httpRealm,formActionOrigin,guid,timeCreated,timeLastUsed,timePasswordChanged
+var csvProfileFirefox = CSVProfile{
+	Format:      FormatFirefox,
+	Name:        "Firefox",
+	URLColumn:   csvColURL,
+	PathFromURL: true, // Firefox has no title column; the path is the URL host.
+	Mapping: map[string]string{
+		"url":      "url",
+		"username": "username",
+		"password": "password",
+	},
+	Required: []string{csvColURL, csvColUsername, csvColPassword, csvColHTTPRealm},
+}
+
+// csvProfiles lists the built-in CSV import profiles in header-sniffing
+// priority order. Profiles whose Required columns are all present win; the
+// first match is returned.
+var csvProfiles = []CSVProfile{csvProfileApple, csvProfileChrome, csvProfileFirefox}
+
+// CSVProfileFor returns the built-in CSV profile for format, if any.
+func CSVProfileFor(format Format) (*CSVProfile, bool) {
+	for i := range csvProfiles {
+		if csvProfiles[i].Format == format {
+			return &csvProfiles[i], true
+		}
+	}
+	return nil, false
+}
+
+// IsCSVFormat reports whether format is CSV-based: the generic format or one
+// of the built-in profiles.
+func IsCSVFormat(format Format) bool {
+	if format == FormatCSV {
+		return true
+	}
+	_, ok := CSVProfileFor(format)
+	return ok
+}
+
+// NewCSVProfile creates a CSV importer using the built-in profile for format.
+// A non-empty userMapping overrides the profile mapping. It returns an error
+// for formats without a built-in profile.
+func NewCSVProfile(format Format, userMapping string) (Importer, error) {
+	profile, ok := CSVProfileFor(format)
+	if !ok {
+		return nil, fmt.Errorf("no built-in CSV profile for format %q", format)
+	}
+	return &csvImporter{profile: profile, mapping: userMapping}, nil
+}
+
+// DetectCSVProfile matches a CSV header row against the built-in profiles.
+// It returns the matching profile format, or FormatCSV when the header does
+// not match any known profile (the generic CSV mapping then applies).
+func DetectCSVProfile(header []string) Format {
+	columns := make(map[string]bool, len(header))
+	for _, column := range header {
+		column = strings.ToLower(strings.TrimSpace(column))
+		if column != "" {
+			columns[column] = true
+		}
+	}
+	for i := range csvProfiles {
+		if profileColumnsPresent(columns, csvProfiles[i].Required) {
+			return csvProfiles[i].Format
+		}
+	}
+	return FormatCSV
+}
+
+func profileColumnsPresent(columns map[string]bool, required []string) bool {
+	for _, column := range required {
+		if !columns[column] {
+			return false
+		}
+	}
+	return true
+}
+
+// CSVEffectiveMapping returns the field→column mapping in effect for a CSV
+// import: the user-provided mapping when non-empty, otherwise the built-in
+// profile mapping, otherwise the generic default.
+func CSVEffectiveMapping(format Format, userMapping string) (map[string]string, error) {
+	var profile *CSVProfile
+	if p, ok := CSVProfileFor(format); ok {
+		profile = p
+	}
+	return csvMapping(userMapping, profile)
+}
+
+// hostFromURL extracts the host name from a login URL. It tolerates URLs
+// without a scheme and strips credentials, ports and paths:
+//
+//	https://github.com/login → github.com
+//	user:pass@example.com:8080/x → example.com
+func hostFromURL(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	if i := strings.Index(raw, "://"); i >= 0 {
+		raw = raw[i+3:]
+	}
+	if i := strings.Index(raw, "@"); i >= 0 {
+		raw = raw[i+1:]
+	}
+	if i := strings.IndexAny(raw, "/?#"); i >= 0 {
+		raw = raw[:i]
+	}
+	if strings.HasPrefix(raw, "[") {
+		if i := strings.Index(raw, "]"); i >= 0 {
+			return raw[:i+1]
+		}
+	}
+	if i := strings.Index(raw, ":"); i >= 0 {
+		raw = raw[:i]
+	}
+	return raw
+}
+
+// uniquePath returns path, or a path with a -2/-3/... suffix when the base
+// path is already taken within the import batch, so every entry gets a
+// distinct vault path. Empty paths pass through unchanged.
+func uniquePath(used map[string]bool, path string) string {
+	if path == "" {
+		return ""
+	}
+	if !used[path] {
+		used[path] = true
+		return path
+	}
+	for i := 2; ; i++ {
+		candidate := fmt.Sprintf("%s-%d", path, i)
+		if !used[candidate] {
+			used[candidate] = true
+			return candidate
+		}
+	}
+}

--- a/internal/importer/csv_profiles_test.go
+++ b/internal/importer/csv_profiles_test.go
@@ -1,0 +1,343 @@
+package importer
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestAppleCSVProfile(t *testing.T) {
+	f := openFixture(t, "testdata/csv/apple.csv")
+	defer f.Close()
+
+	imp, err := NewCSVProfile(FormatApple, "")
+	if err != nil {
+		t.Fatalf("NewCSVProfile() error = %v", err)
+	}
+	entries, err := imp.Parse(f)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if len(entries) != 3 {
+		t.Fatalf("Parse() returned %d entries, want 3", len(entries))
+	}
+
+	github := findEntry(t, entries, "GitHub")
+	assertStringField(t, github.Data, "username", "octocat@example.com")
+	assertStringField(t, github.Data, "url", "https://github.com/login")
+	assertStringField(t, github.Data, "password", "gh-apple-secret")
+	assertStringField(t, github.Data, "notes", "Primary GitHub account")
+	assertTOTPSecret(t, github.Data, "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ")
+	assertTOTPParams(t, github.Data, "SHA1", float64(6), float64(30))
+
+	icloud := findEntry(t, entries, "iCloud-Mail")
+	if _, ok := icloud.Data["totp"]; ok {
+		t.Errorf("entry without OTPAuth should not carry totp data")
+	}
+
+	bank := findEntry(t, entries, "Bank-of-Example")
+	assertStringField(t, bank.Data, "notes", "Checking account, with comma")
+	assertTOTPSecret(t, bank.Data, "JBSWY3DPEHPK3PXPJBSWY3DPEHPK3PXP")
+}
+
+func TestChromeCSVProfile(t *testing.T) {
+	f := openFixture(t, "testdata/csv/chrome.csv")
+	defer f.Close()
+
+	imp, err := NewCSVProfile(FormatChrome, "")
+	if err != nil {
+		t.Fatalf("NewCSVProfile() error = %v", err)
+	}
+	entries, err := imp.Parse(f)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if len(entries) != 5 {
+		t.Fatalf("Parse() returned %d entries, want 5", len(entries))
+	}
+	assertUniqueNonEmptyPaths(t, entries)
+
+	github := findEntry(t, entries, "GitHub")
+	assertStringField(t, github.Data, "username", "octocat@example.com")
+	assertStringField(t, github.Data, "password", "gh-chrome-secret")
+	assertStringField(t, github.Data, "notes", "Main GitHub account")
+
+	// Empty name falls back to the URL host.
+	google := findEntry(t, entries, "mail.google.com")
+	assertStringField(t, google.Data, "username", "user@gmail.com")
+	assertStringField(t, google.Data, "notes", "Google account without a name")
+
+	// Duplicate title gets a -2 suffix.
+	second := findEntry(t, entries, "GitHub-2")
+	assertStringField(t, second.Data, "username", "second@example.com")
+
+	assertStringField(t, findEntry(t, entries, "Company-VPN").Data, "password", "company-vpn-secret")
+	assertStringField(t, findEntry(t, entries, "AWS-Console").Data, "password", "aws-admin-secret")
+}
+
+func TestFirefoxCSVProfile(t *testing.T) {
+	f := openFixture(t, "testdata/csv/firefox.csv")
+	defer f.Close()
+
+	imp, err := NewCSVProfile(FormatFirefox, "")
+	if err != nil {
+		t.Fatalf("NewCSVProfile() error = %v", err)
+	}
+	entries, err := imp.Parse(f)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if len(entries) != 4 {
+		t.Fatalf("Parse() returned %d entries, want 4", len(entries))
+	}
+	assertUniqueNonEmptyPaths(t, entries)
+
+	github := findEntry(t, entries, "github.com")
+	assertStringField(t, github.Data, "username", "octocat@example.com")
+	assertStringField(t, github.Data, "password", "gh-firefox-secret")
+
+	// Same host as the first row gets a -2 suffix.
+	second := findEntry(t, entries, "github.com-2")
+	assertStringField(t, second.Data, "username", "second@example.com")
+
+	// HTTP basic-auth login derives its path from the URL host too.
+	intranet := findEntry(t, entries, "intranet.example.com")
+	assertStringField(t, intranet.Data, "username", "jdoe")
+	assertStringField(t, intranet.Data, "password", "http-basic-secret")
+}
+
+func TestCSVProfileMappingOverride(t *testing.T) {
+	csvData := strings.NewReader(strings.Join([]string{
+		"name,url,username,password,note",
+		"Example,https://example.com,user@example.com,secret,note text",
+	}, "\n"))
+
+	imp, err := NewCSVProfile(FormatChrome, "path=name,password=password")
+	if err != nil {
+		t.Fatalf("NewCSVProfile() error = %v", err)
+	}
+	entries, err := imp.Parse(csvData)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("Parse() returned %d entries, want 1", len(entries))
+	}
+	entry := entries[0]
+	if entry.Path != "Example" {
+		t.Errorf("path = %q, want Example", entry.Path)
+	}
+	assertStringField(t, entry.Data, "password", "secret")
+	if _, ok := entry.Data["username"]; ok {
+		t.Errorf("username should not be mapped with the override mapping")
+	}
+	if _, ok := entry.Data["note"]; ok {
+		t.Errorf("note should not be mapped with the override mapping")
+	}
+}
+
+func TestCSVProfileEmptyNameAndURL(t *testing.T) {
+	csvData := strings.NewReader(strings.Join([]string{
+		"name,url,username,password,note",
+		",,user,secret,note text",
+	}, "\n"))
+
+	imp, err := NewCSVProfile(FormatChrome, "")
+	if err != nil {
+		t.Fatalf("NewCSVProfile() error = %v", err)
+	}
+	entries, err := imp.Parse(csvData)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("Parse() returned %d entries, want 1", len(entries))
+	}
+	if entries[0].Path != "" {
+		t.Errorf("path = %q, want empty when name and url are both empty", entries[0].Path)
+	}
+}
+
+func TestCSVProfileInvalidTOTPWarning(t *testing.T) {
+	csvData := strings.NewReader(strings.Join([]string{
+		"Title,URL,Username,Password,Notes,OTPAuth",
+		"Example,https://example.com,user,secret,notes,not-a-totp-value",
+	}, "\n"))
+
+	imp, err := NewCSVProfile(FormatApple, "")
+	if err != nil {
+		t.Fatalf("NewCSVProfile() error = %v", err)
+	}
+	entries, err := imp.Parse(csvData)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("Parse() returned %d entries, want 1", len(entries))
+	}
+	entry := entries[0]
+	if _, ok := entry.Data["totp"]; ok {
+		t.Errorf("invalid OTPAuth should not produce totp data")
+	}
+	if len(entry.Warnings) == 0 {
+		t.Errorf("invalid OTPAuth should produce a warning")
+	}
+}
+
+func TestDetectCSVProfile(t *testing.T) {
+	tests := []struct {
+		name   string
+		header string
+		want   Format
+	}{
+		{"apple", "Title,URL,Username,Password,Notes,OTPAuth", FormatApple},
+		{"apple lowercase", "title,url,username,password,notes,otpauth", FormatApple},
+		{"apple with spaces", "Title, URL, Username, Password, Notes, OTPAuth", FormatApple},
+		{"chrome", "name,url,username,password,note", FormatChrome},
+		{"chrome with path", "name,url,username,password,note,extra", FormatChrome},
+		{"firefox", "url,username,password,httpRealm,formActionOrigin,guid,timeCreated,timeLastUsed,timePasswordChanged", FormatFirefox},
+		{"firefox minimal", "url,username,password,httpRealm", FormatFirefox},
+		{"generic", "title,username,password,url,notes", FormatCSV},
+		{"generic with otp", "title,username,password,url,notes,otp", FormatCSV},
+		{"empty", "", FormatCSV},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var header []string
+			if tt.header != "" {
+				header = strings.Split(tt.header, ",")
+			}
+			if got := DetectCSVProfile(header); got != tt.want {
+				t.Errorf("DetectCSVProfile(%q) = %q, want %q", tt.header, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCSVEffectiveMapping(t *testing.T) {
+	t.Run("apple profile default", func(t *testing.T) {
+		mapping, err := CSVEffectiveMapping(FormatApple, "")
+		if err != nil {
+			t.Fatalf("CSVEffectiveMapping() error = %v", err)
+		}
+		if mapping["otp"] != "OTPAuth" {
+			t.Errorf("otp column = %q, want OTPAuth", mapping["otp"])
+		}
+		if mapping["title"] != "Title" {
+			t.Errorf("title column = %q, want Title", mapping["title"])
+		}
+	})
+
+	t.Run("user mapping overrides profile", func(t *testing.T) {
+		mapping, err := CSVEffectiveMapping(FormatChrome, "path=name,password=password")
+		if err != nil {
+			t.Fatalf("CSVEffectiveMapping() error = %v", err)
+		}
+		if len(mapping) != 2 {
+			t.Errorf("mapping has %d entries, want 2", len(mapping))
+		}
+	})
+
+	t.Run("generic default", func(t *testing.T) {
+		mapping, err := CSVEffectiveMapping(FormatCSV, "")
+		if err != nil {
+			t.Fatalf("CSVEffectiveMapping() error = %v", err)
+		}
+		if mapping["title"] != "title" {
+			t.Errorf("title column = %q, want title", mapping["title"])
+		}
+	})
+
+	t.Run("invalid user mapping", func(t *testing.T) {
+		if _, err := CSVEffectiveMapping(FormatFirefox, "nonsense"); err == nil {
+			t.Fatal("expected error for invalid mapping")
+		}
+	})
+}
+
+func TestNewCSVProfileRejectsGenericFormat(t *testing.T) {
+	if _, err := NewCSVProfile(FormatCSV, ""); err == nil {
+		t.Fatal("expected error for format without a built-in profile")
+	}
+}
+
+func TestNewSupportsProfiles(t *testing.T) {
+	for _, format := range []Format{FormatApple, FormatChrome, FormatFirefox} {
+		imp, err := New(format)
+		if err != nil {
+			t.Fatalf("New(%q) error = %v", format, err)
+		}
+		if _, ok := imp.(*csvImporter); !ok {
+			t.Errorf("New(%q) = %T, want *csvImporter", format, imp)
+		}
+	}
+}
+
+func TestHostFromURL(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"https://github.com/login", "github.com"},
+		{"http://example.com", "example.com"},
+		{"example.com/path", "example.com"},
+		{"user:pass@example.com:8080/x", "example.com"},
+		{"https://sub.example.org:8443/a?b=c", "sub.example.org"},
+		{"https://[::1]:8080/", "[::1]"},
+		{"", ""},
+		{"   ", ""},
+	}
+	for _, tt := range tests {
+		if got := hostFromURL(tt.in); got != tt.want {
+			t.Errorf("hostFromURL(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestUniquePath(t *testing.T) {
+	used := make(map[string]bool)
+	if got := uniquePath(used, "github.com"); got != "github.com" {
+		t.Errorf("first path = %q, want github.com", got)
+	}
+	if got := uniquePath(used, "github.com"); got != "github.com-2" {
+		t.Errorf("second path = %q, want github.com-2", got)
+	}
+	if got := uniquePath(used, "github.com"); got != "github.com-3" {
+		t.Errorf("third path = %q, want github.com-3", got)
+	}
+	if got := uniquePath(used, ""); got != "" {
+		t.Errorf("empty path = %q, want empty", got)
+	}
+}
+
+func assertUniqueNonEmptyPaths(t *testing.T, entries []ImportedEntry) {
+	t.Helper()
+	seen := make(map[string]bool, len(entries))
+	for _, entry := range entries {
+		if entry.Path == "" {
+			t.Errorf("entry has empty path: %#v", entry.Data)
+			continue
+		}
+		if seen[entry.Path] {
+			t.Errorf("duplicate path %q", entry.Path)
+		}
+		seen[entry.Path] = true
+	}
+}
+
+func assertTOTPParams(t *testing.T, data map[string]any, algorithm string, digits, period float64) {
+	t.Helper()
+	totp, ok := data["totp"].(map[string]any)
+	if !ok {
+		t.Fatalf("data[totp] = %#v, want map", data["totp"])
+	}
+	if got := totp["algorithm"]; got != algorithm {
+		t.Errorf("totp[algorithm] = %v, want %s", got, algorithm)
+	}
+	if got := totp["digits"]; got != digits {
+		t.Errorf("totp[digits] = %v, want %v", got, digits)
+	}
+	if got := totp["period"]; got != period {
+		t.Errorf("totp[period] = %v, want %v", got, period)
+	}
+}

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -54,6 +54,15 @@ const (
 	FormatBitwarden Format = "bitwarden"
 	FormatPass      Format = "pass"
 	FormatCSV       Format = "csv"
+	// FormatApple is the Apple Passwords / iCloud Keychain CSV export
+	// (Title,URL,Username,Password,Notes,OTPAuth).
+	FormatApple Format = "apple"
+	// FormatChrome is the Chrome / Chromium browser CSV export
+	// (name,url,username,password,note).
+	FormatChrome Format = "chrome"
+	// FormatFirefox is the Firefox CSV export
+	// (url,username,password,httpRealm,formActionOrigin,guid,timeCreated,timeLastUsed,timePasswordChanged).
+	FormatFirefox Format = "firefox"
 )
 
 // New creates an Importer for the given format.
@@ -67,6 +76,8 @@ func New(format Format) (Importer, error) {
 		return &passImporter{}, nil
 	case FormatCSV:
 		return &csvImporter{}, nil
+	case FormatApple, FormatChrome, FormatFirefox:
+		return NewCSVProfile(format, "")
 	default:
 		return nil, fmt.Errorf("unsupported import format: %s", format)
 	}

--- a/internal/importer/testdata/csv/apple.csv
+++ b/internal/importer/testdata/csv/apple.csv
@@ -1,0 +1,4 @@
+Title,URL,Username,Password,Notes,OTPAuth
+GitHub,https://github.com/login,octocat@example.com,gh-apple-secret,"Primary GitHub account",otpauth://totp/GitHub:octocat@example.com?secret=GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ&issuer=GitHub&algorithm=SHA1&digits=6&period=30
+iCloud Mail,https://www.icloud.com/mail,user@icloud.com,icloud-mail-secret,Personal mail,
+Bank of Example,https://bank.example.com/login,jane.doe@example.com,bank-checking-2026,"Checking account, with comma",otpauth://totp/Bank%20of%20Example:jane.doe@example.com?secret=JBSWY3DPEHPK3PXPJBSWY3DPEHPK3PXP&issuer=Bank+of+Example

--- a/internal/importer/testdata/csv/chrome.csv
+++ b/internal/importer/testdata/csv/chrome.csv
@@ -1,0 +1,6 @@
+name,url,username,password,note
+GitHub,https://github.com/login,octocat@example.com,gh-chrome-secret,Main GitHub account
+,https://mail.google.com/,user@gmail.com,gmail-chrome-secret,Google account without a name
+Company VPN,https://vpn.company.example/,vpn.user,company-vpn-secret,VPN credentials
+AWS Console,https://console.aws.amazon.com/,root@company.example,aws-admin-secret,AWS root
+GitHub,https://github.com/settings,second@example.com,gh-chrome-secret-2,Second GitHub account

--- a/internal/importer/testdata/csv/firefox.csv
+++ b/internal/importer/testdata/csv/firefox.csv
@@ -1,0 +1,5 @@
+url,username,password,httpRealm,formActionOrigin,guid,timeCreated,timeLastUsed,timePasswordChanged
+https://github.com/login,octocat@example.com,gh-firefox-secret,,https://github.com,{00000000-0000-0000-0000-000000000001},1735689600000,1735776000000,1735776000000
+https://gitlab.com/users/sign_in,dev@example.com,gitlab-firefox-secret,,https://gitlab.com,{00000000-0000-0000-0000-000000000002},1735689600000,1735776000000,1735776000000
+https://intranet.example.com/,jdoe,http-basic-secret,Example Intranet,,{00000000-0000-0000-0000-000000000003},1735689600000,1735776000000,1735776000000
+https://github.com/login,second@example.com,gh-firefox-secret-2,,https://github.com,{00000000-0000-0000-0000-000000000004},1735689600000,1735776000000,1735776000000


### PR DESCRIPTION
Implements #735: built-in CSV import profiles for the three most common
password-manager CSV exports, auto-detected from the header row.

- **Apple Passwords / iCloud Keychain**: `Title,URL,Username,Password,Notes,OTPAuth`
- **Chrome / Chromium**: `name,url,username,password,note`
- **Firefox**: `url,username,password,httpRealm,formActionOrigin,guid,time*`

Also:
- `--format apple|chrome|firefox` selects a profile explicitly; header
  sniffing applies when `--format` is omitted for `.csv` files
- entry paths derived from the URL host when the source has no title
  (Firefox always, Chrome when the name is empty)
- colliding paths within a batch are de-duplicated (`-2`, `-3`, ...)
- `--dry-run` reports the resolved format and effective CSV mapping

Tests cover header sniffing per profile, generic-CSV fallback and the
URL-host path derivation.

Closes #735