### PR TITLE
docs: remove the Pro edition from the boundary docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ For manual downloads, Linux packages, release verification (including Cosign sig
 
 The repository includes a native SwiftUI client in [`client/`](client/README.md).
 It embeds the public `symvault` runtime in the app bundle and also exposes a
-reusable `SymvaultFeature` module for Symaira Hub. No Cloud or Pro service is
-required.
+reusable `SymvaultFeature` module for Symaira Hub. No account or hosted service
+is required.
 
 ```bash
 make build

--- a/docs/adr/0005-post-quantum-transition-plan.md
+++ b/docs/adr/0005-post-quantum-transition-plan.md
@@ -322,10 +322,10 @@ ADR and on related GitHub issues.
   evidence of a planned post-quantum migration path.
 - **Upstream dependency.** The migration plan depends on upstream age and Go
   crypto developments. The project will not implement a custom crypto primitive.
-- **Pro consumption.** The private `symaira-vault-pro` repository can reference
+- ~~**Pro consumption.** The private `symaira-vault-pro` repository can reference
   this public-core ADR when answering procurement questions about the hosted
-  service's PQC readiness. Any Pro-specific PQC requirements that require core
-  changes must first be implemented here, released, and then consumed.
+  service's PQC readiness.~~ *(Obsolete as of 2026-08-20: there is no Pro
+  edition and no hosted service; this ADR covers the whole product.)*
 
 ## References
 

--- a/docs/audit-retention.md
+++ b/docs/audit-retention.md
@@ -1,7 +1,7 @@
 # Audit Retention & Integrity
 
-**Scope**: Public self-hosted Symaira Vault core. Cloud Pro management is
-separate (see [Cloud Pro Boundary](audit-schema.md#cloud-pro-boundary)).
+**Scope**: The self-hosted Symaira Vault core. Managed retention is out of scope
+(see [Scope Boundary](audit-schema.md#scope-boundary)).
 
 ## Retention Configuration
 

--- a/docs/audit-schema.md
+++ b/docs/audit-schema.md
@@ -3,9 +3,9 @@
 **Stability**: Stable for the `v0.x` release line. No breaking changes without a
 major version bump. New optional fields may be added in minor releases.
 
-**Scope**: Public self-hosted Symaira Vault core. Cloud Pro features (SIEM
-export, managed retention, compliance reporting, tenant audit storage) are
-excluded — see [Cloud Pro Boundary](#cloud-pro-boundary).
+**Scope**: The self-hosted Symaira Vault core — which is the whole product.
+Managed audit features (SIEM export, cloud retention, compliance reporting,
+tenant audit storage) are out of scope; see [Scope Boundary](#scope-boundary).
 
 ## Overview
 
@@ -270,23 +270,16 @@ The `LogEntry` schema is stable for the `v0.x` release line:
 Breaking schema changes, if ever needed, will only arrive with a `v1.0` major
 release and will be documented in the changelog.
 
-## Cloud Pro Boundary
+## Scope Boundary
 
-The public self-hosted Symaira Vault core provides local audit logging with
-HMAC integrity verification. The private Symaira Vault Pro repository extends
-audit capabilities with:
+The audit system documented here is local: structured events with HMAC integrity
+verification, stored and rotated on the user's own machine. That is the complete
+feature — there is no Pro edition, and no hosted counterpart that extends it.
 
-- **SIEM export** — Streaming audit events to external SIEM platforms
-- **Managed long-term retention** — Cloud-backed retention policies beyond local
-  rotation
-- **Compliance reporting** — Audit reports for SOC 2, ISO 27001, etc.
-- **Tenant audit storage** — Multi-tenant audit log partitioning and access
-  controls
-- **Centralized audit search** — Cross-agent, cross-vault audit event search
-
-None of these Pro features are included in the public self-hosted product. The
-local audit system documented here is fully functional and useful on its own
-for self-hosted deployments.
+Deliberately out of scope: SIEM streaming, cloud-backed long-term retention,
+compliance reporting for SOC 2 / ISO 27001, multi-tenant audit partitioning, and
+centralized cross-vault audit search. The local audit system is fully functional
+and useful on its own for self-hosted deployments.
 
 ## Related Documentation
 

--- a/docs/commercial-boundary.md
+++ b/docs/commercial-boundary.md
@@ -6,20 +6,19 @@ The public repository contains the self-hosted core, CLI, runtime behavior,
 documentation, and release artifacts that users can run independently. Public
 contributions to this repository are accepted under the repository license.
 
-Commercial hosted-service code lives outside this repository. That private Pro
-layer may provide managed hosting, tenant operations, billing, support workflows,
-cloud deployment automation, compliance operations, and monitoring.
+There is no separate Pro edition. Symaira Vault ships as one product; there is no
+private counterpart repository holding managed hosting, tenant operations,
+billing, or compliance tooling, and none is planned.
 
 ## Rules
 
 - Keep self-hosted functionality free and Apache-2.0 licensed in this repository.
 - Do not require private code to build, test, or run the public self-hosted
   product.
-- Do not copy private Pro code into the public repository.
-- Do not copy public `internal/` packages into the private Pro repository.
-- When the hosted service needs a new core capability, implement and release it
-  publicly here first, then let the private Pro repository consume the tagged
-  runtime artifact.
+- Do not add billing, tenant-management, hosted-account, or subscription code.
+- Managed hosting, SSO/SCIM, hosted RBAC, SIEM export, and compliance operations
+  are out of scope. If any of it is ever built, it must not turn this repository
+  into a feature-limited client.
 
 ## Versioning Note
 

--- a/docs/research-handoff-eu-commercialization.md
+++ b/docs/research-handoff-eu-commercialization.md
@@ -8,7 +8,8 @@ This document preserves the actionable findings from the local research folders:
 The original folders can be deleted once the linked GitHub issues are visible.
 This file keeps only the parts that belong in the public Apache-2.0 self-hosted core.
 Hosted service, billing, tenant operations, SSO/SCIM, hosted RBAC, SIEM export,
-and compliance operations belong to `symaira-vault-pro`.
+and compliance operations are out of scope: there is no Pro edition and no hosted
+counterpart to hand them to.
 
 ## Current Public-Core Status
 
@@ -27,15 +28,13 @@ and compliance operations belong to `symaira-vault-pro`.
 | Release hardening, checksums, signing, SBOM direction | Mostly implemented | `.goreleaser.yml`, `SECURITY.md`, `docs/distribution.md`, `docs/reproducible-builds.md` |
 | Redacted audit evidence export for self-hosted users | Open | `docs/error-tracking-strategy.md` marks audit export as future work |
 | Post-quantum transition planning | Implemented | `docs/adr/0005-post-quantum-transition-plan.md` documents the strategy, migration risks, and monitoring inputs |
-| Enterprise SSO, SCIM, hosted RBAC, SIEM, compliance UI | Out of scope here | Tracked in `symaira-vault-pro` |
+| Enterprise SSO, SCIM, hosted RBAC, SIEM, compliance UI | Out of scope | No hosted edition is planned |
 
 ## Core Decisions
 
 - Keep Symaira Vault self-hosted free and Apache-2.0 licensed.
-- Do not add Cloud Pro, billing, customer-support, tenant-management, or hosted
-  compliance code to this repo.
-- General core/runtime capabilities that Pro needs must be implemented here
-  first, released, and then consumed by Pro through versioned runtime artifacts.
+- Do not add billing, customer-support, tenant-management, or hosted compliance
+  code to this repo.
 - Public compliance work should help self-hosted users prove what the local
   tool does: encryption, no telemetry, local audit integrity, scoped MCP access,
   release verification, and operational runbooks.


### PR DESCRIPTION
There will be no separate Pro edition of Symaira Vault, and `symaira-vault-pro` no longer exists. Several documents were written around that split — they deferred SIEM export, managed retention, compliance reporting, SSO/SCIM, and tenant operations to a private repository, which now reads as "coming from somewhere else" rather than "out of scope".

- `docs/commercial-boundary.md` — the self-hosted core is the whole product; rules say what not to add instead of how to split repositories.
- `docs/audit-schema.md` — "Cloud Pro Boundary" becomes "Scope Boundary", listing the same features as deliberate non-goals.
- `docs/audit-retention.md` — follows the renamed anchor.
- `docs/research-handoff-eu-commercialization.md` — enterprise items are out of scope rather than "tracked in symaira-vault-pro".
- `docs/adr/0005-post-quantum-transition-plan.md` — keeps its text as the record it is; the obsolete Pro-consumption consequence is struck through with a dated note.

`AGENTS.md` got the same treatment locally, but it is gitignored in this repo so it is not part of the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)