### PR TITLE
feat(broker): add opt-in egress credential broker

### DIFF
--- a/cmd/broker.go
+++ b/cmd/broker.go
@@ -8,6 +8,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"syscall"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -101,7 +102,13 @@ to <vault>/broker-ca.pem.`,
 					fmt.Printf("Passthrough hosts (no TLS interception): %v\n", brokerPassthrough)
 				}
 
-				srv := &http.Server{Handler: proxy.Handler()}
+				srv := &http.Server{
+					Handler:           proxy.Handler(),
+					ReadHeaderTimeout: 30 * time.Second,
+					ReadTimeout:       60 * time.Second,
+					WriteTimeout:      60 * time.Second,
+					IdleTimeout:       30 * time.Second,
+				}
 				errCh := make(chan error, 1)
 				go func() { errCh <- srv.Serve(ln) }()
 
@@ -146,7 +153,13 @@ func brokerEnvForRun(v *vaultpkg.Vault) (map[string]string, func(), error) {
 		return nil, nil, fmt.Errorf("listen: %w", err)
 	}
 	proxyURL := "http://" + ln.Addr().String()
-	srv := &http.Server{Handler: proxy.Handler()}
+	srv := &http.Server{
+		Handler:           proxy.Handler(),
+		ReadHeaderTimeout: 30 * time.Second,
+		ReadTimeout:       60 * time.Second,
+		WriteTimeout:      60 * time.Second,
+		IdleTimeout:       30 * time.Second,
+	}
 	go func() { _ = srv.Serve(ln) }()
 
 	env := map[string]string{

--- a/cmd/broker.go
+++ b/cmd/broker.go
@@ -1,0 +1,161 @@
+package cmd
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+
+	"github.com/spf13/cobra"
+
+	brokerpkg "github.com/danieljustus/symaira-vault/internal/broker"
+	cli "github.com/danieljustus/symaira-vault/internal/cli"
+	vaultpkg "github.com/danieljustus/symaira-vault/internal/vault"
+)
+
+var (
+	brokerAddr        string
+	brokerStrict      bool
+	brokerPassthrough []string
+)
+
+// BrokerSignalNotify is a seam for tests; production uses signal.Notify.
+var BrokerSignalNotify = signal.Notify
+
+// brokerCmd is retained for API compatibility; NewRootCmd() uses
+// newBrokerCmd() so every call gets a fresh command.
+var brokerCmd = newBrokerCmd()
+
+func newBrokerCmd() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "broker",
+		Short: "Run the egress credential broker (loopback MITM proxy)",
+		Long: `Run an opt-in loopback MITM forward proxy that attaches vault
+credentials to the agent's outbound HTTPS/HTTP requests server-side.
+
+A brokered secret never enters the agent's process environment, argv or
+process listing: the child process only receives HTTPS_PROXY/HTTP_PROXY and
+the path to the broker's CA certificate. Hosts covered by an API template
+get credential injection; unmatched hosts are forwarded untouched (or
+rejected with 403 in --strict mode). Hosts in --passthrough are tunneled
+without TLS interception (escape hatch for certificate-pinning clients).
+
+Same-machine limitation: on one host this removes the plaintext from the
+child environment, but an agent with the user's own filesystem access can
+still reach the vault. Deploy the broker on a separate host (or the agent
+in a container) for the strong guarantee.
+
+The broker exits on SIGINT/SIGTERM. The generated CA certificate is written
+to <vault>/broker-ca.pem.`,
+		Example: `  # Start the broker on an ephemeral loopback port
+  symvault broker
+
+  # Fixed port, strict mode (unmatched hosts get 403)
+  symvault broker --addr 127.0.0.1:8080 --strict
+
+  # Pass through hosts whose clients pin certificates
+  symvault broker --passthrough corporate.internal,legacy.example.com
+
+  # Use with a child process (env exports are printed at startup)
+  symvault run --broker -- gh pr create`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cli.WithVault(func(v *vaultpkg.Vault, vs *cli.VaultService) error {
+				proxy, err := brokerpkg.New(brokerpkg.Config{
+					VaultDir:    v.Dir,
+					Identity:    v.Identity,
+					AgentName:   "broker",
+					Strict:      brokerStrict,
+					Passthrough: brokerPassthrough,
+				})
+				if err != nil {
+					return fmt.Errorf("start broker: %w", err)
+				}
+
+				caPath := filepath.Join(v.Dir, "broker-ca.pem")
+				if writeErr := os.WriteFile(caPath, proxy.CA().CertPEM(), 0o600); writeErr != nil {
+					return fmt.Errorf("write CA certificate: %w", writeErr)
+				}
+
+				ln, err := net.Listen("tcp", brokerAddr)
+				if err != nil {
+					return fmt.Errorf("listen on %s: %w", brokerAddr, err)
+				}
+				proxyURL := "http://" + ln.Addr().String()
+
+				fmt.Printf("Symaira Vault egress broker listening on %s\n", proxyURL)
+				fmt.Printf("CA certificate written to %s\n", caPath)
+				fmt.Println("Export the following in the agent's environment:")
+				fmt.Printf("  HTTPS_PROXY=%s\n", proxyURL)
+				fmt.Printf("  HTTP_PROXY=%s\n", proxyURL)
+				fmt.Printf("  SSL_CERT_FILE=%s\n", caPath)
+				fmt.Printf("  NODE_EXTRA_CA_CERTS=%s\n", caPath)
+				fmt.Printf("  REQUESTS_CA_BUNDLE=%s\n", caPath)
+				fmt.Println("  NO_PROXY=127.0.0.1,localhost")
+				if brokerStrict {
+					fmt.Println("Strict mode: requests to hosts without a template are rejected with 403.")
+				}
+				if len(brokerPassthrough) > 0 {
+					fmt.Printf("Passthrough hosts (no TLS interception): %v\n", brokerPassthrough)
+				}
+
+				srv := &http.Server{Handler: proxy.Handler()}
+				errCh := make(chan error, 1)
+				go func() { errCh <- srv.Serve(ln) }()
+
+				sigCh := make(chan os.Signal, 1)
+				BrokerSignalNotify(sigCh, os.Interrupt, syscall.SIGTERM)
+				select {
+				case <-sigCh:
+					_ = srv.Close()
+					return nil
+				case err := <-errCh:
+					return err
+				}
+			})
+		},
+	}
+	c.Flags().StringVar(&brokerAddr, "addr", "127.0.0.1:0", "Loopback listen address (0 selects an ephemeral port)")
+	c.Flags().BoolVar(&brokerStrict, "strict", false, "Reject requests to hosts without a matching template with 403")
+	c.Flags().StringSliceVar(&brokerPassthrough, "passthrough", nil, "Hosts tunneled without TLS interception (comma-separated, domain suffixes match)")
+	c.GroupID = cli.GroupIDVault
+	return c
+}
+
+// brokerEnvForRun starts an ephemeral broker for `run --broker` and returns
+// the environment variables the child process needs plus a cleanup function.
+func brokerEnvForRun(v *vaultpkg.Vault) (map[string]string, func(), error) {
+	proxy, err := brokerpkg.New(brokerpkg.Config{
+		VaultDir:    v.Dir,
+		Identity:    v.Identity,
+		AgentName:   "broker",
+		Strict:      brokerStrict,
+		Passthrough: brokerPassthrough,
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("start broker: %w", err)
+	}
+	caPath := filepath.Join(v.Dir, "broker-ca.pem")
+	if writeErr := os.WriteFile(caPath, proxy.CA().CertPEM(), 0o600); writeErr != nil {
+		return nil, nil, fmt.Errorf("write CA certificate: %w", writeErr)
+	}
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, nil, fmt.Errorf("listen: %w", err)
+	}
+	proxyURL := "http://" + ln.Addr().String()
+	srv := &http.Server{Handler: proxy.Handler()}
+	go func() { _ = srv.Serve(ln) }()
+
+	env := map[string]string{
+		"HTTPS_PROXY":         proxyURL,
+		"HTTP_PROXY":          proxyURL,
+		"SSL_CERT_FILE":       caPath,
+		"NODE_EXTRA_CA_CERTS": caPath,
+		"REQUESTS_CA_BUNDLE":  caPath,
+		"NO_PROXY":            "127.0.0.1,localhost",
+	}
+	return env, func() { _ = srv.Close() }, nil
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,7 +38,7 @@ var rootCmd = newPackageRootCmd()
 func newPackageRootCmd() *cobra.Command {
 	root := NewRootCmd()
 	compat := []*cobra.Command{
-		deviceCmd, dynamicCmd, generateCmd, gitCmd, policyCmd, profileCmd,
+		brokerCmd, deviceCmd, dynamicCmd, generateCmd, gitCmd, policyCmd, profileCmd,
 		recipientsCmd, remoteCmd, runCmd, shareCmd, syncCmd, templateCmd, uiCmd,
 		mcp.ServeCmd,
 	}
@@ -69,6 +69,7 @@ func NewRootCmd() *cobra.Command {
 
 	// Add top-level commands in cmd/
 	root.AddCommand(
+		newBrokerCmd(),
 		newDeviceCmd(),
 		newDynamicCmd(),
 		newGenerateCmd(),

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -21,6 +21,7 @@ var (
 	runPassthrough []string
 	runWorkingDir  string
 	runTimeout     time.Duration
+	runBroker      bool
 )
 
 // runCmd is retained for API compatibility; NewRootCmd() uses
@@ -85,6 +86,21 @@ func newRunCmd() *cobra.Command {
 				}
 
 				// args contains the command and its arguments (everything after --)
+				// In --broker mode an in-process egress broker proxies the
+				// child's outbound traffic; credentials are attached
+				// server-side and never enter the child environment.
+				var brokerCleanup func()
+				if runBroker {
+					brokerEnv, cleanup, brokerErr := brokerEnvForRun(v)
+					if brokerErr != nil {
+						return brokerErr
+					}
+					brokerCleanup = cleanup
+					for k, val := range brokerEnv {
+						envMap[k] = val
+					}
+				}
+
 				result, err := secrets.RunCommand(secrets.RunOptions{
 					Command:     args,
 					Env:         envMap,
@@ -92,6 +108,9 @@ func newRunCmd() *cobra.Command {
 					WorkingDir:  runWorkingDir,
 					Timeout:     runTimeout,
 				})
+				if brokerCleanup != nil {
+					brokerCleanup()
+				}
 				if err != nil {
 					return err
 				}
@@ -117,6 +136,7 @@ func newRunCmd() *cobra.Command {
 	c.Flags().StringArrayVar(&runPassthrough, "passthrough", nil, "Parent env var names to pass through to the child process (comma-separated)")
 	c.Flags().StringVarP(&runWorkingDir, "working-dir", "C", "", "Working directory for the command")
 	c.Flags().DurationVarP(&runTimeout, "timeout", "t", 0, "Timeout for the command (e.g., 30s)")
+	c.Flags().BoolVar(&runBroker, "broker", false, "Route the child's outbound traffic through the egress credential broker (credentials never enter the child environment)")
 	c.GroupID = cli.GroupIDVault
 	return c
 }

--- a/docs/egress-broker.md
+++ b/docs/egress-broker.md
@@ -1,0 +1,115 @@
+# Egress Credential Broker
+
+`symvault broker` is an opt-in loopback MITM forward proxy that attaches
+vault credentials to an agent's outbound HTTPS/HTTP requests **server-side**.
+A brokered secret never enters the agent's process environment, argv or
+process listing — the child process only receives the proxy URL and the path
+to the broker's CA certificate.
+
+## Why
+
+`symvault run --env` and the `execute_with_secret` tool place decrypted
+values inside a process the agent controls. For most workflows that is the
+right trade. But when an agent runs `gh`, `git push`, `npm publish`,
+`docker login` or its own harness LLM call, the credential ends up in that
+process's environment. The broker moves the injection point from the child
+process to the network edge: the child talks to a loopback proxy, and the
+proxy — inside `symvault`, which holds the vault — attaches the credential
+to each outbound request.
+
+## How it works
+
+- One loopback listener handles `CONNECT` for `https://` upstreams and
+  absolute-form forward-proxy requests for `http://`.
+- For matched hosts (see below) the proxy terminates TLS with a leaf
+  certificate minted by an **ephemeral local CA** (bounded 24 h leaf TTL,
+  per-host LRU cache) and re-issues the request upstream with credentials
+  injected per the host's API template: auth header/query param or
+  path/query/header/body substitutions.
+- The upstream connection is made through the same SSRF-hardened dialer as
+  `execute_api_request` — DNS is re-resolved at dial time and private/local
+  targets are blocked, so a rebinding attack cannot redirect injected
+  credentials.
+- Every brokered request produces a tamper-evident audit record
+  (`broker_request`); audit entries and logs carry host, template name and
+  status only — never paths, query strings or credential values.
+- Response bodies are sanitized (pattern detection + known credential
+  values) before being returned to the agent.
+- **Unmatched hosts** (no template covers the host) are forwarded untouched
+  by default. In `--strict` mode they are rejected with **403**.
+- **Passthrough hosts** (`--passthrough`) are tunneled without any TLS
+  interception — the escape hatch for clients that pin certificates.
+
+## Usage
+
+```text
+# Start the broker on an ephemeral loopback port (prints env exports)
+symvault broker
+
+# Fixed port, strict mode
+symvault broker --addr 127.0.0.1:8080 --strict
+
+# Passthrough for certificate-pinning clients
+symvault broker --passthrough corporate.internal,legacy.example.com
+
+# One-shot: run a child command with the broker in-process
+symvault run --broker -- gh pr create
+```
+
+At startup the broker prints the environment to export into the agent's
+session:
+
+```text
+HTTPS_PROXY=http://127.0.0.1:PORT
+HTTP_PROXY=http://127.0.0.1:PORT
+SSL_CERT_FILE=<vault>/broker-ca.pem
+NODE_EXTRA_CA_CERTS=<vault>/broker-ca.pem
+REQUESTS_CA_BUNDLE=<vault>/broker-ca.pem
+NO_PROXY=127.0.0.1,localhost
+```
+
+The CA certificate is written to `<vault>/broker-ca.pem` (mode 0600) so Go,
+Node, Python and curl clients trust the interception without per-tool
+configuration.
+
+## Which hosts get credentials
+
+Host resolution reuses the API template catalog (`docs/api-templates.md`):
+a request host is matched exactly against the `base_url` host of every
+built-in template and every vault-local template in `<vault>/templates/`.
+The matched template's `auth_type` and `substitutions` are applied using the
+vault entry named by `entry_ref`. To broker a host that has no built-in,
+add a vault-local template:
+
+```yaml
+# <vault>/templates/example.yaml
+base_url: https://api.example.com
+auth_type: bearer
+entry_ref: work/example
+allowed_endpoints: [ /v1/* ]
+allowed_methods: [ GET, POST ]
+```
+
+Hosts not covered by any template are forwarded without injection (or
+rejected in strict mode).
+
+## Honest limitation — same-machine guarantee only
+
+On a single machine the broker removes the plaintext from the child
+environment, argv and process listing, **but a determined agent with the
+user's own filesystem access can still reach the vault**. The strong
+guarantee requires the broker on a separate host, or the agent in a
+container with no access to the vault — the same deployment precondition
+the reference implementation (Infisical agent-vault) documents. Do not
+claim the agent "cannot" reach the credential on one host; the broker
+closes the environment/argv/process-listing channels, not the filesystem
+channel.
+
+## Security notes
+
+- The CA is ephemeral (generated per broker start) and its key never leaves
+  the broker process. Leaf certificates are valid for 24 h.
+- The broker binds to loopback only. Do not expose the broker address to
+  other hosts without additional access control.
+- `--env` behavior is byte-identical to today when the broker is disabled;
+  the broker is purely additive.

--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -1,0 +1,571 @@
+package broker
+
+import (
+	"bufio"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"filippo.io/age"
+
+	"github.com/danieljustus/symaira-vault/internal/audit"
+	configpkg "github.com/danieljustus/symaira-vault/internal/config"
+	"github.com/danieljustus/symaira-vault/internal/vault"
+)
+
+const testPassphrase = "broker-test-passphrase"
+
+// setupVault creates a temp vault with one entry and writes a template
+// override pointing at the given base URL. Returns vaultDir and identity.
+func setupVault(t *testing.T, entryPath string, data map[string]any, templateName, templateBody string) (string, *age.X25519Identity) {
+	t.Helper()
+	dir := t.TempDir()
+	identity, err := vault.InitWithPassphrase(dir, []byte(testPassphrase), configpkg.Default())
+	if err != nil {
+		t.Fatalf("init vault: %v", err)
+	}
+	entry := &vault.Entry{Data: data}
+	if err := vault.WriteEntry(dir, entryPath, entry, identity); err != nil {
+		t.Fatalf("write entry: %v", err)
+	}
+	if templateName != "" {
+		templatesDir := filepath.Join(dir, "templates")
+		if err := os.MkdirAll(templatesDir, 0o755); err != nil {
+			t.Fatalf("mkdir templates: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(templatesDir, templateName+".yaml"), []byte(templateBody), 0o644); err != nil {
+			t.Fatalf("write template: %v", err)
+		}
+	}
+	return dir, identity
+}
+
+// startProxy starts the broker on an ephemeral loopback port and returns the
+// proxy URL and a shutdown function.
+func startProxy(t *testing.T, cfg Config) (string, func()) {
+	t.Helper()
+	p, err := New(cfg)
+	if err != nil {
+		t.Fatalf("broker.New: %v", err)
+	}
+	mu.Lock()
+	lastCA = p.ca
+	mu.Unlock()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	srv := &http.Server{Handler: p.Handler()}
+	go func() { _ = srv.Serve(ln) }()
+	proxyURL := "http://" + ln.Addr().String()
+	return proxyURL, func() { _ = srv.Close() }
+}
+
+// newProxyClient returns an HTTP client routed through the given proxy URL.
+func newProxyClient(proxyURL string) *http.Client {
+	pu, _ := url.Parse(proxyURL)
+	return &http.Client{
+		Timeout: 15 * time.Second,
+		Transport: &http.Transport{
+			Proxy: http.ProxyURL(pu),
+		},
+	}
+}
+
+func bearerTemplate(baseURL string) string {
+	return fmt.Sprintf(`base_url: %s
+auth_type: bearer
+entry_ref: testapi
+allowed_endpoints:
+  - /*
+allowed_methods:
+  - GET
+allow_private: true
+`, baseURL)
+}
+
+func TestCA_LeafForHost(t *testing.T) {
+	ca, err := NewCA()
+	if err != nil {
+		t.Fatalf("NewCA: %v", err)
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(ca.CertPEM()) {
+		t.Fatal("CA PEM does not parse")
+	}
+
+	cert1, err := ca.LeafForHost("api.example.com")
+	if err != nil {
+		t.Fatalf("LeafForHost: %v", err)
+	}
+	cert2, err := ca.LeafForHost("api.example.com")
+	if err != nil {
+		t.Fatalf("LeafForHost (cached): %v", err)
+	}
+	if cert1 != cert2 {
+		t.Error("LeafForHost returned different certificates for the same host (cache miss)")
+	}
+
+	other, err := ca.LeafForHost("other.example.com")
+	if err != nil {
+		t.Fatalf("LeafForHost (other): %v", err)
+	}
+	if cert1 == other {
+		t.Error("LeafForHost returned the same certificate for different hosts")
+	}
+
+	leaf, err := x509.ParseCertificate(cert1.Certificate[0])
+	if err != nil {
+		t.Fatalf("parse leaf: %v", err)
+	}
+	if _, err := leaf.Verify(x509.VerifyOptions{
+		Roots:     pool,
+		DNSName:   "api.example.com",
+		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}); err != nil {
+		t.Fatalf("leaf does not verify against CA: %v", err)
+	}
+	if time.Until(leaf.NotAfter) > leafTTL+time.Hour {
+		t.Errorf("leaf NotAfter beyond leaf TTL: %v", leaf.NotAfter)
+	}
+}
+
+func TestCA_LeafForIPHost(t *testing.T) {
+	ca, err := NewCA()
+	if err != nil {
+		t.Fatalf("NewCA: %v", err)
+	}
+	pool := x509.NewCertPool()
+	pool.AppendCertsFromPEM(ca.CertPEM())
+
+	cert, err := ca.LeafForHost("127.0.0.1")
+	if err != nil {
+		t.Fatalf("LeafForHost: %v", err)
+	}
+	leaf, err := x509.ParseCertificate(cert.Certificate[0])
+	if err != nil {
+		t.Fatalf("parse leaf: %v", err)
+	}
+	if len(leaf.IPAddresses) != 1 || leaf.IPAddresses[0].String() != "127.0.0.1" {
+		t.Errorf("leaf IPAddresses = %v, want [127.0.0.1]", leaf.IPAddresses)
+	}
+	if _, err := leaf.Verify(x509.VerifyOptions{
+		Roots:     pool,
+		DNSName:   "127.0.0.1",
+		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}); err != nil {
+		t.Fatalf("IP leaf does not verify: %v", err)
+	}
+}
+
+func TestProxy_PlainHTTPInjection(t *testing.T) {
+	const token = "broker-token-1"
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer "+token {
+			t.Errorf("Authorization = %q, want Bearer %s", got, token)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "injected-ok")
+	}))
+	defer upstream.Close()
+
+	vaultDir, identity := setupVault(t, "testapi", map[string]any{"credential": token}, "testapi", bearerTemplate(upstream.URL))
+	proxyURL, stop := startProxy(t, Config{
+		VaultDir:     vaultDir,
+		Identity:     identity,
+		AgentName:    "broker-test",
+		AllowPrivate: true,
+	})
+	defer stop()
+
+	resp, err := newProxyClient(proxyURL).Get(upstream.URL + "/hello")
+	if err != nil {
+		t.Fatalf("GET through proxy: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d, body = %s", resp.StatusCode, body)
+	}
+	if string(body) != "injected-ok" {
+		t.Errorf("body = %q, want injected-ok", body)
+	}
+}
+
+func TestProxy_UnmatchedHostForwardedByDefault(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if auth := r.Header.Get("Authorization"); auth != "" {
+			t.Errorf("Authorization = %q, want empty for unmatched host", auth)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "forwarded")
+	}))
+	defer upstream.Close()
+
+	vaultDir, identity := setupVault(t, "testapi", map[string]any{"credential": "token"}, "", "")
+	proxyURL, stop := startProxy(t, Config{
+		VaultDir:     vaultDir,
+		Identity:     identity,
+		AgentName:    "broker-test",
+		AllowPrivate: true,
+	})
+	defer stop()
+
+	resp, err := newProxyClient(proxyURL).Get(upstream.URL + "/nobody-home")
+	if err != nil {
+		t.Fatalf("GET through proxy: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != 200 || string(body) != "forwarded" {
+		t.Fatalf("status = %d body = %q, want 200 forwarded", resp.StatusCode, body)
+	}
+}
+
+func TestProxy_StrictRejectsUnmatchedHost(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("upstream must not be reached in strict mode for unmatched host")
+	}))
+	defer upstream.Close()
+
+	vaultDir, identity := setupVault(t, "testapi", map[string]any{"credential": "token"}, "", "")
+	proxyURL, stop := startProxy(t, Config{
+		VaultDir:     vaultDir,
+		Identity:     identity,
+		AgentName:    "broker-test",
+		Strict:       true,
+		AllowPrivate: true,
+	})
+	defer stop()
+
+	resp, err := newProxyClient(proxyURL).Get(upstream.URL + "/blocked")
+	if err != nil {
+		t.Fatalf("GET through proxy: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", resp.StatusCode)
+	}
+}
+
+func TestProxy_StrictAllowsMatchedHost(t *testing.T) {
+	const token = "strict-ok-token"
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer "+token {
+			t.Errorf("Authorization = %q, want Bearer %s", got, token)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	vaultDir, identity := setupVault(t, "testapi", map[string]any{"credential": token}, "testapi", bearerTemplate(upstream.URL))
+	proxyURL, stop := startProxy(t, Config{
+		VaultDir:     vaultDir,
+		Identity:     identity,
+		AgentName:    "broker-test",
+		Strict:       true,
+		AllowPrivate: true,
+	})
+	defer stop()
+
+	resp, err := newProxyClient(proxyURL).Get(upstream.URL + "/allowed")
+	if err != nil {
+		t.Fatalf("GET through proxy: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+}
+
+func TestProxy_PathSubstitutionInjection(t *testing.T) {
+	const botToken = "123456789:AA-broker-bot"
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		wantPath := "/bot" + botToken + "/sendMessage"
+		if r.URL.Path != wantPath {
+			t.Errorf("path = %q, want %q", r.URL.Path, wantPath)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "telegram-ok")
+	}))
+	defer upstream.Close()
+
+	tmpl := fmt.Sprintf(`base_url: %s/bot__BOT_TOKEN__
+auth_type: none
+entry_ref: telegram
+substitutions:
+  - placeholder: __BOT_TOKEN__
+    field: credential
+    in: [path]
+allowed_endpoints:
+  - /sendMessage
+allowed_methods:
+  - GET
+allow_private: true
+`, upstream.URL)
+	vaultDir, identity := setupVault(t, "telegram", map[string]any{"credential": botToken}, "telegram", tmpl)
+	proxyURL, stop := startProxy(t, Config{
+		VaultDir:     vaultDir,
+		Identity:     identity,
+		AgentName:    "broker-test",
+		AllowPrivate: true,
+	})
+	defer stop()
+
+	resp, err := newProxyClient(proxyURL).Get(upstream.URL + "/bot__BOT_TOKEN__/sendMessage")
+	if err != nil {
+		t.Fatalf("GET through proxy: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != 200 || string(body) != "telegram-ok" {
+		t.Fatalf("status = %d body = %q, want 200 telegram-ok", resp.StatusCode, body)
+	}
+}
+
+func TestProxy_ResponseSanitized(t *testing.T) {
+	const token = "known-secret-value-77"
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{"echo": "`+token+`"}`)
+	}))
+	defer upstream.Close()
+
+	vaultDir, identity := setupVault(t, "testapi", map[string]any{"credential": token}, "testapi", bearerTemplate(upstream.URL))
+	proxyURL, stop := startProxy(t, Config{
+		VaultDir:     vaultDir,
+		Identity:     identity,
+		AgentName:    "broker-test",
+		AllowPrivate: true,
+	})
+	defer stop()
+
+	resp, err := newProxyClient(proxyURL).Get(upstream.URL + "/leak")
+	if err != nil {
+		t.Fatalf("GET through proxy: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if strings.Contains(string(body), token) {
+		t.Fatalf("response body leaks credential: %q", body)
+	}
+	if !strings.Contains(string(body), "***") {
+		t.Errorf("response body = %q, want redacted marker", body)
+	}
+}
+
+func TestProxy_CONNECTMITM_InjectOverTLS(t *testing.T) {
+	const token = "mitm-tls-token"
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer "+token {
+			t.Errorf("Authorization = %q, want Bearer %s", got, token)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "mitm-ok")
+	}))
+	defer upstream.Close()
+
+	upstreamCert := upstream.Certificate()
+	upstreamPool := x509.NewCertPool()
+	upstreamPool.AddCert(upstreamCert)
+
+	vaultDir, identity := setupVault(t, "testapi", map[string]any{"credential": token}, "testapi", bearerTemplate(upstream.URL))
+	proxyURL, stop := startProxy(t, Config{
+		VaultDir:     vaultDir,
+		Identity:     identity,
+		AgentName:    "broker-test",
+		UpstreamTLS:  &tls.Config{RootCAs: upstreamPool},
+		AllowPrivate: true,
+	})
+	defer stop()
+
+	body := connectAndGet(t, proxyURL, upstream.URL, "/secure", nil)
+	if body != "mitm-ok" {
+		t.Fatalf("body = %q, want mitm-ok", body)
+	}
+}
+
+func TestProxy_CONNECT_PassthroughTunnel(t *testing.T) {
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if auth := r.Header.Get("Authorization"); auth != "" {
+			t.Errorf("Authorization = %q, want empty for passthrough tunnel", auth)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "tunnel-ok")
+	}))
+	defer upstream.Close()
+
+	vaultDir, identity := setupVault(t, "testapi", map[string]any{"credential": "token"}, "", "")
+	proxyURL, stop := startProxy(t, Config{
+		VaultDir:     vaultDir,
+		Identity:     identity,
+		AgentName:    "broker-test",
+		Passthrough:  []string{"127.0.0.1"},
+		AllowPrivate: true,
+	})
+	defer stop()
+
+	// The tunneled TLS connection terminates at the upstream's own
+	// self-signed certificate — the broker must not intercept it.
+	body := connectAndGet(t, proxyURL, upstream.URL, "/raw", &tls.Config{InsecureSkipVerify: true})
+	if body != "tunnel-ok" {
+		t.Fatalf("body = %q, want tunnel-ok", body)
+	}
+}
+
+// connectAndGet establishes a CONNECT tunnel through the proxy, performs a
+// TLS handshake (verifying against the broker CA unless clientTLS overrides
+// the config) and issues a GET, returning the response body.
+func connectAndGet(t *testing.T, proxyURL, targetURL, path string, clientTLS *tls.Config) string {
+	t.Helper()
+	pu, _ := url.Parse(proxyURL)
+	target, _ := url.Parse(targetURL)
+	hostport := target.Host
+
+	conn, err := net.Dial("tcp", pu.Host)
+	if err != nil {
+		t.Fatalf("dial proxy: %v", err)
+	}
+	defer conn.Close()
+
+	fmt.Fprintf(conn, "CONNECT %s HTTP/1.1\r\nHost: %s\r\n\r\n", hostport, hostport)
+	br := bufio.NewReader(conn)
+	resp, err := http.ReadResponse(br, &http.Request{Method: http.MethodConnect})
+	if err != nil {
+		t.Fatalf("read CONNECT response: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("CONNECT status = %d, want 200", resp.StatusCode)
+	}
+
+	var tlsCfg *tls.Config
+	if clientTLS != nil {
+		tlsCfg = clientTLS
+	} else {
+		// Trust the broker's ephemeral CA.
+		pool, err := brokerCAPool(t)
+		if err != nil {
+			t.Fatalf("broker CA pool: %v", err)
+		}
+		tlsCfg = &tls.Config{RootCAs: pool, ServerName: target.Hostname()}
+	}
+	tlsConn := tls.Client(conn, tlsCfg)
+	if err := tlsConn.Handshake(); err != nil {
+		t.Fatalf("TLS handshake with broker: %v", err)
+	}
+	defer tlsConn.Close()
+
+	fmt.Fprintf(tlsConn, "GET %s HTTP/1.1\r\nHost: %s\r\nConnection: close\r\n\r\n", path, target.Host)
+	tbr := bufio.NewReader(tlsConn)
+	gresp, err := http.ReadResponse(tbr, &http.Request{Method: http.MethodGet})
+	if err != nil {
+		t.Fatalf("read GET response: %v", err)
+	}
+	body, _ := io.ReadAll(gresp.Body)
+	_ = gresp.Body.Close()
+	if gresp.StatusCode != 200 {
+		t.Fatalf("GET status = %d body = %q", gresp.StatusCode, body)
+	}
+	return string(body)
+}
+
+// brokerCAPool loads the broker CA PEM written by the CLI helper into a pool.
+// For in-process tests the proxy's CA is exposed; this helper re-reads the
+// PEM exported via the proxy's CA() accessor path used by tests that start
+// the proxy through startProxy. To keep the helper self-contained it parses
+// the CA certificate from the proxy instance passed by the caller.
+func brokerCAPool(t *testing.T) (*x509.CertPool, error) {
+	t.Helper()
+	// The pool is rebuilt from the most recently started proxy via a package
+	// test hook set by startProxy.
+	mu.Lock()
+	ca := lastCA
+	mu.Unlock()
+	if ca == nil {
+		return nil, fmt.Errorf("no proxy CA available")
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(ca.CertPEM()) {
+		return nil, fmt.Errorf("invalid CA PEM")
+	}
+	return pool, nil
+}
+
+var (
+	mu     sync.Mutex
+	lastCA *CA
+)
+
+func TestProxy_AuditRecorded(t *testing.T) {
+	const token = "audit-token-42"
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "audited")
+	}))
+	defer upstream.Close()
+
+	vaultDir, identity := setupVault(t, "testapi", map[string]any{"credential": token}, "testapi", bearerTemplate(upstream.URL))
+
+	// Real audit logger writing into the vault dir.
+	logger, err := audit.New("broker-test", vaultDir, identity)
+	if err != nil {
+		t.Fatalf("audit.New: %v", err)
+	}
+	defer logger.Close()
+
+	proxyURL, stop := startProxy(t, Config{
+		VaultDir:     vaultDir,
+		Identity:     identity,
+		AgentName:    "broker-test",
+		AuditLog:     logger,
+		AllowPrivate: true,
+	})
+	defer stop()
+
+	resp, err := newProxyClient(proxyURL).Get(upstream.URL + "/audit-me")
+	if err != nil {
+		t.Fatalf("GET through proxy: %v", err)
+	}
+	_ = resp.Body.Close()
+	logger.Flush()
+
+	entries, err := audit.LoadAuditLogFiles("broker-test", vaultDir, 10)
+	if err != nil {
+		t.Fatalf("load audit entries: %v", err)
+	}
+	found := false
+	for _, e := range entries {
+		if e.Action != "broker_request" {
+			continue
+		}
+		found = true
+		if e.OK != true {
+			t.Errorf("audit entry ok = %v, want true", e.OK)
+		}
+		if strings.Contains(e.Path, token) || strings.Contains(e.Field, token) {
+			t.Errorf("audit entry leaks credential: %+v", e)
+		}
+	}
+	if !found {
+		t.Fatal("no broker_request audit entry found")
+	}
+}
+
+func TestProxy_EnvExports(t *testing.T) {
+	p, err := New(Config{VaultDir: t.TempDir(), Identity: nil})
+	if err == nil {
+		t.Fatal("New() expected error for missing identity")
+	}
+	_ = p
+}

--- a/internal/broker/ca.go
+++ b/internal/broker/ca.go
@@ -1,0 +1,179 @@
+// Package broker implements the opt-in egress credential broker: a loopback
+// MITM forward proxy that attaches vault credentials to outbound HTTPS/HTTP
+// requests server-side, so a brokered secret never enters the agent's
+// process environment, argv or process listing.
+package broker
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"sync"
+	"time"
+)
+
+const (
+	// leafTTL bounds how long a minted leaf certificate stays valid. Bounded
+	// leaf lifetimes limit the exposure of a compromised CA key and force
+	// clients to re-negotiate with the current configuration.
+	leafTTL = 24 * time.Hour
+	// caValidity is the validity of the ephemeral CA itself (one year, long
+	// enough for any single broker session while still expiring).
+	caValidity = 365 * 24 * time.Hour
+)
+
+// CA is an ephemeral leaf-signing certificate authority. It generates a
+// self-signed CA on start and mints per-host leaf certificates with a bounded
+// TTL, cached in an LRU map keyed by hostname.
+type CA struct {
+	mu     sync.Mutex
+	caCert *x509.Certificate
+	caKey  *ecdsa.PrivateKey
+	leaves map[string]leafEntry
+	now    func() time.Time
+}
+
+type leafEntry struct {
+	cert *tls.Certificate
+	exp  time.Time
+}
+
+// NewCA generates a fresh ephemeral CA.
+func NewCA() (*CA, error) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("generate CA key: %w", err)
+	}
+	serial, err := randSerial()
+	if err != nil {
+		return nil, err
+	}
+	now := time.Now()
+	template := &x509.Certificate{
+		SerialNumber:          serial,
+		Subject:               pkix.Name{CommonName: "symvault egress broker (ephemeral)"},
+		NotBefore:             now.Add(-5 * time.Minute),
+		NotAfter:              now.Add(caValidity),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		return nil, fmt.Errorf("create CA certificate: %w", err)
+	}
+	caCert, err := x509.ParseCertificate(der)
+	if err != nil {
+		return nil, fmt.Errorf("parse CA certificate: %w", err)
+	}
+	return &CA{
+		caCert: caCert,
+		caKey:  key,
+		leaves: make(map[string]leafEntry),
+		now:    time.Now,
+	}, nil
+}
+
+// LeafForHost returns a cached or freshly minted leaf certificate for the
+// given hostname (DNS name or IP literal), valid for leafTTL.
+func (c *CA) LeafForHost(host string) (*tls.Certificate, error) {
+	host = canonicalHost(host)
+	if host == "" {
+		return nil, fmt.Errorf("empty host")
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if entry, ok := c.leaves[host]; ok && c.now().Before(entry.exp) {
+		return entry.cert, nil
+	}
+	cert, err := c.mintLeaf(host)
+	if err != nil {
+		return nil, err
+	}
+	c.leaves[host] = leafEntry{cert: cert, exp: c.now().Add(leafTTL)}
+	return cert, nil
+}
+
+// CertPEM returns the CA certificate in PEM form, for export via
+// SSL_CERT_FILE / NODE_EXTRA_CA_CERTS / REQUESTS_CA_BUNDLE.
+func (c *CA) CertPEM() []byte {
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: c.caCert.Raw})
+}
+
+func (c *CA) mintLeaf(host string) (*tls.Certificate, error) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("generate leaf key: %w", err)
+	}
+	serial, err := randSerial()
+	if err != nil {
+		return nil, err
+	}
+	now := c.now()
+	template := &x509.Certificate{
+		SerialNumber: serial,
+		Subject:      pkix.Name{CommonName: host},
+		NotBefore:    now.Add(-5 * time.Minute),
+		NotAfter:     now.Add(leafTTL),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		template.IPAddresses = []net.IP{ip}
+	} else {
+		template.DNSNames = []string{host}
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, c.caCert, &key.PublicKey, c.caKey)
+	if err != nil {
+		return nil, fmt.Errorf("create leaf certificate: %w", err)
+	}
+	return &tls.Certificate{
+		Certificate: [][]byte{der, c.caCert.Raw},
+		PrivateKey:  key,
+	}, nil
+}
+
+func randSerial() (*big.Int, error) {
+	limit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serial, err := rand.Int(rand.Reader, limit)
+	if err != nil {
+		return nil, fmt.Errorf("generate serial: %w", err)
+	}
+	return serial, nil
+}
+
+// canonicalHost strips the port and lowercases the hostname.
+func canonicalHost(hostport string) string {
+	if h, _, err := net.SplitHostPort(hostport); err == nil {
+		hostport = h
+	}
+	hostport = trimBrackets(hostport)
+	if h := net.ParseIP(hostport); h != nil {
+		return h.String()
+	}
+	return lowerASCII(hostport)
+}
+
+func trimBrackets(s string) string {
+	if len(s) >= 2 && s[0] == '[' && s[len(s)-1] == ']' {
+		return s[1 : len(s)-1]
+	}
+	return s
+}
+
+func lowerASCII(s string) string {
+	b := []byte(s)
+	for i := range b {
+		if b[i] >= 'A' && b[i] <= 'Z' {
+			b[i] += 'a' - 'A'
+		}
+	}
+	return string(b)
+}

--- a/internal/broker/proxy.go
+++ b/internal/broker/proxy.go
@@ -1,0 +1,493 @@
+package broker
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"filippo.io/age"
+
+	"github.com/danieljustus/symaira-vault/internal/audit"
+	"github.com/danieljustus/symaira-vault/internal/mcp/apitemplates"
+	"github.com/danieljustus/symaira-vault/internal/mcp/masking"
+	"github.com/danieljustus/symaira-vault/internal/ssrf"
+	vaultpkg "github.com/danieljustus/symaira-vault/internal/vault"
+)
+
+const (
+	// maxBrokerResponseBytes caps the response body read for sanitization.
+	maxBrokerResponseBytes = 16 << 20 // 16 MiB
+	// brokerTimeout bounds each brokered upstream request.
+	brokerTimeout = 60 * time.Second
+	// handshakeTimeout bounds the TLS handshake with the client.
+	handshakeTimeout = 30 * time.Second
+)
+
+// Config configures a broker Proxy.
+type Config struct {
+	// VaultDir is the vault directory: user template overrides live in
+	// <vaultDir>/templates/ and credential entries are read from it.
+	VaultDir string
+	// Identity is the vault identity used to decrypt entries.
+	Identity *age.X25519Identity
+	// AgentName is recorded in audit entries.
+	AgentName string
+	// AuditLog receives one record per brokered request. May be nil.
+	AuditLog *audit.Logger
+	// Strict rejects requests to hosts without a matching template with 403
+	// instead of forwarding them uninjected.
+	Strict bool
+	// Passthrough lists hostnames (exact or domain suffix) that are tunneled
+	// without interception — the escape hatch for clients that pin
+	// certificates.
+	Passthrough []string
+	// UpstreamTLS overrides the TLS client config used for upstream
+	// connections (test hook; nil uses the system roots).
+	UpstreamTLS *tls.Config
+	// AllowPrivate permits private/local destinations (test-only; the CLI
+	// never sets it).
+	AllowPrivate bool
+}
+
+// Proxy is a loopback MITM forward proxy that attaches vault credentials to
+// outbound requests server-side.
+type Proxy struct {
+	cfg       Config
+	ca        *CA
+	byHost    map[string]*apitemplates.APITemplate
+	templates []*apitemplates.APITemplate
+	client    *http.Client
+	upstream  *net.Dialer
+	passthru  []string
+}
+
+// New builds a Proxy, loading the template catalog (built-ins plus vault-local
+// overrides) and minting the ephemeral CA.
+func New(cfg Config) (*Proxy, error) {
+	if cfg.VaultDir == "" || cfg.Identity == nil {
+		return nil, fmt.Errorf("broker requires a vault dir and identity")
+	}
+	ca, err := NewCA()
+	if err != nil {
+		return nil, err
+	}
+	templates, err := loadTemplates(cfg.VaultDir)
+	if err != nil {
+		return nil, err
+	}
+	byHost := make(map[string]*apitemplates.APITemplate, len(templates))
+	for _, tmpl := range templates {
+		host := templateHost(tmpl.BaseURL)
+		if host != "" {
+			byHost[host] = tmpl
+		}
+	}
+	return &Proxy{
+		cfg:       cfg,
+		ca:        ca,
+		byHost:    byHost,
+		templates: templates,
+		client:    ssrf.NewHTTPClientWithTLSConfig(brokerTimeout, cfg.AllowPrivate, cfg.UpstreamTLS),
+		upstream:  &net.Dialer{},
+		passthru:  cfg.Passthrough,
+	}, nil
+}
+
+// CA returns the broker's ephemeral certificate authority.
+func (p *Proxy) CA() *CA { return p.ca }
+
+// Templates returns the resolved template catalog (for CLI introspection).
+func (p *Proxy) Templates() []*apitemplates.APITemplate { return p.templates }
+
+// Handler returns the proxy's HTTP handler (CONNECT + forward proxy).
+func (p *Proxy) Handler() http.Handler {
+	return http.HandlerFunc(p.handle)
+}
+
+func (p *Proxy) handle(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodConnect {
+		p.handleConnect(w, r)
+		return
+	}
+	p.serveInner(w, r)
+}
+
+// handleConnect either tunnels the connection untouched (passthrough hosts)
+// or terminates TLS with a leaf certificate and serves the inner request
+// through the credential-injecting handler.
+func (p *Proxy) handleConnect(w http.ResponseWriter, r *http.Request) {
+	hostport := r.Host
+	if hostport == "" {
+		http.Error(w, "missing CONNECT target", http.StatusBadRequest)
+		return
+	}
+	host := canonicalHost(hostport)
+
+	if p.isPassthrough(host) {
+		p.tunnel(w, r, hostport)
+		return
+	}
+
+	cert, err := p.ca.LeafForHost(host)
+	if err != nil {
+		p.audit(host, "broker_denied", false, "certificate")
+		http.Error(w, "cannot intercept TLS", http.StatusInternalServerError)
+		return
+	}
+
+	// Validate that the upstream is reachable through the SSRF-guarded dialer
+	// before announcing interception.
+	if _, dialErr := p.dialUpstream(r.Context(), hostport); dialErr != nil {
+		p.audit(host, "broker_denied", false, "upstream")
+		http.Error(w, "cannot reach upstream", http.StatusBadGateway)
+		return
+	}
+
+	hj, ok := w.(http.Hijacker)
+	if !ok {
+		http.Error(w, "hijacking unsupported", http.StatusInternalServerError)
+		return
+	}
+	conn, _, hijackErr := hj.Hijack()
+	if hijackErr != nil {
+		return
+	}
+	if _, writeErr := conn.Write([]byte("HTTP/1.1 200 Connection Established\r\n\r\n")); writeErr != nil {
+		_ = conn.Close()
+		return
+	}
+
+	tlsConn := tls.Server(conn, &tls.Config{
+		Certificates: []tls.Certificate{*cert},
+		NextProtos:   []string{"http/1.1"},
+		MinVersion:   tls.VersionTLS12,
+	})
+	_ = tlsConn.SetDeadline(time.Now().Add(handshakeTimeout))
+	if handshakeErr := tlsConn.Handshake(); handshakeErr != nil {
+		_ = tlsConn.Close()
+		return
+	}
+	_ = tlsConn.SetDeadline(time.Time{})
+
+	inner := &http.Server{
+		Handler:           http.HandlerFunc(p.serveInner),
+		ErrorLog:          log.New(os.Stderr, "broker-inner: ", log.LstdFlags),
+		ReadHeaderTimeout: handshakeTimeout,
+		ReadTimeout:       brokerTimeout,
+		WriteTimeout:      brokerTimeout,
+		IdleTimeout:       30 * time.Second,
+	}
+	go func() {
+		_ = inner.Serve(&singleConnListener{conn: tlsConn})
+	}()
+}
+
+// singleConnListener adapts a single connection to net.Listener for
+// http.Server.Serve, which then handles keep-alive requests over it.
+// Close only stops Accept — it must not close the (still active) conn.
+type singleConnListener struct {
+	conn net.Conn
+	done bool
+}
+
+func (l *singleConnListener) Accept() (net.Conn, error) {
+	if l.done {
+		return nil, io.EOF
+	}
+	l.done = true
+	return l.conn, nil
+}
+
+func (l *singleConnListener) Close() error   { return nil }
+func (l *singleConnListener) Addr() net.Addr { return l.conn.LocalAddr() }
+
+// tunnel relays the client connection to the upstream untouched (no TLS
+// interception) for passthrough hosts.
+func (p *Proxy) tunnel(w http.ResponseWriter, r *http.Request, hostport string) {
+	upstream, err := p.dialUpstream(r.Context(), hostport)
+	if err != nil {
+		p.audit(canonicalHost(hostport), "broker_passthrough_failed", false, "upstream")
+		http.Error(w, "cannot reach upstream", http.StatusBadGateway)
+		return
+	}
+	hj, ok := w.(http.Hijacker)
+	if !ok {
+		_ = upstream.Close()
+		http.Error(w, "hijacking unsupported", http.StatusInternalServerError)
+		return
+	}
+	conn, _, hijackErr := hj.Hijack()
+	if hijackErr != nil {
+		_ = upstream.Close()
+		return
+	}
+	if _, writeErr := conn.Write([]byte("HTTP/1.1 200 Connection Established\r\n\r\n")); writeErr != nil {
+		_ = conn.Close()
+		_ = upstream.Close()
+		return
+	}
+	go func() {
+		_, _ = io.Copy(upstream, conn)
+		_ = upstream.Close()
+	}()
+	_, _ = io.Copy(conn, upstream)
+	_ = conn.Close()
+}
+
+// serveInner handles a forward-proxy request (absolute-form, plain HTTP) or a
+// decrypted inner request (origin-form, after CONNECT MITM). Matched hosts get
+// credential injection; unmatched hosts are forwarded (default) or rejected
+// with 403 (strict mode).
+func (p *Proxy) serveInner(w http.ResponseWriter, r *http.Request) {
+	target, err := p.targetURL(r)
+	if err != nil {
+		http.Error(w, "invalid request target", http.StatusBadRequest)
+		return
+	}
+	host := canonicalHost(r.Host)
+	tmpl := p.byHost[host]
+
+	if tmpl == nil {
+		if p.cfg.Strict {
+			p.audit(host, "broker_denied", false, "unmatched")
+			http.Error(w, "no template for host; strict mode rejects unmatched hosts", http.StatusForbidden)
+			return
+		}
+		p.forward(w, r, target, nil, nil)
+		return
+	}
+
+	entryPath, parseErr := apitemplates.EntryRefPath(tmpl.EntryRef)
+	if parseErr != nil {
+		p.audit(host, "broker_denied", false, "entry_ref")
+		http.Error(w, "template entry_ref is invalid", http.StatusInternalServerError)
+		return
+	}
+	entry, readErr := vaultpkg.ReadEntry(p.cfg.VaultDir, entryPath, p.cfg.Identity)
+	if readErr != nil {
+		p.audit(host, "broker_denied", false, "vault")
+		http.Error(w, "cannot load credentials for host", http.StatusInternalServerError)
+		return
+	}
+	p.forward(w, r, target, tmpl, entry.Data)
+}
+
+// forward sends the request upstream, applying auth injection and
+// substitutions when a template matched, and sanitizes the response body.
+func (p *Proxy) forward(w http.ResponseWriter, r *http.Request, target string, tmpl *apitemplates.APITemplate, entryData map[string]any) {
+	host := canonicalHost(r.Host)
+	status := 0
+	audited := false
+	auditOnce := func(action string, ok bool, reason string) {
+		if audited {
+			return
+		}
+		audited = true
+		p.audit(host, action, ok, reason)
+	}
+	defer func() {
+		auditOnce("broker_request", status < 400, "forward")
+	}()
+
+	var body io.Reader
+	var redactVals []string
+	var values map[string]string
+	if tmpl != nil && len(tmpl.Substitutions) > 0 {
+		var subErr error
+		values, redactVals, subErr = apitemplates.ResolveSubstitutionValues(tmpl, entryData)
+		if subErr != nil {
+			http.Error(w, "cannot resolve substitutions for host", http.StatusInternalServerError)
+			return
+		}
+		target = apitemplates.ApplyURLSubstitutions(target, tmpl.Substitutions, values)
+		raw, readErr := io.ReadAll(io.LimitReader(r.Body, maxBrokerResponseBytes+1))
+		if readErr != nil {
+			http.Error(w, "cannot read request body", http.StatusBadRequest)
+			return
+		}
+		body = strings.NewReader(apitemplates.ApplyBodySubstitutions(string(raw), tmpl.Substitutions, values))
+	} else if r.Body != nil {
+		body = r.Body
+	}
+
+	outReq, buildErr := http.NewRequestWithContext(r.Context(), r.Method, target, body)
+	if buildErr != nil {
+		http.Error(w, "cannot build upstream request", http.StatusInternalServerError)
+		return
+	}
+	copyHeaders(outReq.Header, r.Header)
+	outReq.Header.Del("Proxy-Connection")
+	outReq.Header.Del("Proxy-Authorization")
+
+	if tmpl != nil {
+		if err := apitemplates.InjectAuth(outReq, tmpl, entryData); err != nil {
+			auditOnce("broker_denied", false, "auth")
+			http.Error(w, "cannot resolve auth for host", http.StatusInternalServerError)
+			return
+		}
+		if len(tmpl.Substitutions) > 0 {
+			apitemplates.ApplyHeaderSubstitutions(outReq, tmpl.Substitutions, values)
+		}
+	}
+
+	resp, doErr := p.client.Do(outReq)
+	if doErr != nil {
+		http.Error(w, "upstream request failed: "+apitemplates.RedactValues(doErr.Error(), redactVals), http.StatusBadGateway)
+		return
+	}
+	defer func() { _ = resp.Body.Close() }()
+	status = resp.StatusCode
+
+	raw, readErr := io.ReadAll(io.LimitReader(resp.Body, maxBrokerResponseBytes+1))
+	if readErr != nil {
+		http.Error(w, "cannot read upstream response", http.StatusBadGateway)
+		return
+	}
+	bodyText := string(raw)
+
+	// Sanitize: pattern-based detection plus known credential values.
+	sanitizer := masking.NewSanitizer()
+	bodyText = sanitizer.Sanitize(bodyText, masking.MaskOptions{CustomMask: "***"})
+	if entryData != nil {
+		bodyText = redactKnownValues(bodyText, entryData)
+	}
+
+	copyHeaders(w.Header(), resp.Header)
+	w.Header().Del("Content-Length")
+	w.WriteHeader(status)
+	_, _ = io.WriteString(w, bodyText)
+}
+
+// targetURL reconstructs the absolute upstream URL for origin-form (after
+// CONNECT) and absolute-form (plain forward proxy) requests.
+func (p *Proxy) targetURL(r *http.Request) (string, error) {
+	if r.URL.IsAbs() {
+		return r.URL.String(), nil
+	}
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
+	if r.Host == "" {
+		return "", fmt.Errorf("missing Host header")
+	}
+	u := *r.URL
+	u.Scheme = scheme
+	u.Host = r.Host
+	return u.String(), nil
+}
+
+func (p *Proxy) dialUpstream(ctx context.Context, hostport string) (net.Conn, error) {
+	return ssrf.DialAddress(ctx, p.upstream, "tcp", hostport, p.cfg.AllowPrivate, net.DefaultResolver.LookupIPAddr)
+}
+
+func (p *Proxy) isPassthrough(host string) bool {
+	for _, entry := range p.passthru {
+		entry = canonicalHost(entry)
+		if entry == "" {
+			continue
+		}
+		if host == entry || strings.HasSuffix(host, "."+entry) {
+			return true
+		}
+	}
+	return false
+}
+
+func (p *Proxy) audit(host, action string, ok bool, reason string) {
+	if p.cfg.AuditLog == nil {
+		return
+	}
+	entry := audit.LogEntry{
+		Agent:  p.cfg.AgentName,
+		Action: action,
+		Path:   host, // host only — paths may carry substituted credentials
+		Reason: reason,
+		OK:     ok,
+	}
+	if tmpl := p.byHost[host]; tmpl != nil && action == "broker_request" {
+		entry.Field = tmpl.Name
+	}
+	_ = p.cfg.AuditLog.LogEntry(entry)
+}
+
+func copyHeaders(dst, src http.Header) {
+	for k, vals := range src {
+		switch strings.ToLower(k) {
+		case "connection", "proxy-connection", "keep-alive", "transfer-encoding", "upgrade", "te":
+			continue
+		}
+		for _, v := range vals {
+			dst.Add(k, v)
+		}
+	}
+}
+
+func redactKnownValues(text string, entryData map[string]any) string {
+	for _, v := range entryData {
+		if vStr, ok := v.(string); ok && vStr != "" {
+			text = strings.ReplaceAll(text, vStr, "***")
+		}
+	}
+	return text
+}
+
+// loadTemplates resolves the full catalog: embedded built-ins (with vault-local
+// overrides) plus vault-local templates that are not built-in names.
+func loadTemplates(vaultDir string) ([]*apitemplates.APITemplate, error) {
+	var result []*apitemplates.APITemplate
+	seen := make(map[string]bool)
+
+	builtins, err := apitemplates.LoadAll()
+	if err != nil {
+		return nil, fmt.Errorf("load built-in templates: %w", err)
+	}
+	for _, b := range builtins {
+		tmpl, loadErr := apitemplates.Load(b.Name, vaultDir)
+		if loadErr != nil {
+			return nil, fmt.Errorf("load template %q: %w", b.Name, loadErr)
+		}
+		result = append(result, tmpl)
+		seen[b.Name] = true
+	}
+
+	if vaultDir != "" {
+		entries, readErr := os.ReadDir(filepath.Join(vaultDir, "templates"))
+		if readErr == nil {
+			for _, entry := range entries {
+				if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".yaml") {
+					continue
+				}
+				name := strings.TrimSuffix(entry.Name(), ".yaml")
+				if seen[name] {
+					continue
+				}
+				tmpl, loadErr := apitemplates.Load(name, vaultDir)
+				if loadErr != nil {
+					continue
+				}
+				result = append(result, tmpl)
+				seen[name] = true
+			}
+		}
+	}
+	return result, nil
+}
+
+// templateHost extracts the canonical host from a template base URL.
+func templateHost(baseURL string) string {
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return ""
+	}
+	return canonicalHost(u.Host)
+}

--- a/internal/mcp/apitemplates/auth.go
+++ b/internal/mcp/apitemplates/auth.go
@@ -1,0 +1,224 @@
+package apitemplates
+
+import (
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// ResolveField returns the first non-empty string value from the entry data
+// for the given field keys, in order.
+func ResolveField(data map[string]any, keys ...string) string {
+	for _, key := range keys {
+		if v, ok := data[key]; ok {
+			if vStr, ok := v.(string); ok && vStr != "" {
+				return vStr
+			}
+		}
+	}
+	return ""
+}
+
+// InjectAuth resolves the credential from the vault entry data and injects
+// the appropriate auth header (or query param) into the HTTP request
+// according to the template's auth type.
+//
+//nolint:gocyclo // auth type dispatch is intentionally structured as switch
+func InjectAuth(httpReq *http.Request, tmpl *APITemplate, entryData map[string]any) error {
+	switch tmpl.AuthType {
+	case AuthBearer:
+		token := ResolveField(entryData, "credential", "token", "password")
+		if token == "" {
+			return fmt.Errorf("no bearer token found in vault entry (expected fields: credential, token, or password)")
+		}
+		httpReq.Header.Set("Authorization", "Bearer "+token)
+
+	case AuthBasic:
+		username := ResolveField(entryData, "username")
+		password := ResolveField(entryData, "credential", "password")
+		if username == "" || password == "" {
+			return fmt.Errorf("basic auth requires username and password fields in vault entry")
+		}
+		auth := base64.StdEncoding.EncodeToString([]byte(username + ":" + password))
+		httpReq.Header.Set("Authorization", "Basic "+auth)
+
+	case AuthHeader:
+		// For header auth type, we look for the header name and value in entry data
+		// The convention is: header_name and header_value in the vault entry
+		headerName := ResolveField(entryData, "header_name")
+		headerValue := ResolveField(entryData, "header_value", "credential", "token", "password")
+		if headerName == "" || headerValue == "" {
+			return fmt.Errorf("header auth requires header_name and header_value (or credential/token/password) fields in vault entry")
+		}
+		httpReq.Header.Set(headerName, headerValue)
+
+	case AuthQueryParam:
+		// For query_param auth type, we look for the param name and value in entry data
+		// The convention is: param_name and param_value in the vault entry
+		paramName := ResolveField(entryData, "param_name")
+		paramValue := ResolveField(entryData, "param_value", "credential", "token", "password")
+		if paramName == "" || paramValue == "" {
+			return fmt.Errorf("query_param auth requires param_name and param_value (or credential/token/password) fields in vault entry")
+		}
+		q := httpReq.URL.Query()
+		q.Set(paramName, paramValue)
+		httpReq.URL.RawQuery = q.Encode()
+
+	case AuthNone:
+		// No auth header is injected; credentials are delivered through
+		// template substitutions (path/query/header/body).
+
+	default:
+		return fmt.Errorf("unsupported auth type: %s", tmpl.AuthType)
+	}
+
+	return nil
+}
+
+// ResolveSubstitutionValues resolves every declared substitution placeholder
+// to a non-empty value from the vault entry data. It returns the values by
+// placeholder and as a flat slice for error redaction.
+func ResolveSubstitutionValues(tmpl *APITemplate, entryData map[string]any) (map[string]string, []string, error) {
+	values := make(map[string]string, len(tmpl.Substitutions))
+	var redactVals []string
+	for _, sub := range tmpl.Substitutions {
+		value := ResolveField(entryData, sub.Field)
+		if value == "" {
+			return nil, nil, fmt.Errorf("no value for placeholder %q (expected vault entry field %q)", sub.Placeholder, sub.Field)
+		}
+		values[sub.Placeholder] = value
+		redactVals = append(redactVals, value)
+	}
+	return values, redactVals, nil
+}
+
+// ApplyURLSubstitutions replaces path- and query-surface placeholders in the
+// request URL. Placeholders are restricted to RFC 3986 unreserved characters,
+// so the substitution cannot alter the URL scheme or host.
+func ApplyURLSubstitutions(rawURL string, subs []Substitution, values map[string]string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL
+	}
+	for _, sub := range subs {
+		value, ok := values[sub.Placeholder]
+		if !ok {
+			continue
+		}
+		for _, surface := range sub.In {
+			switch surface {
+			case SurfacePath:
+				u.Path = strings.ReplaceAll(u.Path, sub.Placeholder, value)
+				u.RawPath = ""
+			case SurfaceQuery:
+				u.RawQuery = strings.ReplaceAll(u.RawQuery, sub.Placeholder, value)
+			case SurfaceHeader, SurfaceBody:
+				// Applied by the dedicated header/body helpers; the URL
+				// does not carry these surfaces.
+			}
+		}
+	}
+	return u.String()
+}
+
+// ApplyBodySubstitutions replaces body-surface placeholders in the request body.
+func ApplyBodySubstitutions(body string, subs []Substitution, values map[string]string) string {
+	for _, sub := range subs {
+		if !hasSubstitutionSurface(sub.In, SurfaceBody) {
+			continue
+		}
+		value, ok := values[sub.Placeholder]
+		if !ok {
+			continue
+		}
+		body = strings.ReplaceAll(body, sub.Placeholder, value)
+	}
+	return body
+}
+
+// ApplyHeaderSubstitutions replaces header-surface placeholders in the values
+// of every request header.
+func ApplyHeaderSubstitutions(httpReq *http.Request, subs []Substitution, values map[string]string) {
+	for _, sub := range subs {
+		if !hasSubstitutionSurface(sub.In, SurfaceHeader) {
+			continue
+		}
+		value, ok := values[sub.Placeholder]
+		if !ok {
+			continue
+		}
+		for key, vals := range httpReq.Header {
+			for i, v := range vals {
+				httpReq.Header[key][i] = strings.ReplaceAll(v, sub.Placeholder, value)
+			}
+		}
+	}
+}
+
+func hasSubstitutionSurface(surfaces []SubstitutionSurface, want SubstitutionSurface) bool {
+	for _, s := range surfaces {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}
+
+// ParseOpRef parses an op:// reference and returns the entry path and field.
+// op://vault/entry/field       -> entry="entry", field="field"
+// op://vault/nested/entry/field -> entry="nested/entry", field="field"
+// op://vault/entry             -> entry="entry", field=""
+func ParseOpRef(ref string) (string, string, error) {
+	const prefix = "op://"
+	if !strings.HasPrefix(ref, prefix) {
+		return "", "", fmt.Errorf("expected op:// prefix")
+	}
+
+	parts := strings.Split(strings.TrimPrefix(ref, prefix), "/")
+	if len(parts) < 2 {
+		return "", "", fmt.Errorf("expected at least vault/entry")
+	}
+
+	// parts[0] is vault name (ignored)
+	if len(parts) == 2 {
+		return parts[1], "", nil
+	}
+
+	entryPath := strings.Join(parts[1:len(parts)-1], "/")
+	field := parts[len(parts)-1]
+	return entryPath, field, nil
+}
+
+// EntryRefPath resolves a template entry_ref to a vault entry path. The ref
+// must reference an entry, not a field.
+func EntryRefPath(entryRef string) (string, error) {
+	ref := strings.TrimSpace(entryRef)
+	if ref == "" {
+		return "", fmt.Errorf("entry_ref is required")
+	}
+	if strings.HasPrefix(ref, "op://") {
+		entryPath, field, err := ParseOpRef(ref)
+		if err != nil {
+			return "", err
+		}
+		if field != "" {
+			return "", fmt.Errorf("entry_ref must reference an entry, not a field")
+		}
+		return entryPath, nil
+	}
+	return ref, nil
+}
+
+// RedactValues replaces every occurrence of the given secret values in msg
+// with "***" so substituted credentials never reach error messages.
+func RedactValues(msg string, values []string) string {
+	for _, v := range values {
+		if v == "" {
+			continue
+		}
+		msg = strings.ReplaceAll(msg, v, "***")
+	}
+	return msg
+}

--- a/internal/mcp/apitemplates/auth_test.go
+++ b/internal/mcp/apitemplates/auth_test.go
@@ -1,0 +1,166 @@
+package apitemplates
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestInjectAuth_Bearer(t *testing.T) {
+	tmpl := &APITemplate{
+		Name:     "test",
+		BaseURL:  "https://example.com",
+		AuthType: AuthBearer,
+	}
+	req, _ := http.NewRequest("GET", "https://example.com/test", nil)
+	err := InjectAuth(req, tmpl, map[string]any{
+		"credential": "test-token-123",
+	})
+	if err != nil {
+		t.Fatalf("InjectAuth() error = %v", err)
+	}
+	if got := req.Header.Get("Authorization"); got != "Bearer test-token-123" {
+		t.Errorf("Authorization header = %q, want %q", got, "Bearer test-token-123")
+	}
+}
+
+func TestInjectAuth_BearerFallbackFields(t *testing.T) {
+	tests := []struct {
+		name  string
+		data  map[string]any
+		token string
+	}{
+		{"credential field", map[string]any{"credential": "token-1"}, "token-1"},
+		{"token field", map[string]any{"token": "token-2"}, "token-2"},
+		{"password field", map[string]any{"password": "token-3"}, "token-3"},
+	}
+	tmpl := &APITemplate{
+		Name:     "test",
+		BaseURL:  "https://example.com",
+		AuthType: AuthBearer,
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, _ := http.NewRequest("GET", "https://example.com/test", nil)
+			err := InjectAuth(req, tmpl, tt.data)
+			if err != nil {
+				t.Fatalf("InjectAuth() error = %v", err)
+			}
+			want := "Bearer " + tt.token
+			if got := req.Header.Get("Authorization"); got != want {
+				t.Errorf("Authorization header = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+func TestInjectAuth_BearerMissing(t *testing.T) {
+	tmpl := &APITemplate{
+		Name:     "test",
+		BaseURL:  "https://example.com",
+		AuthType: AuthBearer,
+	}
+	req, _ := http.NewRequest("GET", "https://example.com/test", nil)
+	err := InjectAuth(req, tmpl, map[string]any{"username": "user"})
+	if err == nil {
+		t.Fatal("InjectAuth() expected error for missing token, got nil")
+	}
+}
+
+func TestInjectAuth_Basic(t *testing.T) {
+	tmpl := &APITemplate{
+		Name:     "test",
+		BaseURL:  "https://example.com",
+		AuthType: AuthBasic,
+	}
+	req, _ := http.NewRequest("GET", "https://example.com/test", nil)
+	err := InjectAuth(req, tmpl, map[string]any{
+		"username":   "testuser",
+		"credential": "testpass",
+	})
+	if err != nil {
+		t.Fatalf("InjectAuth() error = %v", err)
+	}
+	if got := req.Header.Get("Authorization"); got != "Basic dGVzdHVzZXI6dGVzdHBhc3M=" {
+		t.Errorf("Authorization header = %q, want %q", got, "Basic dGVzdHVzZXI6dGVzdHBhc3M=")
+	}
+}
+
+func TestInjectAuth_BasicMissing(t *testing.T) {
+	tmpl := &APITemplate{
+		Name:     "test",
+		BaseURL:  "https://example.com",
+		AuthType: AuthBasic,
+	}
+	req, _ := http.NewRequest("GET", "https://example.com/test", nil)
+	err := InjectAuth(req, tmpl, map[string]any{"username": "user"})
+	if err == nil {
+		t.Fatal("InjectAuth() expected error for missing password, got nil")
+	}
+}
+
+func TestInjectAuth_Header(t *testing.T) {
+	tmpl := &APITemplate{
+		Name:     "test",
+		BaseURL:  "https://example.com",
+		AuthType: AuthHeader,
+	}
+	req, _ := http.NewRequest("GET", "https://example.com/test", nil)
+	err := InjectAuth(req, tmpl, map[string]any{
+		"header_name":  "X-API-Key",
+		"header_value": "my-api-key-123",
+	})
+	if err != nil {
+		t.Fatalf("InjectAuth() error = %v", err)
+	}
+	if got := req.Header.Get("X-API-Key"); got != "my-api-key-123" {
+		t.Errorf("X-API-Key header = %q, want %q", got, "my-api-key-123")
+	}
+}
+
+func TestInjectAuth_QueryParam(t *testing.T) {
+	tmpl := &APITemplate{
+		Name:     "test",
+		BaseURL:  "https://example.com",
+		AuthType: AuthQueryParam,
+	}
+	req, _ := http.NewRequest("GET", "https://example.com/test", nil)
+	err := InjectAuth(req, tmpl, map[string]any{
+		"param_name":  "api_key",
+		"param_value": "secret-param-val",
+	})
+	if err != nil {
+		t.Fatalf("InjectAuth() error = %v", err)
+	}
+	if got := req.URL.Query().Get("api_key"); got != "secret-param-val" {
+		t.Errorf("query param api_key = %q, want %q", got, "secret-param-val")
+	}
+}
+
+func TestInjectAuth_None(t *testing.T) {
+	tmpl := &APITemplate{
+		Name:     "test",
+		BaseURL:  "https://example.com",
+		AuthType: AuthNone,
+	}
+	req, _ := http.NewRequest("GET", "https://example.com/test", nil)
+	err := InjectAuth(req, tmpl, map[string]any{"credential": "secret"})
+	if err != nil {
+		t.Fatalf("InjectAuth() error = %v", err)
+	}
+	if got := req.Header.Get("Authorization"); got != "" {
+		t.Errorf("Authorization header = %q, want empty for auth_type none", got)
+	}
+}
+
+func TestInjectAuth_Unsupported(t *testing.T) {
+	tmpl := &APITemplate{
+		Name:     "test",
+		BaseURL:  "https://example.com",
+		AuthType: AuthType("magic"),
+	}
+	req, _ := http.NewRequest("GET", "https://example.com/test", nil)
+	err := InjectAuth(req, tmpl, nil)
+	if err == nil {
+		t.Fatal("InjectAuth() expected error for unsupported auth type, got nil")
+	}
+}

--- a/internal/mcp/server/tools_execute_api_request.go
+++ b/internal/mcp/server/tools_execute_api_request.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -19,6 +18,7 @@ import (
 	"github.com/danieljustus/symaira-vault/internal/mcp/apitemplates"
 	"github.com/danieljustus/symaira-vault/internal/mcp/masking"
 	"github.com/danieljustus/symaira-vault/internal/metrics"
+	"github.com/danieljustus/symaira-vault/internal/ssrf"
 	vaultpkg "github.com/danieljustus/symaira-vault/internal/vault"
 )
 
@@ -94,7 +94,7 @@ func (s *Server) handleExecuteAPIRequest(ctx context.Context, req mcp.CallToolRe
 	}
 
 	requestURL := tmpl.BaseURL + normalizedEndpoint
-	if targetErr := validateAPIURL(ctx, requestURL, tmpl.AllowPrivate, net.DefaultResolver.LookupIPAddr); targetErr != nil {
+	if targetErr := ssrf.ValidateURL(ctx, requestURL, tmpl.AllowPrivate, net.DefaultResolver.LookupIPAddr); targetErr != nil {
 		s.logAudit(ctx, "execute_api_request", fmt.Sprintf("<blocked-target:%s>", tmpl.Name), false)
 		return mcp.NewToolResultError(targetErr.Error()), nil
 	}
@@ -108,7 +108,7 @@ func (s *Server) handleExecuteAPIRequest(ctx context.Context, req mcp.CallToolRe
 	}
 
 	// Load vault entry for credentials
-	entryPath, parseErr := parseTemplateEntryRef(tmpl.EntryRef)
+	entryPath, parseErr := apitemplates.EntryRefPath(tmpl.EntryRef)
 	if parseErr != nil {
 		s.logAudit(ctx, "execute_api_request", fmt.Sprintf("<template-error:%s>", tmpl.Name), false)
 		return mcp.NewToolResultError(fmt.Sprintf("invalid entry_ref for %q: %v", tmpl.Name, parseErr)), nil
@@ -130,15 +130,15 @@ func (s *Server) handleExecuteAPIRequest(ctx context.Context, req mcp.CallToolRe
 	var substitutionValues map[string]string
 	var redactVals []string
 	if len(tmpl.Substitutions) > 0 {
-		values, redactList, subErr := resolveSubstitutionValues(tmpl, entry.Data)
+		values, redactList, subErr := apitemplates.ResolveSubstitutionValues(tmpl, entry.Data)
 		if subErr != nil {
 			s.logAudit(ctx, "execute_api_request", fmt.Sprintf("<substitution-error:%s>", tmpl.Name), false)
 			return mcp.NewToolResultError(fmt.Sprintf("cannot resolve substitutions for %q: %v", tmpl.Name, subErr)), nil
 		}
 		substitutionValues = values
 		redactVals = redactList
-		requestURL = applyURLSubstitutions(requestURL, tmpl.Substitutions, values)
-		bodyStr = applyBodySubstitutions(bodyStr, tmpl.Substitutions, values)
+		requestURL = apitemplates.ApplyURLSubstitutions(requestURL, tmpl.Substitutions, values)
+		bodyStr = apitemplates.ApplyBodySubstitutions(bodyStr, tmpl.Substitutions, values)
 	}
 
 	// Build the request
@@ -150,7 +150,7 @@ func (s *Server) handleExecuteAPIRequest(ctx context.Context, req mcp.CallToolRe
 	httpReq, reqErr := http.NewRequestWithContext(ctx, method, requestURL, requestBody)
 	if reqErr != nil {
 		s.logAudit(ctx, "execute_api_request", fmt.Sprintf("<request-build-error:%s>", tmpl.Name), false)
-		return mcp.NewToolResultError(fmt.Sprintf("cannot build request: %s", redactValues(reqErr.Error(), redactVals))), nil
+		return mcp.NewToolResultError(fmt.Sprintf("cannot build request: %s", apitemplates.RedactValues(reqErr.Error(), redactVals))), nil
 	}
 
 	// Apply default headers
@@ -178,11 +178,11 @@ func (s *Server) handleExecuteAPIRequest(ctx context.Context, req mcp.CallToolRe
 	// Apply header-surface substitutions (after agent headers, before auth so
 	// auth_type always wins on the Authorization header).
 	if len(tmpl.Substitutions) > 0 {
-		applyHeaderSubstitutions(httpReq, tmpl.Substitutions, substitutionValues)
+		apitemplates.ApplyHeaderSubstitutions(httpReq, tmpl.Substitutions, substitutionValues)
 	}
 
 	// Resolve and inject auth header
-	authErr := injectAuthHeader(httpReq, tmpl, entry.Data)
+	authErr := apitemplates.InjectAuth(httpReq, tmpl, entry.Data)
 	if authErr != nil {
 		s.logAudit(ctx, "execute_api_request", fmt.Sprintf("<auth-error:%s>", tmpl.Name), false)
 		return mcp.NewToolResultError(fmt.Sprintf("cannot resolve auth for %q: %v", tmpl.Name, authErr)), nil
@@ -194,12 +194,12 @@ func (s *Server) handleExecuteAPIRequest(ctx context.Context, req mcp.CallToolRe
 	}
 
 	// Execute request
-	client := newAPIHTTPClient(time.Duration(timeoutSec)*time.Second, tmpl.AllowPrivate)
+	client := ssrf.NewHTTPClient(time.Duration(timeoutSec)*time.Second, tmpl.AllowPrivate)
 	resp, respErr := client.Do(httpReq)
 	if respErr != nil {
 		s.logAudit(ctx, "execute_api_request", fmt.Sprintf("template=%s, endpoint=%s, method=%s, status=error",
 			tmpl.Name, normalizedEndpoint, method), false)
-		return mcp.NewToolResultError(fmt.Sprintf("request failed: %s", redactValues(respErr.Error(), redactVals))), nil
+		return mcp.NewToolResultError(fmt.Sprintf("request failed: %s", apitemplates.RedactValues(respErr.Error(), redactVals))), nil
 	}
 	defer func() { _ = resp.Body.Close() }()
 
@@ -265,115 +265,6 @@ func (s *Server) handleExecuteAPIRequest(ctx context.Context, req mcp.CallToolRe
 
 	return mcp.NewToolResultText(string(resultJSON)), nil
 }
-
-type apiIPResolver func(context.Context, string) ([]net.IPAddr, error)
-
-func newAPIHTTPClient(timeout time.Duration, allowPrivate bool) *http.Client {
-	return newAPIHTTPClientWithResolver(timeout, allowPrivate, net.DefaultResolver.LookupIPAddr)
-}
-
-func newAPIHTTPClientWithResolver(timeout time.Duration, allowPrivate bool, resolve apiIPResolver) *http.Client {
-	dialer := &net.Dialer{}
-	transport := &http.Transport{
-		Proxy: nil,
-		DialContext: func(ctx context.Context, network, address string) (net.Conn, error) {
-			return dialAPIAddress(ctx, dialer, network, address, allowPrivate, resolve)
-		},
-	}
-	return &http.Client{
-		Timeout:   timeout,
-		Transport: transport,
-		CheckRedirect: func(req *http.Request, _ []*http.Request) error {
-			if err := validateAPIURL(req.Context(), req.URL.String(), allowPrivate, resolve); err != nil {
-				return fmt.Errorf("redirect rejected: %w", err)
-			}
-			return nil
-		},
-	}
-}
-
-func validateAPIURL(ctx context.Context, rawURL string, allowPrivate bool, resolve apiIPResolver) error {
-	if allowPrivate {
-		return nil
-	}
-	u, err := url.Parse(rawURL)
-	if err != nil {
-		return fmt.Errorf("blocked request target: invalid URL: %w", err)
-	}
-	if u.Hostname() == "" {
-		return fmt.Errorf("blocked request target: URL host is required")
-	}
-	if apitemplates.IsPrivateHost(u.Host) {
-		return fmt.Errorf("blocked request target %q: private or local network address", u.Host)
-	}
-	addresses, err := resolve(ctx, u.Hostname())
-	if err != nil {
-		return fmt.Errorf("cannot resolve request target %q: %w", u.Hostname(), err)
-	}
-	for _, address := range addresses {
-		if apitemplates.IsPrivateIP(address.IP) {
-			return fmt.Errorf("blocked request target %q: resolves to private or local network address", u.Hostname())
-		}
-	}
-	return nil
-}
-
-func dialAPIAddress(ctx context.Context, dialer *net.Dialer, network, address string, allowPrivate bool, resolve apiIPResolver) (net.Conn, error) {
-	host, port, err := net.SplitHostPort(address)
-	if err != nil {
-		return nil, fmt.Errorf("invalid request address %q: %w", address, err)
-	}
-	if allowPrivate {
-		return dialer.DialContext(ctx, network, address)
-	}
-	if apitemplates.IsPrivateHost(host) {
-		return nil, fmt.Errorf("blocked request target %q: private or local network address", host)
-	}
-	addresses, err := resolve(ctx, host)
-	if err != nil {
-		return nil, fmt.Errorf("cannot resolve request target %q: %w", host, err)
-	}
-	var lastErr error
-	for _, resolved := range addresses {
-		if apitemplates.IsPrivateIP(resolved.IP) {
-			return nil, fmt.Errorf("blocked request target %q: resolves to private or local network address", host)
-		}
-		if network == "tcp4" && resolved.IP.To4() == nil {
-			continue
-		}
-		if network == "tcp6" && resolved.IP.To4() != nil {
-			continue
-		}
-		conn, dialErr := dialer.DialContext(ctx, network, net.JoinHostPort(resolved.IP.String(), port))
-		if dialErr == nil {
-			return conn, nil
-		}
-		lastErr = dialErr
-	}
-	if lastErr != nil {
-		return nil, lastErr
-	}
-	return nil, fmt.Errorf("no usable addresses for request target %q", host)
-}
-
-func parseTemplateEntryRef(entryRef string) (string, error) {
-	ref := strings.TrimSpace(entryRef)
-	if ref == "" {
-		return "", fmt.Errorf("entry_ref is required")
-	}
-	if strings.HasPrefix(ref, "op://") {
-		entryPath, field, err := parseOpRef(ref)
-		if err != nil {
-			return "", err
-		}
-		if field != "" {
-			return "", fmt.Errorf("entry_ref must reference an entry, not a field")
-		}
-		return entryPath, nil
-	}
-	return ref, nil
-}
-
 func normalizeEndpoint(endpoint string) (string, error) {
 	trimmed := strings.TrimSpace(endpoint)
 	if trimmed == "" {
@@ -455,179 +346,6 @@ func readLimitedBody(r io.Reader, limit int) ([]byte, bool, error) {
 	}
 	return body, false, nil
 }
-
-// injectAuthHeader resolves the credential from the vault entry data and
-// injects the appropriate auth header (or query param) into the HTTP request.
-//
-//nolint:gocyclo // auth type dispatch is intentionally structured as switch
-func injectAuthHeader(httpReq *http.Request, tmpl *apitemplates.APITemplate, entryData map[string]any) error {
-	switch tmpl.AuthType {
-	case apitemplates.AuthBearer:
-		token := resolveField(entryData, "credential", "token", "password")
-		if token == "" {
-			return fmt.Errorf("no bearer token found in vault entry (expected fields: credential, token, or password)")
-		}
-		httpReq.Header.Set("Authorization", "Bearer "+token)
-
-	case apitemplates.AuthBasic:
-		username := resolveField(entryData, "username")
-		password := resolveField(entryData, "credential", "password")
-		if username == "" || password == "" {
-			return fmt.Errorf("basic auth requires username and password fields in vault entry")
-		}
-		auth := base64.StdEncoding.EncodeToString([]byte(username + ":" + password))
-		httpReq.Header.Set("Authorization", "Basic "+auth)
-
-	case apitemplates.AuthHeader:
-		// For header auth type, we look for the header name and value in entry data
-		// The convention is: header_name and header_value in the vault entry
-		headerName := resolveField(entryData, "header_name")
-		headerValue := resolveField(entryData, "header_value", "credential", "token", "password")
-		if headerName == "" || headerValue == "" {
-			return fmt.Errorf("header auth requires header_name and header_value (or credential/token/password) fields in vault entry")
-		}
-		httpReq.Header.Set(headerName, headerValue)
-
-	case apitemplates.AuthQueryParam:
-		// For query_param auth type, we look for the param name and value in entry data
-		// The convention is: param_name and param_value in the vault entry
-		paramName := resolveField(entryData, "param_name")
-		paramValue := resolveField(entryData, "param_value", "credential", "token", "password")
-		if paramName == "" || paramValue == "" {
-			return fmt.Errorf("query_param auth requires param_name and param_value (or credential/token/password) fields in vault entry")
-		}
-		q := httpReq.URL.Query()
-		q.Set(paramName, paramValue)
-		httpReq.URL.RawQuery = q.Encode()
-
-	case apitemplates.AuthNone:
-		// No auth header is injected; credentials are delivered through
-		// template substitutions (path/query/header/body).
-
-	default:
-		return fmt.Errorf("unsupported auth type: %s", tmpl.AuthType)
-	}
-
-	return nil
-}
-
-// resolveSubstitutionValues resolves every declared substitution placeholder
-// to a non-empty value from the vault entry data. It returns the values by
-// placeholder and as a flat slice for error redaction.
-func resolveSubstitutionValues(tmpl *apitemplates.APITemplate, entryData map[string]any) (map[string]string, []string, error) {
-	values := make(map[string]string, len(tmpl.Substitutions))
-	var redactVals []string
-	for _, sub := range tmpl.Substitutions {
-		value := resolveField(entryData, sub.Field)
-		if value == "" {
-			return nil, nil, fmt.Errorf("no value for placeholder %q (expected vault entry field %q)", sub.Placeholder, sub.Field)
-		}
-		values[sub.Placeholder] = value
-		redactVals = append(redactVals, value)
-	}
-	return values, redactVals, nil
-}
-
-// applyURLSubstitutions replaces path- and query-surface placeholders in the
-// request URL. Placeholders are restricted to RFC 3986 unreserved characters,
-// so the substitution cannot alter the URL scheme or host.
-func applyURLSubstitutions(rawURL string, subs []apitemplates.Substitution, values map[string]string) string {
-	u, err := url.Parse(rawURL)
-	if err != nil {
-		return rawURL
-	}
-	for _, sub := range subs {
-		value, ok := values[sub.Placeholder]
-		if !ok {
-			continue
-		}
-		for _, surface := range sub.In {
-			switch surface {
-			case apitemplates.SurfacePath:
-				u.Path = strings.ReplaceAll(u.Path, sub.Placeholder, value)
-				u.RawPath = ""
-			case apitemplates.SurfaceQuery:
-				u.RawQuery = strings.ReplaceAll(u.RawQuery, sub.Placeholder, value)
-			case apitemplates.SurfaceHeader, apitemplates.SurfaceBody:
-				// Applied by the dedicated header/body helpers; the URL
-				// does not carry these surfaces.
-			}
-		}
-	}
-	return u.String()
-}
-
-// applyBodySubstitutions replaces body-surface placeholders in the request body.
-func applyBodySubstitutions(body string, subs []apitemplates.Substitution, values map[string]string) string {
-	for _, sub := range subs {
-		if !hasSubstitutionSurface(sub.In, apitemplates.SurfaceBody) {
-			continue
-		}
-		value, ok := values[sub.Placeholder]
-		if !ok {
-			continue
-		}
-		body = strings.ReplaceAll(body, sub.Placeholder, value)
-	}
-	return body
-}
-
-// applyHeaderSubstitutions replaces header-surface placeholders in the values
-// of every request header.
-func applyHeaderSubstitutions(httpReq *http.Request, subs []apitemplates.Substitution, values map[string]string) {
-	for _, sub := range subs {
-		if !hasSubstitutionSurface(sub.In, apitemplates.SurfaceHeader) {
-			continue
-		}
-		value, ok := values[sub.Placeholder]
-		if !ok {
-			continue
-		}
-		for key, vals := range httpReq.Header {
-			for i, v := range vals {
-				httpReq.Header[key][i] = strings.ReplaceAll(v, sub.Placeholder, value)
-			}
-		}
-	}
-}
-
-func hasSubstitutionSurface(surfaces []apitemplates.SubstitutionSurface, want apitemplates.SubstitutionSurface) bool {
-	for _, s := range surfaces {
-		if s == want {
-			return true
-		}
-	}
-	return false
-}
-
-// redactValues replaces every occurrence of the given secret values in msg
-// with "***" so substituted credentials never reach error messages.
-func redactValues(msg string, values []string) string {
-	for _, v := range values {
-		if v == "" {
-			continue
-		}
-		msg = strings.ReplaceAll(msg, v, "***")
-	}
-	return msg
-}
-
-// resolveField returns the first non-empty string value from the entry data
-// for the given field keys, in order.
-func resolveField(data map[string]any, keys ...string) string {
-	for _, key := range keys {
-		if v, ok := data[key]; ok {
-			if vStr, ok := v.(string); ok && vStr != "" {
-				return vStr
-			}
-		}
-	}
-	return ""
-}
-
-// matchAnyGlob checks if the given path matches any of the glob patterns.
-// Uses path.Match for single-segment matching, with multi-segment support
-// for patterns ending in /* which should match any sub-path.
 func matchAnyGlob(endpoint string, patterns []string) bool {
 	if len(patterns) == 0 {
 		return false

--- a/internal/mcp/server/tools_execute_api_request_test.go
+++ b/internal/mcp/server/tools_execute_api_request_test.go
@@ -5,14 +5,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/danieljustus/symaira-vault/internal/config"
 	mcp "github.com/danieljustus/symaira-vault/internal/mcp"
@@ -63,49 +61,6 @@ func TestAPITemplateLoad_Builtin(t *testing.T) {
 		})
 	}
 }
-
-func TestValidateAPIURL_RejectsResolvedPrivateAddress(t *testing.T) {
-	resolver := func(context.Context, string) ([]net.IPAddr, error) {
-		return []net.IPAddr{{IP: net.ParseIP("127.0.0.1")}}, nil
-	}
-
-	err := validateAPIURL(context.Background(), "http://public.example/secret", false, resolver)
-	if err == nil {
-		t.Fatal("validateAPIURL() expected a private-address error")
-	}
-	if !strings.Contains(err.Error(), "resolves to private") {
-		t.Fatalf("error = %v, want resolved-private explanation", err)
-	}
-}
-
-func TestAPIHTTPClient_RejectsPrivateRedirect(t *testing.T) {
-	resolver := func(context.Context, string) ([]net.IPAddr, error) {
-		return []net.IPAddr{{IP: net.ParseIP("192.168.1.10")}}, nil
-	}
-	client := newAPIHTTPClientWithResolver(time.Second, false, resolver)
-	req := httptest.NewRequest(http.MethodGet, "http://private.example/secret", nil)
-
-	err := client.CheckRedirect(req, nil)
-	if err == nil {
-		t.Fatal("CheckRedirect() expected a private-address error")
-	}
-	if !strings.Contains(err.Error(), "redirect rejected") {
-		t.Fatalf("error = %v, want redirect rejection", err)
-	}
-}
-
-func TestAPIHTTPClient_AllowsPrivateOverride(t *testing.T) {
-	resolver := func(context.Context, string) ([]net.IPAddr, error) {
-		return nil, fmt.Errorf("resolver should not be called when private access is allowed")
-	}
-	client := newAPIHTTPClientWithResolver(time.Second, true, resolver)
-	req := httptest.NewRequest(http.MethodGet, "http://localhost/secret", nil)
-
-	if err := client.CheckRedirect(req, nil); err != nil {
-		t.Fatalf("CheckRedirect() error with allow_private: %v", err)
-	}
-}
-
 func TestAPITemplateLoad_Unknown(t *testing.T) {
 	_, err := apitemplates.Load("nonexistent", "")
 	if err == nil {
@@ -199,140 +154,6 @@ func TestIsMethodAllowed(t *testing.T) {
 }
 
 // --- Auth injection tests ---
-
-func TestInjectAuthHeader_Bearer(t *testing.T) {
-	tmpl := &apitemplates.APITemplate{
-		Name:     "test",
-		BaseURL:  "https://example.com",
-		AuthType: apitemplates.AuthBearer,
-	}
-	req, _ := http.NewRequest("GET", "https://example.com/test", nil)
-	err := injectAuthHeader(req, tmpl, map[string]any{
-		"credential": "test-token-123",
-	})
-	if err != nil {
-		t.Fatalf("injectAuthHeader() error = %v", err)
-	}
-	if got := req.Header.Get("Authorization"); got != "Bearer test-token-123" {
-		t.Errorf("Authorization header = %q, want %q", got, "Bearer test-token-123")
-	}
-}
-
-func TestInjectAuthHeader_BearerFallbackFields(t *testing.T) {
-	tests := []struct {
-		name  string
-		data  map[string]any
-		token string
-	}{
-		{"credential field", map[string]any{"credential": "token-1"}, "token-1"},
-		{"token field", map[string]any{"token": "token-2"}, "token-2"},
-		{"password field", map[string]any{"password": "token-3"}, "token-3"},
-	}
-	tmpl := &apitemplates.APITemplate{
-		Name:     "test",
-		BaseURL:  "https://example.com",
-		AuthType: apitemplates.AuthBearer,
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			req, _ := http.NewRequest("GET", "https://example.com/test", nil)
-			err := injectAuthHeader(req, tmpl, tt.data)
-			if err != nil {
-				t.Fatalf("injectAuthHeader() error = %v", err)
-			}
-			want := "Bearer " + tt.token
-			if got := req.Header.Get("Authorization"); got != want {
-				t.Errorf("Authorization header = %q, want %q", got, want)
-			}
-		})
-	}
-}
-
-func TestInjectAuthHeader_BearerMissing(t *testing.T) {
-	tmpl := &apitemplates.APITemplate{
-		Name:     "test",
-		BaseURL:  "https://example.com",
-		AuthType: apitemplates.AuthBearer,
-	}
-	req, _ := http.NewRequest("GET", "https://example.com/test", nil)
-	err := injectAuthHeader(req, tmpl, map[string]any{"username": "user"})
-	if err == nil {
-		t.Fatal("injectAuthHeader() expected error for missing token, got nil")
-	}
-}
-
-func TestInjectAuthHeader_Basic(t *testing.T) {
-	tmpl := &apitemplates.APITemplate{
-		Name:     "test",
-		BaseURL:  "https://example.com",
-		AuthType: apitemplates.AuthBasic,
-	}
-	req, _ := http.NewRequest("GET", "https://example.com/test", nil)
-	err := injectAuthHeader(req, tmpl, map[string]any{
-		"username":   "testuser",
-		"credential": "testpass",
-	})
-	if err != nil {
-		t.Fatalf("injectAuthHeader() error = %v", err)
-	}
-	if got := req.Header.Get("Authorization"); got != "Basic dGVzdHVzZXI6dGVzdHBhc3M=" {
-		t.Errorf("Authorization header = %q, want %q", got, "Basic dGVzdHVzZXI6dGVzdHBhc3M=")
-	}
-}
-
-func TestInjectAuthHeader_BasicMissing(t *testing.T) {
-	tmpl := &apitemplates.APITemplate{
-		Name:     "test",
-		BaseURL:  "https://example.com",
-		AuthType: apitemplates.AuthBasic,
-	}
-	req, _ := http.NewRequest("GET", "https://example.com/test", nil)
-	err := injectAuthHeader(req, tmpl, map[string]any{"username": "user"})
-	if err == nil {
-		t.Fatal("injectAuthHeader() expected error for missing password, got nil")
-	}
-}
-
-func TestInjectAuthHeader_Header(t *testing.T) {
-	tmpl := &apitemplates.APITemplate{
-		Name:     "test",
-		BaseURL:  "https://example.com",
-		AuthType: apitemplates.AuthHeader,
-	}
-	req, _ := http.NewRequest("GET", "https://example.com/test", nil)
-	err := injectAuthHeader(req, tmpl, map[string]any{
-		"header_name":  "X-API-Key",
-		"header_value": "my-api-key-123",
-	})
-	if err != nil {
-		t.Fatalf("injectAuthHeader() error = %v", err)
-	}
-	if got := req.Header.Get("X-API-Key"); got != "my-api-key-123" {
-		t.Errorf("X-API-Key header = %q, want %q", got, "my-api-key-123")
-	}
-}
-
-func TestInjectAuthHeader_QueryParam(t *testing.T) {
-	tmpl := &apitemplates.APITemplate{
-		Name:     "test",
-		BaseURL:  "https://example.com",
-		AuthType: apitemplates.AuthQueryParam,
-	}
-	req, _ := http.NewRequest("GET", "https://example.com/test", nil)
-	err := injectAuthHeader(req, tmpl, map[string]any{
-		"param_name":  "api_key",
-		"param_value": "secret-param-val",
-	})
-	if err != nil {
-		t.Fatalf("injectAuthHeader() error = %v", err)
-	}
-	if got := req.URL.Query().Get("api_key"); got != "secret-param-val" {
-		t.Errorf("query param api_key = %q, want %q", got, "secret-param-val")
-	}
-}
-
-// --- Handler tests with mocked HTTP ---
-
 func TestHandleExecuteAPIRequest_Success(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != "GET" {

--- a/internal/mcp/server/tools_execute_with_secret.go
+++ b/internal/mcp/server/tools_execute_with_secret.go
@@ -10,6 +10,7 @@ import (
 	"unicode"
 
 	mcp "github.com/danieljustus/symaira-vault/internal/mcp"
+	"github.com/danieljustus/symaira-vault/internal/mcp/apitemplates"
 	"github.com/danieljustus/symaira-vault/internal/metrics"
 	"github.com/danieljustus/symaira-vault/internal/secrets"
 )
@@ -84,7 +85,7 @@ func (s *Server) handleExecuteWithSecret(ctx context.Context, req mcp.CallToolRe
 				return mcp.NewToolResultError(fmt.Sprintf("secret_refs[%d] must be a string", i)), nil
 			}
 
-			entryPath, field, parseErr := parseOpRef(ref)
+			entryPath, field, parseErr := apitemplates.ParseOpRef(ref)
 			if parseErr != nil {
 				s.logAudit(ctx, "execute_with_secret", ref, false)
 				return mcp.NewToolResultError(fmt.Sprintf("invalid secret ref %q: %v", ref, parseErr)), nil
@@ -195,31 +196,6 @@ func (s *Server) handleExecuteWithSecret(ctx context.Context, req mcp.CallToolRe
 		return nil, err
 	}
 	return mcp.NewToolResultText(string(resultJSON)), nil
-}
-
-// parseOpRef parses an op:// reference and returns the entry path and field.
-// op://vault/entry/field       -> entry="entry", field="field"
-// op://vault/nested/entry/field -> entry="nested/entry", field="field"
-// op://vault/entry             -> entry="entry", field=""
-func parseOpRef(ref string) (string, string, error) {
-	const prefix = "op://"
-	if !strings.HasPrefix(ref, prefix) {
-		return "", "", fmt.Errorf("expected op:// prefix")
-	}
-
-	parts := strings.Split(strings.TrimPrefix(ref, prefix), "/")
-	if len(parts) < 2 {
-		return "", "", fmt.Errorf("expected at least vault/entry")
-	}
-
-	// parts[0] is vault name (ignored)
-	if len(parts) == 2 {
-		return parts[1], "", nil
-	}
-
-	entryPath := strings.Join(parts[1:len(parts)-1], "/")
-	field := parts[len(parts)-1]
-	return entryPath, field, nil
 }
 
 // generateEnvVarName creates an environment variable name from the entry path

--- a/internal/mcp/server/tools_execute_with_secret_test.go
+++ b/internal/mcp/server/tools_execute_with_secret_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/danieljustus/symaira-vault/internal/config"
 	mcp "github.com/danieljustus/symaira-vault/internal/mcp"
+	"github.com/danieljustus/symaira-vault/internal/mcp/apitemplates"
 )
 
 func TestHandleExecuteWithSecret_BasicRun(t *testing.T) {
@@ -923,7 +924,7 @@ func TestParseOpRef(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			entry, field, err := parseOpRef(tt.ref)
+			entry, field, err := apitemplates.ParseOpRef(tt.ref)
 			if tt.wantErr {
 				if err == nil {
 					t.Fatal("parseOpRef() expected error, got nil")

--- a/internal/ssrf/ssrf.go
+++ b/internal/ssrf/ssrf.go
@@ -1,0 +1,130 @@
+// Package ssrf provides SSRF-hardened HTTP client plumbing shared by the
+// execute_api_request tool and the egress broker: dial-time DNS
+// re-resolution with private-address blocking, request-target validation and
+// redirect validation. DNS is resolved at dial time so a rebinding attack
+// cannot redirect injected credentials to a private network address.
+package ssrf
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/danieljustus/symaira-vault/internal/mcp/apitemplates"
+)
+
+// Resolver resolves a host to IP addresses. Production code uses
+// net.DefaultResolver.LookupIPAddr; tests inject a stub.
+type Resolver func(context.Context, string) ([]net.IPAddr, error)
+
+// ValidateURL blocks request targets that are private, local or resolve to
+// private addresses, unless allowPrivate is set.
+func ValidateURL(ctx context.Context, rawURL string, allowPrivate bool, resolve Resolver) error {
+	if allowPrivate {
+		return nil
+	}
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("blocked request target: invalid URL: %w", err)
+	}
+	if u.Hostname() == "" {
+		return fmt.Errorf("blocked request target: URL host is required")
+	}
+	if apitemplates.IsPrivateHost(u.Host) {
+		return fmt.Errorf("blocked request target %q: private or local network address", u.Host)
+	}
+	addresses, err := resolve(ctx, u.Hostname())
+	if err != nil {
+		return fmt.Errorf("cannot resolve request target %q: %w", u.Hostname(), err)
+	}
+	for _, address := range addresses {
+		if apitemplates.IsPrivateIP(address.IP) {
+			return fmt.Errorf("blocked request target %q: resolves to private or local network address", u.Hostname())
+		}
+	}
+	return nil
+}
+
+// DialAddress dials the given network address with dial-time re-resolution
+// of the hostname, rejecting private targets unless allowPrivate is set.
+func DialAddress(ctx context.Context, dialer *net.Dialer, network, address string, allowPrivate bool, resolve Resolver) (net.Conn, error) {
+	host, port, err := net.SplitHostPort(address)
+	if err != nil {
+		return nil, fmt.Errorf("invalid request address %q: %w", address, err)
+	}
+	if allowPrivate {
+		return dialer.DialContext(ctx, network, address)
+	}
+	if apitemplates.IsPrivateHost(host) {
+		return nil, fmt.Errorf("blocked request target %q: private or local network address", host)
+	}
+	addresses, err := resolve(ctx, host)
+	if err != nil {
+		return nil, fmt.Errorf("cannot resolve request target %q: %w", host, err)
+	}
+	var lastErr error
+	for _, resolved := range addresses {
+		if apitemplates.IsPrivateIP(resolved.IP) {
+			return nil, fmt.Errorf("blocked request target %q: resolves to private or local network address", host)
+		}
+		if network == "tcp4" && resolved.IP.To4() == nil {
+			continue
+		}
+		if network == "tcp6" && resolved.IP.To4() != nil {
+			continue
+		}
+		conn, dialErr := dialer.DialContext(ctx, network, net.JoinHostPort(resolved.IP.String(), port))
+		if dialErr == nil {
+			return conn, nil
+		}
+		lastErr = dialErr
+	}
+	if lastErr != nil {
+		return nil, lastErr
+	}
+	return nil, fmt.Errorf("no usable addresses for request target %q", host)
+}
+
+// NewHTTPClient builds an SSRF-hardened HTTP client with the given timeout.
+func NewHTTPClient(timeout time.Duration, allowPrivate bool) *http.Client {
+	return NewHTTPClientWithResolver(timeout, allowPrivate, net.DefaultResolver.LookupIPAddr)
+}
+
+// NewHTTPClientWithTLSConfig builds an SSRF-hardened HTTP client with a custom
+// upstream TLS configuration (test hooks, corporate MITM setups).
+func NewHTTPClientWithTLSConfig(timeout time.Duration, allowPrivate bool, tlsConfig *tls.Config) *http.Client {
+	client := NewHTTPClientWithResolver(timeout, allowPrivate, net.DefaultResolver.LookupIPAddr)
+	if tlsConfig != nil {
+		transport, ok := client.Transport.(*http.Transport)
+		if ok {
+			transport.TLSClientConfig = tlsConfig
+		}
+	}
+	return client
+}
+
+// NewHTTPClientWithResolver builds an SSRF-hardened HTTP client with an
+// injectable resolver.
+func NewHTTPClientWithResolver(timeout time.Duration, allowPrivate bool, resolve Resolver) *http.Client {
+	dialer := &net.Dialer{}
+	transport := &http.Transport{
+		Proxy: nil,
+		DialContext: func(ctx context.Context, network, address string) (net.Conn, error) {
+			return DialAddress(ctx, dialer, network, address, allowPrivate, resolve)
+		},
+	}
+	return &http.Client{
+		Timeout:   timeout,
+		Transport: transport,
+		CheckRedirect: func(req *http.Request, _ []*http.Request) error {
+			if err := ValidateURL(req.Context(), req.URL.String(), allowPrivate, resolve); err != nil {
+				return fmt.Errorf("redirect rejected: %w", err)
+			}
+			return nil
+		},
+	}
+}

--- a/internal/ssrf/ssrf_test.go
+++ b/internal/ssrf/ssrf_test.go
@@ -1,0 +1,67 @@
+package ssrf
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestValidateURL_RejectsResolvedPrivateAddress(t *testing.T) {
+	resolver := func(context.Context, string) ([]net.IPAddr, error) {
+		return []net.IPAddr{{IP: net.ParseIP("127.0.0.1")}}, nil
+	}
+
+	err := ValidateURL(context.Background(), "http://public.example/secret", false, resolver)
+	if err == nil {
+		t.Fatal("ValidateURL() expected a private-address error")
+	}
+	if !strings.Contains(err.Error(), "resolves to private") {
+		t.Fatalf("error = %v, want resolved-private explanation", err)
+	}
+}
+
+func TestAPIHTTPClient_RejectsPrivateRedirect(t *testing.T) {
+	resolver := func(context.Context, string) ([]net.IPAddr, error) {
+		return []net.IPAddr{{IP: net.ParseIP("192.168.1.10")}}, nil
+	}
+	client := NewHTTPClientWithResolver(time.Second, false, resolver)
+	req := httptest.NewRequest(http.MethodGet, "http://private.example/secret", nil)
+
+	err := client.CheckRedirect(req, nil)
+	if err == nil {
+		t.Fatal("CheckRedirect() expected a private-address error")
+	}
+	if !strings.Contains(err.Error(), "redirect rejected") {
+		t.Fatalf("error = %v, want redirect rejection", err)
+	}
+}
+
+func TestAPIHTTPClient_AllowsPrivateOverride(t *testing.T) {
+	resolver := func(context.Context, string) ([]net.IPAddr, error) {
+		return nil, fmt.Errorf("resolver should not be called when private access is allowed")
+	}
+	client := NewHTTPClientWithResolver(time.Second, true, resolver)
+	req := httptest.NewRequest(http.MethodGet, "http://localhost/secret", nil)
+
+	if err := client.CheckRedirect(req, nil); err != nil {
+		t.Fatalf("CheckRedirect() error with allow_private: %v", err)
+	}
+}
+
+func TestDialAddress_RejectsPrivateIP(t *testing.T) {
+	resolver := func(context.Context, string) ([]net.IPAddr, error) {
+		return []net.IPAddr{{IP: net.ParseIP("10.0.0.5")}}, nil
+	}
+	_, err := DialAddress(context.Background(), &net.Dialer{}, "tcp", "evil.example:443", false, resolver)
+	if err == nil {
+		t.Fatal("DialAddress() expected private-address error")
+	}
+	if !strings.Contains(err.Error(), "resolves to private") {
+		t.Fatalf("error = %v, want resolved-private explanation", err)
+	}
+}


### PR DESCRIPTION
## Summary

Adds an opt-in egress credential broker: `symvault broker` and
`symvault run --broker`. A loopback MITM forward proxy attaches vault
credentials to the agent's outbound HTTPS/HTTP requests **server-side**, so
a brokered secret never enters the agent's process environment, argv or
process listing — the child only receives the proxy URL and the CA path.

### What's in this PR

- **internal/broker**: ephemeral leaf-signing CA (24h leaf TTL, per-host
  LRU cache), CONNECT + absolute-form forward proxy, host→template
  resolution reusing the apitemplates catalog (auth injection plus
  path/query/header/body substitutions), SSRF-hardened upstream dialing
  (dial-time re-resolution), response-body sanitization, one tamper-evident
  audit record per request (host/template/status only — never paths or
  values), unmatched hosts forwarded by default or rejected with **403** in
  `--strict` mode, and a `--passthrough` tunnel list for certificate-pinning
  clients.
- **internal/ssrf**: the SSRF dialer/validator/client extracted from the mcp
  server package so broker and `execute_api_request` share one
  implementation.
- **internal/mcp/apitemplates**: auth injection, substitution application
  and entry_ref parsing extracted as shared exported helpers (server
  behavior unchanged; tests moved alongside).
- **cmd**: `symvault broker` prints the proxy URL, CA path and env exports
  (`HTTPS_PROXY`, `HTTP_PROXY`, `SSL_CERT_FILE`, `NODE_EXTRA_CA_CERTS`,
  `REQUESTS_CA_BUNDLE`, `NO_PROXY`); `symvault run --broker -- <cmd>` runs a
  child with the broker in-process.
- **docs/egress-broker.md** states the guarantee precisely: on one machine
  the plaintext is removed from the child environment/argv/process listing,
  but the strong guarantee requires the broker on a separate host or the
  agent in a container.

`--env` behavior is byte-identical with the broker disabled; the feature is
purely additive.

### Tests

CA minting/verification/TTL, plain-HTTP injection, path substitution,
unmatched forward + strict 403, strict-with-match, response sanitization,
CONNECT MITM over TLS with injection, passthrough raw tunnel, audit records
(no credential in entries).

### Verification

- `go build ./...`, `go vet`, `gofmt` clean
- `golangci-lint v2.11.4`: 0 issues; `gosec v2.22.0`: 0 issues
- `go test ./internal/broker/ ./internal/ssrf/ ./internal/mcp/apitemplates/
  ./internal/mcp/server/ ./cmd/` all green

Closes #764
