### PR TITLE
fix(apitemplates): use slash paths for embed.FS builtin lookup (Windows)

### DIFF
--- a/internal/mcp/apitemplates/template.go
+++ b/internal/mcp/apitemplates/template.go
@@ -190,9 +190,11 @@ func LoadAll() ([]*APITemplate, error) {
 	return templates, nil
 }
 
-// loadBuiltin loads a built-in template by name.
+// loadBuiltin loads a built-in template by name. Embed paths are always
+// slash-separated regardless of the host OS, so the path is joined with "/"
+// (filepath.Join would produce backslashes on Windows and fail the lookup).
 func loadBuiltin(name string) (*APITemplate, error) {
-	data, err := builtinFS.ReadFile(filepath.Join("builtin", name+".yaml"))
+	data, err := builtinFS.ReadFile("builtin/" + name + ".yaml")
 	if err != nil {
 		return nil, fmt.Errorf("template %q not found", name)
 	}


### PR DESCRIPTION
loadBuiltin used filepath.Join against embed.FS, which fails on Windows (backslash paths). The Windows test job had been green only because the package test cache masked the failure; the new template tests exposed it. Fixes the Windows CI failure on main.