### PR TITLE
ci: shorten pull request feedback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,7 +189,7 @@ jobs:
           CGO_ENABLED: '1'
           SYMVAULT_ALLOW_ENV_PASSPHRASE: '1'
         run: |
-          go test -v -race -timeout=30m -skip 'TestFlow|TestBinaryE2E|Integration' ./...
+          go test -v -timeout=15m -skip 'TestFlow|TestBinaryE2E|Integration' ./...
 
   build-pr:
     name: Build (linux-amd64) — PR


### PR DESCRIPTION
## What changed
- Keep required pull request checks focused on fast feedback.
- Retain comprehensive race, coverage, compatibility, or platform checks on main and weekly schedules.

## Why
Non-required security scans and comprehensive suites were extending pull request latency and, on self-hosted macOS runners, serializing otherwise short required jobs.

## Verification
- `actionlint` passed for every changed workflow.
- Workflow triggers were parsed and verified as schedule/manual-only for CodeQL.
- `git diff --check` passed.
- The new PR-fast Go suite passed locally.
