### PR TITLE
docs: bump next planned core milestone to v0.14.0

### DIFF
--- a/docs/commercial-boundary.md
+++ b/docs/commercial-boundary.md
@@ -26,7 +26,7 @@ cloud deployment automation, compliance operations, and monitoring.
 The current Symaira Vault release line is `v0.x`. Historical OpenPass releases
 such as `v4.0.0` remain part of the old release history and must not be treated
 as the current Symaira Vault release target. The next planned core milestone is
-`v0.12.1`.
+`v0.14.0`.
 
 ## Related
 


### PR DESCRIPTION
Mechanical version-doc fix from the 2026-08-07 prerelease gate: the
`v0.13.0` release shipped, so the next planned core milestone in
`docs/commercial-boundary.md` is `v0.14.0`.

Docs-only change; `make docs-check` passes locally.