### PR TITLE
test(session): cover real touchIDPassphraseStore entry points

### DIFF
--- a/internal/session/touchid_test.go
+++ b/internal/session/touchid_test.go
@@ -4,6 +4,8 @@ package session
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"testing"
 	"time"
 )
@@ -33,5 +35,64 @@ func TestTouchIDAuthenticate_Timeout(t *testing.T) {
 	err := touchIDAuthenticate(ctx, "test")
 	if err == nil {
 		t.Fatal("touchIDAuthenticate with expired timeout should return error")
+	}
+}
+
+// TestTouchIDPassphraseStore_IsAvailable exercises the real (non-mock)
+// touchIDPassphraseStore.IsAvailable, which must delegate to the same
+// package-level touchIDAvailable() check as the authenticator. This is
+// safe on any machine: canEvaluatePolicy is a capability query, it never
+// prompts for biometric authentication.
+func TestTouchIDPassphraseStore_IsAvailable(t *testing.T) {
+	store := &touchIDPassphraseStore{}
+	if got, want := store.IsAvailable(), touchIDAvailable(); got != want {
+		t.Errorf("touchIDPassphraseStore.IsAvailable() = %v, want %v (touchIDAvailable())", got, want)
+	}
+}
+
+// TestTouchIDPassphraseStore_Save_CancelledContext exercises Save's
+// context-cancellation guard. It never reaches the Keychain: a cancelled
+// context is checked before touchIDAvailable(), so this is safe and
+// deterministic regardless of whether the host has Touch ID hardware.
+func TestTouchIDPassphraseStore_Save_CancelledContext(t *testing.T) {
+	store := &touchIDPassphraseStore{}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := store.Save(ctx, "/tmp/does-not-matter", []byte("secret"))
+	if err == nil {
+		t.Fatal("Save with a cancelled context should return an error")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("Save with a cancelled context = %v, want context.Canceled", err)
+	}
+}
+
+// TestTouchIDPassphraseStore_Load_NotConfigured exercises Load and
+// loadFromService end to end against a vault directory that has never
+// had a passphrase stored for it. The Keychain item-existence check
+// (SecItemCopyMatching) reports "not found" before any biometric
+// authentication is requested, so this never prompts and is safe on
+// machines with real Touch ID hardware enrolled.
+func TestTouchIDPassphraseStore_Load_NotConfigured(t *testing.T) {
+	store := &touchIDPassphraseStore{}
+	if !store.IsAvailable() {
+		t.Skip("Touch ID hardware not available on this host")
+	}
+	vaultDir := fmt.Sprintf("/tmp/symvault-coverage-test-%d-never-saved", time.Now().UnixNano())
+	_, err := store.Load(context.Background(), vaultDir)
+	if !errors.Is(err, ErrBiometricNotConfigured) {
+		t.Errorf("Load(%q) with no stored passphrase = %v, want ErrBiometricNotConfigured", vaultDir, err)
+	}
+}
+
+// TestTouchIDPassphraseStore_Delete_NoOp exercises Delete and
+// deleteFromService against a Keychain entry that does not exist.
+// SecItemDelete returning errSecItemNotFound is mapped to success, so
+// deleting a never-stored entry is a safe, deterministic no-op.
+func TestTouchIDPassphraseStore_Delete_NoOp(t *testing.T) {
+	store := &touchIDPassphraseStore{}
+	vaultDir := fmt.Sprintf("/tmp/symvault-coverage-test-%d-never-saved", time.Now().UnixNano())
+	if err := store.Delete(vaultDir); err != nil {
+		t.Errorf("Delete(%q) on a never-stored entry = %v, want nil", vaultDir, err)
 	}
 }


### PR DESCRIPTION
Added 4 safe, deterministic unit tests for the real (non-mock)
touchIDPassphraseStore that verify Save/Load/Delete/IsAvailable
delegate correctly and handle their guard conditions:

- IsAvailable() matches package-level touchIDAvailable()
- Save() with a cancelled context returns context.Canceled before
  ever reaching the Keychain
- Load() for a vault directory with nothing stored returns
  ErrBiometricNotConfigured via the item-existence pre-check, without
  triggering a biometric prompt
- Delete() on a non-existent entry is a safe no-op

None of these touch a real biometric prompt or leave Keychain state
behind. internal/session coverage: 72.1% -> 76.2%.

Investigation note: the coverage drop this issue was filed against
(65.3% -> 64.9% repo-wide after 'chore: remove OpenPass legacy
compatibility surface') was measurement noise, not a code-caused
regression. The removed legacy-alias tests never exercised Save/
Load/Delete/IsAvailable at all (they tested pure string-formatting
helpers). The prior 'coverage' on these functions came from an
earlier test incidentally hitting a leftover real Keychain entry
on this specific developer machine (a successful Touch ID auth from
prior manual use), which is not reproducible in CI or on another
machine — CI never measures this darwin+cgo file's coverage at all,
since the coverage gate runs on ubuntu-latest only. This commit
replaces that accidental, non-portable coverage with real,
deterministic tests.

Closes #792

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
