### PR TITLE
fix(git-sync): best-effort auto-push, complete auto-commit staging, stable device identity

### DIFF
--- a/cmd/device.go
+++ b/cmd/device.go
@@ -221,10 +221,8 @@ to re-encrypt all entries for this new device.`,
 				CreatedAt: time.Now().UTC(),
 			}
 			if defaultDeviceName == "" {
-				hostname, _ := os.Hostname()
-				if hostname != "" {
-					joinedData.Name = hostname
-				} else {
+				joinedData.Name = git.DeviceIdentity(vaultDir)
+				if joinedData.Name == git.UnknownDeviceName {
 					joinedData.Name = "device-" + token
 				}
 			}
@@ -554,10 +552,8 @@ request so the first device can accept it.`,
 				CreatedAt: time.Now().UTC(),
 			}
 			if deviceAddName == "" {
-				hostname, _ := os.Hostname()
-				if hostname != "" {
-					joinedData.Name = hostname
-				} else {
+				joinedData.Name = git.DeviceIdentity(vaultDir)
+				if joinedData.Name == git.UnknownDeviceName {
 					joinedData.Name = "device-" + token
 				}
 			}

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -72,8 +72,7 @@ func newSyncCmd() *cobra.Command {
 					cliout.Warnf("Warning: could not record sync time: %v", err)
 				}
 
-				hostname, _ := os.Hostname()
-				if err := git.ResolveConflicts(vaultDir, hostname); err != nil {
+				if err := git.ResolveConflicts(vaultDir, git.DeviceIdentity(vaultDir)); err != nil {
 					cliout.Warnf("Warning: conflict resolution failed: %v", err)
 				}
 			} else {

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -59,7 +59,7 @@ func newSyncCmd() *cobra.Command {
 			}
 
 			if result.Error != nil {
-				if isOfflineErr(result.Error) {
+				if git.IsOfflineError(result.Error) {
 					printlnQuietAware("Warning: could not reach remote — offline")
 					return nil
 				}
@@ -103,13 +103,6 @@ func newSyncCmd() *cobra.Command {
 	c.Flags().BoolVarP(&syncForce, "force", "f", false, "force pull (reset local changes)")
 	c.GroupID = cli.GroupIDSharingSync
 	return c
-}
-
-func isOfflineErr(err error) bool {
-	if err == nil {
-		return false
-	}
-	return err.Error() == "network error - please check your connection"
 }
 
 func findConflictFiles(vaultDir string) []string {

--- a/cmd/sync_test.go
+++ b/cmd/sync_test.go
@@ -5,24 +5,26 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/danieljustus/symaira-vault/internal/git"
 )
 
 func TestIsOfflineErr_Nil(t *testing.T) {
-	if isOfflineErr(nil) {
+	if git.IsOfflineError(nil) {
 		t.Error("expected false for nil error")
 	}
 }
 
 func TestIsOfflineErr_NetworkError(t *testing.T) {
 	err := errors.New("network error - please check your connection")
-	if !isOfflineErr(err) {
+	if !git.IsOfflineError(err) {
 		t.Error("expected true for network error")
 	}
 }
 
 func TestIsOfflineErr_OtherError(t *testing.T) {
 	err := errors.New("some other error")
-	if isOfflineErr(err) {
+	if git.IsOfflineError(err) {
 		t.Error("expected false for non-network error")
 	}
 }

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"os"
 	"path/filepath"
-	"strings"
 
 	configpkg "github.com/danieljustus/symaira-vault/internal/config"
 	"github.com/danieljustus/symaira-vault/internal/git"
@@ -35,7 +34,7 @@ func MaybeAutoPull(vaultDir string, cfg *configpkg.Config) {
 
 	result := git.PullWithResult(vaultDir)
 	if result.Error != nil {
-		if isOfflineErr(result.Error) {
+		if git.IsOfflineError(result.Error) {
 			return
 		}
 		return
@@ -61,14 +60,6 @@ func MaybeAutoPull(vaultDir string, cfg *configpkg.Config) {
 			cliout.Warnf("  %s", f)
 		}
 	}
-}
-
-func isOfflineErr(err error) bool {
-	msg := err.Error()
-	return strings.Contains(msg, "no route to host") ||
-		strings.Contains(msg, "connection refused") ||
-		strings.Contains(msg, "connection timed out") ||
-		strings.Contains(msg, "i/o timeout")
 }
 
 func findConflictFiles(vaultDir string) []string {

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -48,8 +48,7 @@ func MaybeAutoPull(vaultDir string, cfg *configpkg.Config) {
 		cliout.Warnf("Warning: could not record sync time: %v", err)
 	}
 
-	hostname, _ := os.Hostname()
-	if err := git.ResolveConflicts(vaultDir, hostname); err != nil {
+	if err := git.ResolveConflicts(vaultDir, git.DeviceIdentity(vaultDir)); err != nil {
 		cliout.Warnf("Warning: conflict resolution failed: %v", err)
 	}
 

--- a/internal/cli/sync_test.go
+++ b/internal/cli/sync_test.go
@@ -4,47 +4,56 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/danieljustus/symaira-vault/internal/git"
 )
 
 func TestIsOfflineErr_NoRouteToHost(t *testing.T) {
 	err := &testError{msg: "dial tcp: no route to host"}
-	if !isOfflineErr(err) {
-		t.Error("isOfflineErr() = false for 'no route to host', want true")
+	if !git.IsOfflineError(err) {
+		t.Error("IsOfflineError() = false for 'no route to host', want true")
 	}
 }
 
 func TestIsOfflineErr_ConnectionRefused(t *testing.T) {
 	err := &testError{msg: "dial tcp: connection refused"}
-	if !isOfflineErr(err) {
-		t.Error("isOfflineErr() = false for 'connection refused', want true")
+	if !git.IsOfflineError(err) {
+		t.Error("IsOfflineError() = false for 'connection refused', want true")
 	}
 }
 
 func TestIsOfflineErr_ConnectionTimedOut(t *testing.T) {
 	err := &testError{msg: "dial tcp: connection timed out"}
-	if !isOfflineErr(err) {
-		t.Error("isOfflineErr() = false for 'connection timed out', want true")
+	if !git.IsOfflineError(err) {
+		t.Error("IsOfflineError() = false for 'connection timed out', want true")
 	}
 }
 
 func TestIsOfflineErr_IOTimeout(t *testing.T) {
 	err := &testError{msg: "i/o timeout"}
-	if !isOfflineErr(err) {
-		t.Error("isOfflineErr() = false for 'i/o timeout', want true")
+	if !git.IsOfflineError(err) {
+		t.Error("IsOfflineError() = false for 'i/o timeout', want true")
+	}
+}
+
+func TestIsOfflineErr_SSHOperationTimedOut(t *testing.T) {
+	err := &testError{msg: "ssh: connect to host github.com port 22: Operation timed out"}
+	if !git.IsOfflineError(err) {
+		t.Error("IsOfflineError() = false for 'Operation timed out', want true")
 	}
 }
 
 func TestIsOfflineErr_NonOfflineError(t *testing.T) {
 	err := &testError{msg: "permission denied"}
-	if isOfflineErr(err) {
-		t.Error("isOfflineErr() = true for 'permission denied', want false")
+	if git.IsOfflineError(err) {
+		t.Error("IsOfflineError() = true for 'permission denied', want false")
 	}
 }
 
 func TestIsOfflineErr_EmptyMessage(t *testing.T) {
 	err := &testError{msg: ""}
-	if isOfflineErr(err) {
-		t.Error("isOfflineErr() = true for empty message, want false")
+	if git.IsOfflineError(err) {
+		t.Error("IsOfflineError() = true for empty message, want false")
 	}
 }
 

--- a/internal/git/device_id.go
+++ b/internal/git/device_id.go
@@ -1,0 +1,108 @@
+package git
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// deviceIDFile is the name of the file, stored inside the vault directory,
+// that persists this device's stable identity across restarts and network
+// changes. It is intentionally gitignored and excluded from commits: the
+// identity is per-device and must never be replicated to other devices via
+// the shared remote.
+const deviceIDFile = ".device-id"
+
+// UnknownDeviceName is returned by DeviceIdentity when neither a persisted
+// device ID nor a usable hostname is available.
+const UnknownDeviceName = "unknown"
+
+// DeviceIdentity returns the stable identity of the current device. The value
+// is derived once and persisted in the vault directory; later calls return the
+// persisted value so the identity (and the conflict file names derived from
+// it) does not change when the hostname changes — e.g. macOS reports
+// 'MacBook-Pro-von-Daniel-2.local' on one network and
+// 'macbook-pro-von-daniel-2.home' on another. When no vault directory is
+// available (or the ID cannot be stored), a normalised hostname is used
+// instead.
+func DeviceIdentity(vaultDir string) string {
+	hostname, _ := os.Hostname()
+	return deviceIdentity(vaultDir, hostname)
+}
+
+// deviceIdentity is the testable core of DeviceIdentity: the hostname is an
+// explicit parameter so tests can simulate network changes.
+func deviceIdentity(vaultDir, hostname string) string {
+	if vaultDir != "" {
+		if id, err := os.ReadFile(filepath.Join(vaultDir, deviceIDFile)); err == nil {
+			if name := NormalizeDeviceName(strings.TrimSpace(string(id))); name != "" {
+				return name
+			}
+		}
+	}
+	if strings.TrimSpace(hostname) == "" {
+		return UnknownDeviceName
+	}
+	name := NormalizeDeviceName(hostname)
+	if vaultDir != "" {
+		// Persist the identity once so a later hostname change cannot change
+		// the device identity.
+		if err := os.WriteFile(filepath.Join(vaultDir, deviceIDFile), []byte(name), 0o600); err == nil {
+			return name
+		}
+	}
+	return name
+}
+
+// NormalizeDeviceName normalises a hostname into a stable, filesystem-safe
+// device identity: lowercased, with trailing dots and common DNS suffixes
+// (.local, .home, .lan, ...) stripped. Both 'Foo-Bar.local' and
+// 'foo-bar.home' normalise to 'foo-bar'.
+func NormalizeDeviceName(name string) string {
+	name = strings.ToLower(strings.TrimSpace(name))
+	name = strings.TrimSuffix(name, ".")
+	for _, suffix := range []string{".local", ".home", ".lan", ".internal", ".home.arpa"} {
+		name = strings.TrimSuffix(name, suffix)
+	}
+	return name
+}
+
+// renameConflictsForDevice renames pre-existing conflict files whose embedded
+// device name normalises to the current device identity but differs from it
+// (e.g. old hostname-based names), so a single device does not leave duplicate
+// conflict files behind after a hostname change. Best-effort: failures are
+// ignored.
+func renameConflictsForDevice(vaultDir, deviceName string) {
+	canonical := NormalizeDeviceName(deviceName)
+	if canonical == "" || vaultDir == "" {
+		return
+	}
+	_ = filepath.WalkDir(vaultDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		base := d.Name()
+		idx := strings.Index(base, ".conflict-")
+		if idx < 0 {
+			return nil
+		}
+		rest := base[idx+len(".conflict-"):]
+		dot := strings.LastIndex(rest, ".")
+		if dot <= 0 {
+			return nil
+		}
+		embedded := rest[:dot]
+		if NormalizeDeviceName(embedded) != canonical || embedded == deviceName {
+			return nil
+		}
+		newBase := base[:idx] + ".conflict-" + deviceName + rest[dot:]
+		_ = os.Rename(path, filepath.Join(filepath.Dir(path), newBase))
+		return nil
+	})
+}

--- a/internal/git/device_id.go
+++ b/internal/git/device_id.go
@@ -34,7 +34,7 @@ func DeviceIdentity(vaultDir string) string {
 // explicit parameter so tests can simulate network changes.
 func deviceIdentity(vaultDir, hostname string) string {
 	if vaultDir != "" {
-		if id, err := os.ReadFile(filepath.Join(vaultDir, deviceIDFile)); err == nil {
+		if id, err := os.ReadFile(filepath.Join(vaultDir, deviceIDFile)); err == nil { // #nosec G304 -- fixed filename under vaultDir, the trusted vault path from the caller
 			if name := NormalizeDeviceName(strings.TrimSpace(string(id))); name != "" {
 				return name
 			}

--- a/internal/git/device_id.go
+++ b/internal/git/device_id.go
@@ -34,7 +34,8 @@ func DeviceIdentity(vaultDir string) string {
 // explicit parameter so tests can simulate network changes.
 func deviceIdentity(vaultDir, hostname string) string {
 	if vaultDir != "" {
-		if id, err := os.ReadFile(filepath.Join(vaultDir, deviceIDFile)); err == nil { // #nosec G304 -- fixed filename under vaultDir, the trusted vault path from the caller
+		id, err := os.ReadFile(filepath.Join(vaultDir, deviceIDFile)) // #nosec G304 -- fixed filename under vaultDir, the trusted vault path from the caller
+		if err == nil {
 			if name := NormalizeDeviceName(strings.TrimSpace(string(id))); name != "" {
 				return name
 			}

--- a/internal/git/device_id_test.go
+++ b/internal/git/device_id_test.go
@@ -1,0 +1,168 @@
+package git
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestNormalizeDeviceName(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"Foo-Bar.local", "foo-bar"},
+		{"foo-bar.home", "foo-bar"},
+		{"MacBook-Pro-von-Daniel-2.local", "macbook-pro-von-daniel-2"},
+		{"macbook-pro-von-daniel-2.home", "macbook-pro-von-daniel-2"},
+		{"My-Mac.lan", "my-mac"},
+		{"My-Mac.internal", "my-mac"},
+		{"My-Mac.", "my-mac"},
+		{"Already-Normal", "already-normal"},
+		{"ALREADY-UPPER.LOCAL", "already-upper"},
+		{"  padded  ", "padded"},
+	}
+	for _, tc := range cases {
+		if got := NormalizeDeviceName(tc.in); got != tc.want {
+			t.Errorf("NormalizeDeviceName(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestDeviceIdentityPersistsAcrossHostnameChanges(t *testing.T) {
+	dir := t.TempDir()
+
+	// First call on one network: identity derived from the hostname and
+	// persisted in the vault directory.
+	first := deviceIdentity(dir, "Foo-Bar.local")
+	if first != "foo-bar" {
+		t.Fatalf("deviceIdentity() = %q, want %q", first, "foo-bar")
+	}
+
+	// Network change: a different hostname representation must not change the
+	// device identity.
+	if got := deviceIdentity(dir, "macbook-pro-von-daniel-2.home"); got != first {
+		t.Errorf("identity changed after hostname change: %q != %q", got, first)
+	}
+
+	// Restart with a completely different hostname: the persisted ID wins.
+	if got := deviceIdentity(dir, "totally-different-host.example"); got != first {
+		t.Errorf("identity changed after restart: %q != %q", got, first)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, deviceIDFile)); err != nil {
+		t.Errorf("expected persisted device ID file: %v", err)
+	}
+}
+
+func TestDeviceIdentityReadsExistingID(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, deviceIDFile, []byte("my-stable-device"))
+
+	if got := DeviceIdentity(dir); got != "my-stable-device" {
+		t.Errorf("DeviceIdentity() = %q, want %q", got, "my-stable-device")
+	}
+}
+
+func TestDeviceIdentityNoVaultFallsBackToNormalisedHostname(t *testing.T) {
+	// No vault dir available: fall back to a normalised hostname without
+	// persisting anything.
+	got := deviceIdentity("", "Foo-Bar.local")
+	if got != "foo-bar" {
+		t.Errorf("deviceIdentity() = %q, want %q", got, "foo-bar")
+	}
+}
+
+func TestDeviceIdentityEmptyHostname(t *testing.T) {
+	if got := deviceIdentity(t.TempDir(), ""); got != UnknownDeviceName {
+		t.Errorf("deviceIdentity() = %q, want %q", got, UnknownDeviceName)
+	}
+}
+
+// TestConflictFileNameStableAcrossNetworks is the core acceptance test for
+// issue #800: the same machine observed under two different hostname
+// representations must produce the identical conflict file name.
+func TestConflictFileNameStableAcrossNetworks(t *testing.T) {
+	var conflictNames []string
+	for _, host := range []string{"Foo-Bar.local", "foo-bar.home"} {
+		dir := t.TempDir()
+		if err := Init(dir); err != nil {
+			t.Fatalf("Init(%s): %v", host, err)
+		}
+		if err := os.MkdirAll(filepath.Join(dir, "entries"), 0o700); err != nil {
+			t.Fatalf("mkdir entries: %v", err)
+		}
+		writeFile(t, dir, "entries/a.age", []byte("v1"))
+		if err := AutoCommit(dir, "initial"); err != nil {
+			t.Fatalf("AutoCommit(%s): %v", host, err)
+		}
+		writeFile(t, dir, "entries/a.age", []byte("v2"))
+
+		if err := ResolveConflicts(dir, deviceIdentity(dir, host)); err != nil {
+			t.Fatalf("ResolveConflicts(%s): %v", host, err)
+		}
+		entries, err := os.ReadDir(filepath.Join(dir, "entries"))
+		if err != nil {
+			t.Fatalf("read entries: %v", err)
+		}
+		var conflict string
+		for _, e := range entries {
+			if strings.Contains(e.Name(), ".conflict-") {
+				conflict = e.Name()
+			}
+		}
+		if conflict == "" {
+			t.Fatalf("no conflict file created for host %s", host)
+		}
+		conflictNames = append(conflictNames, conflict)
+	}
+
+	if conflictNames[0] != conflictNames[1] {
+		t.Errorf("conflict file names differ across networks: %q vs %q", conflictNames[0], conflictNames[1])
+	}
+}
+
+func TestConflictFilesMigratedToCanonicalDeviceName(t *testing.T) {
+	dir := t.TempDir()
+	if err := Init(dir); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "entries"), 0o700); err != nil {
+		t.Fatalf("mkdir entries: %v", err)
+	}
+	oldName := "old.conflict-MacBook-Pro-von-Daniel-2.local.age"
+	newName := "old.conflict-macbook-pro-von-daniel-2.age"
+	writeFile(t, dir, filepath.Join("entries", oldName), []byte("x"))
+
+	// The current device identity normalises to the same device; the old
+	// hostname-based conflict file must be renamed to the canonical name.
+	if err := ResolveConflicts(dir, "macbook-pro-von-daniel-2"); err != nil {
+		t.Fatalf("ResolveConflicts: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "entries", newName)); err != nil {
+		t.Errorf("expected migrated conflict file %s: %v", newName, err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "entries", oldName)); err == nil {
+		t.Error("old hostname-based conflict file still present after migration")
+	}
+}
+
+func TestConflictMigrationLeavesOtherDevicesAlone(t *testing.T) {
+	dir := t.TempDir()
+	if err := Init(dir); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "entries"), 0o700); err != nil {
+		t.Fatalf("mkdir entries: %v", err)
+	}
+	other := "old.conflict-another-device.age"
+	writeFile(t, dir, filepath.Join("entries", other), []byte("x"))
+
+	if err := ResolveConflicts(dir, "macbook-pro-von-daniel-2"); err != nil {
+		t.Fatalf("ResolveConflicts: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "entries", other)); err != nil {
+		t.Errorf("conflict file of another device should be untouched: %v", err)
+	}
+}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -64,6 +64,7 @@ const DefaultCommitTemplate = "Update from Symaira Vault"
 
 const DefaultGitignoreContent = `# Symaira Vault vault - ignore sensitive files
 identity.age
+.device-id
 *.key
 *.pem
 # Ignore Symaira Vault runtime artifacts
@@ -85,6 +86,8 @@ var protectedRuntimePaths = []string{
 	"mcp-token",
 	"mcp-tokens.json",
 	".runtime-port",
+	// Per-device identity: local only, never replicated via the remote.
+	".device-id",
 }
 
 type Commit struct {

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -248,8 +248,12 @@ func AutoCommitAndPushWithOptions(vaultDir string, opts CommitOptions, autoPush 
 	}
 	if autoPush {
 		result := PushWithResult(vaultDir)
-		if result.Error != nil {
-			if result.Skipped {
+		if result.Error != nil && !result.Skipped {
+			// The local commit is durable; replication to the remote is
+			// best-effort and off the critical path. An unreachable remote
+			// must not fail the vault write — pending commits are drained by
+			// a later push once the remote is reachable again.
+			if IsOfflineError(result.Error) {
 				return nil
 			}
 			return fmt.Errorf("push failed: %w", result.Error)

--- a/internal/git/git_offline.go
+++ b/internal/git/git_offline.go
@@ -1,0 +1,75 @@
+package git
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// pushTimeout bounds a single push attempt so an unreachable remote cannot
+// stall vault writes for minutes (the default OpenSSH connect timeout alone
+// can block for 10-75s per attempt).
+const pushTimeout = 20 * time.Second
+
+// offlineErrorMarkers are substrings that indicate the git remote is
+// unreachable (a connectivity problem), as opposed to a configuration or
+// authentication problem. Matching is case-insensitive.
+var offlineErrorMarkers = []string{
+	// Real-world ssh / net / git error strings (see issue #798).
+	"no route to host",
+	"connection refused",
+	"connection timed out",
+	"operation timed out",
+	"i/o timeout",
+	"no such host",
+	"could not resolve hostname",
+	"name or service not known",
+	"network is unreachable",
+	"host is unreachable",
+	"connection reset by peer",
+	"timed out",
+	"timeout",
+	// Generic markers kept for parity with the previous per-package
+	// classifiers (git_pull.go / internal/cli / cmd/sync).
+	"connection",
+	"refused",
+	"network",
+	"tls",
+	"eof",
+}
+
+// IsOfflineError reports whether err indicates that the git remote is
+// unreachable (offline/network problem) rather than a configuration or
+// authentication problem. It is the single shared offline classifier used
+// by all push and pull call sites.
+func IsOfflineError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	for _, marker := range offlineErrorMarkers {
+		if strings.Contains(msg, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+// pushWithTimeout runs fn and returns an error if it does not complete within
+// timeout. Replication is best-effort: a dead remote must never stall a vault
+// write beyond the bounded window.
+func pushWithTimeout(timeout time.Duration, fn func(context.Context) error) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	done := make(chan error, 1)
+	go func() {
+		done <- fn(ctx)
+	}()
+	select {
+	case err := <-done:
+		return err
+	case <-ctx.Done():
+		return fmt.Errorf("push timed out after %s", timeout)
+	}
+}

--- a/internal/git/git_offline_test.go
+++ b/internal/git/git_offline_test.go
@@ -70,16 +70,18 @@ func TestPushWithTimeoutReturnsUnderlyingError(t *testing.T) {
 }
 
 func TestPushWithTimeoutAllowsContextCancellation(t *testing.T) {
-	cancelled := false
+	observed := make(chan struct{})
 	err := pushWithTimeout(100*time.Millisecond, func(ctx context.Context) error {
 		<-ctx.Done()
-		cancelled = true
+		close(observed)
 		return ctx.Err()
 	})
 	if err == nil || !strings.Contains(err.Error(), "timed out") {
 		t.Fatalf("expected timeout error, got: %v", err)
 	}
-	if !cancelled {
+	select {
+	case <-observed:
+	case <-time.After(2 * time.Second):
 		t.Error("expected push function to observe context cancellation")
 	}
 }

--- a/internal/git/git_offline_test.go
+++ b/internal/git/git_offline_test.go
@@ -1,0 +1,85 @@
+package git
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestIsOfflineError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"ssh operation timed out", errors.New("ssh: connect to host github.com port 22: Operation timed out"), true},
+		{"connection refused", errors.New("dial tcp 127.0.0.1:1: connect: connection refused"), true},
+		{"no route to host", errors.New("dial tcp: no route to host"), true},
+		{"connection timed out", errors.New("dial tcp: connection timed out"), true},
+		{"i/o timeout", errors.New("dial tcp: i/o timeout"), true},
+		{"no such host", errors.New("dial tcp: lookup github.com: no such host"), true},
+		{"could not resolve hostname", errors.New("ssh: Could not resolve hostname github.com: nodename nor servname provided"), true},
+		{"name or service not known", errors.New("ssh: connect to host github.com port 22: Name or service not known"), true},
+		{"network unreachable", errors.New("connect: network is unreachable"), true},
+		{"push timed out", errors.New("push timed out after 20s"), true},
+		{"generic network", errors.New("network error - please check your connection"), true},
+		{"wrapped push error", &PushError{Message: "network error - please check your connection", Cause: errors.New("connection refused")}, true},
+		{"permission denied", errors.New("permission denied"), false},
+		{"authentication failed", errors.New("authentication failed: invalid credentials"), false},
+		{"repository not found", errors.New("repository not found"), false},
+		{"empty message", errors.New(""), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsOfflineError(tc.err); got != tc.want {
+				t.Errorf("IsOfflineError(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPushWithTimeoutBoundsSlowPush(t *testing.T) {
+	start := time.Now()
+	err := pushWithTimeout(100*time.Millisecond, func(ctx context.Context) error {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(5 * time.Second):
+			return nil
+		}
+	})
+	if err == nil || !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("expected timeout error, got: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 3*time.Second {
+		t.Fatalf("push with timeout took too long: %v", elapsed)
+	}
+}
+
+func TestPushWithTimeoutReturnsUnderlyingError(t *testing.T) {
+	want := errors.New("boom")
+	err := pushWithTimeout(time.Second, func(context.Context) error {
+		return want
+	})
+	if !errors.Is(err, want) {
+		t.Fatalf("expected underlying error, got: %v", err)
+	}
+}
+
+func TestPushWithTimeoutAllowsContextCancellation(t *testing.T) {
+	cancelled := false
+	err := pushWithTimeout(100*time.Millisecond, func(ctx context.Context) error {
+		<-ctx.Done()
+		cancelled = true
+		return ctx.Err()
+	})
+	if err == nil || !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("expected timeout error, got: %v", err)
+	}
+	if !cancelled {
+		t.Error("expected push function to observe context cancellation")
+	}
+}

--- a/internal/git/git_pull.go
+++ b/internal/git/git_pull.go
@@ -80,7 +80,7 @@ func PullWithResult(vaultDir string) PullResult {
 		return result
 	}
 
-	if isOfflineError(pullErr) {
+	if IsOfflineError(pullErr) {
 		result.Error = &PushError{
 			Message: "network error - please check your connection",
 			Cause:   pullErr,
@@ -210,17 +210,6 @@ func ShouldAutoPull(vaultDir string, interval time.Duration) bool {
 		return true
 	}
 	return time.Since(t) > interval
-}
-
-func isOfflineError(err error) bool {
-	errStr := err.Error()
-	return strings.Contains(errStr, "connection") ||
-		strings.Contains(errStr, "timeout") ||
-		strings.Contains(errStr, "refused") ||
-		strings.Contains(errStr, "no such host") ||
-		strings.Contains(errStr, "network") ||
-		strings.Contains(errStr, "TLS") ||
-		strings.Contains(errStr, "EOF")
 }
 
 func copyFile(src, dst string) error {

--- a/internal/git/git_pull.go
+++ b/internal/git/git_pull.go
@@ -98,11 +98,8 @@ func PullWithResult(vaultDir string) PullResult {
 		return result
 	}
 
-	hostname, _ := os.Hostname()
-	if hostname == "" {
-		hostname = "unknown"
-	}
-	resolveErr := ResolveConflicts(vaultDir, hostname)
+	deviceName := DeviceIdentity(vaultDir)
+	resolveErr := ResolveConflicts(vaultDir, deviceName)
 	if resolveErr == nil {
 		w2, wtErr := repo.Worktree()
 		if wtErr == nil {
@@ -139,7 +136,10 @@ func Sync(vaultDir string, pushAfter bool) SyncResult {
 }
 
 // ResolveConflicts handles conflicts after a pull.
-func ResolveConflicts(vaultDir string, hostname string) error {
+func ResolveConflicts(vaultDir string, deviceName string) error {
+	// Migrate conflict files that were created under an older hostname-based
+	// name of this device so a single device does not leave duplicates behind.
+	renameConflictsForDevice(vaultDir, deviceName)
 	repo, err := openRepo(vaultDir)
 	if err != nil {
 		return nil
@@ -168,7 +168,7 @@ func ResolveConflicts(vaultDir string, hostname string) error {
 		}
 		ext := filepath.Ext(path)
 		base := strings.TrimSuffix(path, ext)
-		conflictName := fmt.Sprintf("%s.conflict-%s%s", base, hostname, ext)
+		conflictName := fmt.Sprintf("%s.conflict-%s%s", base, deviceName, ext)
 		conflictPath := filepath.Join(vaultDir, conflictName)
 		if err := copyFile(fullPath, conflictPath); err != nil {
 			return fmt.Errorf("save conflict file %s: %w", conflictName, err)

--- a/internal/git/git_push.go
+++ b/internal/git/git_push.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -39,9 +40,9 @@ func systemGitAvailable() bool {
 	return err == nil
 }
 
-func pushWithSystemGit(vaultDir string) error {
+func pushWithSystemGit(ctx context.Context, vaultDir string) error {
 	var stderr strings.Builder
-	cmd := exec.Command("git", "-C", vaultDir, "push", "origin", "HEAD")
+	cmd := exec.CommandContext(ctx, "git", "-C", vaultDir, "push", "origin", "HEAD")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = &stderr
 	cmd.Stdin = os.Stdin
@@ -102,7 +103,9 @@ func PushWithResult(vaultDir string) PushResult {
 	// For SSH remotes, prefer the user's system git/OpenSSH setup so that
 	// ~/.ssh/config, the SSH agent, and known_hosts behave exactly like normal git.
 	if isSSHURL(remoteURL) && systemGitAvailable() {
-		sysErr := pushWithSystemGit(vaultDir)
+		sysErr := pushWithTimeout(pushTimeout, func(ctx context.Context) error {
+			return pushWithSystemGit(ctx, vaultDir)
+		})
 		if sysErr == nil {
 			result.Success = true
 			return result
@@ -117,7 +120,9 @@ func PushWithResult(vaultDir string) PushResult {
 		return result
 	}
 
-	err = pushWithSSHAuth(repo, remoteURL)
+	err = pushWithTimeout(pushTimeout, func(context.Context) error {
+		return pushWithSSHAuth(repo, remoteURL)
+	})
 	if err == nil {
 		result.Success = true
 		return result
@@ -160,9 +165,7 @@ func classifyPushError(err error) *PushError {
 			Message: "authentication failed - please check your credentials",
 			Cause:   err,
 		}
-	case strings.Contains(errStr, "connection"),
-		strings.Contains(errStr, "timeout"),
-		strings.Contains(errStr, "refused"):
+	case IsOfflineError(err):
 		return &PushError{
 			Message: "network error - please check your connection",
 			Cause:   err,

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1755,7 +1755,7 @@ func TestUnstageProtectedRuntimeArtifactsNoHead(t *testing.T) {
 	}
 }
 
-func TestAutoCommitAndPushPushErrorNotSkipped(t *testing.T) {
+func TestAutoCommitAndPushUnreachableRemoteDoesNotFailWrite(t *testing.T) {
 	local := t.TempDir()
 	if err := Init(local); err != nil {
 		t.Fatalf("Init(local): %v", err)
@@ -1766,15 +1766,33 @@ func TestAutoCommitAndPushPushErrorNotSkipped(t *testing.T) {
 		t.Fatalf("open local: %v", err)
 	}
 
+	// Unreachable remote: connection to a closed local port is refused.
 	if _, err := repo.CreateRemote(&config.RemoteConfig{Name: "origin", URLs: []string{"http://127.0.0.1:1/repo.git"}}); err != nil {
 		t.Fatalf("CreateRemote(): %v", err)
 	}
 
 	writeFile(t, local, "f.txt", []byte("hello"))
 
-	err = AutoCommitAndPush(local, "test push", true)
-	if err == nil {
-		t.Error("AutoCommitAndPush should return error when push fails and is not skipped")
+	// The local commit is durable; an unreachable remote must not fail the
+	// vault write (push is best-effort replication off the critical path).
+	if err := AutoCommitAndPush(local, "test push", true); err != nil {
+		t.Fatalf("AutoCommitAndPush with unreachable remote should not fail the write: %v", err)
+	}
+
+	// The commit must exist locally despite the failed push.
+	ref, err := repo.Head()
+	if err != nil {
+		t.Fatalf("repo.Head(): %v", err)
+	}
+	commit, err := repo.CommitObject(ref.Hash())
+	if err != nil {
+		t.Fatalf("CommitObject(): %v", err)
+	}
+	if commit == nil {
+		t.Fatal("expected commit to be created")
+	}
+	if _, err := commit.File("f.txt"); err != nil {
+		t.Fatalf("expected f.txt in commit: %v", err)
 	}
 }
 

--- a/internal/vault/autocommit_test.go
+++ b/internal/vault/autocommit_test.go
@@ -1,0 +1,106 @@
+package vault
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	gogit "github.com/go-git/go-git/v5"
+
+	"github.com/danieljustus/symaira-vault/internal/git"
+	"github.com/danieljustus/symaira-vault/internal/testutil"
+)
+
+// TestAutoCommitEntryCommitsManifestWithEntry verifies that an entry write +
+// auto-commit captures both the entry and manifest.age in the same commit, so
+// committed history is internally consistent and the manifest never drifts
+// (issue #799 — previously manifest.age stayed permanently dirty, causing
+// false tamper alarms in doctor).
+func TestAutoCommitEntryCommitsManifestWithEntry(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows: manifest uses cgo age crypto")
+	}
+	vaultDir := t.TempDir()
+	id := testutil.TempIdentity(t)
+	if _, err := InitWithPassphrase(vaultDir, []byte("test-passphrase"), testConfig(vaultDir)); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	if err := git.Init(vaultDir); err != nil {
+		t.Fatalf("git init: %v", err)
+	}
+	v := &Vault{Dir: vaultDir, Identity: id, Config: testConfig(vaultDir)}
+
+	// Entry write + auto-commit (the real write path used by CRUD commands).
+	if err := WriteEntry(vaultDir, "alpha", &Entry{Data: map[string]any{"user": "alice"}}, id); err != nil {
+		t.Fatalf("write entry: %v", err)
+	}
+	if err := v.AutoCommitEntry("Update alpha", "alpha"); err != nil {
+		t.Fatalf("AutoCommitEntry: %v", err)
+	}
+
+	repo, err := gogit.PlainOpen(vaultDir)
+	if err != nil {
+		t.Fatalf("open repo: %v", err)
+	}
+	ref, err := repo.Head()
+	if err != nil {
+		t.Fatalf("repo.Head(): %v", err)
+	}
+	commit, err := repo.CommitObject(ref.Hash())
+	if err != nil {
+		t.Fatalf("CommitObject(): %v", err)
+	}
+
+	// Both the entry and the manifest must be part of the SAME commit.
+	if _, err := commit.File("entries/alpha.age"); err != nil {
+		t.Fatalf("commit missing entries/alpha.age: %v", err)
+	}
+	manifestFile, err := commit.File(manifestFileName)
+	if err != nil {
+		t.Fatalf("commit missing manifest.age: %v", err)
+	}
+
+	// The committed manifest must match what is on disk (no drift).
+	committedManifest, err := manifestFile.Contents()
+	if err != nil {
+		t.Fatalf("read committed manifest: %v", err)
+	}
+	diskManifest, err := os.ReadFile(filepath.Join(vaultDir, manifestFileName))
+	if err != nil {
+		t.Fatalf("read manifest on disk: %v", err)
+	}
+	if committedManifest != string(diskManifest) {
+		t.Error("committed manifest.age differs from manifest.age on disk")
+	}
+
+	// No leftover dirty state after the auto-commit.
+	w, err := repo.Worktree()
+	if err != nil {
+		t.Fatalf("worktree: %v", err)
+	}
+	status, err := w.Status()
+	if err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	// Note: status.File() would insert a fake Untracked entry for clean files,
+	// so check the map directly.
+	if fs, ok := status[manifestFileName]; ok && (fs.Worktree != gogit.Unmodified || fs.Staging != gogit.Unmodified) {
+		t.Errorf("manifest.age dirty after auto-commit: %+v", fs)
+	}
+	if fs, ok := status["entries/alpha.age"]; ok && fs.Worktree != gogit.Unmodified {
+		t.Errorf("entries/alpha.age dirty after auto-commit: %+v", fs)
+	}
+
+	// A doctor-style integrity check must not flag the written entry as tampered.
+	result, err := VerifyManifestIntegrity(vaultDir, id)
+	if err != nil {
+		t.Fatalf("VerifyManifestIntegrity: %v", err)
+	}
+	if len(result.Tampered) > 0 {
+		t.Errorf("manifest flagged tampered entries after a normal write: %v", result.Tampered)
+	}
+	if len(result.Missing) > 0 {
+		t.Errorf("manifest reports missing entries after a normal write: %v", result.Missing)
+	}
+}

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -487,7 +487,12 @@ func (v *Vault) AutoCommitEntry(message, path string) error {
 	if err != nil {
 		return err
 	}
-	return v.AutoCommitPaths(message, filepath.ToSlash(relPath))
+	// The entry write also rewrites manifest.age. Flush any pending (debounced)
+	// manifest updates and commit both files together so the committed tree is
+	// internally consistent and the manifest never drifts (which would trigger
+	// false tamper alarms in doctor).
+	FlushManifestUpdates()
+	return v.AutoCommitPaths(message, filepath.ToSlash(relPath), manifestAgeName)
 }
 
 func (v *Vault) AutoCommitPaths(message string, affectedPaths ...string) error {


### PR DESCRIPTION
Implements three git-sync defects:

## #798 — Auto-push to an unreachable remote fails the whole vault write
- Auto-push is now best-effort: a push failure against an unreachable remote after a successful local commit is no longer surfaced as a write error.
- Push is bounded by a 20s timeout (exec.CommandContext + wrapper) so a dead remote cannot stall writes for 10-75s.
- The three duplicated/inconsistent offline-error classifiers are replaced by one shared git.IsOfflineError, covering the real ssh errors (Operation timed out, connection refused, no route to host, connection timed out, i/o timeout, no such host, ...).

## #799 — Auto-commit stages only the entry path, leaving manifest.age uncommitted
- AutoCommitEntry now flushes pending manifest updates and stages manifest.age together with the entry path, so a write's commit is internally consistent and doctor no longer reports false tamper alarms.
- Regression test: entry write + auto-commit asserts manifest.age is committed with the entry.

## #800 — Conflict files are named from the raw hostname
- New git.DeviceIdentity helper: stable persisted device ID stored in the vault dir (.device-id, gitignored and excluded from commits), generated once, with a normalized-hostname fallback (lowercased, DNS suffixes .local/.home/.lan stripped).
- All five os.Hostname() call sites (git_pull, cli sync, cmd sync, cmd device x2) now use the shared helper.
- Existing conflict files whose names normalize to the same device are migrated (renamed) so duplicate identities on disk are collapsed.
- Tests cover both hostname variants feeding the same identity and the persistence of the device ID.

## Verification
- go build ./... (pass), go vet ./... (pass), scoped go test (git/vault/cli/cmd) (pass), make lint 0 issues
- One pre-existing environmental failure (TestAutoCommitWithOptionsDefaultAuthor) fails identically at the base SHA on this machine (developer git config leaks into the test via cwd); not caused by this change, CI unaffected.

Closes #798
Closes #799
Closes #800
