### PR TITLE
fix(broker): audit failed brokered requests as failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ A modern, secure command-line password manager written in Go. Uses [age](https:/
 
 ![Symaira Vault demo](docs/assets/symvault-demo.gif)
 
+> **Status:** pre-1.0 — the CLI surface and vault format are stabilizing under [SemVer](https://semver.org/); see [CHANGELOG.md](CHANGELOG.md) for the release history.
+
 > **Safety Notice**: Symaira Vault manages sensitive secrets. Use at your own risk, keep tested backups of your vault, and verify recovery before relying on it for critical credentials.
 
 ## Features

--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -562,6 +562,68 @@ func TestProxy_AuditRecorded(t *testing.T) {
 	}
 }
 
+func TestProxy_FailedRequestAuditedAsFailure(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("upstream must not be reached when substitutions cannot be resolved")
+	}))
+	defer upstream.Close()
+
+	tmpl := fmt.Sprintf(`base_url: %s
+auth_type: none
+entry_ref: testapi
+substitutions:
+  - placeholder: __MISSING_FIELD__
+    field: missing_field
+    in: [path]
+allow_private: true
+`, upstream.URL)
+
+	vaultDir, identity := setupVault(t, "testapi", map[string]any{"credential": "token"}, "testapi", tmpl)
+
+	logger, err := audit.New("broker-test", vaultDir, identity)
+	if err != nil {
+		t.Fatalf("audit.New: %v", err)
+	}
+	defer logger.Close()
+
+	proxyURL, stop := startProxy(t, Config{
+		VaultDir:     vaultDir,
+		Identity:     identity,
+		AgentName:    "broker-test",
+		AuditLog:     logger,
+		AllowPrivate: true,
+	})
+	defer stop()
+
+	resp, err := newProxyClient(proxyURL).Get(upstream.URL + "/__MISSING_FIELD__")
+	if err != nil {
+		t.Fatalf("GET through proxy: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500 for unresolvable substitution", resp.StatusCode)
+	}
+	logger.Flush()
+
+	entries, err := audit.LoadAuditLogFiles("broker-test", vaultDir, 10)
+	if err != nil {
+		t.Fatalf("load audit entries: %v", err)
+	}
+	found := false
+	for _, e := range entries {
+		if e.Action != "broker_request" {
+			continue
+		}
+		found = true
+		if e.OK != false {
+			t.Errorf("audit entry ok = %v, want false for failed brokered request", e.OK)
+		}
+	}
+	if !found {
+		t.Fatal("no broker_request audit entry found")
+	}
+}
+
 func TestProxy_EnvExports(t *testing.T) {
 	p, err := New(Config{VaultDir: t.TempDir(), Identity: nil})
 	if err == nil {

--- a/internal/broker/proxy.go
+++ b/internal/broker/proxy.go
@@ -285,7 +285,10 @@ func (p *Proxy) serveInner(w http.ResponseWriter, r *http.Request) {
 // substitutions when a template matched, and sanitizes the response body.
 func (p *Proxy) forward(w http.ResponseWriter, r *http.Request, target string, tmpl *apitemplates.APITemplate, entryData map[string]any) {
 	host := canonicalHost(r.Host)
-	status := 0
+	// Default to a failure status so error paths below (substitution
+	// resolution, body read, request build, upstream failure) are audited
+	// as failures; the real status overwrites this on success.
+	status := http.StatusInternalServerError
 	audited := false
 	auditOnce := func(action string, ok bool, reason string) {
 		if audited {


### PR DESCRIPTION
## What

The credential broker's `forward()` path initialized its audit status sentinel to `0` and deferred an audit entry computed as `status < 400`. Every error path that returned before a real response status was assigned (unresolvable substitutions, unreadable request bodies, upstream request failures) was therefore recorded in the audit log as a successful `broker_request` — misleading for a security feature whose audit trail is the primary incident record.

## Fix

- `internal/broker/proxy.go`: initialize `status` to `http.StatusInternalServerError` so error paths are audited as failures; the real response status still overwrites it on success.
- `internal/broker/broker_test.go`: regression test `TestProxy_FailedRequestAuditedAsFailure` — a request with an unresolvable substitution returns 500, never reaches the upstream, and produces a `broker_request` audit entry with `ok=false`.
- `README.md`: add a pre-1.0 stability/status indicator.

## Verification

- `go test -count=1 -run 'TestProxy|TestCA' ./internal/broker/` — pass (incl. new test)
- `gofmt -l internal/broker/` — clean
- `go vet ./internal/broker/` — clean