### PR TITLE
fix(auth): allow Touch ID unlock without a TTY

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -90,7 +91,19 @@ var (
 	SessionGetCacheStatus func() session.CacheStatus                                          = session.GetCacheStatus
 	SessionLoadIdentity   func(vaultDir string) (string, error)                               = session.LoadIdentity
 	SessionSaveIdentity   func(vaultDir string, identity string, ttl time.Duration) error     = session.SaveIdentity
+	SessionHasGUISession  func() bool                                                         = session.HasGUISession
 )
+
+// currentCommandPath is the cobra command path of the command currently
+// executing (e.g. "symvault unlock"), set by the root PersistentPreRunE.
+// It is used to tailor lock/dead-end guidance to the command the user ran.
+var currentCommandPath string
+
+// invokedCommandIsUnlock reports whether the currently executing command
+// is `symvault unlock` (or any command whose path ends in "unlock").
+func invokedCommandIsUnlock() bool {
+	return currentCommandPath == "unlock" || strings.HasSuffix(currentCommandPath, " unlock")
+}
 
 // CLIContext groups mutable state that was previously stored as package-level
 // globals. Holding state in a context struct makes test isolation straightforward:
@@ -238,6 +251,7 @@ Daily use:
 		SilenceUsage:  true,
 		SilenceErrors: false,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			currentCommandPath = cmd.CommandPath()
 			if OutputFormat != outputFormatText {
 				if !CommandSupportsJSON(cmd) {
 					return errorspkg.NewCLIError(errorspkg.ExitUsage,
@@ -322,7 +336,11 @@ func ExecuteRoot(cmd *cobra.Command) error {
 			case errorspkg.ExitNotInitialized:
 				cliout.Hintf("Run 'symvault init' for a quick start, or 'symvault setup' for the guided wizard.")
 			case errorspkg.ExitLocked:
-				cliout.Hintf("Unlock with 'symvault unlock'. For non-interactive use, set SYMVAULT_PASSPHRASE together with SYMVAULT_ALLOW_ENV_PASSPHRASE=1 (or security.allow_env_passphrase: true in config.yaml) — the passphrase variable alone is ignored.")
+				if invokedCommandIsUnlock() {
+					cliout.Hintf("Enable Touch ID with 'symvault auth set touchid', or for non-interactive use set SYMVAULT_PASSPHRASE together with SYMVAULT_ALLOW_ENV_PASSPHRASE=1 (or security.allow_env_passphrase: true in config.yaml) — the passphrase variable alone is ignored.")
+				} else {
+					cliout.Hintf("Unlock with 'symvault unlock'. For non-interactive use, set SYMVAULT_PASSPHRASE together with SYMVAULT_ALLOW_ENV_PASSPHRASE=1 (or security.allow_env_passphrase: true in config.yaml) — the passphrase variable alone is ignored.")
+				}
 			case errorspkg.ExitConfigError:
 				cliout.Hintf("Run 'symvault doctor' to diagnose and fix configuration issues.")
 			case errorspkg.ExitSuccess, errorspkg.ExitGeneralError, errorspkg.ExitPermissionDenied, errorspkg.ExitInvalidInput, errorspkg.ExitDoctorWarn, errorspkg.ExitDoctorFail, errorspkg.ExitUpdateAvailable:

--- a/internal/cli/unlock.go
+++ b/internal/cli/unlock.go
@@ -145,15 +145,18 @@ func resolveUnlockPassphrase(vaultDir string, interactive bool, cfg *configpkg.C
 	passphraseFromEnv := false
 	passphraseFromBiometric := false
 	if err != nil || len(passphrase) == 0 {
-		if cfg.EffectiveAuthMethod() == configpkg.AuthMethodTouchID && interactive {
+		if cfg.EffectiveAuthMethod() == configpkg.AuthMethodTouchID && SessionHasGUISession() {
+			// Touch ID is a LocalAuthentication GUI prompt, not a terminal
+			// prompt: it works without a controlling TTY, so attempt it
+			// whenever a GUI session exists — even for agents/scripts.
 			biometricCtx, biometricCancel := context.WithTimeout(context.Background(), 30*time.Second)
 			defer biometricCancel()
 			if biometricPassphrase, biometricErr := SessionLoadBiometric(biometricCtx, vaultDir); biometricErr == nil && len(biometricPassphrase) > 0 {
 				passphrase = biometricPassphrase
 				passphraseFromBiometric = true
 			}
-		} else if cfg.EffectiveAuthMethod() == configpkg.AuthMethodTouchID && !interactive {
-			cliout.Warnf("Touch ID skipped in non-interactive mode; use 'symvault unlock' or enable security.allow_env_passphrase / SYMVAULT_ALLOW_ENV_PASSPHRASE")
+		} else if cfg.EffectiveAuthMethod() == configpkg.AuthMethodTouchID && !interactive && !SessionHasGUISession() {
+			cliout.Warnf("Touch ID skipped (no GUI session); use 'symvault unlock' in a graphical session or enable security.allow_env_passphrase / SYMVAULT_ALLOW_ENV_PASSPHRASE")
 		}
 		if len(passphrase) == 0 && IsEnvPassphraseAllowed(cfg) {
 			// Check the early-cached env passphrase first (sniffed in main()
@@ -234,6 +237,11 @@ func lockedMessageForCache() string {
 	status := SessionGetCacheStatus()
 	if !status.Persistent {
 		return "vault locked: this build cannot share 'symvault unlock' sessions across processes; use 'symvault unlock', enable Touch ID, or for headless/CI set security.allow_env_passphrase: true / SYMVAULT_ALLOW_ENV_PASSPHRASE=1"
+	}
+	if invokedCommandIsUnlock() {
+		// The user already ran `symvault unlock`; pointing them back at it
+		// would be a dead end. Point at the actual fixes instead.
+		return "vault locked: enable Touch ID with 'symvault auth set touchid' (or for headless/CI set security.allow_env_passphrase: true / SYMVAULT_ALLOW_ENV_PASSPHRASE=1)"
 	}
 	return "vault locked: run 'symvault unlock' first or enable Touch ID with 'symvault auth set touchid' (for headless/CI see security.allow_env_passphrase)"
 }

--- a/internal/cli/unlock_test.go
+++ b/internal/cli/unlock_test.go
@@ -126,6 +126,7 @@ func TestUnlockVaultWithTTLRefreshesTouchIDItemAfterBiometricUnlock(t *testing.T
 	oldSaveBiometric := SessionSaveBiometric
 	oldLoadIdentity := SessionLoadIdentity
 	oldSaveIdentity := SessionSaveIdentity
+	oldHasGUISession := SessionHasGUISession
 	t.Cleanup(func() {
 		SessionLoadPassphrase = oldLoadPassphrase
 		SessionSavePassphrase = oldSavePassphrase
@@ -133,10 +134,12 @@ func TestUnlockVaultWithTTLRefreshesTouchIDItemAfterBiometricUnlock(t *testing.T
 		SessionSaveBiometric = oldSaveBiometric
 		SessionLoadIdentity = oldLoadIdentity
 		SessionSaveIdentity = oldSaveIdentity
+		SessionHasGUISession = oldHasGUISession
 	})
 
 	SessionLoadIdentity = func(string) (string, error) { return "", errors.New("miss") }
 	SessionLoadPassphrase = func(string) ([]byte, error) { return nil, errors.New("miss") }
+	SessionHasGUISession = func() bool { return true }
 	SessionSavePassphrase = func(string, []byte, time.Duration) error { return nil }
 	SessionSaveIdentity = func(string, string, time.Duration) error { return nil }
 	SessionLoadBiometric = func(context.Context, string) ([]byte, error) {

--- a/internal/cli/unlock_test.go
+++ b/internal/cli/unlock_test.go
@@ -30,12 +30,15 @@ func TestUnlockVaultWithTTL_InteractiveSkipsBiometric(t *testing.T) {
 
 	oldLoadPassphrase := SessionLoadPassphrase
 	oldLoadBiometric := SessionLoadBiometric
+	oldHasGUISession := SessionHasGUISession
 	t.Cleanup(func() {
 		SessionLoadPassphrase = oldLoadPassphrase
 		SessionLoadBiometric = oldLoadBiometric
+		SessionHasGUISession = oldHasGUISession
 	})
 
 	SessionLoadPassphrase = func(string) ([]byte, error) { return nil, errors.New("miss") }
+	SessionHasGUISession = func() bool { return false }
 
 	biometricCalled := false
 	SessionLoadBiometric = func(context.Context, string) ([]byte, error) {
@@ -43,13 +46,63 @@ func TestUnlockVaultWithTTL_InteractiveSkipsBiometric(t *testing.T) {
 		return append([]byte(nil), passphrase...), nil
 	}
 
-	// Non-interactive unlock: biometric must NOT be called.
+	// Headless non-interactive unlock: biometric must NOT be called.
 	_, _, err := UnlockVaultWithTTL(vaultDir, false, 0, false)
 	if err == nil {
 		t.Fatal("expected locked error for non-interactive unlock without session or env passphrase")
 	}
 	if biometricCalled {
-		t.Fatal("SessionLoadBiometric must not be called in non-interactive mode")
+		t.Fatal("SessionLoadBiometric must not be called without a GUI session")
+	}
+}
+
+func TestUnlockVaultWithTTL_NonInteractiveUsesBiometricInGUISession(t *testing.T) {
+	vaultDir := t.TempDir()
+	passphrase := []byte("test-passphrase")
+	cfg := configpkg.Default()
+	if err := cfg.SetAuthMethod(configpkg.AuthMethodTouchID); err != nil {
+		t.Fatalf("SetAuthMethod() error = %v", err)
+	}
+	if _, err := vaultpkg.InitWithPassphrase(vaultDir, passphrase, cfg); err != nil {
+		t.Fatalf("InitWithPassphrase() error = %v", err)
+	}
+	if err := cfg.SaveTo(filepath.Join(vaultDir, "config.yaml")); err != nil {
+		t.Fatalf("SaveTo() error = %v", err)
+	}
+
+	oldLoadIdentity := SessionLoadIdentity
+	oldLoadPassphrase := SessionLoadPassphrase
+	oldLoadBiometric := SessionLoadBiometric
+	oldSavePassphrase := SessionSavePassphrase
+	oldSaveIdentity := SessionSaveIdentity
+	oldSaveBiometric := SessionSaveBiometric
+	oldHasGUISession := SessionHasGUISession
+	t.Cleanup(func() {
+		SessionLoadIdentity = oldLoadIdentity
+		SessionLoadPassphrase = oldLoadPassphrase
+		SessionLoadBiometric = oldLoadBiometric
+		SessionSavePassphrase = oldSavePassphrase
+		SessionSaveIdentity = oldSaveIdentity
+		SessionSaveBiometric = oldSaveBiometric
+		SessionHasGUISession = oldHasGUISession
+	})
+
+	SessionLoadIdentity = func(string) (string, error) { return "", errors.New("miss") }
+	SessionLoadPassphrase = func(string) ([]byte, error) { return nil, errors.New("miss") }
+	SessionHasGUISession = func() bool { return true }
+	SessionLoadBiometric = func(context.Context, string) ([]byte, error) {
+		return append([]byte(nil), passphrase...), nil
+	}
+	SessionSavePassphrase = func(string, []byte, time.Duration) error { return nil }
+	SessionSaveIdentity = func(string, string, time.Duration) error { return nil }
+	SessionSaveBiometric = func(context.Context, string, []byte) error { return nil }
+
+	v, _, err := UnlockVaultWithTTL(vaultDir, false, 0, false)
+	if err != nil {
+		t.Fatalf("non-interactive GUI unlock error = %v", err)
+	}
+	if v == nil {
+		t.Fatal("non-interactive GUI unlock returned nil vault")
 	}
 }
 

--- a/internal/session/guisession_darwin.go
+++ b/internal/session/guisession_darwin.go
@@ -1,0 +1,22 @@
+//go:build darwin
+
+package session
+
+import (
+	"os/exec"
+	"strings"
+)
+
+// HasGUISession reports whether the process runs inside a macOS Aqua
+// (GUI) session. Biometric prompts (Touch ID) are LocalAuthentication
+// GUI prompts: they can be shown without a controlling TTY, but only
+// when an Aqua session is present. launchctl managername returns "Aqua"
+// for GUI login sessions and "Background"/"System" for SSH, daemon and
+// CI contexts.
+func HasGUISession() bool {
+	out, err := exec.Command("launchctl", "managername").Output()
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(out)) == "Aqua"
+}

--- a/internal/session/guisession_nondarwin.go
+++ b/internal/session/guisession_nondarwin.go
@@ -1,0 +1,10 @@
+//go:build !darwin
+
+package session
+
+// HasGUISession reports whether the process runs inside a GUI session.
+// Only macOS supports biometric GUI prompts today; other platforms have
+// no Aqua session to probe and always report false.
+func HasGUISession() bool {
+	return false
+}


### PR DESCRIPTION
Closes #804

- Attempt Touch ID whenever the configured auth method has a macOS GUI session, independent of TTY state.
- Keep headless/CI fallback behavior and the existing 30-second timeout.
- Replace the dead-end unlock guidance when the failing command is already `symvault unlock`.
- Added injectable GUI-session detection and non-interactive coverage.