### PR TITLE
test(cmd): cover auth lifecycle and remaining CRUD commands

### DIFF
--- a/cmd/auth/auth_rotate.go
+++ b/cmd/auth/auth_rotate.go
@@ -121,6 +121,9 @@ Optionally re-encrypts all entries with the new passphrase.`,
 				}
 			}
 
+			if cfg.Vault == nil {
+				cfg.Vault = &configpkg.VaultConfig{}
+			}
 			cfg.Vault.LastRotated = time.Now().UTC()
 			if saveErr := cfg.SaveTo(filepath.Join(vaultDir, "config.yaml")); saveErr != nil {
 				return fmt.Errorf("save config: %w", saveErr)

--- a/cmd/auth/auth_rotate_test.go
+++ b/cmd/auth/auth_rotate_test.go
@@ -1,0 +1,230 @@
+package auth
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	configpkg "github.com/danieljustus/symaira-vault/internal/config"
+	"github.com/danieljustus/symaira-vault/internal/session"
+	vaultpkg "github.com/danieljustus/symaira-vault/internal/vault"
+)
+
+const (
+	testCurrentPassphrase = "test-passphrase"
+	testNewPassphrase     = "new-strong-passphrase-2026"
+)
+
+// runRotate executes the given rotate-passphrase command with stdin lines
+// (old, new, confirm[, confirm-prompt answer]) and returns stdout.
+//
+// NOTE: the command must be constructed BEFORE the caller sets the
+// package-level rotateYes/rotateReencrypt vars — pflag's flag registration
+// resets the bound variable to the flag default.
+func runRotate(t *testing.T, cmd *cobra.Command, input string) (string, error) {
+	t.Helper()
+	restoreStdin := pipeStdin(t, input)
+	defer restoreStdin()
+
+	var err error
+	out := captureStdout(t, func() {
+		err = cmd.RunE(cmd, nil)
+	})
+	return out, err
+}
+
+func TestRotatePassphrase_HappyPath(t *testing.T) {
+	vaultDir, _ := setupTestVault(t)
+	swapSessionManager(t, &testKeyring{store: map[string]string{}}, true)
+
+	cmd := newRotatePassphraseCmd()
+	rotateYes = true
+	rotateReencrypt = false
+	t.Cleanup(func() {
+		rotateYes = false
+		rotateReencrypt = true
+	})
+
+	out, err := runRotate(t, cmd, testCurrentPassphrase+"\n"+testNewPassphrase+"\n"+testNewPassphrase+"\n")
+	if err != nil {
+		t.Fatalf("rotate error = %v", err)
+	}
+	if !strings.Contains(out, "Passphrase rotated successfully.") {
+		t.Errorf("output = %q, want success message", out)
+	}
+
+	// The vault must now open with the new passphrase.
+	if _, err := vaultpkg.OpenWithPassphrase(vaultDir, []byte(testNewPassphrase)); err != nil {
+		t.Errorf("open vault with new passphrase: %v", err)
+	}
+	if _, err := vaultpkg.OpenWithPassphrase(vaultDir, []byte(testCurrentPassphrase)); err == nil {
+		t.Error("vault still opens with the old passphrase after rotation")
+	}
+
+	// The session cache must hold the new passphrase.
+	got, err := session.LoadPassphrase(vaultDir)
+	if err != nil {
+		t.Fatalf("load cached session: %v", err)
+	}
+	if string(got) != testNewPassphrase {
+		t.Errorf("cached passphrase = %q, want %q", got, testNewPassphrase)
+	}
+
+	// The config must record the rotation timestamp.
+	cfg, err := configpkg.Load(vaultDir + "/config.yaml")
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if cfg.Vault == nil || cfg.Vault.LastRotated.IsZero() {
+		t.Error("config LastRotated was not updated after rotation")
+	}
+}
+
+func TestRotatePassphrase_WrongCurrentPassphrase(t *testing.T) {
+	setupTestVault(t)
+	swapSessionManager(t, &testKeyring{store: map[string]string{}}, true)
+
+	cmd := newRotatePassphraseCmd()
+	rotateYes = true
+	t.Cleanup(func() { rotateYes = false })
+
+	_, err := runRotate(t, cmd, "wrong-passphrase\n"+testNewPassphrase+"\n"+testNewPassphrase+"\n")
+	if err == nil {
+		t.Fatal("expected error for wrong current passphrase, got nil")
+	}
+	if !strings.Contains(err.Error(), "current passphrase is incorrect") {
+		t.Errorf("error = %v, want incorrect-passphrase message", err)
+	}
+}
+
+func TestRotatePassphrase_NewPassphraseTooShort(t *testing.T) {
+	setupTestVault(t)
+	swapSessionManager(t, &testKeyring{store: map[string]string{}}, true)
+
+	cmd := newRotatePassphraseCmd()
+	rotateYes = true
+	t.Cleanup(func() { rotateYes = false })
+
+	_, err := runRotate(t, cmd, testCurrentPassphrase+"\nshort\nshort\n")
+	if err == nil {
+		t.Fatal("expected error for short passphrase, got nil")
+	}
+	if !strings.Contains(err.Error(), "at least 12 characters") {
+		t.Errorf("error = %v, want minimum-length message", err)
+	}
+}
+
+func TestRotatePassphrase_ConfirmationMismatch(t *testing.T) {
+	setupTestVault(t)
+	swapSessionManager(t, &testKeyring{store: map[string]string{}}, true)
+
+	cmd := newRotatePassphraseCmd()
+	rotateYes = true
+	t.Cleanup(func() { rotateYes = false })
+
+	_, err := runRotate(t, cmd, testCurrentPassphrase+"\n"+testNewPassphrase+"\nother-strong-passphrase-99\n")
+	if err == nil {
+		t.Fatal("expected error for mismatched confirmation, got nil")
+	}
+	if !strings.Contains(err.Error(), "passphrases do not match") {
+		t.Errorf("error = %v, want mismatch message", err)
+	}
+}
+
+func TestRotatePassphrase_SamePassphraseRejected(t *testing.T) {
+	setupTestVault(t)
+	swapSessionManager(t, &testKeyring{store: map[string]string{}}, true)
+
+	cmd := newRotatePassphraseCmd()
+	rotateYes = true
+	t.Cleanup(func() { rotateYes = false })
+
+	_, err := runRotate(t, cmd, testCurrentPassphrase+"\n"+testCurrentPassphrase+"\n"+testCurrentPassphrase+"\n")
+	if err == nil {
+		t.Fatal("expected error for unchanged passphrase, got nil")
+	}
+	if !strings.Contains(err.Error(), "must be different") {
+		t.Errorf("error = %v, want different-passphrase message", err)
+	}
+}
+
+func TestRotatePassphrase_CancelConfirmation(t *testing.T) {
+	vaultDir, _ := setupTestVault(t)
+	swapSessionManager(t, &testKeyring{store: map[string]string{}}, true)
+
+	cmd := newRotatePassphraseCmd()
+	// rotateYes stays false (flag default): the confirmation prompt runs.
+
+	var err error
+	restoreStdin := pipeStdin(t, testCurrentPassphrase+"\n"+testNewPassphrase+"\n"+testNewPassphrase+"\nn\n")
+	defer restoreStdin()
+	stderr := captureStderr(t, func() {
+		err = cmd.RunE(cmd, nil)
+	})
+	if err != nil {
+		t.Fatalf("rotate cancel error = %v", err)
+	}
+	if !strings.Contains(stderr, "Canceled") {
+		t.Errorf("stderr = %q, want canceled message", stderr)
+	}
+
+	// Nothing must have changed: the vault still opens with the old passphrase.
+	if _, err := vaultpkg.OpenWithPassphrase(vaultDir, []byte(testCurrentPassphrase)); err != nil {
+		t.Errorf("open vault with old passphrase after cancel: %v", err)
+	}
+	if _, err := vaultpkg.OpenWithPassphrase(vaultDir, []byte(testNewPassphrase)); err == nil {
+		t.Error("vault opens with the new passphrase despite cancellation")
+	}
+}
+
+func TestRotatePassphrase_ReadCurrentPassphraseFails(t *testing.T) {
+	setupTestVault(t)
+	swapSessionManager(t, &testKeyring{store: map[string]string{}}, true)
+
+	cmd := newRotatePassphraseCmd()
+	rotateYes = true
+	t.Cleanup(func() { rotateYes = false })
+
+	// Empty stdin: the first hidden-input read hits EOF.
+	_, err := runRotate(t, cmd, "")
+	if err == nil {
+		t.Fatal("expected error for empty stdin, got nil")
+	}
+	if !strings.Contains(err.Error(), "cannot read current passphrase") {
+		t.Errorf("error = %v, want read-failure message", err)
+	}
+}
+
+func TestRotatePassphrase_UpdatesTouchIDStore(t *testing.T) {
+	vaultDir, _ := setupTestVault(t)
+	swapSessionManager(t, &testKeyring{store: map[string]string{}}, true)
+	store := installTestBiometricStore(t, true)
+
+	cmd := newRotatePassphraseCmd()
+	rotateYes = true
+	rotateReencrypt = false
+	t.Cleanup(func() {
+		rotateYes = false
+		rotateReencrypt = true
+	})
+
+	// Switch the config to touchid so the rotate path refreshes biometrics.
+	cfg, err := configpkg.Load(vaultDir + "/config.yaml")
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if err := cfg.SetAuthMethod(configpkg.AuthMethodTouchID); err != nil {
+		t.Fatalf("SetAuthMethod: %v", err)
+	}
+	if err := cfg.SaveTo(vaultDir + "/config.yaml"); err != nil {
+		t.Fatalf("SaveTo: %v", err)
+	}
+
+	if _, err := runRotate(t, cmd, testCurrentPassphrase+"\n"+testNewPassphrase+"\n"+testNewPassphrase+"\n"); err != nil {
+		t.Fatalf("rotate error = %v", err)
+	}
+	if string(store.saved) != testNewPassphrase {
+		t.Errorf("biometric store saved %q, want %q", store.saved, testNewPassphrase)
+	}
+}

--- a/cmd/auth/auth_test.go
+++ b/cmd/auth/auth_test.go
@@ -1,0 +1,321 @@
+package auth
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	cli "github.com/danieljustus/symaira-vault/internal/cli"
+	configpkg "github.com/danieljustus/symaira-vault/internal/config"
+	"github.com/danieljustus/symaira-vault/internal/session"
+)
+
+// installTestBiometricStore swaps the process-wide biometric passphrase store
+// for the recording fake so auth set/status tests can exercise the
+// Touch ID branches deterministically.
+func installTestBiometricStore(t *testing.T, available bool) *testBiometricStore {
+	t.Helper()
+	store := &testBiometricStore{available: available}
+	old := session.DefaultBiometricPassphraseStore()
+	session.SetBiometricPassphraseStore(store)
+	t.Cleanup(func() { session.SetBiometricPassphraseStore(old) })
+	return store
+}
+
+func TestAuthStatus_TextOutput(t *testing.T) {
+	setupTestVault(t)
+	swapSessionManager(t, &testKeyring{store: map[string]string{}}, true)
+	// The darwin build installs a real Touch ID store in init(); pin the
+	// fake (unavailable) store so the text branch is deterministic.
+	installTestBiometricStore(t, false)
+
+	out := captureStdout(t, func() {
+		if err := AuthStatusCmd.RunE(AuthStatusCmd, nil); err != nil {
+			t.Fatalf("auth status error = %v", err)
+		}
+	})
+
+	for _, want := range []string{
+		"Vault: ",
+		"Auth method: passphrase",
+		"Touch ID available: false",
+		"Session cache: os-keyring (persistent: true)",
+		"Keyring health: available",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestAuthStatus_KeyringUnavailableBranch(t *testing.T) {
+	setupTestVault(t)
+	swapSessionManager(t, &testKeyring{store: map[string]string{}}, false)
+
+	out := captureStdout(t, func() {
+		if err := AuthStatusCmd.RunE(AuthStatusCmd, nil); err != nil {
+			t.Fatalf("auth status error = %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "Keyring health: unavailable") {
+		t.Errorf("output missing keyring-unavailable health:\n%s", out)
+	}
+	if !strings.Contains(out, "Session cache: memory (persistent: false)") {
+		t.Errorf("output missing memory cache status:\n%s", out)
+	}
+}
+
+func TestAuthStatus_TouchIDAvailableFlag(t *testing.T) {
+	setupTestVault(t)
+	swapSessionManager(t, &testKeyring{store: map[string]string{}}, true)
+	installTestBiometricStore(t, true)
+
+	out := captureStdout(t, func() {
+		if err := AuthStatusCmd.RunE(AuthStatusCmd, nil); err != nil {
+			t.Fatalf("auth status error = %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "Touch ID available: true") {
+		t.Errorf("output missing Touch ID availability:\n%s", out)
+	}
+}
+
+func TestAuthStatus_JSONFlag(t *testing.T) {
+	setupTestVault(t)
+	swapSessionManager(t, &testKeyring{store: map[string]string{}}, true)
+
+	oldJSON := AuthStatusJSON
+	AuthStatusJSON = true
+	t.Cleanup(func() { AuthStatusJSON = oldJSON })
+
+	out := captureStdout(t, func() {
+		if err := AuthStatusCmd.RunE(AuthStatusCmd, nil); err != nil {
+			t.Fatalf("auth status error = %v", err)
+		}
+	})
+
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &parsed); err != nil {
+		t.Fatalf("invalid JSON output: %v\noutput: %s", err, out)
+	}
+	for _, key := range []string{"vault", "method", "touchIDAvailable", "cache", "keyringHealth"} {
+		if _, ok := parsed[key]; !ok {
+			t.Errorf("JSON missing key %q: %v", key, parsed)
+		}
+	}
+	if parsed["keyringHealth"] != "available" {
+		t.Errorf("keyringHealth = %v, want available", parsed["keyringHealth"])
+	}
+	if parsed["method"] != configpkg.AuthMethodPassphrase {
+		t.Errorf("method = %v, want %q", parsed["method"], configpkg.AuthMethodPassphrase)
+	}
+}
+
+func TestAuthStatus_JSONOutputFormatGlobalFlag(t *testing.T) {
+	setupTestVault(t)
+	swapSessionManager(t, &testKeyring{store: map[string]string{}}, false)
+	setOutputFormat(t, "json")
+
+	oldJSON := AuthStatusJSON
+	AuthStatusJSON = false
+	t.Cleanup(func() { AuthStatusJSON = oldJSON })
+
+	out := captureStdout(t, func() {
+		if err := AuthStatusCmd.RunE(AuthStatusCmd, nil); err != nil {
+			t.Fatalf("auth status error = %v", err)
+		}
+	})
+
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &parsed); err != nil {
+		t.Fatalf("invalid JSON output: %v\noutput: %s", err, out)
+	}
+	if parsed["keyringHealth"] != "unavailable" {
+		t.Errorf("keyringHealth = %v, want unavailable", parsed["keyringHealth"])
+	}
+	cache, ok := parsed["cache"].(map[string]any)
+	if !ok {
+		t.Fatalf("cache = %v (%T), want object", parsed["cache"], parsed["cache"])
+	}
+	if cache["persistent"] != false {
+		t.Errorf("cache.persistent = %v, want false", cache["persistent"])
+	}
+	if cache["backend"] != session.CacheBackendMemory {
+		t.Errorf("cache.backend = %v, want %q", cache["backend"], session.CacheBackendMemory)
+	}
+}
+
+func TestAuthStatus_QuietModeSuppressesOutput(t *testing.T) {
+	setupTestVault(t)
+	swapSessionManager(t, &testKeyring{store: map[string]string{}}, true)
+	setQuietMode(t, true)
+
+	out := captureStdout(t, func() {
+		if err := AuthStatusCmd.RunE(AuthStatusCmd, nil); err != nil {
+			t.Fatalf("auth status error = %v", err)
+		}
+	})
+	if strings.TrimSpace(out) != "" {
+		t.Errorf("quiet mode should suppress status output, got %q", out)
+	}
+}
+
+func TestAuthStatus_VaultNotInitialized(t *testing.T) {
+	// Point at an empty temp dir with no vault.
+	cli.Vault = t.TempDir()
+	err := AuthStatusCmd.RunE(AuthStatusCmd, nil)
+	if err == nil {
+		t.Fatal("expected error for uninitialized vault, got nil")
+	}
+	if !strings.Contains(err.Error(), "vault not initialized") {
+		t.Errorf("error = %v, want vault-not-initialized", err)
+	}
+}
+
+func TestAuthSet_PassphraseUpdatesConfig(t *testing.T) {
+	vaultDir, _ := setupTestVault(t)
+	swapSessionManager(t, &testKeyring{store: map[string]string{}}, true)
+	// Pin the fake store so ClearBiometricPassphrase stays hermetic.
+	installTestBiometricStore(t, false)
+
+	// First switch to touchid so the passphrase path must clear biometrics.
+	cfg, err := configpkg.Load(vaultDir + "/config.yaml")
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if err := cfg.SetAuthMethod(configpkg.AuthMethodTouchID); err != nil {
+		t.Fatalf("SetAuthMethod: %v", err)
+	}
+	if err := cfg.SaveTo(vaultDir + "/config.yaml"); err != nil {
+		t.Fatalf("SaveTo: %v", err)
+	}
+
+	out := captureStdout(t, func() {
+		if err := AuthSetCmd.RunE(AuthSetCmd, []string{"passphrase"}); err != nil {
+			t.Fatalf("auth set passphrase error = %v", err)
+		}
+	})
+	if !strings.Contains(out, "Auth method set to passphrase") {
+		t.Errorf("output = %q, want passphrase confirmation", out)
+	}
+
+	loaded, err := configpkg.Load(vaultDir + "/config.yaml")
+	if err != nil {
+		t.Fatalf("reload config: %v", err)
+	}
+	if got := loaded.EffectiveAuthMethod(); got != configpkg.AuthMethodPassphrase {
+		t.Errorf("auth method = %q, want %q", got, configpkg.AuthMethodPassphrase)
+	}
+}
+
+func TestAuthSet_TouchIDHappyPath(t *testing.T) {
+	vaultDir, passphrase := setupTestVault(t)
+	swapSessionManager(t, &testKeyring{store: map[string]string{}}, true)
+	store := installTestBiometricStore(t, true)
+	saveTestSession(t, vaultDir, passphrase)
+
+	out := captureStdout(t, func() {
+		if err := AuthSetCmd.RunE(AuthSetCmd, []string{"touchid"}); err != nil {
+			t.Fatalf("auth set touchid error = %v", err)
+		}
+	})
+	if !strings.Contains(out, "Auth method set to touchid") {
+		t.Errorf("output = %q, want touchid confirmation", out)
+	}
+	if string(store.saved) != string(passphrase) {
+		t.Errorf("saved biometric passphrase = %q, want %q", store.saved, passphrase)
+	}
+
+	loaded, err := configpkg.Load(vaultDir + "/config.yaml")
+	if err != nil {
+		t.Fatalf("reload config: %v", err)
+	}
+	if got := loaded.EffectiveAuthMethod(); got != configpkg.AuthMethodTouchID {
+		t.Errorf("auth method = %q, want %q", got, configpkg.AuthMethodTouchID)
+	}
+}
+
+func TestAuthSet_TouchIDUnavailable(t *testing.T) {
+	setupTestVault(t)
+	swapSessionManager(t, &testKeyring{store: map[string]string{}}, true)
+	// Explicitly report Touch ID as unavailable (darwin registers a real
+	// store in init(), so the noop fallback is never active there).
+	installTestBiometricStore(t, false)
+
+	err := AuthSetCmd.RunE(AuthSetCmd, []string{"touchid"})
+	if err == nil {
+		t.Fatal("expected error when Touch ID is unavailable, got nil")
+	}
+	if !strings.Contains(err.Error(), "touch ID is not available") {
+		t.Errorf("error = %v, want touch-ID-unavailable message", err)
+	}
+}
+
+func TestAuthSet_TouchIDRejectsInvalidPassphrase(t *testing.T) {
+	_, passphrase := setupTestVault(t)
+	swapSessionManager(t, &testKeyring{store: map[string]string{}}, true)
+	installTestBiometricStore(t, true)
+
+	// Remove the env passphrase so the command falls through to stdin, and
+	// re-set it afterwards because passphraseForBiometricSetup unsets it.
+	restoreStdin := pipeStdin(t, "wrong-passphrase\n")
+	defer restoreStdin()
+
+	t.Setenv("SYMVAULT_PASSPHRASE", "")
+	t.Setenv("OPENPASS_PASSPHRASE", "")
+
+	err := AuthSetCmd.RunE(AuthSetCmd, []string{"touchid"})
+	if err == nil {
+		t.Fatal("expected error for invalid passphrase, got nil")
+	}
+	if !strings.Contains(err.Error(), "open vault") {
+		t.Errorf("error = %v, want open-vault failure", err)
+	}
+
+	// passphraseForBiometricSetup unsets the env passphrase; restore it so
+	// later tests in this process keep working.
+	t.Setenv("SYMVAULT_PASSPHRASE", string(passphrase))
+	t.Setenv("OPENPASS_PASSPHRASE", string(passphrase))
+}
+
+func TestAuthSet_InvalidMethod(t *testing.T) {
+	setupTestVault(t)
+
+	err := AuthSetCmd.RunE(AuthSetCmd, []string{"bogus"})
+	if err == nil {
+		t.Fatal("expected error for invalid auth method, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid authMethod") {
+		t.Errorf("error = %v, want invalid-authMethod message", err)
+	}
+}
+
+func TestAuthSet_ArgsValidation(t *testing.T) {
+	set := newAuthSetCmd()
+
+	err := set.Args(set, nil)
+	if err == nil {
+		t.Fatal("expected error for missing argument, got nil")
+	}
+	if !strings.Contains(err.Error(), "requires exactly 1 argument") {
+		t.Errorf("error = %v, want exactly-1-argument message", err)
+	}
+
+	if err := set.Args(set, []string{"passphrase"}); err != nil {
+		t.Errorf("Args with one argument returned error: %v", err)
+	}
+}
+
+func TestAuthSet_NotInitialized(t *testing.T) {
+	cli.Vault = t.TempDir()
+	err := AuthSetCmd.RunE(AuthSetCmd, []string{"passphrase"})
+	if err == nil {
+		t.Fatal("expected error for uninitialized vault, got nil")
+	}
+	// loadAuthConfig wraps the not-initialized check in a plain error.
+	if !strings.Contains(err.Error(), "vault not initialized") {
+		t.Errorf("error = %v, want vault-not-initialized message", err)
+	}
+}

--- a/cmd/auth/commands_test.go
+++ b/cmd/auth/commands_test.go
@@ -3,6 +3,8 @@ package auth
 import (
 	"testing"
 
+	cli "github.com/danieljustus/symaira-vault/internal/cli"
+
 	"github.com/spf13/cobra"
 )
 
@@ -49,5 +51,74 @@ func TestNewCommands_FreshTrees(t *testing.T) {
 		if !childNames[want] {
 			t.Errorf("auth command missing child %q", want)
 		}
+	}
+}
+
+// TestNewCommands_Assembly guards the wiring contract of the assembled tree:
+// group IDs, child wiring, and per-command flags must survive constructor
+// refactors.
+func TestNewCommands_Assembly(t *testing.T) {
+	cmds := NewCommands()
+	byName := map[string]*cobra.Command{}
+	for _, c := range cmds {
+		byName[c.Name()] = c
+	}
+
+	for _, name := range []string{"auth", "lock", "unlock"} {
+		if byName[name] == nil {
+			t.Fatalf("NewCommands() missing %q", name)
+		}
+	}
+
+	if got := byName["auth"].GroupID; got != cli.GroupIDAuthAccess {
+		t.Errorf("auth GroupID = %q, want %q", got, cli.GroupIDAuthAccess)
+	}
+	if got := byName["lock"].GroupID; got != cli.GroupIDAuthAccess {
+		t.Errorf("lock GroupID = %q, want %q", got, cli.GroupIDAuthAccess)
+	}
+	if got := byName["unlock"].GroupID; got != cli.GroupIDAuthAccess {
+		t.Errorf("unlock GroupID = %q, want %q", got, cli.GroupIDAuthAccess)
+	}
+
+	status := byName["auth"].Commands()
+	if len(status) != 3 {
+		t.Fatalf("auth has %d children, want 3", len(status))
+	}
+	var statusCmd *cobra.Command
+	for _, c := range status {
+		if c.Name() == "status" {
+			statusCmd = c
+		}
+	}
+	if statusCmd == nil {
+		t.Fatal("auth missing status child")
+	}
+	if statusCmd.Flags().Lookup("json") == nil {
+		t.Error("status command missing --json flag")
+	}
+
+	unlock := byName["unlock"]
+	if unlock.Flags().Lookup("ttl") == nil {
+		t.Error("unlock command missing --ttl flag")
+	}
+	if unlock.Flags().Lookup("check") == nil {
+		t.Error("unlock command missing --check flag")
+	}
+
+	rotate := byName["auth"].Commands()
+	var rotateCmd *cobra.Command
+	for _, c := range rotate {
+		if c.Name() == "rotate-passphrase" {
+			rotateCmd = c
+		}
+	}
+	if rotateCmd == nil {
+		t.Fatal("auth missing rotate-passphrase child")
+	}
+	if rotateCmd.Flags().Lookup("reencrypt") == nil {
+		t.Error("rotate command missing --reencrypt flag")
+	}
+	if rotateCmd.Flags().Lookup("yes") == nil {
+		t.Error("rotate command missing --yes flag")
 	}
 }

--- a/cmd/auth/helpers_test.go
+++ b/cmd/auth/helpers_test.go
@@ -1,0 +1,210 @@
+package auth
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	cli "github.com/danieljustus/symaira-vault/internal/cli"
+	configpkg "github.com/danieljustus/symaira-vault/internal/config"
+	"github.com/danieljustus/symaira-vault/internal/session"
+	vaultpkg "github.com/danieljustus/symaira-vault/internal/vault"
+)
+
+// captureStdout runs fn while capturing everything written to os.Stdout.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stdout = w
+	fn()
+	_ = w.Close()
+	os.Stdout = oldStdout
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+	_ = r.Close()
+	return buf.String()
+}
+
+// captureStderr runs fn while capturing everything written to os.Stderr.
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	oldStderr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stderr = w
+	fn()
+	_ = w.Close()
+	os.Stderr = oldStderr
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+	_ = r.Close()
+	return buf.String()
+}
+
+// pipeStdin replaces os.Stdin with a pipe pre-filled with input.
+func pipeStdin(t *testing.T, input string) func() {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	oldStdin := os.Stdin
+	os.Stdin = r
+	_, _ = w.WriteString(input)
+	_ = w.Close()
+	return func() {
+		os.Stdin = oldStdin
+		_ = r.Close()
+	}
+}
+
+// setupTestVault initializes a temp vault, points the global --vault flag and
+// the SYMVAULT_VAULT env var at it, and opts into env-passphrase unlocking for
+// the duration of the test — the same fixture shape cmd/file uses.
+func setupTestVault(t *testing.T) (string, []byte) {
+	t.Helper()
+	vaultDir := t.TempDir()
+	passphrase := []byte("test-passphrase")
+	if _, err := vaultpkg.InitWithPassphrase(vaultDir, passphrase, configpkg.Default()); err != nil {
+		t.Fatalf("init vault: %v", err)
+	}
+	t.Cleanup(vaultpkg.FlushManifestUpdates)
+
+	origVault := cli.Vault
+	var origChanged bool
+	if cli.VaultFlag != nil {
+		origChanged = cli.VaultFlag.Changed
+	}
+	cli.Vault = vaultDir
+	if cli.VaultFlag != nil {
+		_ = cli.VaultFlag.Value.Set(vaultDir)
+		cli.VaultFlag.Changed = true
+	}
+	t.Cleanup(func() {
+		cli.Vault = origVault
+		if cli.VaultFlag != nil {
+			_ = cli.VaultFlag.Value.Set(origVault)
+			cli.VaultFlag.Changed = origChanged
+		}
+	})
+	t.Setenv("SYMVAULT_VAULT", vaultDir)
+	t.Setenv("SYMVAULT_ALLOW_ENV_PASSPHRASE", "1")
+	t.Setenv("SYMVAULT_PASSPHRASE", string(passphrase))
+	t.Setenv("OPENPASS_PASSPHRASE", string(passphrase))
+	return vaultDir, passphrase
+}
+
+// testKeyring is a minimal in-memory KeyringBackend used to swap the session
+// manager in tests. When fail is set every operation fails, which lets tests
+// reach the keyring-error branches deterministically.
+type testKeyring struct {
+	mu    sync.Mutex
+	store map[string]string
+	fail  bool
+}
+
+func (k *testKeyring) Get(key string) (string, error) {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	if k.fail {
+		return "", session.ErrKeyringUnavailable
+	}
+	v, ok := k.store[key]
+	if !ok {
+		return "", session.ErrKeyringNotFound
+	}
+	return v, nil
+}
+
+func (k *testKeyring) Set(key, value string) error {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	if k.fail {
+		return session.ErrKeyringUnavailable
+	}
+	if k.store == nil {
+		k.store = map[string]string{}
+	}
+	k.store[key] = value
+	return nil
+}
+
+func (k *testKeyring) Delete(key string) error {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	if k.fail {
+		return session.ErrKeyringUnavailable
+	}
+	delete(k.store, key)
+	return nil
+}
+
+// swapSessionManager installs a session manager backed by a testKeyring with
+// the given persistence status and restores the previous manager on cleanup.
+// This is the seam used to exercise both the keyring-available ("persistent")
+// and keyring-unavailable ("memory-only") branches of the auth commands.
+func swapSessionManager(t *testing.T, backend *testKeyring, persistent bool) {
+	t.Helper()
+	orig := session.DefaultManager()
+	status := session.CacheStatus{
+		Backend:    session.CacheBackendMemory,
+		Persistent: persistent,
+		Message:    "test session cache",
+	}
+	if persistent {
+		status.Backend = session.CacheBackendOSKeyring
+	}
+	session.SetDefaultManager(session.NewManager(backend, func() session.CacheStatus { return status }))
+	t.Cleanup(func() { session.SetDefaultManager(orig) })
+}
+
+// testBiometricStore is a fake BiometricPassphraseStore that records the
+// saved passphrase, mirroring the cmd package's cmdRecordingBiometricStore.
+type testBiometricStore struct {
+	available bool
+	saved     []byte
+}
+
+func (s *testBiometricStore) IsAvailable() bool { return s.available }
+func (s *testBiometricStore) Save(_ context.Context, _ string, passphrase []byte) error {
+	s.saved = append([]byte(nil), passphrase...)
+	return nil
+}
+func (s *testBiometricStore) Load(context.Context, string) ([]byte, error) {
+	return nil, session.ErrBiometricNotConfigured
+}
+func (s *testBiometricStore) Delete(string) error { return nil }
+
+// setOutputFormat changes the global output format and restores it on cleanup.
+func setOutputFormat(t *testing.T, format string) {
+	t.Helper()
+	orig := cli.OutputFormat
+	cli.OutputFormat = format
+	t.Cleanup(func() { cli.OutputFormat = orig })
+}
+
+// setQuietMode changes the global quiet mode and restores it on cleanup.
+func setQuietMode(t *testing.T, quiet bool) {
+	t.Helper()
+	orig := cli.QuietMode
+	cli.QuietMode = quiet
+	t.Cleanup(func() { cli.QuietMode = orig })
+}
+
+// saveTestSession stores a passphrase in the currently active session manager
+// so unlock/lock tests can assert against a real cached session.
+func saveTestSession(t *testing.T, vaultDir string, passphrase []byte) {
+	t.Helper()
+	if err := session.SavePassphrase(vaultDir, passphrase, 30*time.Minute); err != nil {
+		t.Fatalf("save session: %v", err)
+	}
+}

--- a/cmd/auth/lock_test.go
+++ b/cmd/auth/lock_test.go
@@ -1,0 +1,71 @@
+package auth
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	cli "github.com/danieljustus/symaira-vault/internal/cli"
+	errorspkg "github.com/danieljustus/symaira-vault/internal/errors"
+	"github.com/danieljustus/symaira-vault/internal/session"
+)
+
+func TestLock_HappyPathClearsSession(t *testing.T) {
+	vaultDir, passphrase := setupTestVault(t)
+	swapSessionManager(t, &testKeyring{store: map[string]string{}}, true)
+	saveTestSession(t, vaultDir, passphrase)
+
+	cmd := newLockCmd()
+	stderr := captureStderr(t, func() {
+		if err := cmd.RunE(cmd, nil); err != nil {
+			t.Fatalf("lock error = %v", err)
+		}
+	})
+	if !strings.Contains(stderr, "Vault locked") {
+		t.Errorf("stderr = %q, want lock confirmation", stderr)
+	}
+
+	// The cached passphrase must be gone after locking.
+	if _, err := session.LoadPassphrase(vaultDir); err == nil {
+		t.Fatal("session still present after lock")
+	}
+}
+
+func TestLock_NotInitialized(t *testing.T) {
+	cli.Vault = t.TempDir()
+	swapSessionManager(t, &testKeyring{store: map[string]string{}}, true)
+
+	cmd := newLockCmd()
+	err := cmd.RunE(cmd, nil)
+	if err == nil {
+		t.Fatal("expected error for uninitialized vault, got nil")
+	}
+	var cliErr *errorspkg.CLIError
+	if !errors.As(err, &cliErr) {
+		t.Fatalf("error = %T, want *errorspkg.CLIError", err)
+	}
+	if cliErr.Code != errorspkg.ExitNotInitialized {
+		t.Errorf("exit code = %d, want %d", cliErr.Code, errorspkg.ExitNotInitialized)
+	}
+}
+
+func TestLock_KeyringUnavailable(t *testing.T) {
+	setupTestVault(t)
+	swapSessionManager(t, &testKeyring{fail: true}, true)
+
+	cmd := newLockCmd()
+	err := cmd.RunE(cmd, nil)
+	if err == nil {
+		t.Fatal("expected error when keyring is unavailable, got nil")
+	}
+	if !strings.Contains(err.Error(), "cannot clear session") {
+		t.Errorf("error = %v, want cannot-clear-session message", err)
+	}
+	var cliErr *errorspkg.CLIError
+	if !errors.As(err, &cliErr) {
+		t.Fatalf("error = %T, want *errorspkg.CLIError", err)
+	}
+	if cliErr.Code != errorspkg.ExitGeneralError {
+		t.Errorf("exit code = %d, want %d", cliErr.Code, errorspkg.ExitGeneralError)
+	}
+}

--- a/cmd/auth/unlock_test.go
+++ b/cmd/auth/unlock_test.go
@@ -1,0 +1,158 @@
+package auth
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	cli "github.com/danieljustus/symaira-vault/internal/cli"
+	errorspkg "github.com/danieljustus/symaira-vault/internal/errors"
+	"github.com/danieljustus/symaira-vault/internal/session"
+)
+
+func TestUnlock_HappyPath(t *testing.T) {
+	vaultDir, passphrase := setupTestVault(t)
+	swapSessionManager(t, &testKeyring{store: map[string]string{}}, true)
+
+	cmd := newAuthUnlockCmd()
+	stderr := captureStderr(t, func() {
+		if err := cmd.RunE(cmd, nil); err != nil {
+			t.Fatalf("unlock error = %v", err)
+		}
+	})
+	if !strings.Contains(stderr, "Vault unlocked") {
+		t.Errorf("stderr = %q, want unlock confirmation", stderr)
+	}
+
+	// The passphrase must now be cached in the session manager.
+	got, err := session.LoadPassphrase(vaultDir)
+	if err != nil {
+		t.Fatalf("load cached session: %v", err)
+	}
+	if string(got) != string(passphrase) {
+		t.Errorf("cached passphrase = %q, want %q", got, passphrase)
+	}
+}
+
+func TestUnlock_TTLOverride(t *testing.T) {
+	vaultDir, _ := setupTestVault(t)
+	swapSessionManager(t, &testKeyring{store: map[string]string{}}, true)
+
+	cmd := newAuthUnlockCmd()
+	if err := cmd.Flags().Set("ttl", "15m"); err != nil {
+		t.Fatalf("set ttl flag: %v", err)
+	}
+
+	stderr := captureStderr(t, func() {
+		if err := cmd.RunE(cmd, nil); err != nil {
+			t.Fatalf("unlock error = %v", err)
+		}
+	})
+	if !strings.Contains(stderr, "session TTL: 15m0s") {
+		t.Errorf("stderr = %q, want overridden TTL", stderr)
+	}
+
+	sess, err := session.LoadPassphrase(vaultDir)
+	if err != nil {
+		t.Fatalf("load cached session: %v", err)
+	}
+	_ = sess
+}
+
+func TestUnlock_MemoryOnlyCacheRejected(t *testing.T) {
+	setupTestVault(t)
+	swapSessionManager(t, &testKeyring{store: map[string]string{}}, false)
+
+	cmd := newAuthUnlockCmd()
+	err := cmd.RunE(cmd, nil)
+	if err == nil {
+		t.Fatal("expected error for memory-only cache, got nil")
+	}
+	if !strings.Contains(err.Error(), "memory-only") {
+		t.Errorf("error = %v, want memory-only message", err)
+	}
+	var cliErr *errorspkg.CLIError
+	if !errors.As(err, &cliErr) {
+		t.Fatalf("error = %T, want *errorspkg.CLIError", err)
+	}
+	if cliErr.Code != errorspkg.ExitLocked {
+		t.Errorf("exit code = %d, want %d", cliErr.Code, errorspkg.ExitLocked)
+	}
+}
+
+func TestUnlock_KeyringUnavailable(t *testing.T) {
+	setupTestVault(t)
+	swapSessionManager(t, &testKeyring{fail: true}, true)
+
+	cmd := newAuthUnlockCmd()
+	err := cmd.RunE(cmd, nil)
+	if err == nil {
+		t.Fatal("expected error when keyring is unavailable, got nil")
+	}
+	if !strings.Contains(err.Error(), "save session") {
+		t.Errorf("error = %v, want save-session failure", err)
+	}
+}
+
+func TestUnlock_NotInitialized(t *testing.T) {
+	cli.Vault = t.TempDir()
+	swapSessionManager(t, &testKeyring{store: map[string]string{}}, true)
+
+	cmd := newAuthUnlockCmd()
+	err := cmd.RunE(cmd, nil)
+	if err == nil {
+		t.Fatal("expected error for uninitialized vault, got nil")
+	}
+	var cliErr *errorspkg.CLIError
+	if !errors.As(err, &cliErr) {
+		t.Fatalf("error = %T, want *errorspkg.CLIError", err)
+	}
+	if cliErr.Code != errorspkg.ExitNotInitialized {
+		t.Errorf("exit code = %d, want %d", cliErr.Code, errorspkg.ExitNotInitialized)
+	}
+}
+
+func TestUnlock_CheckActiveSession(t *testing.T) {
+	vaultDir, passphrase := setupTestVault(t)
+	swapSessionManager(t, &testKeyring{store: map[string]string{}}, true)
+	saveTestSession(t, vaultDir, passphrase)
+
+	cmd := newAuthUnlockCmd()
+	if err := cmd.Flags().Set("check", "true"); err != nil {
+		t.Fatalf("set check flag: %v", err)
+	}
+
+	stderr := captureStderr(t, func() {
+		if err := cmd.RunE(cmd, nil); err != nil {
+			t.Fatalf("unlock --check error = %v", err)
+		}
+	})
+	if !strings.Contains(stderr, "Session active") {
+		t.Errorf("stderr = %q, want session-active message", stderr)
+	}
+}
+
+func TestUnlock_CheckNoSession(t *testing.T) {
+	setupTestVault(t)
+	swapSessionManager(t, &testKeyring{store: map[string]string{}}, true)
+
+	cmd := newAuthUnlockCmd()
+	if err := cmd.Flags().Set("check", "true"); err != nil {
+		t.Fatalf("set check flag: %v", err)
+	}
+
+	err := cmd.RunE(cmd, nil)
+	if err == nil {
+		t.Fatal("expected error when no session is active, got nil")
+	}
+	if !strings.Contains(err.Error(), "no active session") {
+		t.Errorf("error = %v, want no-active-session message", err)
+	}
+	var cliErr *errorspkg.CLIError
+	if !errors.As(err, &cliErr) {
+		t.Fatalf("error = %T, want *errorspkg.CLIError", err)
+	}
+	if cliErr.Code != errorspkg.ExitLocked {
+		t.Errorf("exit code = %d, want %d", cliErr.Code, errorspkg.ExitLocked)
+	}
+}

--- a/cmd/crud/delete_test.go
+++ b/cmd/crud/delete_test.go
@@ -1,0 +1,130 @@
+package crud
+
+import (
+	"strings"
+	"testing"
+
+	cli "github.com/danieljustus/symaira-vault/internal/cli"
+)
+
+func TestDeleteCommand_ConfirmYes(t *testing.T) {
+	setupTestVault(t)
+	addTestEntry(t, "github", map[string]any{"username": "octocat", "password": "s3cret"})
+
+	cmd := newDeleteCmd()
+	cmd.SetArgs([]string{"github"})
+	withStdin(t, "y\n", func() {
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+	})
+
+	if entryExists(t) {
+		t.Error("entry still exists after confirmed delete")
+	}
+}
+
+func TestDeleteCommand_Cancel(t *testing.T) {
+	setupTestVault(t)
+	addTestEntry(t, "github", map[string]any{"password": "s3cret"})
+
+	cmd := newDeleteCmd()
+	cmd.SetArgs([]string{"github"})
+	stderr := captureStderr(t, func() {
+		withStdin(t, "n\n", func() {
+			if err := cmd.Execute(); err != nil {
+				t.Fatalf("Execute() error = %v", err)
+			}
+		})
+	})
+	if !strings.Contains(stderr, "Canceled") {
+		t.Errorf("stderr = %q, want cancellation notice", stderr)
+	}
+
+	if !entryExists(t) {
+		t.Error("entry was deleted despite cancel")
+	}
+}
+
+func TestDeleteCommand_YesFlag(t *testing.T) {
+	setupTestVault(t)
+	addTestEntry(t, "github", map[string]any{"password": "s3cret"})
+
+	cmd := newDeleteCmd()
+	DeleteYes = true
+	t.Cleanup(func() { DeleteYes = false })
+	cmd.SetArgs([]string{"github"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	if entryExists(t) {
+		t.Error("entry still exists after --yes delete")
+	}
+}
+
+func TestDeleteCommand_JSONOutput(t *testing.T) {
+	setupTestVault(t)
+	addTestEntry(t, "github", map[string]any{"password": "s3cret"})
+
+	setJSONOutput(t)
+	cmd := newDeleteCmd()
+	DeleteYes = true
+	t.Cleanup(func() { DeleteYes = false })
+	cmd.SetArgs([]string{"github"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+}
+
+func TestDeleteCommand_JSONCancel(t *testing.T) {
+	setupTestVault(t)
+	addTestEntry(t, "github", map[string]any{"password": "s3cret"})
+
+	setJSONOutput(t)
+	cmd := newDeleteCmd()
+	cmd.SetArgs([]string{"github"})
+	withStdin(t, "n\n", func() {
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+	})
+
+	if !entryExists(t) {
+		t.Error("entry was deleted despite JSON-format cancel")
+	}
+}
+
+func TestDeleteCommand_NotFound(t *testing.T) {
+	setupTestVault(t)
+
+	cmd := newDeleteCmd()
+	DeleteYes = true
+	t.Cleanup(func() { DeleteYes = false })
+	cmd.SetArgs([]string{"missing"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Execute() = nil, want not-found error")
+	}
+	if !strings.Contains(err.Error(), "cannot delete") {
+		t.Errorf("error = %q, want write-failure message", err)
+	}
+}
+
+func TestNewCommands_Assembly(t *testing.T) {
+	cmds := NewCommands()
+	got := make(map[string]bool, len(cmds))
+	for _, c := range cmds {
+		got[c.Name()] = true
+	}
+	for _, want := range []string{"add", "delete", "edit", "find", "get", "list", "set"} {
+		if !got[want] {
+			t.Errorf("NewCommands() missing %q", want)
+		}
+	}
+	for _, c := range cmds {
+		if c.GroupID != cli.GroupIDEssentials {
+			t.Errorf("command %q GroupID = %q, want %q", c.Name(), c.GroupID, cli.GroupIDEssentials)
+		}
+	}
+}

--- a/cmd/crud/edit_test.go
+++ b/cmd/crud/edit_test.go
@@ -1,0 +1,110 @@
+package crud
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	cli "github.com/danieljustus/symaira-vault/internal/cli"
+	"github.com/danieljustus/symaira-vault/internal/secureedit"
+)
+
+// fakeEditor returns an OSCreateTemp and EDITOR that make secureedit write the
+// given updated JSON body to a temp file and exit successfully, mimicking a
+// user editing an entry and saving.
+func fakeEditor(t *testing.T, updatedJSON string) {
+	t.Helper()
+	dir := t.TempDir()
+	bodyPath := filepath.Join(dir, "body.json")
+	if err := os.WriteFile(bodyPath, []byte(updatedJSON), 0o600); err != nil {
+		t.Fatalf("write fake body: %v", err)
+	}
+
+	script := "#!/bin/sh\ncp " + bodyPath + " \"$1\"\n"
+	scriptPath := filepath.Join(dir, "editor.sh")
+	if err := os.WriteFile(scriptPath, []byte(script), 0o700); err != nil {
+		t.Fatalf("write editor script: %v", err)
+	}
+
+	origCreateTemp := OSCreateTemp
+	origEditor := EditorFlag
+	t.Cleanup(func() {
+		OSCreateTemp = origCreateTemp
+		EditorFlag = origEditor
+	})
+	OSCreateTemp = secureedit.CreateTemp
+	EditorFlag = scriptPath
+}
+
+func TestEditCommand_UpdatesEntry(t *testing.T) {
+	setupTestVault(t)
+	addTestEntry(t, "github", map[string]any{"username": "octocat", "password": "oldpass"})
+
+	updated := `{"data":{"username":"octocat","password":"newpass"},"meta":{"created":"2026-01-01T00:00:00Z","updated":"2026-01-01T00:00:00Z","version":2}}`
+
+	cmd := newEditCmd()
+	fakeEditor(t, updated) // must run after newEditCmd(): flag registration resets EditorFlag
+	cmd.SetArgs([]string{"github"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	entry := getTestEntry(t, "github")
+	if got, _ := entry.GetField("password"); got != "newpass" {
+		t.Errorf("password after edit = %q, want %q", got, "newpass")
+	}
+}
+
+func TestEditCommand_NotFound(t *testing.T) {
+	setupTestVault(t)
+
+	cmd := newEditCmd()
+	cmd.SetArgs([]string{"missing"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Execute() = nil, want not-found error")
+	}
+	if !strings.Contains(err.Error(), "entry not found") {
+		t.Errorf("error = %q, want not-found message", err)
+	}
+}
+
+func TestEditCommand_EditorFailure(t *testing.T) {
+	setupTestVault(t)
+	addTestEntry(t, "github", map[string]any{"password": "s3cret"})
+
+	dir := t.TempDir()
+	script := "#!/bin/sh\nexit 3\n"
+	scriptPath := filepath.Join(dir, "editor.sh")
+	if err := os.WriteFile(scriptPath, []byte(script), 0o700); err != nil {
+		t.Fatalf("write editor script: %v", err)
+	}
+
+	cmd := newEditCmd()
+	origEditor := EditorFlag
+	t.Cleanup(func() { EditorFlag = origEditor })
+	EditorFlag = scriptPath // must run after newEditCmd(): flag registration resets EditorFlag
+
+	cmd.SetArgs([]string{"github"})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("Execute() = nil, want editor error")
+	}
+
+	// The entry must be unchanged.
+	entry := getTestEntry(t, "github")
+	if got, _ := entry.GetField("password"); got != "s3cret" {
+		t.Errorf("password after failed edit = %q, want %q", got, "s3cret")
+	}
+}
+
+func TestNewEditCmd_Flags(t *testing.T) {
+	cmd := newEditCmd()
+	flag := cmd.Flags().Lookup("editor")
+	if flag == nil {
+		t.Fatal("--editor flag missing")
+	}
+	if cmd.GroupID != cli.GroupIDEssentials {
+		t.Errorf("GroupID = %q, want %q", cmd.GroupID, cli.GroupIDEssentials)
+	}
+}

--- a/cmd/crud/get_test.go
+++ b/cmd/crud/get_test.go
@@ -1,0 +1,91 @@
+package crud
+
+import (
+	"strings"
+	"testing"
+
+	cli "github.com/danieljustus/symaira-vault/internal/cli"
+)
+
+func TestGetCommand_ExactPath(t *testing.T) {
+	setupTestVault(t)
+	addTestEntry(t, "github", map[string]any{"username": "octocat", "password": "s3cret"})
+
+	cmd := newGetCmd()
+	cmd.SetArgs([]string{"github"})
+	cmd.SetOut(&strings.Builder{})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+}
+
+func TestGetCommand_Field(t *testing.T) {
+	setupTestVault(t)
+	addTestEntry(t, "github", map[string]any{"username": "octocat", "password": "s3cret"})
+
+	cmd := newGetCmd()
+	cmd.SetArgs([]string{"github.username"})
+	cmd.SetOut(&strings.Builder{})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+}
+
+func TestGetCommand_NotFound(t *testing.T) {
+	setupTestVault(t)
+
+	cmd := newGetCmd()
+	cmd.SetArgs([]string{"missing"})
+	cmd.SetOut(&strings.Builder{})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Execute() = nil, want not-found error")
+	}
+	if !strings.Contains(err.Error(), "not found") && !strings.Contains(err.Error(), "not exist") {
+		t.Errorf("error = %q, want not-found message", err)
+	}
+}
+
+func TestGetCommand_JSONOutput(t *testing.T) {
+	setupTestVault(t)
+	addTestEntry(t, "github", map[string]any{"username": "octocat", "password": "s3cret"})
+
+	setJSONOutput(t)
+	cmd := newGetCmd()
+	GetPrint = true
+	t.Cleanup(func() { GetPrint = false })
+	cmd.SetArgs([]string{"github"})
+	out := captureStdout(t, func() {
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+	})
+	if !strings.Contains(out, `"Path"`) {
+		t.Errorf("JSON output = %q, want path field", out)
+	}
+}
+
+func TestGetCommand_JSONFlag(t *testing.T) {
+	setupTestVault(t)
+	addTestEntry(t, "github", map[string]any{"username": "octocat", "password": "s3cret"})
+
+	cmd := newGetCmd()
+	GetPrint = true
+	t.Cleanup(func() { GetPrint = false })
+	cmd.SetArgs([]string{"github"})
+	var out strings.Builder
+	cmd.SetOut(&out)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+}
+
+func TestNewGetCmd_Flags(t *testing.T) {
+	cmd := newGetCmd()
+	if cmd.Flags().Lookup("print") == nil {
+		t.Error("--print flag missing")
+	}
+	if cmd.GroupID != cli.GroupIDEssentials {
+		t.Errorf("GroupID = %q, want %q", cmd.GroupID, cli.GroupIDEssentials)
+	}
+}

--- a/cmd/crud/helpers_test.go
+++ b/cmd/crud/helpers_test.go
@@ -1,0 +1,163 @@
+package crud
+
+import (
+	"bufio"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	cli "github.com/danieljustus/symaira-vault/internal/cli"
+	configpkg "github.com/danieljustus/symaira-vault/internal/config"
+	vaultpkg "github.com/danieljustus/symaira-vault/internal/vault"
+)
+
+// setupTestVault initializes a temp vault, points the global --vault flag at
+// it, and opts into env-passphrase unlocking for the duration of the test —
+// the same fixture shape cmd/file and cmd/auth use.
+func setupTestVault(t *testing.T) {
+	t.Helper()
+
+	vaultDir := t.TempDir()
+	passphrase := []byte("test-passphrase")
+	if _, err := vaultpkg.InitWithPassphrase(vaultDir, passphrase, configpkg.Default()); err != nil {
+		t.Fatalf("init vault: %v", err)
+	}
+	t.Cleanup(vaultpkg.FlushManifestUpdates)
+
+	origVault := cli.Vault
+	var origChanged bool
+	if cli.VaultFlag != nil {
+		origChanged = cli.VaultFlag.Changed
+	}
+	cli.Vault = vaultDir
+	if cli.VaultFlag != nil {
+		_ = cli.VaultFlag.Value.Set(vaultDir)
+		cli.VaultFlag.Changed = true
+	}
+	t.Cleanup(func() {
+		cli.Vault = origVault
+		if cli.VaultFlag != nil {
+			_ = cli.VaultFlag.Value.Set(origVault)
+			cli.VaultFlag.Changed = origChanged
+		}
+	})
+
+	t.Setenv("SYMVAULT_VAULT", vaultDir)
+	t.Setenv("SYMVAULT_ALLOW_ENV_PASSPHRASE", "1")
+	t.Setenv("SYMVAULT_PASSPHRASE", string(passphrase))
+	t.Setenv("OPENPASS_PASSPHRASE", string(passphrase))
+}
+
+// withStdin runs fn with os.Stdin replaced by a pipe pre-filled with input.
+func withStdin(t *testing.T, input string, fn func()) {
+	t.Helper()
+	oldStdin := os.Stdin
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stdin = r
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, _ = io.WriteString(w, input)
+		_ = w.Close()
+	}()
+	defer func() { os.Stdin = oldStdin }()
+	fn()
+	<-done
+}
+
+// setJSONOutput switches the global output format to JSON and restores it on
+// cleanup.
+func setJSONOutput(t *testing.T) {
+	t.Helper()
+	orig := cli.OutputFormat
+	cli.OutputFormat = "json"
+	t.Cleanup(func() { cli.OutputFormat = orig })
+}
+
+// addTestEntry writes an entry into the vault via a fresh WithVaultRaw call.
+func addTestEntry(t *testing.T, path string, fields map[string]any) {
+	t.Helper()
+	err := cli.WithVaultRaw(func(_ *vaultpkg.Vault, vs *cli.VaultService) error {
+		return vs.SetFieldsWithProvenance(path, fields, vaultpkg.WriteRecord{Action: "test"})
+	})
+	if err != nil {
+		t.Fatalf("seed entry %q: %v", path, err)
+	}
+}
+
+// entryExists reports whether the seeded "github" entry still exists, without
+// failing the test when it does not (unlike getTestEntry, which is for
+// read-back asserts).
+func entryExists(t *testing.T) bool {
+	t.Helper()
+	exists := false
+	err := cli.WithVaultRaw(func(_ *vaultpkg.Vault, vs *cli.VaultService) error {
+		entry, err := vs.GetEntry("github")
+		if err == nil && entry != nil {
+			exists = true
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("check entry: %v", err)
+	}
+	return exists
+}
+
+// getTestEntry re-reads an entry from the vault via a fresh WithVaultRaw call.
+func getTestEntry(t *testing.T, path string) *vaultpkg.Entry {
+	t.Helper()
+	var got *vaultpkg.Entry
+	err := cli.WithVaultRaw(func(_ *vaultpkg.Vault, vs *cli.VaultService) error {
+		entry, err := vs.GetEntry(path)
+		if err != nil {
+			return err
+		}
+		got = entry
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("read back entry %q: %v", path, err)
+	}
+	return got
+}
+
+// captureStderr runs fn while capturing everything written to os.Stderr.
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	oldStderr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stderr = w
+	fn()
+	_ = w.Close()
+	os.Stderr = oldStderr
+	var buf strings.Builder
+	_, _ = io.Copy(&buf, bufio.NewReader(r))
+	_ = r.Close()
+	return buf.String()
+}
+
+// captureStdout runs fn while capturing everything written to os.Stdout.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stdout = w
+	fn()
+	_ = w.Close()
+	os.Stdout = oldStdout
+	var buf strings.Builder
+	_, _ = io.Copy(&buf, bufio.NewReader(r))
+	_ = r.Close()
+	return buf.String()
+}

--- a/cmd/crud/list_test.go
+++ b/cmd/crud/list_test.go
@@ -1,0 +1,69 @@
+package crud
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestListCommand_Empty(t *testing.T) {
+	setupTestVault(t)
+
+	cmd := newListCmd()
+	var out strings.Builder
+	cmd.SetOut(&out)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+}
+
+func TestListCommand_ListsEntries(t *testing.T) {
+	setupTestVault(t)
+	addTestEntry(t, "github", map[string]any{"password": "a"})
+	addTestEntry(t, "work/aws", map[string]any{"password": "b"})
+
+	cmd := newListCmd()
+	out := captureStdout(t, func() {
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+	})
+	if !strings.Contains(out, "github") || !strings.Contains(out, "work/aws") {
+		t.Errorf("list output = %q, want both entries", out)
+	}
+}
+
+func TestListCommand_Prefix(t *testing.T) {
+	setupTestVault(t)
+	addTestEntry(t, "github", map[string]any{"password": "a"})
+	addTestEntry(t, "work/aws", map[string]any{"password": "b"})
+
+	cmd := newListCmd()
+	cmd.SetArgs([]string{"work/"})
+	out := captureStdout(t, func() {
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+	})
+	if strings.Contains(out, "github") {
+		t.Errorf("prefix list output = %q, want only work/ entries", out)
+	}
+	if !strings.Contains(out, "aws") {
+		t.Errorf("prefix list output = %q, want work/aws", out)
+	}
+}
+
+func TestListCommand_JSONOutput(t *testing.T) {
+	setupTestVault(t)
+	addTestEntry(t, "github", map[string]any{"password": "a"})
+
+	setJSONOutput(t)
+	cmd := newListCmd()
+	out := captureStdout(t, func() {
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+	})
+	if !strings.Contains(out, "github") {
+		t.Errorf("JSON list output = %q, want entry path", out)
+	}
+}


### PR DESCRIPTION
Implements #746: close the command-layer coverage gap.

- **cmd/auth**: 0.0% → 83.2%. Status (text + JSON, keyring-unavailable,
  cache status), lock, unlock (TTL override, memory-only cache, `--check`),
  rotate (happy path, wrong old passphrase, mismatch/short, cancel,
  Touch ID branch), command assembly.
- **cmd/crud**: 5.1% → 37.6%. Delete (confirm-yes / cancel / `--yes` /
  JSON output / not-found), edit (fake-editor update, not-found, editor
  failure leaves entry unchanged), get (text / field / JSON / not-found),
  list (all / prefix / JSON), command assembly.

Also fixes a pre-existing nil-pointer panic in `rotate-passphrase`: a
config without a `vault:` section left `cfg.Vault` nil at the
`LastRotated` write (same guard pattern as `cmd/admin/migrate.go`).

Tests model the existing `cmd/file` fixture pattern (temp vault +
env-passphrase unlock + session-manager swap).

Closes #746