### PR TITLE
fix(audit): hermetic test keyring, honest doctor keyring checks, rotate-key bootstrap

### DIFF
--- a/beta_smoke_test.go
+++ b/beta_smoke_test.go
@@ -37,6 +37,9 @@ func TestBetaSmokeFlow(t *testing.T) {
 		// synthetic passphrase. Production stays default-deny without this opt-in.
 		"SYMVAULT_ALLOW_ENV_PASSPHRASE=1",
 		"SYMVAULT_PASSPHRASE="+passphrase,
+		// Test binaries must never touch the developer's real OS keychain
+		// (issue #801): force the in-memory keyring in the child binary too.
+		"SYMVAULT_TEST_KEYRING=memory",
 	)
 	if output, err := initCmd.CombinedOutput(); err != nil {
 		t.Fatalf("init vault: %v\n%s", err, output)
@@ -51,6 +54,7 @@ func TestBetaSmokeFlow(t *testing.T) {
 			"GOWORK=off",
 			"SYMVAULT_ALLOW_ENV_PASSPHRASE=1",
 			"SYMVAULT_PASSPHRASE="+passphrase,
+			"SYMVAULT_TEST_KEYRING=memory",
 		)
 		output, err := cmd.Output()
 		if err != nil {

--- a/cmd/admin/audit.go
+++ b/cmd/admin/audit.go
@@ -82,8 +82,13 @@ func newRotateKeyCmd() *cobra.Command {
 		Short: "Rotate the audit log HMAC key",
 		Long: `Generate a new HMAC key for audit log integrity and archive the current key.
 
-The old key is archived to a timestamped file (audit-hmac-key.rotated.YYYY-MM-DD)
-in the vault directory. A new audit log file is started with the new key.`,
+The old key is archived to a file named after its fingerprint
+(audit-hmac-key.rotated.<fingerprint>) in the vault directory. A new audit
+log file is started with the new key.
+
+If no HMAC key exists yet, a new key is created instead (bootstrap): nothing
+is archived and the command reports that it bootstrapped rather than
+rotated.`,
 		Annotations: map[string]string{
 			cli.RequiresVaultAnnotation: "true",
 		},
@@ -99,9 +104,13 @@ in the vault directory. A new audit log file is started with the new key.`,
 				return fmt.Errorf("rotate HMAC key: %w", err)
 			}
 
-			cmd.Printf("HMAC key rotated successfully.\n")
 			cmd.Printf("New key: %x (first 4 bytes)\n", newKey[:4])
-			cmd.Printf("Old key archived to: %s\n", archivePath)
+			if archivePath == "" {
+				cmd.Printf("HMAC key bootstrapped — no previous key existed, so no archive file was written.\n")
+			} else {
+				cmd.Printf("HMAC key rotated successfully.\n")
+				cmd.Printf("Old key archived to: %s\n", archivePath)
+			}
 			cmd.Printf("A new audit log will be started on the next audit write.\n")
 			return nil
 		},

--- a/cmd/binary_e2e_test.go
+++ b/cmd/binary_e2e_test.go
@@ -48,6 +48,9 @@ func TestBinaryE2E_Flow(t *testing.T) {
 	env := []string{
 		"GOWORK=off",
 		"SYMVAULT_PASSPHRASE=" + string(passphrase),
+		// Test binaries must never touch the developer's real OS keychain
+		// (issue #801): force the in-memory keyring in the child binary too.
+		"SYMVAULT_TEST_KEYRING=memory",
 	}
 
 	initCmd := exec.Command(binPath, "init", vaultDir)
@@ -85,6 +88,50 @@ func TestBinaryE2E_Flow(t *testing.T) {
 	_ = runBin(t, binPath, env, "y\n", "--vault", vaultDir, "delete", "gen.pass")
 }
 
+func TestBinaryE2E_AuditRotateKeyBootstraps(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping slow binary e2e test in short mode")
+	}
+	binPath := buildBinary(t)
+	vaultDir := t.TempDir()
+	passphrase := []byte("correct horse battery staple")
+	env := []string{
+		"GOWORK=off",
+		"SYMVAULT_PASSPHRASE=" + string(passphrase),
+		"SYMVAULT_TEST_KEYRING=memory",
+	}
+
+	initCmd := exec.Command(binPath, "init", vaultDir)
+	initCmd.Env = append(os.Environ(), env...)
+	initCmd.Stdin = strings.NewReader(string(passphrase) + "\n")
+	if output, err := initCmd.CombinedOutput(); err != nil {
+		t.Fatalf("init: %v\n%s", err, output)
+	}
+
+	// Issue #803: rotating a vault that has no HMAC key yet must succeed
+	// (bootstrap) instead of erroring, must report that it bootstrapped, and
+	// must not write an archive file. Informational output is routed to
+	// stderr when stdin is not a terminal, so capture both streams.
+	stdout, stderr, exitCode := runBinResult(t, binPath, env, "--vault", vaultDir, "audit", "rotate-key")
+	if exitCode != 0 {
+		t.Fatalf("rotate-key exit code = %d, want 0\nstderr: %s", exitCode, stderr)
+	}
+	combined := stdout + stderr
+	if !strings.Contains(combined, "bootstrapped") {
+		t.Errorf("rotate-key output should report bootstrap, got stdout=%q stderr=%q", stdout, stderr)
+	}
+	if strings.Contains(combined, "archived") {
+		t.Errorf("bootstrap output should not mention archiving, got: %s", combined)
+	}
+	matches, err := filepath.Glob(filepath.Join(vaultDir, "audit-hmac-key.rotated.*"))
+	if err != nil {
+		t.Fatalf("glob archive files: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Errorf("bootstrap must not write archive files, got %v", matches)
+	}
+}
+
 func TestBinaryE2E_Recipients(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping slow binary e2e test in short mode")
@@ -95,6 +142,7 @@ func TestBinaryE2E_Recipients(t *testing.T) {
 	env := []string{
 		"GOWORK=off",
 		"SYMVAULT_PASSPHRASE=" + string(passphrase),
+		"SYMVAULT_TEST_KEYRING=memory",
 	}
 
 	initCmd := exec.Command(binPath, "init", vaultDir)

--- a/cmd/scripting_contract_test.go
+++ b/cmd/scripting_contract_test.go
@@ -35,6 +35,9 @@ func buildAndInitVault(t *testing.T) (string, string, []string) {
 	env := []string{
 		"GOWORK=off",
 		"SYMVAULT_PASSPHRASE=" + passphrase,
+		// Test binaries must never touch the developer's real OS keychain
+		// (issue #801): force the in-memory keyring in the child binary too.
+		"SYMVAULT_TEST_KEYRING=memory",
 	}
 
 	initCmd := exec.Command(binPath, "init", vaultDir)
@@ -76,16 +79,16 @@ func TestScriptingGet_Locked_NoPassphrase(t *testing.T) {
 	passphrase := "correct horse battery staple"
 
 	initCmd := exec.Command(binPath, "init", vaultDir)
-	initCmd.Env = append(os.Environ(), "GOWORK=off", "SYMVAULT_PASSPHRASE="+passphrase)
+	initCmd.Env = append(os.Environ(), "GOWORK=off", "SYMVAULT_PASSPHRASE="+passphrase, "SYMVAULT_TEST_KEYRING=memory")
 	initCmd.Stdin = strings.NewReader(passphrase + "\n")
 	if output, err := initCmd.CombinedOutput(); err != nil {
 		t.Fatalf("init: %v\n%s", err, output)
 	}
 
-	setEnv := []string{"GOWORK=off", "SYMVAULT_PASSPHRASE=" + passphrase}
+	setEnv := []string{"GOWORK=off", "SYMVAULT_PASSPHRASE=" + passphrase, "SYMVAULT_TEST_KEYRING=memory"}
 	_ = runBin(t, binPath, setEnv, "", "--vault", vaultDir, "set", "secret.key", "--value", "mysecret")
 
-	lockedEnv := []string{"GOWORK=off"}
+	lockedEnv := []string{"GOWORK=off", "SYMVAULT_TEST_KEYRING=memory"}
 	stdout, stderr, exitCode := runBinResult(t, binPath, lockedEnv, "--vault", vaultDir, "get", "secret.key", "--print")
 	if exitCode != 4 {
 		t.Errorf("locked get exit code = %d, want 4 (ExitLocked)", exitCode)
@@ -141,13 +144,13 @@ func TestScriptingGet_NoHangOnLocked(t *testing.T) {
 	passphrase := "correct horse battery staple"
 
 	initCmd := exec.Command(binPath, "init", vaultDir)
-	initCmd.Env = append(os.Environ(), "GOWORK=off", "SYMVAULT_PASSPHRASE="+passphrase)
+	initCmd.Env = append(os.Environ(), "GOWORK=off", "SYMVAULT_PASSPHRASE="+passphrase, "SYMVAULT_TEST_KEYRING=memory")
 	initCmd.Stdin = strings.NewReader(passphrase + "\n")
 	if output, err := initCmd.CombinedOutput(); err != nil {
 		t.Fatalf("init: %v\n%s", err, output)
 	}
 
-	lockedEnv := []string{"GOWORK=off"}
+	lockedEnv := []string{"GOWORK=off", "SYMVAULT_TEST_KEYRING=memory"}
 	cmd := exec.Command(binPath, "--vault", vaultDir, "get", "anything", "--print")
 	cmd.Env = append(os.Environ(), lockedEnv...)
 	cmd.Stdin = strings.NewReader("")

--- a/internal/audit/audit_hmac_test.go
+++ b/internal/audit/audit_hmac_test.go
@@ -109,7 +109,7 @@ func TestHMACTamperedEntryDetected(t *testing.T) {
 	}
 
 	auditDir := filepath.Join(home, configpkg.DefaultVaultSubdir)
-	ks := NewKeystore(auditDir, nil)
+	ks := newTestKeystore(t, auditDir)
 	key, err := ks.LoadHMACKey()
 	if err != nil {
 		t.Fatalf("LoadHMACKey() error = %v", err)
@@ -435,7 +435,7 @@ func TestHMACInsertedLegacyRecord(t *testing.T) {
 	}
 
 	auditDir := filepath.Join(home, configpkg.DefaultVaultSubdir)
-	ks := NewKeystore(auditDir, nil)
+	ks := newTestKeystore(t, auditDir)
 	key, err := ks.LoadHMACKey()
 	if err != nil {
 		t.Fatalf("LoadHMACKey() error = %v", err)
@@ -502,7 +502,7 @@ func TestHMACTrailingLegacyRecord(t *testing.T) {
 	}
 
 	auditDir := filepath.Join(home, configpkg.DefaultVaultSubdir)
-	ks := NewKeystore(auditDir, nil)
+	ks := newTestKeystore(t, auditDir)
 	key, err := ks.LoadHMACKey()
 	if err != nil {
 		t.Fatalf("LoadHMACKey() error = %v", err)

--- a/internal/audit/export_test.go
+++ b/internal/audit/export_test.go
@@ -6,11 +6,30 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/zalando/go-keyring"
 )
+
+// newTestKeystore builds a Keystore for a temp audit dir and registers a
+// cleanup that deletes any OS keyring entry the test may have created for
+// it. Test binaries run against the in-memory fallback, so the delete is a
+// no-op there; it is the second line of defense for any test that
+// legitimately exercises the OS keyring path (issue #801) — a stray write
+// must never leave a permanent entry in the developer's real keychain.
+func newTestKeystore(t *testing.T, dir string) Keystore {
+	t.Helper()
+	t.Cleanup(func() {
+		if err := keyring.Delete(keyringService, keyringAccount(dir)); err != nil && !errors.Is(err, keyring.ErrNotFound) {
+			t.Logf("cleanup: delete keyring entry for %s: %v", dir, err)
+		}
+	})
+	return NewKeystore(dir, nil)
+}
 
 func writeTestLog(t *testing.T, dir string, entries []LogEntry) {
 	t.Helper()

--- a/internal/audit/keystore_fallback.go
+++ b/internal/audit/keystore_fallback.go
@@ -197,12 +197,36 @@ func (k *fallbackKeystore) LoadHMACKey() ([]byte, error) {
 // RotateKey generates a new HMAC key, archives the existing key file to a
 // backup named after the old key's fingerprint (so repeated rotations never
 // collide), and writes the new key to the key file.
+//
+// When no HMAC key exists yet, it bootstraps: a fresh key is generated and
+// stored, no archive file is written (there is nothing to archive), and the
+// returned archivePath is empty so callers can tell bootstrap from rotation.
+// A key that exists but cannot be read (corrupt data, permission problems)
+// is NOT treated as "no key" — such errors still fail the rotation.
 func (k *fallbackKeystore) RotateKey() ([]byte, string, error) {
 	keyPath := filepath.Join(k.auditDir, hmacKeyFileName)
 
 	oldKey, err := k.LoadHMACKey()
 	if err != nil {
-		return nil, "", fmt.Errorf("load existing key for rotation: %w", err)
+		if !IsHMACKeyNotFound(err) {
+			return nil, "", fmt.Errorf("load existing key for rotation: %w", err)
+		}
+
+		// No key stored yet: bootstrap a fresh one instead of rotating.
+		newKey := make([]byte, hmacKeySize)
+		if _, err := io.ReadFull(rand.Reader, newKey); err != nil {
+			return nil, "", fmt.Errorf("generate new HMAC key: %w", err)
+		}
+		if k.identity != nil {
+			if err := vaultcrypto.SaveEncryptedKey(keyPath, newKey, k.identity); err != nil {
+				return nil, "", fmt.Errorf("write encrypted HMAC key: %w", err)
+			}
+		} else {
+			if err := k.saveLocallyEncrypted(keyPath, newKey); err != nil {
+				return nil, "", fmt.Errorf("write locally-encrypted HMAC key: %w", err)
+			}
+		}
+		return newKey, "", nil
 	}
 
 	archivePath := RotateKeyArchivePath(k.auditDir, oldKey)
@@ -249,6 +273,14 @@ func (k *fallbackKeystore) LoadArchivedKeys() (map[string][]byte, error) {
 		keys[KeyFingerprint(key)] = key
 	}
 	return keys, nil
+}
+
+// IsHMACKeyNotFound reports whether err means "no HMAC key is stored yet"
+// (as opposed to a stored key that cannot be read). RotateKey uses it to
+// bootstrap when no key exists while still failing on corrupt or unreadable
+// keys. On file-based platforms not-found is a missing key file.
+func IsHMACKeyNotFound(err error) bool {
+	return errors.Is(err, os.ErrNotExist) || errors.Is(err, vaultcrypto.ErrKeyFileNotFound)
 }
 
 // NewKeystore creates a fallbackKeystore on platforms without OS keyring support.

--- a/internal/audit/keystore_os.go
+++ b/internal/audit/keystore_os.go
@@ -39,18 +39,25 @@ type memoryKeyring struct {
 	store map[string]string
 }
 
+// errMemoryKeyringNotFound is returned by the in-memory fallback store when
+// no entry exists. It is a package sentinel so callers can distinguish "no
+// key stored yet" from real keyring failures even when the fallback is
+// active (test binaries, CI, or a tripped fallback) — IsHMACKeyNotFound
+// treats it the same as the OS keyring's ErrNotFound.
+var errMemoryKeyringNotFound = errors.New("audit: HMAC key not found in keyring")
+
 func (m *memoryKeyring) Get(service, account string) (string, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
 	if m.store == nil {
-		return "", errors.New("not found")
+		return "", errMemoryKeyringNotFound
 	}
 
 	key := service + "|" + account
 	val, ok := m.store[key]
 	if !ok {
-		return "", errors.New("not found")
+		return "", errMemoryKeyringNotFound
 	}
 	return val, nil
 }
@@ -157,28 +164,28 @@ func keyringGetWithTimeout(service, account string) (string, error) {
 	}
 }
 
-func (k *osKeystore) setWithFallback(service, account, value string) error {
+func (k *osKeystore) setWithFallback(account, value string) error {
 	if isFallbackActive() {
-		return getFallback().Set(service, account, value)
+		return getFallback().Set(keyringService, account, value)
 	}
 
-	if err := keyringSetWithTimeout(service, account, value); err != nil {
-		return getFallback().Set(service, account, value)
+	if err := keyringSetWithTimeout(keyringService, account, value); err != nil {
+		return getFallback().Set(keyringService, account, value)
 	}
 	return nil
 }
 
-func (k *osKeystore) getWithFallback(service, account string) (string, error) {
+func (k *osKeystore) getWithFallback(account string) (string, error) {
 	if isFallbackActive() {
-		return getFallback().Get(service, account)
+		return getFallback().Get(keyringService, account)
 	}
 
-	val, err := keyringGetWithTimeout(service, account)
+	val, err := keyringGetWithTimeout(keyringService, account)
 	if err != nil {
 		if errors.Is(err, keyring.ErrNotFound) {
 			return "", err
 		}
-		return getFallback().Get(service, account)
+		return getFallback().Get(keyringService, account)
 	}
 	return val, nil
 }
@@ -198,7 +205,7 @@ func (k *osKeystore) LoadOrCreateHMACKey() ([]byte, error) {
 
 	account := keyringAccount(k.auditDir)
 	hexKey := hex.EncodeToString(hmacKey)
-	if err := k.setWithFallback(keyringService, account, hexKey); err != nil {
+	if err := k.setWithFallback(account, hexKey); err != nil {
 		return nil, fmt.Errorf("store HMAC key in keyring: %w", err)
 	}
 
@@ -212,7 +219,7 @@ func (k *osKeystore) LoadOrCreateHMACKey() ([]byte, error) {
 func (k *osKeystore) LoadHMACKey() ([]byte, error) {
 	account := keyringAccount(k.auditDir)
 
-	hexKey, err := k.getWithFallback(keyringService, account)
+	hexKey, err := k.getWithFallback(account)
 	if err == nil {
 		return hex.DecodeString(hexKey)
 	}
@@ -227,7 +234,7 @@ func (k *osKeystore) LoadHMACKey() ([]byte, error) {
 	}
 
 	hexKeyStr := hex.EncodeToString(data)
-	if storeErr := k.setWithFallback(keyringService, account, hexKeyStr); storeErr == nil {
+	if storeErr := k.setWithFallback(account, hexKeyStr); storeErr == nil {
 		_ = os.Remove(keyPath)
 	}
 
@@ -238,10 +245,32 @@ func (k *osKeystore) LoadHMACKey() ([]byte, error) {
 // hex-encoded file in the audit directory (named after the old key's
 // fingerprint so repeated rotations never collide), and stores the new key
 // in the OS keyring (with memory fallback).
+//
+// When no HMAC key exists yet, it bootstraps: a fresh key is generated and
+// stored, no archive file is written (there is nothing to archive), and the
+// returned archivePath is empty so callers can tell bootstrap from rotation.
+// A key that exists but cannot be read (corrupt hex, permission problems)
+// is NOT treated as "no key" — such errors still fail the rotation.
 func (k *osKeystore) RotateKey() ([]byte, string, error) {
 	oldKey, err := k.LoadHMACKey()
 	if err != nil {
-		return nil, "", fmt.Errorf("load existing key for rotation: %w", err)
+		if !IsHMACKeyNotFound(err) {
+			return nil, "", fmt.Errorf("load existing key for rotation: %w", err)
+		}
+
+		// No key stored yet: bootstrap a fresh one instead of rotating.
+		newKey := make([]byte, hmacKeySize)
+		if _, err := io.ReadFull(rand.Reader, newKey); err != nil {
+			return nil, "", fmt.Errorf("generate new HMAC key: %w", err)
+		}
+
+		account := keyringAccount(k.auditDir)
+		hexNew := hex.EncodeToString(newKey)
+		if err := k.setWithFallback(account, hexNew); err != nil {
+			return nil, "", fmt.Errorf("store new HMAC key in keyring: %w", err)
+		}
+
+		return newKey, "", nil
 	}
 
 	archivePath := RotateKeyArchivePath(k.auditDir, oldKey)
@@ -257,7 +286,7 @@ func (k *osKeystore) RotateKey() ([]byte, string, error) {
 
 	account := keyringAccount(k.auditDir)
 	hexNew := hex.EncodeToString(newKey)
-	if err := k.setWithFallback(keyringService, account, hexNew); err != nil {
+	if err := k.setWithFallback(account, hexNew); err != nil {
 		return nil, "", fmt.Errorf("store new HMAC key in keyring: %w", err)
 	}
 
@@ -289,6 +318,15 @@ func (k *osKeystore) LoadArchivedKeys() (map[string][]byte, error) {
 	return keys, nil
 }
 
+// IsHMACKeyNotFound reports whether err means "no HMAC key is stored yet"
+// (as opposed to a stored key that cannot be read). RotateKey uses it to
+// bootstrap when no key exists while still failing on corrupt or unreadable
+// keys. On OS keyring platforms not-found is the OS keyring's ErrNotFound or
+// the in-memory fallback's sentinel.
+func IsHMACKeyNotFound(err error) bool {
+	return errors.Is(err, keyring.ErrNotFound) || errors.Is(err, errMemoryKeyringNotFound)
+}
+
 // NewKeystore creates a Keystore backed by the OS keyring.
 // The identity parameter is used by the fallback keystore for encrypting
 // keys at rest and is ignored on OS keyring platforms.
@@ -297,7 +335,7 @@ func NewKeystore(auditDir string, identity *age.X25519Identity) Keystore {
 }
 
 func isTestOrCI() bool {
-	if os.Getenv("CI") != "" || os.Getenv("GITHUB_ACTIONS") != "" || os.Getenv("HEADLESS") != "" {
+	if os.Getenv("CI") != "" || os.Getenv("GITHUB_ACTIONS") != "" || os.Getenv("HEADLESS") != "" || os.Getenv("SYMVAULT_TEST_KEYRING") == "memory" {
 		return true
 	}
 	for _, arg := range os.Args {

--- a/internal/audit/keystore_rotate_bootstrap_test.go
+++ b/internal/audit/keystore_rotate_bootstrap_test.go
@@ -1,0 +1,152 @@
+package audit
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/zalando/go-keyring"
+)
+
+// TestRotateKeyBootstrapsWhenNoKeyExists is the #803 regression: rotating a
+// vault that has no stored HMAC key must succeed (bootstrap) instead of
+// failing with "load existing key for rotation", must not write an archive
+// file, and must leave a usable key behind.
+func TestRotateKeyBootstrapsWhenNoKeyExists(t *testing.T) {
+	dir := t.TempDir()
+	ks := newTestKeystore(t, dir)
+
+	// Sanity: no key exists yet.
+	if _, err := ks.LoadHMACKey(); !IsHMACKeyNotFound(err) {
+		t.Fatalf("precondition: LoadHMACKey() error = %v, want not-found", err)
+	}
+
+	newKey, archivePath, err := ks.RotateKey()
+	if err != nil {
+		t.Fatalf("RotateKey() on vault without a key error = %v", err)
+	}
+	if len(newKey) != hmacKeySize {
+		t.Fatalf("bootstrapped key length %d, want %d", len(newKey), hmacKeySize)
+	}
+	if archivePath != "" {
+		t.Fatalf("bootstrap archivePath = %q, want empty (nothing to archive)", archivePath)
+	}
+
+	// The bootstrapped key must be loadable afterwards.
+	loaded, err := ks.LoadHMACKey()
+	if err != nil {
+		t.Fatalf("LoadHMACKey() after bootstrap error = %v", err)
+	}
+	if string(loaded) != string(newKey) {
+		t.Fatal("loaded key does not match bootstrapped key")
+	}
+
+	// No archive file may be written for a bootstrap.
+	matches, err := filepath.Glob(filepath.Join(dir, hmacKeyFileName+".rotated.*"))
+	if err != nil {
+		t.Fatalf("glob archive files: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("bootstrap wrote %d archive file(s): %v", len(matches), matches)
+	}
+}
+
+// TestRotateKeyWithExistingKeyStillArchives guards the #803 risk that the
+// bootstrap path masks real rotation: with an existing key, rotation must
+// still archive the old key under its fingerprint, unchanged.
+func TestRotateKeyWithExistingKeyStillArchives(t *testing.T) {
+	dir := t.TempDir()
+	ks := newTestKeystore(t, dir)
+
+	oldKey, err := ks.LoadOrCreateHMACKey()
+	if err != nil {
+		t.Fatalf("LoadOrCreateHMACKey() error = %v", err)
+	}
+
+	newKey, archivePath, err := ks.RotateKey()
+	if err != nil {
+		t.Fatalf("RotateKey() error = %v", err)
+	}
+	if string(newKey) == string(oldKey) {
+		t.Fatal("rotated key should differ from original")
+	}
+
+	wantArchive := RotateKeyArchivePath(dir, oldKey)
+	if archivePath != wantArchive {
+		t.Fatalf("archivePath = %s, want %s", archivePath, wantArchive)
+	}
+	data, err := os.ReadFile(wantArchive)
+	if err != nil {
+		t.Fatalf("archive file missing after rotation: %v", err)
+	}
+	// Archive format is unchanged: hex-encoded old key, named by fingerprint.
+	if !filepath.HasPrefix(filepath.Base(wantArchive), hmacKeyFileName+".rotated.") {
+		t.Fatalf("archive filename %q does not use the fingerprint scheme", filepath.Base(wantArchive))
+	}
+	if len(data) == 0 {
+		t.Fatal("archive file is empty")
+	}
+
+	archived, err := ks.LoadArchivedKeys()
+	if err != nil {
+		t.Fatalf("LoadArchivedKeys() error = %v", err)
+	}
+	loadedOld, ok := archived[KeyFingerprint(oldKey)]
+	if !ok {
+		t.Fatalf("LoadArchivedKeys() missing old key fingerprint %s", KeyFingerprint(oldKey))
+	}
+	if string(loadedOld) != string(oldKey) {
+		t.Fatal("archived key does not match original key")
+	}
+}
+
+// TestRotateKeyCorruptEntryFailsNotBootstraps is the #803 risk guard: a key
+// that exists but is unreadable (corrupt hex) must NOT be treated as "no
+// key". Rotation must fail loudly instead of silently overwriting the entry.
+func TestRotateKeyCorruptEntryFailsNotBootstraps(t *testing.T) {
+	dir := t.TempDir()
+	ks := newTestKeystore(t, dir)
+
+	// Seed a corrupt (non-hex) value for this audit dir directly in the
+	// keyring store, as if a previous write had been corrupted.
+	if err := getFallback().Set(keyringService, keyringAccount(dir), "not-hex-at-all"); err != nil {
+		t.Fatalf("seed corrupt keyring value: %v", err)
+	}
+	// Precondition: load fails with a decode error, not a not-found error.
+	if _, err := ks.LoadHMACKey(); err == nil || IsHMACKeyNotFound(err) {
+		t.Fatalf("precondition: LoadHMACKey() error = %v, want corrupt-key error", err)
+	}
+
+	_, archivePath, err := ks.RotateKey()
+	if err == nil {
+		t.Fatal("RotateKey() succeeded on a corrupt key, want error")
+	}
+	if archivePath != "" {
+		t.Fatalf("corrupt-key rotation returned archivePath %q, want empty", archivePath)
+	}
+	// The corrupt entry must not have been replaced by a bootstrap.
+	if _, err := ks.LoadHMACKey(); err == nil || IsHMACKeyNotFound(err) {
+		t.Fatalf("corrupt entry was overwritten: LoadHMACKey() error = %v", err)
+	}
+}
+
+func TestIsHMACKeyNotFound(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "keyring not found", err: keyring.ErrNotFound, want: true},
+		{name: "memory sentinel", err: errMemoryKeyringNotFound, want: true},
+		{name: "generic error", err: errors.New("boom"), want: false},
+		{name: "nil", err: nil, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsHMACKeyNotFound(tt.err); got != tt.want {
+				t.Errorf("IsHMACKeyNotFound(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/audit/keystore_test.go
+++ b/internal/audit/keystore_test.go
@@ -12,7 +12,7 @@ import (
 func TestKeystoreLoadOrCreateAndLoadBack(t *testing.T) {
 	dir := t.TempDir()
 
-	ks := NewKeystore(dir, nil)
+	ks := newTestKeystore(t, dir)
 	key, err := ks.LoadOrCreateHMACKey()
 	if err != nil {
 		t.Fatalf("LoadOrCreateHMACKey() error = %v", err)
@@ -37,7 +37,7 @@ func TestKeystoreLoadOrCreateAndLoadBack(t *testing.T) {
 func TestKeystoreLoadHMACKeyNotFound(t *testing.T) {
 	dir := t.TempDir()
 
-	ks := NewKeystore(dir, nil)
+	ks := newTestKeystore(t, dir)
 	_, err := ks.LoadHMACKey()
 	if err == nil {
 		t.Fatal("expected error for non-existent key, got nil")
@@ -47,7 +47,7 @@ func TestKeystoreLoadHMACKeyNotFound(t *testing.T) {
 func TestKeystoreRotateKey(t *testing.T) {
 	dir := t.TempDir()
 
-	ks := NewKeystore(dir, nil)
+	ks := newTestKeystore(t, dir)
 	key, err := ks.LoadOrCreateHMACKey()
 	if err != nil {
 		t.Fatalf("LoadOrCreateHMACKey() error = %v", err)
@@ -104,7 +104,7 @@ func keysOf(m map[string][]byte) []string {
 func TestKeystoreIdempotentLoadOrCreate(t *testing.T) {
 	dir := t.TempDir()
 
-	ks := NewKeystore(dir, nil)
+	ks := newTestKeystore(t, dir)
 	key1, err := ks.LoadOrCreateHMACKey()
 	if err != nil {
 		t.Fatalf("first LoadOrCreateHMACKey() error = %v", err)
@@ -136,7 +136,7 @@ func TestKeystoreWithAuditLogIntegration(t *testing.T) {
 
 	auditDir := filepath.Join(home, configpkg.DefaultVaultSubdir)
 
-	ks := NewKeystore(auditDir, nil)
+	ks := newTestKeystore(t, auditDir)
 	loaded, err := ks.LoadHMACKey()
 	if err != nil {
 		t.Fatalf("LoadHMACKey() error = %v", err)

--- a/internal/audit/verify_rotation_test.go
+++ b/internal/audit/verify_rotation_test.go
@@ -40,7 +40,7 @@ func TestVerifyLogAgainstKeysStraddlesRotation(t *testing.T) {
 	_ = logger1.Close()
 
 	auditDir := filepath.Join(home, configpkg.DefaultVaultSubdir)
-	ks := NewKeystore(auditDir, nil)
+	ks := newTestKeystore(t, auditDir)
 	oldKey, err := ks.LoadHMACKey()
 	if err != nil {
 		t.Fatalf("LoadHMACKey() error = %v", err)
@@ -131,7 +131,7 @@ func TestVerifyLogAgainstKeysStraddlesRotationMissingArchiveIsUnverifiable(t *te
 	_ = logger1.Close()
 
 	auditDir := filepath.Join(home, configpkg.DefaultVaultSubdir)
-	ks := NewKeystore(auditDir, nil)
+	ks := newTestKeystore(t, auditDir)
 
 	newKey, _, err := ks.RotateKey()
 	if err != nil {
@@ -177,7 +177,7 @@ func TestVerifyLogAgainstKeysStraddlesRotationMissingArchiveIsUnverifiable(t *te
 // individually recoverable.
 func TestKeystoreRotateKeyTwiceSameDayBothRecoverable(t *testing.T) {
 	dir := t.TempDir()
-	ks := NewKeystore(dir, nil)
+	ks := newTestKeystore(t, dir)
 
 	key0, err := ks.LoadOrCreateHMACKey()
 	if err != nil {

--- a/internal/health/doctor.go
+++ b/internal/health/doctor.go
@@ -6,8 +6,9 @@ import (
 )
 
 const (
-	osDarwin = "darwin"
-	osLinux  = "linux"
+	osDarwin  = "darwin"
+	osLinux   = "linux"
+	osWindows = "windows"
 
 	msgSessionNeeded  = "no active session — run `symvault unlock` first"
 	hintSessionNeeded = "run `symvault unlock` to decrypt entries for password strength analysis"
@@ -92,6 +93,7 @@ var allChecks = []checkDef{
 	{fn: checkRecipientsRecovery},
 	{fn: checkMCPTokens},
 	{fn: checkAuditLog},
+	{fn: checkAuditKeyringOrphans},
 	{fn: checkUpdateAvailable, tags: []string{"network", "slow"}},
 	{fn: checkVaultSize},
 	{fn: checkSearchIndexPersistence},

--- a/internal/health/doctor_keyring.go
+++ b/internal/health/doctor_keyring.go
@@ -1,0 +1,233 @@
+package health
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"time"
+)
+
+// keyringDumpTimeout bounds the `security dump-keychain` enumeration so a
+// locked or slow keychain cannot hang the doctor run (the same failure mode
+// as #682/#703, where keychain operations blocked indefinitely).
+const keyringDumpTimeout = 5 * time.Second
+
+// isTestOrCIEnv reports whether the process is a `go test` binary or running
+// under CI/headless automation. Test and CI processes must never touch the
+// real OS keychain; doctor checks that would enumerate it skip instead and
+// are unit-tested with injected fakes. Mirrors internal/audit's isTestOrCI
+// (kept per-package, see the comment there).
+func isTestOrCIEnv() bool {
+	if os.Getenv("CI") != "" || os.Getenv("GITHUB_ACTIONS") != "" || os.Getenv("HEADLESS") != "" || os.Getenv("SYMVAULT_TEST_KEYRING") == "memory" {
+		return true
+	}
+	for _, arg := range os.Args {
+		if len(arg) >= 6 && arg[:6] == "-test." {
+			return true
+		}
+	}
+	if len(os.Args) > 0 {
+		base := os.Args[0]
+		for i := len(base) - 1; i >= 0; i-- {
+			if base[i] == '/' || base[i] == '\\' {
+				base = base[i+1:]
+				break
+			}
+		}
+		if (len(base) >= 5 && base[len(base)-5:] == ".test") ||
+			(len(base) >= 9 && base[len(base)-9:] == ".test.exe") ||
+			base == "test" { //nolint:goconst // test-binary sentinel, mirrors internal/audit's isTestOrCI
+			return true
+		}
+	}
+	return false
+}
+
+// auditKeyringServices are the service names under which audit HMAC keys
+// may be stored: the current "symaira" and the legacy "openpass" name used
+// before the project rename (May 2026). Both use the identical
+// "audit-hmac-key:<vault-dir>" account scheme.
+var auditKeyringServices = []string{"symaira", "openpass"}
+
+// keyringAccountEntry is a (service, account) pair found in the OS keychain.
+type keyringAccountEntry struct {
+	service string
+	account string
+}
+
+// keyringAuditKeyAccounts returns every account stored under one of
+// auditKeyringServices whose account uses the audit-hmac-key: scheme, from
+// the default OS keychain (macOS only; empty elsewhere). It is a variable so
+// tests can inject a fake entry list without touching the real keychain.
+var keyringAuditKeyAccounts = func() ([]keyringAccountEntry, error) {
+	if runtime.GOOS != osDarwin {
+		return nil, nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), keyringDumpTimeout)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "security", "dump-keychain").Output()
+	if err != nil {
+		return nil, fmt.Errorf("enumerate OS keychain: %w", err)
+	}
+	return parseKeychainDump(out), nil
+}
+
+// keyringEntryDelete removes a single generic-password item from the OS
+// keychain. It is a variable so tests can record deletions instead of
+// invoking the security binary.
+var keyringEntryDelete = func(service, account string) error {
+	out, err := exec.Command("security", "delete-generic-password", "-s", service, "-a", account).CombinedOutput()
+	if err != nil {
+		// A missing item (errSecItemNotFound, security exits 44) is not an
+		// error here: the entry is already gone, which is the desired state.
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == 44 {
+			return nil
+		}
+		if strings.Contains(string(out), "could not be found") {
+			return nil
+		}
+		return fmt.Errorf("delete keychain entry: %w", err)
+	}
+	return nil
+}
+
+// parseBlobAttr splits a `security dump-keychain` attribute line of the form
+//
+//	"svce"<blob>="symaira"
+//	0x00000007 <blob>="symaira"
+//
+// into its attribute name and quoted value. Returns ("", "") for lines that
+// are not string blob attributes.
+func parseBlobAttr(line string) (key, val string) {
+	idx := strings.Index(line, "<blob>=")
+	if idx < 0 {
+		return "", ""
+	}
+	key = strings.Trim(strings.TrimSpace(line[:idx]), `"`)
+	val = strings.Trim(line[idx+len("<blob>="):], `"`)
+	return key, val
+}
+
+// parseKeychainDump extracts every (service, account) pair whose service is
+// one of auditKeyringServices and whose account uses the audit-hmac-key:
+// scheme from a `security dump-keychain` transcript. It understands both
+// attribute naming schemes macOS has used over the years: the human-readable
+// ("svce"/"acct") and the numeric kSecAttrService/kSecAttrAccount form
+// (0x00000007/0x00000008), which macOS prints first within each item. Items
+// are separated by "keychain:" header lines (recent macOS prints no blank
+// lines between items), so each item is flushed when the next header
+// appears.
+func parseKeychainDump(data []byte) []keyringAccountEntry {
+	var entries []keyringAccountEntry
+	var service, account string
+
+	flush := func() {
+		if service != "" && strings.HasPrefix(account, "audit-hmac-key:") && containsString(auditKeyringServices, service) {
+			entries = append(entries, keyringAccountEntry{service: service, account: account})
+		}
+		service, account = "", ""
+	}
+
+	for _, line := range strings.Split(string(data), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "keychain:") {
+			// Item boundary (keychain: header) or legacy blank-line
+			// separator: flush the item just parsed.
+			if service != "" || account != "" {
+				flush()
+			}
+			continue
+		}
+		key, val := parseBlobAttr(trimmed)
+		switch key {
+		case "svce", "0x00000007":
+			service = val
+		case "acct", "0x00000008":
+			account = val
+		}
+	}
+	flush()
+	return entries
+}
+
+func containsString(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}
+
+// auditKeyringOrphansResult is the pure decision logic behind
+// checkAuditKeyringOrphans, unit-testable without a real keychain.
+// entries are the stored (service, account) pairs whose account uses the
+// audit-hmac-key:<vault-dir> scheme; the fix closure deletes every orphan
+// via keyringEntryDelete.
+func auditKeyringOrphansResult(entries []keyringAccountEntry) Result {
+	r := Result{ID: "audit.keyring.orphans", Name: "Orphaned audit HMAC keys in OS keychain"}
+
+	var orphans []keyringAccountEntry
+	for _, e := range entries {
+		dir := strings.TrimPrefix(e.account, "audit-hmac-key:")
+		if dir == e.account { // account does not use the expected scheme
+			continue
+		}
+		if _, err := os.Stat(dir); err != nil {
+			orphans = append(orphans, e)
+		}
+	}
+
+	if len(orphans) == 0 {
+		r.Status = StatusOK
+		r.Message = "no orphaned audit HMAC keys in the OS keychain (service \"symaira\")"
+		return r
+	}
+
+	r.Status = StatusWarn
+	r.Message = fmt.Sprintf("%d audit HMAC key(s) in the OS keychain point to a vault directory that no longer exists", len(orphans))
+	r.Hint = "run `symvault doctor --fix` to remove the orphaned keychain entries"
+	r.Fixable = true
+	r.Fix = func() error {
+		var firstErr error
+		for _, e := range orphans {
+			if err := keyringEntryDelete(e.service, e.account); err != nil && firstErr == nil {
+				firstErr = err
+			}
+		}
+		return firstErr
+	}
+	return r
+}
+
+// checkAuditKeyringOrphans reports service=symaira keychain entries whose
+// vault directory no longer exists. These accumulate when test suites or
+// temporary vaults wrote audit HMAC keys into the developer's real keychain
+// and the directory was deleted afterwards (issue #801); `doctor --fix`
+// purges them so the keychain can be reclaimed.
+func checkAuditKeyringOrphans(_ string, _ Options) Result {
+	r := Result{ID: "audit.keyring.orphans", Name: "Orphaned audit HMAC keys in OS keychain"}
+	if runtime.GOOS != osDarwin {
+		r.Status = StatusOK
+		r.Message = "not applicable on " + runtime.GOOS
+		return r
+	}
+	if isTestOrCIEnv() {
+		r.Status = StatusOK
+		r.Message = "keychain enumeration skipped in test/CI environment"
+		return r
+	}
+	accounts, err := keyringAuditKeyAccounts()
+	if err != nil {
+		r.Status = StatusWarn
+		r.Message = "cannot enumerate OS keychain: " + err.Error()
+		r.Hint = "ensure the login keychain is unlocked, then re-run `symvault doctor`"
+		return r
+	}
+	return auditKeyringOrphansResult(accounts)
+}

--- a/internal/health/doctor_keyring_test.go
+++ b/internal/health/doctor_keyring_test.go
@@ -1,0 +1,183 @@
+package health
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParseBlobAttr(t *testing.T) {
+	tests := []struct {
+		line    string
+		wantKey string
+		wantVal string
+	}{
+		{line: `    "svce"<blob>="symaira"`, wantKey: "svce", wantVal: "symaira"},
+		{line: `    "acct"<blob>="audit-hmac-key:/tmp/x"`, wantKey: "acct", wantVal: "audit-hmac-key:/tmp/x"},
+		{line: `    0x00000007 <blob>="symaira"`, wantKey: "0x00000007", wantVal: "symaira"},
+		{line: `    0x00000008 <blob>="audit-hmac-key:/tmp/x"`, wantKey: "0x00000008", wantVal: "audit-hmac-key:/tmp/x"},
+		{line: `    "data"<blob>=0xabc123`, wantKey: "data", wantVal: "0xabc123"},
+		{line: `    class: "genp"`, wantKey: "", wantVal: ""},
+		{line: `keychain: "/tmp/login.keychain-db"`, wantKey: "", wantVal: ""},
+	}
+	for _, tt := range tests {
+		key, val := parseBlobAttr(tt.line)
+		if key != tt.wantKey || val != tt.wantVal {
+			t.Errorf("parseBlobAttr(%q) = (%q, %q), want (%q, %q)", tt.line, key, val, tt.wantKey, tt.wantVal)
+		}
+	}
+}
+
+// TestParseKeychainDump exercises the structure real `security dump-keychain`
+// output has on recent macOS: each item starts with the numeric attribute
+// form (kSecAttrService/kSecAttrAccount), is followed by the human-readable
+// summary, and items are separated by "keychain:" header lines with no blank
+// lines in between. Both the current "symaira" service and the legacy
+// "openpass" service (pre-rename) must be picked up; other services and
+// non-audit accounts must be ignored.
+func TestParseKeychainDump(t *testing.T) {
+	dump := `keychain: "/Users/dev/Library/Keychains/login.keychain-db"
+version: 512
+class: "genp"
+attributes:
+    0x00000007 <blob>="openpass"
+    0x00000008 <blob>=<NULL>
+    "acct"<blob>="audit-hmac-key:/tmp/dead-vault-1"
+    "cdat"<timedate>=0x31  "20260101T000000Z\000"
+    "svce"<blob>="openpass"
+    "type"<uint32>=<NULL>
+keychain: "/Users/dev/Library/Keychains/login.keychain-db"
+version: 512
+class: "genp"
+attributes:
+    0x00000007 <blob>="symaira"
+    0x00000008 <blob>=<NULL>
+    "acct"<blob>="audit-hmac-key:/tmp/dead-vault-2"
+    "svce"<blob>="symaira"
+    "type"<uint32>=<NULL>
+keychain: "/Users/dev/Library/Keychains/login.keychain-db"
+version: 512
+class: "genp"
+attributes:
+    0x00000007 <blob>="symvault:/tmp/real-vault"
+    0x00000008 <blob>=<NULL>
+    "acct"<blob>="session"
+    "svce"<blob>="symvault:/tmp/real-vault"
+    "type"<uint32>=<NULL>
+keychain: "/Users/dev/Library/Keychains/login.keychain-db"
+version: 512
+class: "genp"
+attributes:
+    0x00000007 <blob>="symaira"
+    0x00000008 <blob>=<NULL>
+    "acct"<blob>="audit-hmac-key:/tmp/live-vault"
+    "svce"<blob>="symaira"
+    "type"<uint32>=<NULL>
+`
+	entries := parseKeychainDump([]byte(dump))
+	want := []keyringAccountEntry{
+		{service: "openpass", account: "audit-hmac-key:/tmp/dead-vault-1"},
+		{service: "symaira", account: "audit-hmac-key:/tmp/dead-vault-2"},
+		{service: "symaira", account: "audit-hmac-key:/tmp/live-vault"},
+	}
+	if len(entries) != len(want) {
+		t.Fatalf("entries = %v, want %v", entries, want)
+	}
+	for i := range want {
+		if entries[i] != want[i] {
+			t.Errorf("entries[%d] = %+v, want %+v", i, entries[i], want[i])
+		}
+	}
+}
+
+// TestAuditKeyringOrphansResult_NoOrphans covers the healthy case: entries
+// whose vault directory still exists are not orphans.
+func TestAuditKeyringOrphansResult_NoOrphans(t *testing.T) {
+	live := t.TempDir()
+	r := auditKeyringOrphansResult([]keyringAccountEntry{
+		{service: "symaira", account: "audit-hmac-key:" + live},
+		{service: "openpass", account: "audit-hmac-key:" + live},
+	})
+	if r.Status != StatusOK {
+		t.Fatalf("status = %s, want ok (message: %s)", r.Status, r.Message)
+	}
+	if r.Fixable || r.Fix != nil {
+		t.Error("no orphans must not be fixable")
+	}
+}
+
+// TestAuditKeyringOrphansResult_ReportsAndFixesOrphans covers the #801
+// maintenance path: entries pointing at deleted vault directories are
+// reported as orphans (under both the current and the legacy service name)
+// and the fix closure deletes exactly those.
+func TestAuditKeyringOrphansResult_ReportsAndFixesOrphans(t *testing.T) {
+	live := t.TempDir()
+	dead := filepath.Join(t.TempDir(), "gone") // never created
+
+	r := auditKeyringOrphansResult([]keyringAccountEntry{
+		{service: "symaira", account: "audit-hmac-key:" + live},
+		{service: "symaira", account: "audit-hmac-key:" + dead},
+		{service: "openpass", account: "audit-hmac-key:/tmp/also-gone"},
+	})
+	if r.Status != StatusWarn {
+		t.Fatalf("status = %s, want warn (message: %s)", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "2 audit HMAC key(s)") {
+		t.Errorf("message = %q, want it to count 2 orphans", r.Message)
+	}
+	if !r.Fixable || r.Fix == nil {
+		t.Fatal("expected Fixable with a fix closure")
+	}
+
+	var deleted []keyringAccountEntry
+	oldDelete := keyringEntryDelete
+	keyringEntryDelete = func(service, account string) error {
+		deleted = append(deleted, keyringAccountEntry{service: service, account: account})
+		return nil
+	}
+	t.Cleanup(func() { keyringEntryDelete = oldDelete })
+
+	if err := r.Fix(); err != nil {
+		t.Fatalf("Fix() error = %v", err)
+	}
+	if len(deleted) != 2 {
+		t.Fatalf("fix deleted %d entries, want 2: %v", len(deleted), deleted)
+	}
+	for _, e := range deleted {
+		if strings.Contains(e.account, live) {
+			t.Errorf("fix deleted the live vault's entry %+v", e)
+		}
+	}
+}
+
+// TestAuditKeyringOrphansResult_SkipsNonSchemeAccounts ensures accounts that
+// do not use the audit-hmac-key: scheme are never considered or deleted.
+func TestAuditKeyringOrphansResult_SkipsNonSchemeAccounts(t *testing.T) {
+	r := auditKeyringOrphansResult([]keyringAccountEntry{
+		{service: "symaira", account: "grant-signing-key:/tmp/whatever"},
+		{service: "symaira", account: "audit-hmac-key"},
+	})
+	if r.Status != StatusOK {
+		t.Fatalf("status = %s, want ok (message: %s)", r.Status, r.Message)
+	}
+}
+
+// TestCheckAuditKeyringOrphans_TestEnvSkipsEnumeration ensures doctor runs
+// inside test binaries never enumerate (or modify) the real keychain.
+func TestCheckAuditKeyringOrphans_TestEnvSkipsEnumeration(t *testing.T) {
+	called := false
+	old := keyringAuditKeyAccounts
+	keyringAuditKeyAccounts = func() ([]keyringAccountEntry, error) {
+		called = true
+		return nil, nil
+	}
+	t.Cleanup(func() { keyringAuditKeyAccounts = old })
+
+	r := checkAuditKeyringOrphans("", Options{})
+	if called {
+		t.Error("keychain enumeration was invoked from a test process")
+	}
+	if r.Status != StatusOK {
+		t.Fatalf("status = %s, want ok (message: %s)", r.Status, r.Message)
+	}
+}

--- a/internal/health/doctor_mcp.go
+++ b/internal/health/doctor_mcp.go
@@ -78,6 +78,12 @@ func checkAuditLog(vaultDir string, _ Options) Result {
 	ks := audit.NewKeystore(vaultDir, nil)
 	keys, currentKid, keyErr := audit.LoadVerificationKeys(ks)
 	if keyErr != nil {
+		if audit.IsHMACKeyNotFound(keyErr) {
+			r.Status = StatusWarn
+			r.Message = "no HMAC key exists yet — audit log entries cannot be verified"
+			r.Hint = "run `symvault audit rotate-key` to bootstrap an HMAC key"
+			return r
+		}
 		r.Status = StatusWarn
 		r.Message = fmt.Sprintf("cannot read hmac key: %v", keyErr)
 		return r

--- a/internal/health/doctor_session.go
+++ b/internal/health/doctor_session.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
-	"time"
 
 	configpkg "github.com/danieljustus/symaira-vault/internal/config"
 	"github.com/danieljustus/symaira-vault/internal/session"
@@ -39,17 +38,34 @@ func checkAuthMethod(vaultDir string, _ Options) Result {
 	return r
 }
 
+// sessionKeyringProbe verifies that the OS keyring persists data end to end,
+// bypassing the session layer's in-memory fallback. It is a variable so tests
+// can inject a fake probe (e.g. one that succeeds on set but fails on get)
+// without touching the real keychain.
+var sessionKeyringProbe = session.VerifyOSKeyring
+
 func checkSessionCache(vaultDir string, _ Options) Result {
 	r := Result{ID: "session.cache", Name: "Session cache"}
 	status := session.GetCacheStatus()
-	r.Status = StatusOK
 	if status.Backend == "memory" || status.Backend == "" {
 		r.Status = StatusWarn
 		r.Message = "session cache uses in-memory backend (not persistent)"
 		r.Hint = "install a system keyring (macOS Keychain, GNOME Keyring, KWallet) for persistent sessions"
-	} else {
-		r.Message = fmt.Sprintf("backend: %s, persistent: %v", status.Backend, status.Persistent)
+		return r
 	}
+
+	// The configured backend claims the OS keyring, but configuration is not
+	// proof: verify that persistence actually works (write and read-back
+	// against the OS keyring itself, bypassing any in-memory fallback) and
+	// report the verified state.
+	if err := sessionKeyringProbe(); err != nil {
+		r.Status = StatusFail
+		r.Message = fmt.Sprintf("backend: os-keyring (configured), persistent: false — persistence check failed: %v", err)
+		r.Hint = "the OS keyring accepts writes but cannot be read back; check that the login keychain is in the keychain search list (`security list-keychains`) and unlocked"
+		return r
+	}
+	r.Status = StatusOK
+	r.Message = "backend: os-keyring, persistent: true (verified)"
 	return r
 }
 
@@ -354,64 +370,63 @@ func checkEnvPassphrase(vaultDir string, _ Options) Result {
 	return r
 }
 
-func checkSessionKeyring(vaultDir string, _ Options) Result {
+// keyringPlatform reports whether the current OS has a real OS keyring
+// backend (darwin/linux/windows). On other platforms the session cache is
+// memory-only by design, so a memory backend there is not a keyring failure.
+func keyringPlatform(goos string) bool {
+	switch goos {
+	case osDarwin, osLinux, osWindows:
+		return true
+	}
+	return false
+}
+
+// sessionKeyringResult is the decision logic behind checkSessionKeyring,
+// kept pure so unit tests can exercise every branch with injected fakes.
+//
+// backend is the backend reported by the session layer; probe verifies OS
+// keyring persistence bypassing the in-memory fallback; testEnv reports
+// whether this is a test/CI process (there the in-memory backend is forced
+// and must not be reported as a keyring failure).
+func sessionKeyringResult(backend string, probe func() error, testEnv bool) Result {
 	r := Result{ID: "session.keyring", Name: "Session keyring roundtrip"}
-	testData := "symvault-doctor-test"
 
-	saveDone := make(chan error, 1)
-	go func() {
-		saveDone <- session.SavePassphrase(vaultDir, []byte(testData), 10*time.Second)
-	}()
-	select {
-	case err := <-saveDone:
-		if err != nil {
+	if backend == session.CacheBackendMemory || backend == "" {
+		// The session layer is already running on the in-memory fallback (or
+		// this build has no OS keyring at all): a Save→Load roundtrip inside
+		// this process would be served entirely from memory and prove
+		// nothing. Surface the degraded state instead of reporting green.
+		if testEnv {
 			r.Status = StatusWarn
-			r.Message = "cannot write to keyring: " + err.Error()
-			r.Hint = "check OS keyring availability (macOS Keychain, GNOME Keyring, etc.)"
+			r.Message = "OS keyring persistence not verified in test/CI environment (in-memory backend active)"
 			return r
 		}
-	case <-time.After(5 * time.Second):
-		r.Status = StatusWarn
-		r.Message = "save to keyring timed out — keyring unavailable in this environment"
-		return r
-	}
-
-	loadDone := make(chan struct {
-		data []byte
-		err  error
-	}, 1)
-	go func() {
-		data, err := session.LoadPassphrase(vaultDir)
-		loadDone <- struct {
-			data []byte
-			err  error
-		}{data, err}
-	}()
-	var loaded []byte
-	select {
-	case res := <-loadDone:
-		if res.err != nil {
+		if keyringPlatform(runtime.GOOS) {
 			r.Status = StatusFail
-			r.Message = "keyring roundtrip failed: " + res.err.Error()
-			_ = session.ClearSession(vaultDir)
+			r.Message = "OS keyring persistence unavailable — session cache has fallen back to in-memory storage; sessions will not survive process exit"
+			r.Hint = "check that the login keychain is present and in the keychain search list (`security list-keychains`), then re-run `symvault doctor`"
 			return r
 		}
-		loaded = res.data
-	case <-time.After(5 * time.Second):
 		r.Status = StatusWarn
-		r.Message = "load from keyring timed out — keyring unavailable in this environment"
-		_ = session.ClearSession(vaultDir)
+		r.Message = "session cache uses in-memory backend (not persistent on this platform)"
+		r.Hint = "sessions on this platform do not persist across restarts"
 		return r
 	}
 
-	if string(loaded) != testData {
+	// The session layer claims the OS keyring backend: verify persistence
+	// directly against the OS keyring, bypassing any in-memory fallback, so
+	// a broken keychain (e.g. dropped from the search list) fails the check.
+	if err := probe(); err != nil {
 		r.Status = StatusFail
-		r.Message = "keyring returned corrupted data"
-		_ = session.ClearSession(vaultDir)
+		r.Message = "OS keyring persistence check failed: " + err.Error()
+		r.Hint = "writes may land in the default keychain while lookups search a list that excludes it — verify `security list-keychains` includes the login keychain and that it is unlocked"
 		return r
 	}
-	_ = session.ClearSession(vaultDir)
 	r.Status = StatusOK
-	r.Message = "keyring encrypt/decrypt roundtrip OK"
+	r.Message = "OS keyring write/read roundtrip OK (persistence verified)"
 	return r
+}
+
+func checkSessionKeyring(_ string, _ Options) Result {
+	return sessionKeyringResult(session.GetCacheStatus().Backend, sessionKeyringProbe, isTestOrCIEnv())
 }

--- a/internal/health/doctor_session_internal_test.go
+++ b/internal/health/doctor_session_internal_test.go
@@ -1,0 +1,113 @@
+package health
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/danieljustus/symaira-vault/internal/session"
+)
+
+// installFakeSessionStatus swaps the process-wide session manager for one
+// whose cache status reports the given backend, and restores the original on
+// cleanup. This lets checkSessionCache/checkSessionKeyring exercise their
+// OS-keyring branches without touching the real keychain. The keyring
+// backend itself is never used by those checks (they call GetCacheStatus and
+// the injectable probe only), so nil is safe here.
+func installFakeSessionStatus(t *testing.T, backend string) {
+	t.Helper()
+	old := session.DefaultManager()
+	t.Cleanup(func() { session.SetDefaultManager(old) })
+	session.SetDefaultManager(session.NewManager(nil, func() session.CacheStatus {
+		return session.CacheStatus{Backend: backend, Persistent: backend == session.CacheBackendOSKeyring}
+	}))
+}
+
+// TestSessionKeyringResult_SetOKGetFailsReportsFail is the #802 regression:
+// a keyring that accepts writes but fails reads (e.g. the login keychain
+// dropped out of the search list) must make the doctor keyring check FAIL,
+// not report green.
+func TestSessionKeyringResult_SetOKGetFailsReportsFail(t *testing.T) {
+	probe := func() error {
+		return errors.New("keyring read-back failed: secret not found")
+	}
+	r := sessionKeyringResult(session.CacheBackendOSKeyring, probe, false)
+	if r.Status != StatusFail {
+		t.Fatalf("status = %s, want fail (message: %s)", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "persistence check failed") {
+		t.Errorf("message = %q, want it to mention the persistence check", r.Message)
+	}
+}
+
+// TestSessionKeyringResult_HealthyProbeReportsOK ensures a healthy keyring
+// still reports OK (the honest-green case).
+func TestSessionKeyringResult_HealthyProbeReportsOK(t *testing.T) {
+	r := sessionKeyringResult(session.CacheBackendOSKeyring, func() error { return nil }, false)
+	if r.Status != StatusOK {
+		t.Fatalf("status = %s, want ok (message: %s)", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "verified") {
+		t.Errorf("message = %q, want it to say persistence was verified", r.Message)
+	}
+}
+
+// TestSessionKeyringResult_FallbackActiveReportsFail is the #802 regression
+// for the degraded state: when the session layer has already fallen back to
+// in-memory storage in production, the check must surface that as a failure
+// instead of a green roundtrip (which would be served from memory).
+func TestSessionKeyringResult_FallbackActiveReportsFail(t *testing.T) {
+	r := sessionKeyringResult(session.CacheBackendMemory, func() error { return nil }, false)
+	if r.Status != StatusFail {
+		t.Fatalf("status = %s, want fail (message: %s)", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "in-memory") {
+		t.Errorf("message = %q, want it to mention the in-memory fallback", r.Message)
+	}
+}
+
+// TestSessionKeyringResult_TestEnvMemoryIsNotAFailure ensures test/CI
+// processes (where the in-memory backend is forced) are not misreported as a
+// broken keyring.
+func TestSessionKeyringResult_TestEnvMemoryIsNotAFailure(t *testing.T) {
+	r := sessionKeyringResult(session.CacheBackendMemory, func() error { return nil }, true)
+	if r.Status != StatusWarn {
+		t.Fatalf("status = %s, want warn (message: %s)", r.Status, r.Message)
+	}
+}
+
+// TestCheckSessionCache_ReportsVerifiedNotConfiguredState is the #802
+// regression for the cache check: with the backend claiming os-keyring but a
+// failing probe, it must report persistent:false (verified), never the
+// configured persistent:true.
+func TestCheckSessionCache_ReportsVerifiedNotConfiguredState(t *testing.T) {
+	installFakeSessionStatus(t, session.CacheBackendOSKeyring)
+	oldProbe := sessionKeyringProbe
+	sessionKeyringProbe = func() error { return errors.New("keyring read-back failed: secret not found") }
+	t.Cleanup(func() { sessionKeyringProbe = oldProbe })
+
+	r := checkSessionCache("", Options{})
+	if r.Status != StatusFail {
+		t.Fatalf("status = %s, want fail (message: %s)", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "persistent: false") {
+		t.Errorf("message = %q, want it to report persistent: false", r.Message)
+	}
+}
+
+// TestCheckSessionCache_HealthyProbeReportsVerifiedGreen ensures the cache
+// check reports the verified persistent state when the probe succeeds.
+func TestCheckSessionCache_HealthyProbeReportsVerifiedGreen(t *testing.T) {
+	installFakeSessionStatus(t, session.CacheBackendOSKeyring)
+	oldProbe := sessionKeyringProbe
+	sessionKeyringProbe = func() error { return nil }
+	t.Cleanup(func() { sessionKeyringProbe = oldProbe })
+
+	r := checkSessionCache("", Options{})
+	if r.Status != StatusOK {
+		t.Fatalf("status = %s, want ok (message: %s)", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "persistent: true (verified)") {
+		t.Errorf("message = %q, want it to report persistent: true (verified)", r.Message)
+	}
+}

--- a/internal/mcp/server/grant_keys.go
+++ b/internal/mcp/server/grant_keys.go
@@ -138,8 +138,38 @@ func LoadGrantSigningKey(vaultDir string, identity *age.X25519Identity) ([]byte,
 	return hex.DecodeString(hexKey)
 }
 
+// isTestOrCI reports whether the process is a `go test` binary or running
+// under CI/headless automation. Mirrors internal/audit's isTestOrCI (kept
+// separate per-package): test processes must never reach the real OS
+// keychain, which is what produced the leftover keychain entries in #801.
+func isTestOrCI() bool {
+	if os.Getenv("CI") != "" || os.Getenv("GITHUB_ACTIONS") != "" || os.Getenv("HEADLESS") != "" || os.Getenv("SYMVAULT_TEST_KEYRING") == "memory" {
+		return true
+	}
+	for _, arg := range os.Args {
+		if len(arg) >= 6 && arg[:6] == "-test." {
+			return true
+		}
+	}
+	if len(os.Args) > 0 {
+		base := os.Args[0]
+		for i := len(base) - 1; i >= 0; i-- {
+			if base[i] == '/' || base[i] == '\\' {
+				base = base[i+1:]
+				break
+			}
+		}
+		if (len(base) >= 5 && base[len(base)-5:] == ".test") ||
+			(len(base) >= 9 && base[len(base)-9:] == ".test.exe") ||
+			base == "test" { //nolint:goconst // test-binary sentinel, mirrors internal/audit's isTestOrCI
+			return true
+		}
+	}
+	return false
+}
+
 func init() {
-	if os.Getenv("CI") != "" {
+	if isTestOrCI() {
 		grantFallbackActive = true
 		grantFallback = &memoryGrantKeyring{}
 	}

--- a/internal/session/oskeyring.go
+++ b/internal/session/oskeyring.go
@@ -5,12 +5,14 @@ package session
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"time"
 
 	"github.com/zalando/go-keyring"
 
 	"github.com/danieljustus/symaira-vault/internal/logging"
+	"github.com/danieljustus/symaira-vault/internal/ui/cliout"
 )
 
 // keyringTimeout bounds how long osKeyring waits for the underlying OS
@@ -131,6 +133,44 @@ func deleteWithTimeout(service, account string) error {
 	}
 }
 
+// VerifyOSKeyring performs a write→read→delete roundtrip directly against
+// the OS keyring, bypassing the in-memory fallback, and returns nil when the
+// OS keyring persists data end to end. It exists so `symvault doctor` can
+// fail its keyring checks when persistence is actually broken (e.g. the
+// login keychain dropped out of the keychain search list: writes land in the
+// default keychain, lookups search a list that excludes it) instead of a
+// Save→Load roundtrip inside the same process being silently served by the
+// in-memory fallback. The probe entry is removed again before returning. In
+// test and CI processes it never dials the real keychain and returns
+// ErrKeyringUnavailable instead.
+func VerifyOSKeyring() error {
+	if isTestOrCI() {
+		return ErrKeyringUnavailable
+	}
+
+	service := "symvault-doctor"
+	account := fmt.Sprintf("probe-%d", time.Now().UnixNano())
+	probe := "symvault-doctor-probe-value"
+
+	if err := setWithTimeout(service, account, probe); err != nil {
+		return fmt.Errorf("keyring write failed: %w", err)
+	}
+	defer func() {
+		if err := deleteWithTimeout(service, account); err != nil && !errors.Is(err, keyring.ErrNotFound) {
+			cliout.Warnf("doctor keyring probe cleanup failed for %q: %v", service+":"+account, err)
+		}
+	}()
+
+	got, err := getWithTimeout(service, account)
+	if err != nil {
+		return fmt.Errorf("keyring read-back failed: %w", err)
+	}
+	if got != probe {
+		return fmt.Errorf("keyring read-back returned unexpected data")
+	}
+	return nil
+}
+
 // isTestOrCI reports whether the process is a `go test` binary or running
 // under CI/headless automation. Mirrors internal/audit's isTestOrCI (kept
 // separate per-package to avoid a cross-package dependency for a handful of
@@ -139,7 +179,7 @@ func deleteWithTimeout(service, account string) error {
 // found for wrap-key" dialog in #682 when many test binaries/agents ran in
 // parallel against the developer's real login keychain.
 func isTestOrCI() bool {
-	if os.Getenv("CI") != "" || os.Getenv("GITHUB_ACTIONS") != "" || os.Getenv("HEADLESS") != "" {
+	if os.Getenv("CI") != "" || os.Getenv("GITHUB_ACTIONS") != "" || os.Getenv("HEADLESS") != "" || os.Getenv("SYMVAULT_TEST_KEYRING") == "memory" {
 		return true
 	}
 	for _, arg := range os.Args {


### PR DESCRIPTION
Implements three keyring/audit defects:

## #801 — Test suite writes thousands of HMAC keys into the developer's real OS keychain
- Keystore is now injectable; tests resolve to an in-memory keystore by default so `go test ./...` no longer writes to the OS keychain (verified: audit-hmac-key count delta 0 over a full run).
- t.Cleanup removes keyring entries for temp audit dirs as a second line of defence.
- New maintenance path (doctor/audit) to purge service=symaira accounts whose audit directory no longer exists, so developers can reclaim their keychain.

## #802 — Doctor reports a healthy keyring while the OS keychain is unusable
- The session-keyring roundtrip check now verifies real persistence (write-then-read against the OS keyring) instead of being transparently served by the in-process fallback, so it fails when the keychain is broken (e.g. login keychain dropped from the search list).
- The session-cache check reports the actually-verified backend/persistence, not the configured one; when the fallback is active the degraded state is surfaced clearly.
- Covered by tests using a keystore seam that succeeds on set but fails on get.

## #803 — symvault audit rotate-key cannot bootstrap when no HMAC key exists yet
- RotateKey now bootstraps when no key exists: generates and stores a new key, skips the archive step, and reports that it bootstrapped (distinguishable from a real rotation).
- Rotation with an existing key still archives the old key under its fingerprint, unchanged.
- Doctor hint accurate for the no-key case.
- Tests cover both paths; "not found" is distinguished from other load errors (permissions/corrupt hex still fail).

## Verification
- make build (pass), make lint 0 issues, scoped go test (audit/health/session/mcp/cmd) (pass), keychain delta 0

Closes #801
Closes #802
Closes #803
