### PR TITLE
fix(build): support doctor keyring probe off Darwin

### DIFF
--- a/internal/session/oskeyring_unavailable.go
+++ b/internal/session/oskeyring_unavailable.go
@@ -1,0 +1,10 @@
+//go:build !(darwin || linux || windows || netbsd || openbsd || ((freebsd || dragonfly) && cgo))
+
+package session
+
+// VerifyOSKeyring is unavailable on platforms without the OS-keyring
+// implementation. The doctor reports this as unavailable rather than
+// attempting a platform-specific keychain operation.
+func VerifyOSKeyring() error {
+	return ErrKeyringUnavailable
+}


### PR DESCRIPTION
The doctor keyring probe is unavailable on platforms without the OS-keyring implementation. Provide the compatibility stub so cross-platform builds compile and report the probe as unavailable instead of failing to build.

Verified locally with FreeBSD/arm64, Linux/arm64, Linux/amd64, and Darwin/amd64 cross-builds.