### PR TITLE
fix(git): scope commit identity to vault repository

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -215,11 +215,11 @@ func AutoCommitWithOptions(vaultDir string, opts CommitOptions) error {
 	}
 	authorName := opts.Author
 	if authorName == "" {
-		authorName = gitConfigUser("user.name")
+		authorName = gitConfigUser(vaultDir, "user.name")
 	}
 	authorEmail := opts.Email
 	if authorEmail == "" {
-		authorEmail = gitConfigUser("user.email")
+		authorEmail = gitConfigUser(vaultDir, "user.email")
 	}
 	if authorName == "" {
 		authorName = "Symaira Vault"

--- a/internal/git/git_util.go
+++ b/internal/git/git_util.go
@@ -74,8 +74,11 @@ func formatAuthor(sig object.Signature) string {
 	return fmt.Sprintf("%s <%s>", sig.Name, sig.Email)
 }
 
-func gitConfigUser(key string) string {
-	out, err := exec.Command("git", "config", "--get", key).Output()
+// gitConfigUser resolves identity from the vault repository rather than the
+// caller's working directory, so an unrelated project's local Git config
+// cannot change metadata on vault commits.
+func gitConfigUser(vaultDir, key string) string {
+	out, err := exec.Command("git", "-C", vaultDir, "config", "--get", key).Output()
 	if err != nil {
 		return ""
 	}


### PR DESCRIPTION
## Summary
- Resolve `user.name` and `user.email` with `git -C <vault>` instead of the caller's working directory.
- Prevent unrelated project-local Git configuration from changing vault commit metadata.
- Restore deterministic fallback-author behavior in the isolated default-author test.

## Verification
- `go test ./internal/git -run '^TestAutoCommitWithOptionsDefaultAuthor$' -count=1`
- `go test ./internal/git -count=1`
- `go vet ./internal/git`
- CI-parity race-mode coverage: 65.1% overall, 100% of changed executable statements; repository gate 63.5% passed.
- Required GitHub Actions checks passed, including Test (ubuntu) — PR, lint, security scans, and build.