### PR TITLE
fix(doctor): clean stale atomic-write temp files

### DIFF
--- a/internal/health/doctor.go
+++ b/internal/health/doctor.go
@@ -94,6 +94,7 @@ var allChecks = []checkDef{
 	{fn: checkAuditLog},
 	{fn: checkUpdateAvailable, tags: []string{"network", "slow"}},
 	{fn: checkVaultSize},
+	{fn: checkVaultStaleTempFiles},
 	{fn: checkSearchIndexPersistence},
 	{fn: checkScryptBenchmark, tags: []string{"slow"}},
 	{fn: checkKDFModern},

--- a/internal/health/doctor_tempfiles.go
+++ b/internal/health/doctor_tempfiles.go
@@ -1,0 +1,90 @@
+package health
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// staleTempFileAge is deliberately generous: an atomic write normally takes
+// milliseconds, but a slow or paused process must not lose its in-flight temp
+// file while it is still writing.
+const staleTempFileAge = 24 * time.Hour
+
+func checkVaultStaleTempFiles(vaultDir string, _ Options) Result {
+	r := Result{
+		ID:      "vault.stale_temp_files",
+		Name:    "Stale atomic-write temp files",
+		Fixable: true,
+	}
+	r.Fix = func() error {
+		if FixDryRun {
+			return nil
+		}
+		stale, err := findStaleTempFiles(vaultDir, time.Now())
+		if err != nil {
+			return err
+		}
+		for _, path := range stale {
+			if err := os.Remove(path); err != nil {
+				return fmt.Errorf("remove %s: %w", filepath.Base(path), err)
+			}
+		}
+		return nil
+	}
+
+	stale, err := findStaleTempFiles(vaultDir, time.Now())
+	if err != nil {
+		r.Status = StatusWarn
+		r.Message = "cannot inspect atomic-write temp files: " + err.Error()
+		return r
+	}
+	if len(stale) == 0 {
+		r.Status = StatusOK
+		r.Message = "no stale atomic-write temp files"
+		return r
+	}
+
+	names := make([]string, 0, len(stale))
+	for _, path := range stale {
+		names = append(names, filepath.Base(path))
+	}
+	r.Status = StatusWarn
+	r.Message = fmt.Sprintf("%d stale atomic-write temp file(s): %s", len(names), strings.Join(names, ", "))
+	r.Hint = "run `symvault doctor --fix` to remove files older than 24h"
+	return r
+}
+
+func findStaleTempFiles(vaultDir string, now time.Time) ([]string, error) {
+	entries, err := os.ReadDir(vaultDir)
+	if err != nil {
+		return nil, err
+	}
+
+	stale := make([]string, 0)
+	for _, entry := range entries {
+		// AtomicWriteFile creates names such as manifest.age.tmp-12345.
+		// Restrict the sweep to direct children of vaultDir and this exact
+		// marker; never recurse or inspect unrelated files elsewhere.
+		if entry.IsDir() || !strings.Contains(entry.Name(), ".tmp-") {
+			continue
+		}
+		path := filepath.Join(vaultDir, entry.Name())
+		info, err := os.Lstat(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, err
+		}
+		if !info.Mode().IsRegular() || now.Sub(info.ModTime()) <= staleTempFileAge {
+			continue
+		}
+		stale = append(stale, path)
+	}
+	sort.Strings(stale)
+	return stale, nil
+}

--- a/internal/health/doctor_tempfiles_test.go
+++ b/internal/health/doctor_tempfiles_test.go
@@ -1,0 +1,105 @@
+package health
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestCheckVaultStaleTempFilesReportsOnlyOldDirectChildren(t *testing.T) {
+	vaultDir := t.TempDir()
+	stalePath := filepath.Join(vaultDir, "manifest.age.tmp-old")
+	freshPath := filepath.Join(vaultDir, "manifest.age.tmp-fresh")
+	nestedDir := filepath.Join(vaultDir, "nested")
+	outsidePath := filepath.Join(nestedDir, "other.age.tmp-old")
+
+	for _, path := range []string{stalePath, freshPath} {
+		if err := os.WriteFile(path, []byte("temporary"), 0o600); err != nil {
+			t.Fatalf("WriteFile(%q): %v", path, err)
+		}
+	}
+	if err := os.Mkdir(nestedDir, 0o700); err != nil {
+		t.Fatalf("Mkdir(): %v", err)
+	}
+	if err := os.WriteFile(outsidePath, []byte("temporary"), 0o600); err != nil {
+		t.Fatalf("WriteFile(%q): %v", outsidePath, err)
+	}
+
+	now := time.Now()
+	old := now.Add(-(staleTempFileAge + time.Minute))
+	if err := os.Chtimes(stalePath, old, old); err != nil {
+		t.Fatalf("Chtimes(stale): %v", err)
+	}
+	if err := os.Chtimes(outsidePath, old, old); err != nil {
+		t.Fatalf("Chtimes(outside): %v", err)
+	}
+
+	r := checkVaultStaleTempFiles(vaultDir, Options{})
+	if r.Status != StatusWarn {
+		t.Fatalf("status = %q, want %q", r.Status, StatusWarn)
+	}
+	if !strings.Contains(r.Message, filepath.Base(stalePath)) {
+		t.Errorf("message = %q, want stale filename", r.Message)
+	}
+	if strings.Contains(r.Message, filepath.Base(freshPath)) {
+		t.Errorf("message = %q, must not report fresh filename", r.Message)
+	}
+	if strings.Contains(r.Message, filepath.Base(outsidePath)) {
+		t.Errorf("message = %q, must not inspect nested filename", r.Message)
+	}
+}
+
+func TestCheckVaultStaleTempFilesFixRemovesOldLeavesFreshAndNested(t *testing.T) {
+	vaultDir := t.TempDir()
+	stalePath := filepath.Join(vaultDir, "manifest.age.tmp-old")
+	freshPath := filepath.Join(vaultDir, "manifest.age.tmp-fresh")
+	nestedDir := filepath.Join(vaultDir, "nested")
+	nestedPath := filepath.Join(nestedDir, "manifest.age.tmp-old")
+
+	for _, path := range []string{stalePath, freshPath} {
+		if err := os.WriteFile(path, []byte("temporary"), 0o600); err != nil {
+			t.Fatalf("WriteFile(%q): %v", path, err)
+		}
+	}
+	if err := os.Mkdir(nestedDir, 0o700); err != nil {
+		t.Fatalf("Mkdir(): %v", err)
+	}
+	if err := os.WriteFile(nestedPath, []byte("temporary"), 0o600); err != nil {
+		t.Fatalf("WriteFile(%q): %v", nestedPath, err)
+	}
+
+	old := time.Now().Add(-(staleTempFileAge + time.Minute))
+	if err := os.Chtimes(stalePath, old, old); err != nil {
+		t.Fatalf("Chtimes(stale): %v", err)
+	}
+	if err := os.Chtimes(nestedPath, old, old); err != nil {
+		t.Fatalf("Chtimes(nested): %v", err)
+	}
+
+	r := checkVaultStaleTempFiles(vaultDir, Options{})
+	if r.Fix == nil {
+		t.Fatal("expected stale temp-file check to be fixable")
+	}
+	if err := r.Fix(); err != nil {
+		t.Fatalf("Fix(): %v", err)
+	}
+
+	if _, err := os.Stat(stalePath); !os.IsNotExist(err) {
+		t.Errorf("stale file still exists, stat error = %v", err)
+	}
+	if _, err := os.Stat(freshPath); err != nil {
+		t.Errorf("fresh file should remain, stat error = %v", err)
+	}
+	if _, err := os.Stat(nestedPath); err != nil {
+		t.Errorf("nested file should remain, stat error = %v", err)
+	}
+}
+
+func TestCheckVaultStaleTempFilesNoMatchesIsOK(t *testing.T) {
+	r := checkVaultStaleTempFiles(t.TempDir(), Options{})
+	if r.Status != StatusOK {
+		t.Fatalf("status = %q, want %q", r.Status, StatusOK)
+	}
+}

--- a/internal/health/doctor_test.go
+++ b/internal/health/doctor_test.go
@@ -528,6 +528,7 @@ func TestFix_NonFixableChecks(t *testing.T) {
 		"vault.permissions":      true, // IT IS fixable
 		"git.repo":               true, // IT IS fixable
 		"git.gitignore.protects": true, // IT IS fixable
+		"vault.stale_temp_files": true, // IT IS fixable
 	}
 	// Everything else should NOT be fixable
 	for _, r := range results {


### PR DESCRIPTION
Closes #805

- Add a doctor check for stale `*.tmp-*` files directly in the vault directory.
- Use a 24-hour safety threshold so in-flight writes are not removed.
- Report each stale filename and make `doctor --fix` remove only those files.
- Added coverage for fresh files and nested paths remaining untouched.