### PR TITLE
feat(broker): add run --broker-strict/--broker-passthrough flags

### DIFF
--- a/cmd/broker.go
+++ b/cmd/broker.go
@@ -133,13 +133,17 @@ to <vault>/broker-ca.pem.`,
 
 // brokerEnvForRun starts an ephemeral broker for `run --broker` and returns
 // the environment variables the child process needs plus a cleanup function.
-func brokerEnvForRun(v *vaultpkg.Vault) (map[string]string, func(), error) {
+// strict and passthrough mirror the standalone broker command's --strict and
+// --passthrough flags (run exposes them as --broker-strict and
+// --broker-passthrough because --passthrough already means parent-env
+// passthrough there).
+func brokerEnvForRun(v *vaultpkg.Vault, strict bool, passthrough []string) (map[string]string, func(), error) {
 	proxy, err := brokerpkg.New(brokerpkg.Config{
 		VaultDir:    v.Dir,
 		Identity:    v.Identity,
 		AgentName:   "broker",
-		Strict:      brokerStrict,
-		Passthrough: brokerPassthrough,
+		Strict:      strict,
+		Passthrough: passthrough,
 	})
 	if err != nil {
 		return nil, nil, fmt.Errorf("start broker: %w", err)

--- a/cmd/broker_test.go
+++ b/cmd/broker_test.go
@@ -1,0 +1,322 @@
+package cmd
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	vaultpkg "github.com/danieljustus/symaira-vault/internal/vault"
+)
+
+// Command-layer coverage for the broker CLI wiring (issue #775): the
+// standalone `broker` command (newBrokerCmd) and the `run --broker`
+// env-construction path (brokerEnvForRun), including the #773
+// --broker-strict / --broker-passthrough wiring.
+
+func TestNewBrokerCmd_Flags(t *testing.T) {
+	cmd := newBrokerCmd()
+	for _, name := range []string{"addr", "strict", "passthrough"} {
+		if cmd.Flags().Lookup(name) == nil {
+			t.Errorf("broker command missing --%s flag", name)
+		}
+	}
+}
+
+func TestNewRunCmd_BrokerFlags(t *testing.T) {
+	cmd := newRunCmd()
+	for _, name := range []string{"broker", "broker-strict", "broker-passthrough", "passthrough"} {
+		if cmd.Flags().Lookup(name) == nil {
+			t.Errorf("run command missing --%s flag", name)
+		}
+	}
+}
+
+func TestBrokerCmd_RunE(t *testing.T) {
+	vaultDir, passphrase := initVault(t)
+	setPassEnv(t, string(passphrase))
+	defer setupVaultFlag(t, vaultDir)()
+
+	cmd := newBrokerCmd()
+
+	// Install the signal seam: capture the channel RunE waits on instead of
+	// registering with the OS, and signal readiness once the listener is up
+	// and the startup output has been written.
+	origNotify := BrokerSignalNotify
+	var sigChan chan<- os.Signal
+	notifyReady := make(chan struct{})
+	BrokerSignalNotify = func(c chan<- os.Signal, _ ...os.Signal) {
+		sigChan = c
+		close(notifyReady)
+	}
+	defer func() { BrokerSignalNotify = origNotify }()
+
+	// Capture stdout while the broker runs and blocks.
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stdout = w
+	var buf bytes.Buffer
+	readDone := make(chan struct{})
+	go func() {
+		_, _ = buf.ReadFrom(r)
+		close(readDone)
+	}()
+	restoreStdout := func() {
+		_ = w.Close()
+		os.Stdout = oldStdout
+		<-readDone
+	}
+	defer restoreStdout()
+
+	execDone := make(chan error, 1)
+	go func() { execDone <- cmd.Execute() }()
+
+	select {
+	case <-notifyReady:
+	case execErr := <-execDone:
+		t.Fatalf("broker exited before the signal-wait stage: %v", execErr)
+	case <-time.After(15 * time.Second):
+		t.Fatal("broker never reached the signal-wait stage")
+	}
+
+	// The CA certificate was written with 0600 permissions and parses as PEM.
+	caPath := filepath.Join(vaultDir, "broker-ca.pem")
+	caInfo, statErr := os.Stat(caPath)
+	if statErr != nil {
+		t.Fatalf("stat broker-ca.pem: %v", statErr)
+	}
+	if perm := caInfo.Mode().Perm(); perm != 0o600 {
+		t.Errorf("broker-ca.pem mode = %o, want 0600", perm)
+	}
+	caData, readErr := os.ReadFile(caPath)
+	if readErr != nil {
+		t.Fatalf("read broker-ca.pem: %v", readErr)
+	}
+	block, _ := pem.Decode(caData)
+	if block == nil {
+		t.Fatal("broker-ca.pem is not valid PEM")
+	}
+	if _, parseErr := x509.ParseCertificate(block.Bytes); parseErr != nil {
+		t.Errorf("broker-ca.pem does not parse as an X.509 certificate: %v", parseErr)
+	}
+
+	// Shut the broker down through the signal seam and expect a clean exit.
+	sigChan <- os.Interrupt
+	select {
+	case execErr := <-execDone:
+		if execErr != nil {
+			t.Fatalf("Execute() error = %v", execErr)
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatal("broker did not shut down after signal")
+	}
+
+	restoreStdout()
+	out := buf.String()
+	for _, want := range []string{
+		"egress broker listening on http://127.0.0.1:",
+		"CA certificate written to " + caPath,
+		"HTTPS_PROXY=http://127.0.0.1:",
+		"HTTP_PROXY=http://127.0.0.1:",
+		"SSL_CERT_FILE=" + caPath,
+		"NODE_EXTRA_CA_CERTS=" + caPath,
+		"REQUESTS_CA_BUNDLE=" + caPath,
+		"NO_PROXY=127.0.0.1,localhost",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("stdout missing %q; got:\n%s", want, out)
+		}
+	}
+}
+
+func TestBrokerEnvForRun(t *testing.T) {
+	vaultDir, passphrase := initVault(t)
+	v, err := vaultpkg.OpenWithPassphrase(vaultDir, passphrase)
+	if err != nil {
+		t.Fatalf("open vault: %v", err)
+	}
+
+	env, cleanup, err := brokerEnvForRun(v, false, nil)
+	if err != nil {
+		t.Fatalf("brokerEnvForRun() error = %v", err)
+	}
+	defer cleanup()
+
+	caPath := filepath.Join(vaultDir, "broker-ca.pem")
+
+	for _, key := range []string{"HTTPS_PROXY", "HTTP_PROXY", "SSL_CERT_FILE", "NODE_EXTRA_CA_CERTS", "REQUESTS_CA_BUNDLE", "NO_PROXY"} {
+		if env[key] == "" {
+			t.Errorf("env[%q] is empty", key)
+		}
+	}
+	if env["HTTPS_PROXY"] != env["HTTP_PROXY"] {
+		t.Errorf("HTTPS_PROXY = %q, HTTP_PROXY = %q; want equal", env["HTTPS_PROXY"], env["HTTP_PROXY"])
+	}
+	if !strings.HasPrefix(env["HTTPS_PROXY"], "http://127.0.0.1:") {
+		t.Errorf("HTTPS_PROXY = %q, want loopback proxy URL", env["HTTPS_PROXY"])
+	}
+	if env["SSL_CERT_FILE"] != caPath {
+		t.Errorf("SSL_CERT_FILE = %q, want %q", env["SSL_CERT_FILE"], caPath)
+	}
+	if env["NO_PROXY"] != "127.0.0.1,localhost" {
+		t.Errorf("NO_PROXY = %q, want 127.0.0.1,localhost", env["NO_PROXY"])
+	}
+
+	// The CA file exists, is 0600, and parses as a PEM certificate.
+	info, statErr := os.Stat(caPath)
+	if statErr != nil {
+		t.Fatalf("stat CA: %v", statErr)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("broker-ca.pem mode = %o, want 0600", perm)
+	}
+	caData, readErr := os.ReadFile(caPath)
+	if readErr != nil {
+		t.Fatalf("read CA: %v", readErr)
+	}
+	block, _ := pem.Decode(caData)
+	if block == nil {
+		t.Fatal("broker-ca.pem is not valid PEM")
+	}
+	if _, parseErr := x509.ParseCertificate(block.Bytes); parseErr != nil {
+		t.Errorf("broker-ca.pem does not parse as an X.509 certificate: %v", parseErr)
+	}
+
+	// The cleanup function stops the listener.
+	cleanup()
+	proxyURL, parseErr := url.Parse(env["HTTPS_PROXY"])
+	if parseErr != nil {
+		t.Fatalf("parse proxy URL: %v", parseErr)
+	}
+	conn, dialErr := net.DialTimeout("tcp", proxyURL.Host, 500*time.Millisecond)
+	if dialErr == nil {
+		_ = conn.Close()
+		t.Error("proxy listener still accepting connections after cleanup()")
+	}
+}
+
+// TestBrokerEnvForRun_StrictMode verifies the strict parameter (#773 wiring)
+// reaches the broker: unmatched hosts get 403 instead of being forwarded.
+func TestBrokerEnvForRun_StrictMode(t *testing.T) {
+	vaultDir, passphrase := initVault(t)
+	v, err := vaultpkg.OpenWithPassphrase(vaultDir, passphrase)
+	if err != nil {
+		t.Fatalf("open vault: %v", err)
+	}
+
+	proxyStatus := func(strict bool) int {
+		t.Helper()
+		env, cleanup, envErr := brokerEnvForRun(v, strict, nil)
+		if envErr != nil {
+			t.Fatalf("brokerEnvForRun(strict=%v) error = %v", strict, envErr)
+		}
+		defer cleanup()
+		proxyURL, parseErr := url.Parse(env["HTTPS_PROXY"])
+		if parseErr != nil {
+			t.Fatalf("parse proxy URL: %v", parseErr)
+		}
+		client := &http.Client{
+			Timeout:   10 * time.Second,
+			Transport: &http.Transport{Proxy: http.ProxyURL(proxyURL)},
+		}
+		resp, reqErr := client.Get("http://127.0.0.1:9/probe")
+		if reqErr != nil {
+			t.Fatalf("GET via proxy: %v", reqErr)
+		}
+		defer resp.Body.Close()
+		return resp.StatusCode
+	}
+
+	// Strict: the unmatched loopback host is rejected before any upstream
+	// dial, so the response is a deterministic 403.
+	if got := proxyStatus(true); got != http.StatusForbidden {
+		t.Errorf("strict mode status = %d, want 403", got)
+	}
+	// Non-strict: the unmatched host is forwarded, and the SSRF guard blocks
+	// the private upstream, yielding a deterministic 502.
+	if got := proxyStatus(false); got != http.StatusBadGateway {
+		t.Errorf("non-strict mode status = %d, want 502", got)
+	}
+}
+
+// TestBrokerEnvForRun_Passthrough verifies the passthrough parameter (#773
+// wiring) routes CONNECT requests for listed hosts through the tunnel path
+// (no TLS interception) instead of the intercept path.
+func TestBrokerEnvForRun_Passthrough(t *testing.T) {
+	vaultDir, passphrase := initVault(t)
+	v, err := vaultpkg.OpenWithPassphrase(vaultDir, passphrase)
+	if err != nil {
+		t.Fatalf("open vault: %v", err)
+	}
+
+	env, cleanup, err := brokerEnvForRun(v, false, []string{"unmatched.invalid"})
+	if err != nil {
+		t.Fatalf("brokerEnvForRun() error = %v", err)
+	}
+	defer cleanup()
+
+	proxyURL, parseErr := url.Parse(env["HTTPS_PROXY"])
+	if parseErr != nil {
+		t.Fatalf("parse proxy URL: %v", parseErr)
+	}
+	conn, dialErr := net.DialTimeout("tcp", proxyURL.Host, 5*time.Second)
+	if dialErr != nil {
+		t.Fatalf("dial proxy: %v", dialErr)
+	}
+	defer conn.Close()
+	if _, writeErr := fmt.Fprintf(conn, "CONNECT unmatched.invalid:443 HTTP/1.1\r\nHost: unmatched.invalid:443\r\n\r\n"); writeErr != nil {
+		t.Fatalf("write CONNECT: %v", writeErr)
+	}
+	resp, readErr := http.ReadResponse(bufio.NewReader(conn), nil)
+	if readErr != nil {
+		t.Fatalf("read CONNECT response: %v", readErr)
+	}
+	defer resp.Body.Close()
+	// The tunnel dials the upstream directly and reports the failure as a
+	// 502 ("cannot reach upstream"); a passthrough-listed host is never
+	// offered a MITM handshake.
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Errorf("CONNECT status = %d, want 502 (passthrough tunnel cannot reach upstream)", resp.StatusCode)
+	}
+}
+
+// TestCmdRun_BrokerWiring drives `run --broker` end-to-end and verifies the
+// #773 flags reach the child environment through brokerEnvForRun.
+func TestCmdRun_BrokerWiring(t *testing.T) {
+	vaultDir, passphrase := initVault(t)
+	setPassEnv(t, string(passphrase))
+	defer setupVaultFlag(t, vaultDir)()
+
+	out := execWithStdout("--vault", vaultDir, "run",
+		"--broker", "--broker-strict", "--broker-passthrough", "corp.internal",
+		"--", "sh", "-c", "echo PROXY=$HTTPS_PROXY; echo CERT=$SSL_CERT_FILE; echo NO=$NO_PROXY")
+
+	caPath := filepath.Join(vaultDir, "broker-ca.pem")
+	// The broker proxy URL and NO_PROXY contain an IPv4 literal, which the
+	// run output redaction layer masks as credential-shaped output, so only
+	// assert on the surrounding text.
+	if !strings.Contains(out, "PROXY=http://") {
+		t.Errorf("stdout missing proxy URL, got: %q", out)
+	}
+	if !strings.Contains(out, "CERT="+caPath) {
+		t.Errorf("stdout missing CA path %q, got: %q", caPath, out)
+	}
+	if !strings.Contains(out, "NO=") || !strings.Contains(out, "localhost") {
+		t.Errorf("stdout missing NO_PROXY, got: %q", out)
+	}
+	if _, err := os.Stat(caPath); err != nil {
+		t.Errorf("broker-ca.pem not written: %v", err)
+	}
+}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -16,12 +16,14 @@ import (
 )
 
 var (
-	runEnvFlags    []string
-	runEnvFiles    []string
-	runPassthrough []string
-	runWorkingDir  string
-	runTimeout     time.Duration
-	runBroker      bool
+	runEnvFlags          []string
+	runEnvFiles          []string
+	runPassthrough       []string
+	runWorkingDir        string
+	runTimeout           time.Duration
+	runBroker            bool
+	runBrokerStrict      bool
+	runBrokerPassthrough []string
 )
 
 // runCmd is retained for API compatibility; NewRootCmd() uses
@@ -32,7 +34,9 @@ func newRunCmd() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "run [flags] -- <command> [args...]",
 		Short: "Run a command with secrets injected as environment variables",
-		Long:  "Executes a command with vault secrets injected as environment variables. Use --env NAME=path.field to map secrets.",
+		Long: `Executes a command with vault secrets injected as environment variables. Use --env NAME=path.field to map secrets.
+
+With --broker the child's outbound traffic is routed through an in-process egress credential broker, so brokered secrets never enter the child environment. The broker mode is configured with --broker-strict (reject hosts without a matching template) and --broker-passthrough (tunnel certificate-pinning hosts without TLS interception).`,
 		Example: `  # Inject AWS_SECRET_ACCESS_KEY from vault entry "work/aws.secret"
   symvault run --env AWS_SECRET_ACCESS_KEY=work/aws.secret -- aws s3 ls
 
@@ -41,6 +45,10 @@ func newRunCmd() *cobra.Command {
 
   # Pass through parent NODE_ENV and PORT to the child process
   NODE_ENV=production PORT=8080 symvault run --passthrough NODE_ENV,PORT -- npm start
+
+  # Route the child through the egress broker: strict mode, with one
+  # certificate-pinning host tunneled without TLS interception
+  symvault run --broker --broker-strict --broker-passthrough corp.internal -- ./deploy.sh
 
   # Multiple secrets, custom working dir
   symvault run \
@@ -91,7 +99,7 @@ func newRunCmd() *cobra.Command {
 				// server-side and never enter the child environment.
 				var brokerCleanup func()
 				if runBroker {
-					brokerEnv, cleanup, brokerErr := brokerEnvForRun(v)
+					brokerEnv, cleanup, brokerErr := brokerEnvForRun(v, runBrokerStrict, runBrokerPassthrough)
 					if brokerErr != nil {
 						return brokerErr
 					}
@@ -136,7 +144,9 @@ func newRunCmd() *cobra.Command {
 	c.Flags().StringArrayVar(&runPassthrough, "passthrough", nil, "Parent env var names to pass through to the child process (comma-separated)")
 	c.Flags().StringVarP(&runWorkingDir, "working-dir", "C", "", "Working directory for the command")
 	c.Flags().DurationVarP(&runTimeout, "timeout", "t", 0, "Timeout for the command (e.g., 30s)")
-	c.Flags().BoolVar(&runBroker, "broker", false, "Route the child's outbound traffic through the egress credential broker (credentials never enter the child environment)")
+	c.Flags().BoolVar(&runBroker, "broker", false, "Route the child's outbound traffic through the egress credential broker (credentials never enter the child environment); configure with --broker-strict and --broker-passthrough")
+	c.Flags().BoolVar(&runBrokerStrict, "broker-strict", false, "With --broker: reject requests to hosts without a matching template with 403")
+	c.Flags().StringSliceVar(&runBrokerPassthrough, "broker-passthrough", nil, "With --broker: hosts tunneled without TLS interception (comma-separated, domain suffixes match)")
 	c.GroupID = cli.GroupIDVault
 	return c
 }


### PR DESCRIPTION
Fixes #773
Fixes #775

## Problem
`symvault run --broker -- <cmd>` starts an in-process egress broker via `brokerEnvForRun`, but that function read the `brokerStrict`/`brokerPassthrough` globals that only the standalone `symvault broker` command sets — so the run-mode broker always ran non-strict with no passthrough hosts. The broker CLI wiring had no direct command-layer test coverage (6 of 56 patch statements).

## Change (#773)
- `cmd/run.go`: new `--broker-strict` and `--broker-passthrough` flags (the plain `--passthrough` name stays reserved for parent-env passthrough), documented in the `run --broker` help text with an example.
- `cmd/broker.go`: `brokerEnvForRun` now takes `strict` and `passthrough` parameters instead of reading the standalone-command globals.

## Tests (#775)
New `cmd/broker_test.go` covering:
- `newBrokerCmd`: flags exist (`--addr`, `--strict`, `--passthrough`), RunE starts a broker, writes `<vault>/broker-ca.pem` with 0600 permissions, prints env exports, and shuts down on signal via the `BrokerSignalNotify` seam.
- `brokerEnvForRun`: returns `HTTPS_PROXY`/`HTTP_PROXY`/`SSL_CERT_FILE`/`NODE_EXTRA_CA_CERTS`/`REQUESTS_CA_BUNDLE`/`NO_PROXY`, the CA file exists and parses as PEM, and the cleanup function stops the listener.
- Strict/passthrough wiring through `run --broker`.

## Verification
- `go vet ./cmd/`, `go test ./cmd/ -run 'Broker' -count=1`, full `go test ./cmd/ -count=1` (all pass), `go build ./...`, `gofmt` clean, `git diff --check` clean.