### PR TITLE
feat(mcp): add template substitutions and broaden built-in API catalog

### DIFF
--- a/docs/api-templates.md
+++ b/docs/api-templates.md
@@ -1,0 +1,159 @@
+# API Templates
+
+`symvault` can call external APIs on an agent's behalf through the
+`execute_api_request` MCP tool. Each call is shaped by an **API template**:
+a small YAML file that declares the base URL, the authentication shape, and
+the endpoints/methods the template is allowed to reach. Credentials are
+resolved from a vault entry at request time and never enter the agent's
+environment, argv, logs or audit trail.
+
+## Built-in providers
+
+The following templates ship embedded in the binary (directory
+`internal/mcp/apitemplates/builtin/`):
+
+| Template    | Base URL                          | Auth shape                  |
+|-------------|-----------------------------------|-----------------------------|
+| anthropic   | https://api.anthropic.com         | `Authorization: Bearer`     |
+| github      | https://api.github.com            | `Authorization: Bearer`     |
+| openai      | https://api.openai.com            | `Authorization: Bearer`     |
+| perplexity  | https://api.perplexity.ai         | `Authorization: Bearer`     |
+| slack       | https://slack.com/api             | `Authorization: Bearer`     |
+| gitlab      | https://gitlab.com/api/v4         | `PRIVATE-TOKEN` header      |
+| linear      | https://api.linear.app            | `Authorization: Bearer`     |
+| notion      | https://api.notion.com/v1         | `Authorization: Bearer`     |
+| stripe      | https://api.stripe.com/v1         | `Authorization: Bearer`     |
+| sentry      | https://sentry.io                 | `Authorization: Bearer`     |
+| cloudflare  | https://api.cloudflare.com/client/v4 | `Authorization: Bearer`  |
+| vercel      | https://api.vercel.com            | `Authorization: Bearer`     |
+| resend      | https://api.resend.com            | `Authorization: Bearer`     |
+| gemini      | https://generativelanguage.googleapis.com | `x-goog-api-key` header |
+| openrouter  | https://openrouter.ai/api/v1      | `Authorization: Bearer`     |
+| npm         | https://registry.npmjs.org        | `Authorization: Bearer`     |
+| telegram    | https://api.telegram.org          | token in URL path           |
+
+Each built-in YAML carries a comment citing the vendor documentation its
+auth shape was derived from, and its `allowed_endpoints` / `allowed_methods`
+are deliberately narrow — a built-in is not a blanket grant. Every built-in
+passes `Validate()` (asserted by tests).
+
+The vault entry referenced by `entry_ref` must exist and contain the
+credential. The conventional field name is `credential`; `token` and
+`password` are accepted as fallbacks by the `bearer` shape. For templates
+that need a custom header name (e.g. GitLab's `PRIVATE-TOKEN`), the header
+value is delivered through a substitution placeholder (see below) — the
+entry still only needs a `credential` field.
+
+## Overriding a built-in with a vault-local template
+
+User templates take precedence over built-ins. To override one, place a file
+named after the template in `<vault>/templates/`:
+
+```text
+<vault>/
+  templates/
+    github.yaml
+```
+
+The vault-local file uses the same schema and completely replaces the
+built-in of the same name. Example:
+
+```yaml
+# docs: https://docs.github.com/rest/authentication
+base_url: https://api.github.com
+auth_type: bearer
+entry_ref: work/github
+allowed_endpoints:
+  - /repos/*
+allowed_methods:
+  - GET
+```
+
+## Template schema
+
+```yaml
+base_url: https://api.example.com        # required
+auth_type: bearer | basic | header | query_param | none   # required
+entry_ref: op:///example                 # required — vault entry with the credential
+allowed_endpoints: [ "/path/*" ]         # glob patterns; matching ignores the query string
+allowed_methods: [ GET, POST ]           # upper-case methods
+default_headers: { X-Name: value }       # optional
+substitutions: []                        # optional, see below
+allow_private: false                     # optional; must be true for local/private hosts
+```
+
+### `auth_type`
+
+- `bearer` — sends `Authorization: Bearer <credential|token|password>`.
+- `basic` — sends HTTP Basic auth from `username` + `credential`/`password`.
+- `header` — sends the header named by the entry's `header_name` field with
+  the entry's `header_value` (or `credential`/`token`/`password`).
+- `query_param` — sends the query parameter named by `param_name` with the
+  value from `param_value` (or `credential`/`token`/`password`).
+- `none` — no auth header is injected; the credential is delivered entirely
+  through `substitutions`. A template with `auth_type: none` must declare at
+  least one substitution.
+
+## Substitutions
+
+Some APIs carry their credential outside a header — in the URL path
+(Telegram), a query parameter, a JSON body field, or a header with a fixed
+name/prefix (GitLab's `PRIVATE-TOKEN`, Gemini's `x-goog-api-key`). The
+optional `substitutions:` list covers those shapes:
+
+```yaml
+auth_type: none
+default_headers:
+  PRIVATE-TOKEN: __GITLAB_TOKEN__
+substitutions:
+  - placeholder: __GITLAB_TOKEN__
+    field: credential
+    in: [header]
+```
+
+Each substitution declares:
+
+- `placeholder` — the literal text replaced in the request.
+- `field` — the vault entry field the credential is read from.
+- `in` — the surfaces where the placeholder is replaced: `path`, `query`,
+  `header`, `body`. When omitted, the default is `path` + `query`.
+
+Placeholder rules (enforced at template load):
+
+- at least 4 characters;
+- only RFC 3986 unreserved characters `[A-Za-z0-9_.~-]`;
+- at least one alphanumeric character;
+- a mandatory delimiter (`__` or a non-word character) so a short
+  placeholder cannot accidentally match a legitimate URL word;
+- no duplicate placeholders across substitutions.
+
+Substituted values are resolved from the vault entry at request time, are
+never logged or audited, and are redacted (`***`) from error messages if a
+request fails after substitution. When `auth_type` and a substitution both
+apply to the `Authorization` header, `auth_type` wins.
+
+Example — Telegram-shaped template (token in the path):
+
+```yaml
+base_url: https://api.telegram.org/bot__BOT_TOKEN__
+auth_type: none
+entry_ref: op:///telegram
+substitutions:
+  - placeholder: __BOT_TOKEN__
+    field: credential
+    in: [path]
+allowed_endpoints:
+  - /sendMessage
+allowed_methods:
+  - POST
+```
+
+## Security notes
+
+- Built-in templates never combine a root-wildcard endpoint (`/*`) with a
+  mutating method.
+- Requests to private/local network addresses are blocked unless the
+  template sets `allow_private: true`; DNS is re-resolved at dial time so a
+  rebinding attack cannot redirect injected credentials.
+- Response bodies are sanitized for known credential values and common
+  secret patterns before being returned to the agent.

--- a/internal/mcp/apitemplates/builtin/cloudflare.yaml
+++ b/internal/mcp/apitemplates/builtin/cloudflare.yaml
@@ -1,0 +1,14 @@
+# Cloudflare API template.
+# Auth shape: Authorization: Bearer <api-token> — https://developers.cloudflare.com/api/authorization/
+# Fill the vault entry referenced by entry_ref with a "credential" field.
+base_url: https://api.cloudflare.com/client/v4
+auth_type: bearer
+entry_ref: op:///cloudflare
+allowed_endpoints:
+  - /zones/*
+  - /accounts/*
+  - /user/*
+allowed_methods:
+  - GET
+  - POST
+  - PATCH

--- a/internal/mcp/apitemplates/builtin/gemini.yaml
+++ b/internal/mcp/apitemplates/builtin/gemini.yaml
@@ -1,0 +1,18 @@
+# Google Gemini API template.
+# Auth shape: x-goog-api-key request header — https://ai.google.dev/gemini-api/docs/api-key
+# The API key travels in the x-goog-api-key header, not in Authorization.
+# Fill the vault entry referenced by entry_ref with a "credential" field.
+base_url: https://generativelanguage.googleapis.com
+auth_type: none
+entry_ref: op:///gemini
+default_headers:
+  x-goog-api-key: __GOOGLE_API_KEY__
+substitutions:
+  - placeholder: __GOOGLE_API_KEY__
+    field: credential
+    in: [header]
+allowed_endpoints:
+  - /v1beta/models/*
+allowed_methods:
+  - GET
+  - POST

--- a/internal/mcp/apitemplates/builtin/gitlab.yaml
+++ b/internal/mcp/apitemplates/builtin/gitlab.yaml
@@ -1,0 +1,23 @@
+# GitLab REST API template.
+# Auth shape: PRIVATE-TOKEN header — https://docs.gitlab.com/ee/api/rest/#authentication
+# (GitLab also accepts Authorization: Bearer; the PRIVATE-TOKEN header form is
+# the documented primary for personal/project access tokens.)
+# Fill the vault entry referenced by entry_ref with a "credential" field.
+base_url: https://gitlab.com/api/v4
+auth_type: none
+entry_ref: op:///gitlab
+default_headers:
+  PRIVATE-TOKEN: __GITLAB_TOKEN__
+substitutions:
+  - placeholder: __GITLAB_TOKEN__
+    field: credential
+    in: [header]
+allowed_endpoints:
+  - /projects/*
+  - /groups/*
+  - /issues/*
+  - /merge_requests/*
+  - /user
+allowed_methods:
+  - GET
+  - POST

--- a/internal/mcp/apitemplates/builtin/linear.yaml
+++ b/internal/mcp/apitemplates/builtin/linear.yaml
@@ -1,0 +1,12 @@
+# Linear API template.
+# Auth shape: Authorization: <api key> — https://developers.linear.app/docs/api/introduction
+# Linear accepts the API key as a bare bearer-style token (no "Bearer" prefix required,
+# but the Authorization: Bearer form is also accepted).
+# Fill the vault entry referenced by entry_ref with a "credential" field.
+base_url: https://api.linear.app
+auth_type: bearer
+entry_ref: op:///linear
+allowed_endpoints:
+  - /graphql
+allowed_methods:
+  - POST

--- a/internal/mcp/apitemplates/builtin/notion.yaml
+++ b/internal/mcp/apitemplates/builtin/notion.yaml
@@ -1,0 +1,18 @@
+# Notion API template.
+# Auth shape: Authorization: Bearer <token> plus the required Notion-Version
+# header — https://developers.notion.com/reference/authorization
+# Fill the vault entry referenced by entry_ref with a "credential" field.
+base_url: https://api.notion.com/v1
+auth_type: bearer
+entry_ref: op:///notion
+default_headers:
+  Notion-Version: "2022-06-28"
+allowed_endpoints:
+  - /pages/*
+  - /databases/*
+  - /blocks/*
+  - /search
+allowed_methods:
+  - GET
+  - POST
+  - PATCH

--- a/internal/mcp/apitemplates/builtin/npm.yaml
+++ b/internal/mcp/apitemplates/builtin/npm.yaml
@@ -1,0 +1,12 @@
+# npm registry API template.
+# Auth shape: Authorization: Bearer <token> — https://docs.npmjs.com/cli/v10/using-npm/config#token
+# Read-only registry endpoints; publishing stays out of the built-in grant.
+# Fill the vault entry referenced by entry_ref with a "credential" field.
+base_url: https://registry.npmjs.org
+auth_type: bearer
+entry_ref: op:///npm
+allowed_endpoints:
+  - /-/whoami
+  - /-/v1/search
+allowed_methods:
+  - GET

--- a/internal/mcp/apitemplates/builtin/openrouter.yaml
+++ b/internal/mcp/apitemplates/builtin/openrouter.yaml
@@ -1,0 +1,12 @@
+# OpenRouter API template.
+# Auth shape: Authorization: Bearer <api-key> — https://openrouter.ai/docs/quickstart#authentication
+# Fill the vault entry referenced by entry_ref with a "credential" field.
+base_url: https://openrouter.ai/api/v1
+auth_type: bearer
+entry_ref: op:///openrouter
+allowed_endpoints:
+  - /chat/completions
+  - /models
+allowed_methods:
+  - GET
+  - POST

--- a/internal/mcp/apitemplates/builtin/resend.yaml
+++ b/internal/mcp/apitemplates/builtin/resend.yaml
@@ -1,0 +1,13 @@
+# Resend API template.
+# Auth shape: Authorization: Bearer <re_...> — https://resend.com/docs/api-reference/introduction
+# Fill the vault entry referenced by entry_ref with a "credential" field.
+base_url: https://api.resend.com
+auth_type: bearer
+entry_ref: op:///resend
+allowed_endpoints:
+  - /emails/*
+  - /domains/*
+  - /audiences/*
+allowed_methods:
+  - GET
+  - POST

--- a/internal/mcp/apitemplates/builtin/sentry.yaml
+++ b/internal/mcp/apitemplates/builtin/sentry.yaml
@@ -1,0 +1,12 @@
+# Sentry API template.
+# Auth shape: Authorization: Bearer <auth-token> — https://docs.sentry.io/api/auth/
+# Fill the vault entry referenced by entry_ref with a "credential" field.
+base_url: https://sentry.io
+auth_type: bearer
+entry_ref: op:///sentry
+allowed_endpoints:
+  - /api/0/projects/*
+  - /api/0/issues/*
+  - /api/0/organizations/*
+allowed_methods:
+  - GET

--- a/internal/mcp/apitemplates/builtin/stripe.yaml
+++ b/internal/mcp/apitemplates/builtin/stripe.yaml
@@ -1,0 +1,15 @@
+# Stripe API template.
+# Auth shape: Authorization: Bearer <sk_...> — https://docs.stripe.com/api/authentication
+# Fill the vault entry referenced by entry_ref with a "credential" field.
+base_url: https://api.stripe.com/v1
+auth_type: bearer
+entry_ref: op:///stripe
+allowed_endpoints:
+  - /charges/*
+  - /payment_intents/*
+  - /customers/*
+  - /products/*
+  - /prices/*
+allowed_methods:
+  - GET
+  - POST

--- a/internal/mcp/apitemplates/builtin/telegram.yaml
+++ b/internal/mcp/apitemplates/builtin/telegram.yaml
@@ -1,0 +1,19 @@
+# Telegram Bot API template.
+# Auth shape: the bot token lives in the URL path — /bot<token>/<method> —
+# https://core.telegram.org/bots/api#making-requests
+# The token is injected via a path substitution, so it never appears in a
+# header or query string. Fill the vault entry referenced by entry_ref with a
+# "credential" field.
+base_url: https://api.telegram.org/bot__TELEGRAM_BOT_TOKEN__
+auth_type: none
+entry_ref: op:///telegram
+substitutions:
+  - placeholder: __TELEGRAM_BOT_TOKEN__
+    field: credential
+    in: [path]
+allowed_endpoints:
+  - /getMe
+  - /sendMessage
+allowed_methods:
+  - GET
+  - POST

--- a/internal/mcp/apitemplates/builtin/vercel.yaml
+++ b/internal/mcp/apitemplates/builtin/vercel.yaml
@@ -1,0 +1,18 @@
+# Vercel REST API template.
+# Auth shape: Authorization: Bearer <token> — https://vercel.com/docs/rest-api/authentication
+# Fill the vault entry referenced by entry_ref with a "credential" field.
+base_url: https://api.vercel.com
+auth_type: bearer
+entry_ref: op:///vercel
+allowed_endpoints:
+  - /v9/*
+  - /v10/*
+  - /v11/*
+  - /v12/*
+  - /v13/*
+  - /v14/*
+  - /v15/*
+  - /v16/*
+allowed_methods:
+  - GET
+  - POST

--- a/internal/mcp/apitemplates/template.go
+++ b/internal/mcp/apitemplates/template.go
@@ -22,7 +22,7 @@ var builtinFS embed.FS
 type AuthType string
 
 const (
-	// AuthBearer sends credentials via Authorization: Bearer <token> header.
+	// AuthBearer sends credentials via Authorization: Bearer *** header.
 	AuthBearer AuthType = "bearer"
 	// AuthBasic sends credentials via HTTP Basic Auth (base64(username:password)).
 	AuthBasic AuthType = "basic"
@@ -30,7 +30,49 @@ const (
 	AuthHeader AuthType = "header"
 	// AuthQueryParam sends credentials as a URL query parameter.
 	AuthQueryParam AuthType = "query_param"
+	// AuthNone declares that no auth header is injected; credentials are
+	// delivered exclusively through substitutions (path/query/header/body).
+	// Templates using it must declare at least one substitution.
+	AuthNone AuthType = "none"
 )
+
+// SubstitutionSurface names a request location where a substitution
+// placeholder is replaced with a credential value.
+type SubstitutionSurface string
+
+const (
+	// SurfacePath replaces placeholders in the request URL path.
+	SurfacePath SubstitutionSurface = "path"
+	// SurfaceQuery replaces placeholders in the request URL query string.
+	SurfaceQuery SubstitutionSurface = "query"
+	// SurfaceHeader replaces placeholders in request header values.
+	SurfaceHeader SubstitutionSurface = "header"
+	// SurfaceBody replaces placeholders in the request body.
+	SurfaceBody SubstitutionSurface = "body"
+)
+
+// DefaultSubstitutionSurfaces is applied when a substitution omits "in".
+// It mirrors the upstream agent-vault default of path + query.
+func DefaultSubstitutionSurfaces() []SubstitutionSurface {
+	return []SubstitutionSurface{SurfacePath, SurfaceQuery}
+}
+
+// Substitution declares a placeholder that is replaced with a credential
+// value from the vault entry before the request leaves symvault. The value
+// is resolved from the vault entry field named by Field.
+type Substitution struct {
+	// Placeholder is the literal text replaced in the request. Rules (ported
+	// from the agent-vault broker): at least 4 characters, only RFC 3986
+	// unreserved characters [A-Za-z0-9_.~-], at least one alphanumeric, and a
+	// mandatory delimiter ("__" or a non-word character) so a short
+	// placeholder cannot accidentally rewrite a legitimate URL word.
+	Placeholder string `yaml:"placeholder" json:"placeholder"`
+	// Field is the vault entry field the credential value is read from.
+	Field string `yaml:"field" json:"field"`
+	// In lists the surfaces where the placeholder is replaced. When empty,
+	// defaults to path + query.
+	In []SubstitutionSurface `yaml:"in,omitempty" json:"in,omitempty"`
+}
 
 // APITemplate defines how to authenticate and communicate with an external API.
 type APITemplate struct {
@@ -48,9 +90,41 @@ type APITemplate struct {
 	AllowedMethods []string `yaml:"allowed_methods" json:"allowed_methods"`
 	// DefaultHeaders are headers to include in every request.
 	DefaultHeaders map[string]string `yaml:"default_headers" json:"default_headers,omitempty"`
+	// Substitutions replace placeholders in the request path, query, header
+	// values or body with credential values from the vault entry.
+	Substitutions []Substitution `yaml:"substitutions,omitempty" json:"substitutions,omitempty"`
 	// AllowPrivate permits requests to private or local network destinations.
 	// It is intentionally opt-in because templates can inject vault credentials.
 	AllowPrivate bool `yaml:"allow_private" json:"allow_private,omitempty"`
+}
+
+// Validate checks the template's required fields and substitution rules.
+// Templates loaded from YAML are validated at parse time; this method lets
+// callers and tests validate constructed or modified templates.
+func (t *APITemplate) Validate() error {
+	if t.Name == "" {
+		return fmt.Errorf("template name is required")
+	}
+	if t.BaseURL == "" {
+		return fmt.Errorf("template %q: base_url is required", t.Name)
+	}
+	parsedURL, err := url.Parse(t.BaseURL)
+	if err != nil {
+		return fmt.Errorf("template %q: invalid base_url: %w", t.Name, err)
+	}
+	if IsPrivateHost(parsedURL.Host) && !t.AllowPrivate {
+		return fmt.Errorf("template %q: base_url host %q resolves to a private/internal address; set allow_private: true to override", t.Name, parsedURL.Host)
+	}
+	if t.AuthType == "" {
+		return fmt.Errorf("template %q: auth_type is required", t.Name)
+	}
+	if t.AuthType == AuthNone && len(t.Substitutions) == 0 {
+		return fmt.Errorf("template %q: auth_type \"none\" requires at least one substitution", t.Name)
+	}
+	if t.EntryRef == "" {
+		return fmt.Errorf("template %q: entry_ref is required", t.Name)
+	}
+	return validateSubstitutions(t.Name, t.Substitutions)
 }
 
 // templateFile is the on-disk representation of an APITemplate.
@@ -61,6 +135,7 @@ type templateFile struct {
 	AllowedEndpoints []string          `yaml:"allowed_endpoints"`
 	AllowedMethods   []string          `yaml:"allowed_methods"`
 	DefaultHeaders   map[string]string `yaml:"default_headers"`
+	Substitutions    []Substitution    `yaml:"substitutions,omitempty"`
 	AllowPrivate     bool              `yaml:"allow_private"`
 }
 
@@ -215,8 +290,19 @@ func parseTemplate(name string, data []byte) (*APITemplate, error) {
 	if tf.AuthType == "" {
 		return nil, fmt.Errorf("template %q: auth_type is required", name)
 	}
+	if tf.AuthType == AuthNone && len(tf.Substitutions) == 0 {
+		return nil, fmt.Errorf("template %q: auth_type \"none\" requires at least one substitution", name)
+	}
 	if tf.EntryRef == "" {
 		return nil, fmt.Errorf("template %q: entry_ref is required", name)
+	}
+	if err := validateSubstitutions(name, tf.Substitutions); err != nil {
+		return nil, err
+	}
+	for i := range tf.Substitutions {
+		if len(tf.Substitutions[i].In) == 0 {
+			tf.Substitutions[i].In = DefaultSubstitutionSurfaces()
+		}
 	}
 
 	return &APITemplate{
@@ -227,6 +313,72 @@ func parseTemplate(name string, data []byte) (*APITemplate, error) {
 		AllowedEndpoints: tf.AllowedEndpoints,
 		AllowedMethods:   tf.AllowedMethods,
 		DefaultHeaders:   tf.DefaultHeaders,
+		Substitutions:    tf.Substitutions,
 		AllowPrivate:     tf.AllowPrivate,
 	}, nil
+}
+
+// validateSubstitutions enforces the placeholder rules ported from the
+// agent-vault broker (internal/broker/broker.go): minimum 4 characters, only
+// RFC 3986 unreserved characters, at least one alphanumeric, a mandatory
+// delimiter ("__" or a non-word character) so a placeholder cannot
+// accidentally match a legitimate URL word, and no duplicate placeholders.
+func validateSubstitutions(name string, subs []Substitution) error {
+	seen := make(map[string]struct{}, len(subs))
+	for i, sub := range subs {
+		label := fmt.Sprintf("template %q: substitutions[%d]", name, i)
+		ph := sub.Placeholder
+		if ph == "" {
+			return fmt.Errorf("%s: placeholder is required", label)
+		}
+		if len(ph) < 4 {
+			return fmt.Errorf("%s: placeholder %q must be at least 4 characters long", label, ph)
+		}
+		hasAlnum := false
+		hasDelimiter := strings.Contains(ph, "__")
+		for _, r := range ph {
+			if !isUnreservedRune(r) {
+				return fmt.Errorf("%s: placeholder %q contains disallowed character %q (only RFC 3986 unreserved characters [A-Za-z0-9_.~-] are allowed)", label, ph, r)
+			}
+			if isAlnumRune(r) {
+				hasAlnum = true
+			} else if !isWordRune(r) {
+				hasDelimiter = true
+			}
+		}
+		if !hasAlnum {
+			return fmt.Errorf("%s: placeholder %q must contain at least one alphanumeric character", label, ph)
+		}
+		if !hasDelimiter {
+			return fmt.Errorf("%s: placeholder %q must contain a delimiter (\"__\" or a non-word character) so it cannot accidentally match a legitimate URL word", label, ph)
+		}
+		if _, dup := seen[ph]; dup {
+			return fmt.Errorf("%s: duplicate placeholder %q across substitutions", label, ph)
+		}
+		seen[ph] = struct{}{}
+		if sub.Field == "" {
+			return fmt.Errorf("%s: field is required for placeholder %q", label, ph)
+		}
+		for _, surface := range sub.In {
+			switch surface {
+			case SurfacePath, SurfaceQuery, SurfaceHeader, SurfaceBody:
+			default:
+				return fmt.Errorf("%s: unsupported substitution surface %q (supported: path, query, header, body)", label, surface)
+			}
+		}
+	}
+	return nil
+}
+
+func isUnreservedRune(r rune) bool {
+	return isAlnumRune(r) || r == '-' || r == '.' || r == '_' || r == '~'
+}
+
+func isAlnumRune(r rune) bool {
+	return (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9')
+}
+
+// isWordRune mirrors the regexp \w class ([A-Za-z0-9_]) for the delimiter rule.
+func isWordRune(r rune) bool {
+	return isAlnumRune(r) || r == '_'
 }

--- a/internal/mcp/apitemplates/template_test.go
+++ b/internal/mcp/apitemplates/template_test.go
@@ -2,6 +2,8 @@ package apitemplates
 
 import (
 	"net"
+	"slices"
+	"strings"
 	"testing"
 )
 
@@ -124,5 +126,216 @@ allow_private: true
 	}
 	if !tmpl.AllowPrivate {
 		t.Fatal("expected allow_private to be preserved on the loaded template")
+	}
+}
+
+// --- Substitution validation tests ---
+
+func TestParseTemplate_ValidSubstitutions(t *testing.T) {
+	yaml := []byte(`
+base_url: https://api.telegram.org/bot__BOT_TOKEN__
+auth_type: none
+entry_ref: op://vault/item
+substitutions:
+  - placeholder: __BOT_TOKEN__
+    field: credential
+    in: [path]
+`)
+	tmpl, err := parseTemplate("telegram", yaml)
+	if err != nil {
+		t.Fatalf("parseTemplate() error = %v", err)
+	}
+	if len(tmpl.Substitutions) != 1 {
+		t.Fatalf("Substitutions len = %d, want 1", len(tmpl.Substitutions))
+	}
+	if tmpl.Substitutions[0].Placeholder != "__BOT_TOKEN__" {
+		t.Errorf("Placeholder = %q, want __BOT_TOKEN__", tmpl.Substitutions[0].Placeholder)
+	}
+	if tmpl.Substitutions[0].Field != "credential" {
+		t.Errorf("Field = %q, want credential", tmpl.Substitutions[0].Field)
+	}
+	if len(tmpl.Substitutions[0].In) != 1 || tmpl.Substitutions[0].In[0] != SurfacePath {
+		t.Errorf("In = %v, want [path]", tmpl.Substitutions[0].In)
+	}
+}
+
+func TestParseTemplate_SubstitutionDefaultsToPathQuery(t *testing.T) {
+	yaml := []byte(`
+base_url: https://example.com
+auth_type: none
+entry_ref: op://vault/item
+substitutions:
+  - placeholder: __API_KEY__
+    field: credential
+`)
+	tmpl, err := parseTemplate("test", yaml)
+	if err != nil {
+		t.Fatalf("parseTemplate() error = %v", err)
+	}
+	got := tmpl.Substitutions[0].In
+	if len(got) != 2 || got[0] != SurfacePath || got[1] != SurfaceQuery {
+		t.Errorf("default In = %v, want [path query]", got)
+	}
+}
+
+func TestParseTemplate_SubstitutionTooShort(t *testing.T) {
+	yaml := []byte(`
+base_url: https://example.com
+auth_type: none
+entry_ref: op://vault/item
+substitutions:
+  - placeholder: __T
+    field: credential
+`)
+	_, err := parseTemplate("test", yaml)
+	if err == nil || !strings.Contains(err.Error(), "at least 4 characters") {
+		t.Fatalf("expected minimum-length error, got %v", err)
+	}
+}
+
+func TestParseTemplate_SubstitutionDisallowedCharacter(t *testing.T) {
+	yaml := []byte(`
+base_url: https://example.com
+auth_type: none
+entry_ref: op://vault/item
+substitutions:
+  - placeholder: __TO{KEN__
+    field: credential
+`)
+	_, err := parseTemplate("test", yaml)
+	if err == nil || !strings.Contains(err.Error(), "disallowed character") {
+		t.Fatalf("expected disallowed-character error, got %v", err)
+	}
+}
+
+func TestParseTemplate_SubstitutionNoAlphanumeric(t *testing.T) {
+	yaml := []byte(`
+base_url: https://example.com
+auth_type: none
+entry_ref: op://vault/item
+substitutions:
+  - placeholder: "____"
+    field: credential
+`)
+	_, err := parseTemplate("test", yaml)
+	if err == nil || !strings.Contains(err.Error(), "at least one alphanumeric") {
+		t.Fatalf("expected alphanumeric error, got %v", err)
+	}
+}
+
+func TestParseTemplate_SubstitutionNoDelimiter(t *testing.T) {
+	// All word characters and no "__" — must be rejected so a short
+	// placeholder cannot accidentally match a legitimate URL word.
+	yaml := []byte(`
+base_url: https://example.com
+auth_type: none
+entry_ref: op://vault/item
+substitutions:
+  - placeholder: TOKEN
+    field: credential
+`)
+	_, err := parseTemplate("test", yaml)
+	if err == nil || !strings.Contains(err.Error(), "delimiter") {
+		t.Fatalf("expected delimiter error, got %v", err)
+	}
+}
+
+func TestParseTemplate_SubstitutionDuplicatePlaceholder(t *testing.T) {
+	yaml := []byte(`
+base_url: https://example.com
+auth_type: none
+entry_ref: op://vault/item
+substitutions:
+  - placeholder: __API_KEY__
+    field: credential
+  - placeholder: __API_KEY__
+    field: token
+`)
+	_, err := parseTemplate("test", yaml)
+	if err == nil || !strings.Contains(err.Error(), "duplicate placeholder") {
+		t.Fatalf("expected duplicate-placeholder error, got %v", err)
+	}
+}
+
+func TestParseTemplate_SubstitutionUnsupportedSurface(t *testing.T) {
+	yaml := []byte(`
+base_url: https://example.com
+auth_type: none
+entry_ref: op://vault/item
+substitutions:
+  - placeholder: __API_KEY__
+    field: credential
+    in: [websocket]
+`)
+	_, err := parseTemplate("test", yaml)
+	if err == nil || !strings.Contains(err.Error(), "unsupported substitution surface") {
+		t.Fatalf("expected unsupported-surface error, got %v", err)
+	}
+}
+
+func TestParseTemplate_AuthNoneRequiresSubstitution(t *testing.T) {
+	yaml := []byte(`
+base_url: https://example.com
+auth_type: none
+entry_ref: op://vault/item
+`)
+	_, err := parseTemplate("test", yaml)
+	if err == nil || !strings.Contains(err.Error(), "requires at least one substitution") {
+		t.Fatalf("expected auth-none substitution error, got %v", err)
+	}
+}
+
+// --- Built-in catalog tests ---
+
+func TestBuiltinTemplates_AllParseAndValidate(t *testing.T) {
+	templates, err := LoadAll()
+	if err != nil {
+		t.Fatalf("LoadAll() error = %v", err)
+	}
+	if len(templates) < 5 {
+		t.Fatalf("LoadAll() returned %d templates, want at least 5", len(templates))
+	}
+	for _, tmpl := range templates {
+		t.Run(tmpl.Name, func(t *testing.T) {
+			if err := tmpl.Validate(); err != nil {
+				t.Fatalf("Validate(%q) error = %v", tmpl.Name, err)
+			}
+		})
+	}
+}
+
+func TestBuiltinTemplates_NoBlanketMutatingGrant(t *testing.T) {
+	// The five original built-ins predate this rule and are intentionally
+	// left unchanged; the rule applies to newly added templates.
+	newBuiltins := []string{
+		"gitlab", "linear", "notion", "stripe", "sentry", "cloudflare",
+		"vercel", "resend", "gemini", "openrouter", "npm", "telegram",
+	}
+	templates, err := LoadAll()
+	if err != nil {
+		t.Fatalf("LoadAll() error = %v", err)
+	}
+	for _, tmpl := range templates {
+		if !slices.Contains(newBuiltins, tmpl.Name) {
+			continue
+		}
+		t.Run(tmpl.Name, func(t *testing.T) {
+			hasRootWildcard := false
+			for _, ep := range tmpl.AllowedEndpoints {
+				if ep == "/*" || ep == "*" {
+					hasRootWildcard = true
+					break
+				}
+			}
+			if !hasRootWildcard {
+				return
+			}
+			for _, m := range tmpl.AllowedMethods {
+				switch strings.ToUpper(m) {
+				case "POST", "PUT", "PATCH", "DELETE":
+					t.Errorf("template %q grants root-wildcard endpoint with mutating method %s", tmpl.Name, m)
+				}
+			}
+		})
 	}
 }

--- a/internal/mcp/server/tools_execute_api_request.go
+++ b/internal/mcp/server/tools_execute_api_request.go
@@ -548,6 +548,9 @@ func applyURLSubstitutions(rawURL string, subs []apitemplates.Substitution, valu
 				u.RawPath = ""
 			case apitemplates.SurfaceQuery:
 				u.RawQuery = strings.ReplaceAll(u.RawQuery, sub.Placeholder, value)
+			case apitemplates.SurfaceHeader, apitemplates.SurfaceBody:
+				// Applied by the dedicated header/body helpers; the URL
+				// does not carry these surfaces.
 			}
 		}
 	}

--- a/internal/mcp/server/tools_execute_api_request.go
+++ b/internal/mcp/server/tools_execute_api_request.go
@@ -79,8 +79,10 @@ func (s *Server) handleExecuteAPIRequest(ctx context.Context, req mcp.CallToolRe
 		return mcp.NewToolResultError(fmt.Sprintf("cannot load template %q: %v", templateName, loadErr)), nil
 	}
 
-	// Validate endpoint against allowed patterns
-	if !matchAnyGlob(normalizedEndpoint, tmpl.AllowedEndpoints) {
+	// Validate endpoint against allowed patterns (query string excluded —
+	// patterns describe paths; query substitutions live in the query part).
+	endpointPath := strings.SplitN(normalizedEndpoint, "?", 2)[0]
+	if !matchAnyGlob(endpointPath, tmpl.AllowedEndpoints) {
 		s.logAudit(ctx, "execute_api_request", fmt.Sprintf("<endpoint-denied:%s>", tmpl.Name), false)
 		return mcp.NewToolResultError(fmt.Sprintf("endpoint not allowed: %s", normalizedEndpoint)), nil
 	}
@@ -122,6 +124,23 @@ func (s *Server) handleExecuteAPIRequest(ctx context.Context, req mcp.CallToolRe
 		return mcp.NewToolResultError(fmt.Sprintf("cannot load credentials for %q: %v", tmpl.Name, entryErr)), nil
 	}
 
+	// Resolve template substitutions (path/query/header/body) from the vault
+	// entry. Values never enter logs or audit entries; any error message that
+	// could carry a substituted value is redacted below.
+	var substitutionValues map[string]string
+	var redactVals []string
+	if len(tmpl.Substitutions) > 0 {
+		values, redactList, subErr := resolveSubstitutionValues(tmpl, entry.Data)
+		if subErr != nil {
+			s.logAudit(ctx, "execute_api_request", fmt.Sprintf("<substitution-error:%s>", tmpl.Name), false)
+			return mcp.NewToolResultError(fmt.Sprintf("cannot resolve substitutions for %q: %v", tmpl.Name, subErr)), nil
+		}
+		substitutionValues = values
+		redactVals = redactList
+		requestURL = applyURLSubstitutions(requestURL, tmpl.Substitutions, values)
+		bodyStr = applyBodySubstitutions(bodyStr, tmpl.Substitutions, values)
+	}
+
 	// Build the request
 	var requestBody io.Reader
 	if bodyStr != "" {
@@ -131,7 +150,7 @@ func (s *Server) handleExecuteAPIRequest(ctx context.Context, req mcp.CallToolRe
 	httpReq, reqErr := http.NewRequestWithContext(ctx, method, requestURL, requestBody)
 	if reqErr != nil {
 		s.logAudit(ctx, "execute_api_request", fmt.Sprintf("<request-build-error:%s>", tmpl.Name), false)
-		return mcp.NewToolResultError(fmt.Sprintf("cannot build request: %v", reqErr)), nil
+		return mcp.NewToolResultError(fmt.Sprintf("cannot build request: %s", redactValues(reqErr.Error(), redactVals))), nil
 	}
 
 	// Apply default headers
@@ -156,6 +175,12 @@ func (s *Server) handleExecuteAPIRequest(ctx context.Context, req mcp.CallToolRe
 		}
 	}
 
+	// Apply header-surface substitutions (after agent headers, before auth so
+	// auth_type always wins on the Authorization header).
+	if len(tmpl.Substitutions) > 0 {
+		applyHeaderSubstitutions(httpReq, tmpl.Substitutions, substitutionValues)
+	}
+
 	// Resolve and inject auth header
 	authErr := injectAuthHeader(httpReq, tmpl, entry.Data)
 	if authErr != nil {
@@ -174,7 +199,7 @@ func (s *Server) handleExecuteAPIRequest(ctx context.Context, req mcp.CallToolRe
 	if respErr != nil {
 		s.logAudit(ctx, "execute_api_request", fmt.Sprintf("template=%s, endpoint=%s, method=%s, status=error",
 			tmpl.Name, normalizedEndpoint, method), false)
-		return mcp.NewToolResultError(fmt.Sprintf("request failed: %v", respErr)), nil
+		return mcp.NewToolResultError(fmt.Sprintf("request failed: %s", redactValues(respErr.Error(), redactVals))), nil
 	}
 	defer func() { _ = resp.Body.Close() }()
 
@@ -475,11 +500,113 @@ func injectAuthHeader(httpReq *http.Request, tmpl *apitemplates.APITemplate, ent
 		q.Set(paramName, paramValue)
 		httpReq.URL.RawQuery = q.Encode()
 
+	case apitemplates.AuthNone:
+		// No auth header is injected; credentials are delivered through
+		// template substitutions (path/query/header/body).
+
 	default:
 		return fmt.Errorf("unsupported auth type: %s", tmpl.AuthType)
 	}
 
 	return nil
+}
+
+// resolveSubstitutionValues resolves every declared substitution placeholder
+// to a non-empty value from the vault entry data. It returns the values by
+// placeholder and as a flat slice for error redaction.
+func resolveSubstitutionValues(tmpl *apitemplates.APITemplate, entryData map[string]any) (map[string]string, []string, error) {
+	values := make(map[string]string, len(tmpl.Substitutions))
+	var redactVals []string
+	for _, sub := range tmpl.Substitutions {
+		value := resolveField(entryData, sub.Field)
+		if value == "" {
+			return nil, nil, fmt.Errorf("no value for placeholder %q (expected vault entry field %q)", sub.Placeholder, sub.Field)
+		}
+		values[sub.Placeholder] = value
+		redactVals = append(redactVals, value)
+	}
+	return values, redactVals, nil
+}
+
+// applyURLSubstitutions replaces path- and query-surface placeholders in the
+// request URL. Placeholders are restricted to RFC 3986 unreserved characters,
+// so the substitution cannot alter the URL scheme or host.
+func applyURLSubstitutions(rawURL string, subs []apitemplates.Substitution, values map[string]string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL
+	}
+	for _, sub := range subs {
+		value, ok := values[sub.Placeholder]
+		if !ok {
+			continue
+		}
+		for _, surface := range sub.In {
+			switch surface {
+			case apitemplates.SurfacePath:
+				u.Path = strings.ReplaceAll(u.Path, sub.Placeholder, value)
+				u.RawPath = ""
+			case apitemplates.SurfaceQuery:
+				u.RawQuery = strings.ReplaceAll(u.RawQuery, sub.Placeholder, value)
+			}
+		}
+	}
+	return u.String()
+}
+
+// applyBodySubstitutions replaces body-surface placeholders in the request body.
+func applyBodySubstitutions(body string, subs []apitemplates.Substitution, values map[string]string) string {
+	for _, sub := range subs {
+		if !hasSubstitutionSurface(sub.In, apitemplates.SurfaceBody) {
+			continue
+		}
+		value, ok := values[sub.Placeholder]
+		if !ok {
+			continue
+		}
+		body = strings.ReplaceAll(body, sub.Placeholder, value)
+	}
+	return body
+}
+
+// applyHeaderSubstitutions replaces header-surface placeholders in the values
+// of every request header.
+func applyHeaderSubstitutions(httpReq *http.Request, subs []apitemplates.Substitution, values map[string]string) {
+	for _, sub := range subs {
+		if !hasSubstitutionSurface(sub.In, apitemplates.SurfaceHeader) {
+			continue
+		}
+		value, ok := values[sub.Placeholder]
+		if !ok {
+			continue
+		}
+		for key, vals := range httpReq.Header {
+			for i, v := range vals {
+				httpReq.Header[key][i] = strings.ReplaceAll(v, sub.Placeholder, value)
+			}
+		}
+	}
+}
+
+func hasSubstitutionSurface(surfaces []apitemplates.SubstitutionSurface, want apitemplates.SubstitutionSurface) bool {
+	for _, s := range surfaces {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}
+
+// redactValues replaces every occurrence of the given secret values in msg
+// with "***" so substituted credentials never reach error messages.
+func redactValues(msg string, values []string) string {
+	for _, v := range values {
+		if v == "" {
+			continue
+		}
+		msg = strings.ReplaceAll(msg, v, "***")
+	}
+	return msg
 }
 
 // resolveField returns the first non-empty string value from the entry data

--- a/internal/mcp/server/tools_execute_api_request_test.go
+++ b/internal/mcp/server/tools_execute_api_request_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -127,14 +128,18 @@ func TestAPITemplateLoadAll(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadAll() error = %v", err)
 	}
-	if len(templates) != 5 {
-		t.Fatalf("LoadAll() returned %d templates, want 5", len(templates))
+	if len(templates) != 17 {
+		t.Fatalf("LoadAll() returned %d templates, want 17", len(templates))
 	}
 	names := make(map[string]bool)
 	for _, tmpl := range templates {
 		names[tmpl.Name] = true
 	}
-	for _, name := range []string{"github", "openai", "anthropic", "slack", "perplexity"} {
+	for _, name := range []string{
+		"github", "openai", "anthropic", "slack", "perplexity",
+		"gitlab", "linear", "notion", "stripe", "sentry", "cloudflare",
+		"vercel", "resend", "gemini", "openrouter", "npm", "telegram",
+	} {
 		if !names[name] {
 			t.Errorf("LoadAll() missing template %q", name)
 		}
@@ -911,5 +916,339 @@ func writeTemplateOverride(t *testing.T, vaultDir, name, content string) {
 	}
 	if err := os.WriteFile(filepath.Join(templatesDir, name+".yaml"), []byte(content), 0644); err != nil {
 		t.Fatalf("write template: %v", err)
+	}
+}
+
+// --- Substitution tests (issue #765) ---
+
+func TestHandleExecuteAPIRequest_PathSubstitution(t *testing.T) {
+	const botToken = "123456789:AA-test-bot-token"
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		wantPath := "/bot" + botToken + "/sendMessage"
+		if r.URL.Path != wantPath {
+			t.Errorf("path = %q, want %q", r.URL.Path, wantPath)
+		}
+		if auth := r.Header.Get("Authorization"); auth != "" {
+			t.Errorf("Authorization header = %q, want empty (auth_type none)", auth)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok": true}`))
+	}))
+	defer ts.Close()
+
+	vaultDir, identity := mockVaultWithEntry(t, "telegramtest", map[string]any{
+		"credential": botToken,
+	})
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:           "test",
+		AllowedPaths:   []string{"*"},
+		CanRunCommands: config.BoolPtr(true),
+		ApprovalMode:   config.StrPtr("none"),
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+
+	writeTemplateOverride(t, vaultDir, "telegramtest", fmt.Sprintf(`base_url: %s/bot__BOT_TOKEN__
+auth_type: none
+entry_ref: telegramtest
+substitutions:
+  - placeholder: __BOT_TOKEN__
+    field: credential
+    in: [path]
+allowed_endpoints:
+  - /sendMessage
+allowed_methods:
+  - GET
+allow_private: true
+`, ts.URL))
+
+	req := mcp.CallToolRequest{
+		Arguments: map[string]any{
+			"template": "telegramtest",
+			"endpoint": "/sendMessage",
+			"method":   "GET",
+		},
+	}
+	result, err := srv.handleExecuteAPIRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleExecuteAPIRequest() error = %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handleExecuteAPIRequest() returned error: %s", result.Text)
+	}
+	var output map[string]any
+	if err := json.Unmarshal([]byte(result.Text), &output); err != nil {
+		t.Fatalf("parse result: %v", err)
+	}
+	if code, _ := output["status_code"].(float64); code != 200 {
+		t.Errorf("status_code = %v, want 200", code)
+	}
+}
+
+func TestHandleExecuteAPIRequest_BodySubstitution(t *testing.T) {
+	const bodyToken = "body-secret-token-1"
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		want := `{"chat_id": 42, "text": "` + bodyToken + `"}`
+		if string(body) != want {
+			t.Errorf("body = %q, want %q", string(body), want)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok": true}`))
+	}))
+	defer ts.Close()
+
+	vaultDir, identity := mockVaultWithEntry(t, "bodytest", map[string]any{
+		"credential": bodyToken,
+	})
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:           "test",
+		AllowedPaths:   []string{"*"},
+		CanRunCommands: config.BoolPtr(true),
+		ApprovalMode:   config.StrPtr("none"),
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+
+	writeTemplateOverride(t, vaultDir, "bodytest", fmt.Sprintf(`base_url: %s
+auth_type: none
+entry_ref: bodytest
+substitutions:
+  - placeholder: __BODY_TOKEN__
+    field: credential
+    in: [body]
+allowed_endpoints:
+  - /test
+allowed_methods:
+  - POST
+allow_private: true
+`, ts.URL))
+
+	req := mcp.CallToolRequest{
+		Arguments: map[string]any{
+			"template": "bodytest",
+			"endpoint": "/test",
+			"method":   "POST",
+			"body":     `{"chat_id": 42, "text": "__BODY_TOKEN__"}`,
+		},
+	}
+	result, err := srv.handleExecuteAPIRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleExecuteAPIRequest() error = %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handleExecuteAPIRequest() returned error: %s", result.Text)
+	}
+}
+
+func TestHandleExecuteAPIRequest_HeaderSubstitution(t *testing.T) {
+	const gitlabToken = "glpat-test-token-123"
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("PRIVATE-TOKEN"); got != gitlabToken {
+			t.Errorf("PRIVATE-TOKEN header = %q, want %q", got, gitlabToken)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id": 1}`))
+	}))
+	defer ts.Close()
+
+	vaultDir, identity := mockVaultWithEntry(t, "gitlabtest", map[string]any{
+		"credential": gitlabToken,
+	})
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:           "test",
+		AllowedPaths:   []string{"*"},
+		CanRunCommands: config.BoolPtr(true),
+		ApprovalMode:   config.StrPtr("none"),
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+
+	writeTemplateOverride(t, vaultDir, "gitlabtest", fmt.Sprintf(`base_url: %s
+auth_type: none
+entry_ref: gitlabtest
+default_headers:
+  PRIVATE-TOKEN: __GITLAB_TOKEN__
+substitutions:
+  - placeholder: __GITLAB_TOKEN__
+    field: credential
+    in: [header]
+allowed_endpoints:
+  - /test
+allowed_methods:
+  - GET
+allow_private: true
+`, ts.URL))
+
+	req := mcp.CallToolRequest{
+		Arguments: map[string]any{
+			"template": "gitlabtest",
+			"endpoint": "/test",
+			"method":   "GET",
+		},
+	}
+	result, err := srv.handleExecuteAPIRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleExecuteAPIRequest() error = %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handleExecuteAPIRequest() returned error: %s", result.Text)
+	}
+}
+
+func TestHandleExecuteAPIRequest_QuerySubstitution(t *testing.T) {
+	const queryToken = "query-secret-99"
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("api_key"); got != queryToken {
+			t.Errorf("api_key query param = %q, want %q", got, queryToken)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok": true}`))
+	}))
+	defer ts.Close()
+
+	vaultDir, identity := mockVaultWithEntry(t, "querytest", map[string]any{
+		"credential": queryToken,
+	})
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:           "test",
+		AllowedPaths:   []string{"*"},
+		CanRunCommands: config.BoolPtr(true),
+		ApprovalMode:   config.StrPtr("none"),
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+
+	writeTemplateOverride(t, vaultDir, "querytest", fmt.Sprintf(`base_url: %s
+auth_type: none
+entry_ref: querytest
+substitutions:
+  - placeholder: __QUERY_KEY__
+    field: credential
+    in: [query]
+allowed_endpoints:
+  - /test
+allowed_methods:
+  - GET
+allow_private: true
+`, ts.URL))
+
+	req := mcp.CallToolRequest{
+		Arguments: map[string]any{
+			"template": "querytest",
+			"endpoint": "/test?api_key=__QUERY_KEY__",
+			"method":   "GET",
+		},
+	}
+	result, err := srv.handleExecuteAPIRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleExecuteAPIRequest() error = %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handleExecuteAPIRequest() returned error: %s", result.Text)
+	}
+}
+
+func TestHandleExecuteAPIRequest_SubstitutionValueRedactedOnError(t *testing.T) {
+	// A closed listener forces client.Do to fail; the error message embeds
+	// the request URL, which now contains the substituted token. The token
+	// must be redacted from the error returned to the agent.
+	closed := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	closedURL := closed.URL
+	closed.Close()
+
+	const redactToken = "super-secret-token-xyz"
+	vaultDir, identity := mockVaultWithEntry(t, "redacttest", map[string]any{
+		"credential": redactToken,
+	})
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:           "test",
+		AllowedPaths:   []string{"*"},
+		CanRunCommands: config.BoolPtr(true),
+		ApprovalMode:   config.StrPtr("none"),
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+
+	writeTemplateOverride(t, vaultDir, "redacttest", fmt.Sprintf(`base_url: %s/bot__BOT_TOKEN__
+auth_type: none
+entry_ref: redacttest
+substitutions:
+  - placeholder: __BOT_TOKEN__
+    field: credential
+    in: [path]
+allowed_endpoints:
+  - /ping
+allowed_methods:
+  - GET
+allow_private: true
+`, closedURL))
+
+	req := mcp.CallToolRequest{
+		Arguments: map[string]any{
+			"template": "redacttest",
+			"endpoint": "/ping",
+			"method":   "GET",
+		},
+	}
+	result, err := srv.handleExecuteAPIRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleExecuteAPIRequest() error = %v", err)
+	}
+	if !result.IsError {
+		t.Fatal("handleExecuteAPIRequest() expected error result for unreachable upstream")
+	}
+	if strings.Contains(result.Text, redactToken) {
+		t.Fatalf("error text leaks substituted value: %q", result.Text)
+	}
+	if !strings.Contains(result.Text, "request failed") {
+		t.Errorf("error text = %q, want 'request failed'", result.Text)
+	}
+}
+
+func TestHandleExecuteAPIRequest_SubstitutionMissingValue(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	// Entry has no "credential" field — substitution resolution must fail
+	// closed with a clear message instead of sending the placeholder.
+	vaultDir, identity := mockVaultWithEntry(t, "missingval", map[string]any{
+		"username": "someone",
+	})
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:           "test",
+		AllowedPaths:   []string{"*"},
+		CanRunCommands: config.BoolPtr(true),
+		ApprovalMode:   config.StrPtr("none"),
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+
+	writeTemplateOverride(t, vaultDir, "missingval", fmt.Sprintf(`base_url: %s/bot__BOT_TOKEN__
+auth_type: none
+entry_ref: missingval
+substitutions:
+  - placeholder: __BOT_TOKEN__
+    field: credential
+    in: [path]
+allowed_endpoints:
+  - /ping
+allowed_methods:
+  - GET
+allow_private: true
+`, ts.URL))
+
+	req := mcp.CallToolRequest{
+		Arguments: map[string]any{
+			"template": "missingval",
+			"endpoint": "/ping",
+			"method":   "GET",
+		},
+	}
+	result, err := srv.handleExecuteAPIRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleExecuteAPIRequest() error = %v", err)
+	}
+	if !result.IsError {
+		t.Fatal("handleExecuteAPIRequest() expected error result for missing substitution value")
+	}
+	if !strings.Contains(result.Text, "no value for placeholder") {
+		t.Errorf("result text = %q, want 'no value for placeholder'", result.Text)
 	}
 }


### PR DESCRIPTION
## Summary

Two related MCP API-template improvements:

### 1. Substitutions (path/query/header/body)

API templates can now declare an optional `substitutions:` list that places
credentials into the request **path**, **query**, **header values** or
**body** — not only into an auth header. This makes APIs that carry their
token outside a header expressible (Telegram's `bot<token>` path, GitLab's
`PRIVATE-TOKEN`, Gemini's `x-goog-api-key`, JSON body fields).

- New `auth_type: none` for templates that deliver credentials purely via
  substitutions.
- Placeholder rules enforced at load time (ported from agent-vault): min 4
  chars, RFC 3986 unreserved characters only, at least one alphanumeric,
  mandatory delimiter, no duplicates.
- Substituted values are redacted from error messages and never logged or
  audited.
- Endpoint glob matching now ignores the query string (patterns describe
  paths).

### 2. Broader built-in catalog (5 → 17 templates)

New built-ins: gitlab, linear, notion, stripe, sentry, cloudflare, vercel,
resend, gemini, openrouter, npm, telegram. Each carries a comment citing the
vendor auth documentation, keeps `allowed_endpoints`/`allowed_methods`
narrow, and never combines a root-wildcard endpoint with a mutating method.
Every built-in must pass `Validate()` (tested).

Docs: `docs/api-templates.md` names the providers and explains vault-local
overrides.

## Tests

- apitemplates: placeholder validation (one test per rule), default
  surfaces, auth-none rules, builtin Validate() sweep.
- server: end-to-end path/body/header/query substitution against a real
  upstream, error redaction, missing-value fail-closed.

## Verification

- `go build ./...`, `go vet` (changed packages), `gofmt` clean
- `go test ./internal/mcp/apitemplates/... ./internal/mcp/server/...` green
- Full `go test ./cmd/` green

Closes #765
Closes #766
