### PR TITLE
test(cmd): cover add flows and simplify command setup

### DIFF
--- a/cmd/crud/add_test.go
+++ b/cmd/crud/add_test.go
@@ -4,7 +4,82 @@ import (
 	"io"
 	"os"
 	"testing"
+
+	"github.com/danieljustus/symaira-vault/internal/vault"
 )
+
+func resetAddFlags(t *testing.T) {
+	t.Helper()
+	old := struct {
+		value                               string
+		stdinValue, stdinTOTP, generate     bool
+		length                              int
+		username, url, notes                string
+		totpSecret, totpIssuer, totpAccount string
+		force                               bool
+		typ, usageHint, expiresAt           string
+		autoRotate                          bool
+	}{
+		AddValue, AddStdinValue, AddStdinTOTP, AddGenerate,
+		AddLength, AddUsername, AddURL, AddNotes,
+		AddTOTPSecret, AddTOTPIssuer, AddTOTPAccount,
+		AddForce, AddType, AddUsageHint, AddExpiresAt, AddAutoRotate,
+	}
+	t.Cleanup(func() {
+		AddValue, AddStdinValue, AddStdinTOTP, AddGenerate = old.value, old.stdinValue, old.stdinTOTP, old.generate
+		AddLength, AddUsername, AddURL, AddNotes = old.length, old.username, old.url, old.notes
+		AddTOTPSecret, AddTOTPIssuer, AddTOTPAccount = old.totpSecret, old.totpIssuer, old.totpAccount
+		AddForce, AddType, AddUsageHint, AddExpiresAt, AddAutoRotate = old.force, old.typ, old.usageHint, old.expiresAt, old.autoRotate
+	})
+}
+
+func TestAddCommand_ValueCreatesEntry(t *testing.T) {
+	resetAddFlags(t)
+	setupTestVault(t)
+
+	cmd := newAddCmd()
+	cmd.SetArgs([]string{
+		"github",
+		"--value", "StrongPass123!",
+		"--username", "octocat",
+		"--url", "https://github.com",
+		"--notes", "primary account",
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	entry := getTestEntry(t, "github")
+	if got, _ := entry.GetField("password"); got != "StrongPass123!" {
+		t.Errorf("password = %q, want explicit value", got)
+	}
+	if got, _ := entry.GetField("username"); got != "octocat" {
+		t.Errorf("username = %q, want octocat", got)
+	}
+	if got, _ := entry.GetField("url"); got != "https://github.com" {
+		t.Errorf("url = %q, want GitHub URL", got)
+	}
+}
+
+func TestAddCommand_GenerateCreatesPasswordEntry(t *testing.T) {
+	resetAddFlags(t)
+	setupTestVault(t)
+
+	cmd := newAddCmd()
+	cmd.SetArgs([]string{"generated", "--generate", "--length", "24"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	entry := getTestEntry(t, "generated")
+	value, ok := entry.Data[vault.PrimaryFieldForType(vault.SecretTypePassword)].(string)
+	if !ok {
+		t.Fatalf("generated password has type %T, want string", entry.Data[vault.PrimaryFieldForType(vault.SecretTypePassword)])
+	}
+	if len(value) != 24 {
+		t.Errorf("generated password length = %d, want 24", len(value))
+	}
+}
 
 func TestReadStdinValues_AcceptsEOFWithData(t *testing.T) {
 	tests := []struct {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -42,12 +42,13 @@ func newPackageRootCmd() *cobra.Command {
 		recipientsCmd, remoteCmd, runCmd, shareCmd, syncCmd, templateCmd, uiCmd,
 		mcp.ServeCmd,
 	}
+	compatByName := make(map[string]struct{}, len(compat))
+	for _, compatCmd := range compat {
+		compatByName[compatCmd.Name()] = struct{}{}
+	}
 	for _, c := range root.Commands() {
-		for _, compatCmd := range compat {
-			if c.Name() == compatCmd.Name() {
-				root.RemoveCommand(c)
-				break
-			}
+		if _, ok := compatByName[c.Name()]; ok {
+			root.RemoveCommand(c)
 		}
 	}
 	root.AddCommand(compat...)

--- a/internal/ui/wizard/step_agents.go
+++ b/internal/ui/wizard/step_agents.go
@@ -69,26 +69,11 @@ func (s *AgentsStep) Update(msg tea.Msg) (Step, tea.Cmd) {
 				s.entries[s.cursor].selected = !s.entries[s.cursor].selected
 			}
 		case keyEnter:
-			if s.cursor == len(s.entries) || s.selectedCount() == 0 {
-				// "Skip" or nothing selected.
-				s.done = true
-				return s, stepDoneCmd()
-			}
 			s.done = true
 			return s, stepDoneCmd()
 		}
 	}
 	return s, nil
-}
-
-func (s *AgentsStep) selectedCount() int {
-	n := 0
-	for _, e := range s.entries {
-		if e.selected {
-			n++
-		}
-	}
-	return n
 }
 
 func (s *AgentsStep) View() string {


### PR DESCRIPTION
## Summary
- Add behavior-focused tests for explicit-value and generated-password entry creation.
- Replace nested compatibility-command matching with a name set.
- Remove a redundant agent-selection branch and its now-unused helper.

## Verification
- `GOFLAGS=-mod=mod SYMVAULT_ALLOW_ENV_PASSPHRASE=1 go test -mod=mod -timeout=30m -coverprofile=coverage-cycle08-final.out -covermode=atomic -skip 'TestFlow|TestBinaryE2E|Integration' ./...`\n- Overall coverage: 64.0%, above the repository 63.5% gate.\n- `go vet ./...`, `go build ./...`, and golangci-lint: passed.\n- CRUD package coverage: 50.3%, up from 37.6% before these tests.\n\nThe baseline report predates the current importer and CLI additions; the measured comparison is 64.0% versus 67.3% (-3.3 percentage points), recorded transparently rather than treated as a gate failure.