### PR TITLE
fix(test): stop MCP server and wizard tests polluting the real vault dir

### DIFF
--- a/internal/audit/hermetic_guard_test.go
+++ b/internal/audit/hermetic_guard_test.go
@@ -1,0 +1,98 @@
+package audit_test
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestNoEmptyVaultDirOutsideAuditPackage guards against a whole class of
+// test pollution: audit.New falls back to $HOME/.symvault when vaultDir is
+// empty, so any caller passing "" that does not also redirect HOME appends
+// to the developer's real audit log. That is how internal/mcp/server's
+// newTestServer helper silently grew ~/.symvault/audit-test.log to 132k
+// lines across 52 call sites.
+//
+// The audit package's own tests use the fallback deliberately and always
+// pair it with t.Setenv("HOME", ...), so they are exempt. Everywhere else,
+// pass a real directory (t.TempDir() in tests, the vault dir in production).
+func TestNoEmptyVaultDirOutsideAuditPackage(t *testing.T) {
+	repoRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("resolve repo root: %v", err)
+	}
+
+	// The audit package owns the fallback and tests it directly.
+	exempt := filepath.Join(repoRoot, "internal", "audit")
+
+	var offenders []string
+	fset := token.NewFileSet()
+
+	walkErr := filepath.WalkDir(repoRoot, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			base := d.Name()
+			if base == ".git" || base == "testdata" || base == "node_modules" {
+				return filepath.SkipDir
+			}
+			if path == exempt {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+
+		file, parseErr := parser.ParseFile(fset, path, nil, 0)
+		if parseErr != nil {
+			// Unparseable files are the compiler's problem, not this guard's.
+			return nil //nolint:nilerr // deliberate: skip, do not fail the guard
+		}
+
+		ast.Inspect(file, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok || len(call.Args) < 2 {
+				return true
+			}
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok || sel.Sel.Name != "New" {
+				return true
+			}
+			pkg, ok := sel.X.(*ast.Ident)
+			if !ok || pkg.Name != "audit" {
+				return true
+			}
+			lit, ok := call.Args[1].(*ast.BasicLit)
+			if !ok || lit.Kind != token.STRING {
+				return true
+			}
+			if lit.Value == `""` {
+				rel, relErr := filepath.Rel(repoRoot, path)
+				if relErr != nil {
+					rel = path
+				}
+				offenders = append(offenders, rel+":"+
+					fset.Position(call.Pos()).String()[len(fset.Position(call.Pos()).Filename)+1:])
+			}
+			return true
+		})
+		return nil
+	})
+	if walkErr != nil {
+		t.Fatalf("walk repo: %v", walkErr)
+	}
+
+	if len(offenders) > 0 {
+		t.Errorf("audit.New called with an empty vaultDir outside internal/audit at %d site(s):\n  %s\n\n"+
+			"An empty vaultDir falls back to $HOME/.symvault and writes to the developer's real "+
+			"audit log. Pass t.TempDir() in tests or the vault directory in production.",
+			len(offenders), strings.Join(offenders, "\n  "))
+	}
+}

--- a/internal/mcp/server/mcp_test.go
+++ b/internal/mcp/server/mcp_test.go
@@ -15,7 +15,7 @@ import (
 func newTestServer(t *testing.T, profile config.AgentProfile, transport string) *Server {
 	t.Helper()
 
-	auditLog, err := audit.New("test", "", nil)
+	auditLog, err := audit.New("test", t.TempDir(), nil)
 	if err != nil {
 		t.Fatalf("audit.New() error = %v", err)
 	}

--- a/internal/mcp/server/tools_test_helpers.go
+++ b/internal/mcp/server/tools_test_helpers.go
@@ -17,7 +17,7 @@ import (
 func newTestServerWithVault(t *testing.T, profile config.AgentProfile, transport string, vaultDir string) *Server {
 	t.Helper()
 
-	auditLog, err := audit.New("test", "", nil)
+	auditLog, err := audit.New("test", t.TempDir(), nil)
 	if err != nil {
 		t.Fatalf("audit.New() error = %v", err)
 	}

--- a/internal/ui/wizard/main_test.go
+++ b/internal/ui/wizard/main_test.go
@@ -1,0 +1,32 @@
+package wizard
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+// TestMain redirects the environment variables that os.UserCacheDir and
+// os.UserHomeDir resolve from so wizard tests never write into the
+// developer's real cache or home directory. Without this, every
+// SaveResumeState call in the suite leaves a stale YAML file behind in
+// ~/Library/Caches/symaira/wizard (macOS) or $XDG_CACHE_HOME/symaira/wizard,
+// keyed by a hash of the per-test temp vault dir so it is never reused or
+// cleaned up.
+func TestMain(m *testing.M) {
+	tmpHome, err := os.MkdirTemp("", "symvault-wizard-home")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "create temp home: %v\n", err)
+		os.Exit(1)
+	}
+
+	// HOME covers macOS ($HOME/Library/Caches) and the Linux fallback
+	// ($HOME/.cache); XDG_CACHE_HOME takes precedence on Linux when the
+	// developer has it set, so pin it too.
+	os.Setenv("HOME", tmpHome)
+	os.Setenv("XDG_CACHE_HOME", tmpHome+"/.cache")
+
+	code := m.Run()
+	os.RemoveAll(tmpHome)
+	os.Exit(code)
+}


### PR DESCRIPTION
## Summary
- `newTestServer`/`newTestServerWithVault` in `internal/mcp/server` called `audit.New("test", "", nil)`, whose empty `vaultDir` falls back to `$HOME/.symvault` — appending real audit entries on every test run (132k lines / 29.8MB accumulated since 2026-05-09 on the reporting machine). Both call sites now pass `t.TempDir()`.
- Same root pattern in `internal/ui/wizard`: `SaveResumeState` resolves `os.UserCacheDir()` unguarded, leaving 60+ stale YAML files in the developer's real `~/Library/Caches/symaira/wizard`. Added a package `TestMain` that redirects `HOME`/`XDG_CACHE_HOME`, matching the existing `TestMain` convention in `internal/vault`, `internal/mcp/server`, and `internal/crypto`.
- Added a regression guard (`internal/audit/hermetic_guard_test.go`) that fails if any package outside `internal/audit` calls `audit.New` with an empty `vaultDir`. The audit package's own 88 test call sites use the `$HOME` fallback deliberately, each paired with `t.Setenv("HOME", ...)`, so the fallback itself is preserved — only accidental use elsewhere is now caught.

## Test plan
- [x] `go test -race ./...` passes
- [x] `make lint` / `make vet` / `make fmt-check` clean
- [x] Reintroduced the original bug and confirmed the new guard test fails with the exact file:line
- [x] Ran the full suite against the real `$HOME` and diffed keychain / `~/.symvault` / wizard cache state before vs. after — no pollution (one unrelated legitimate audit-log rotation from live session activity, not from tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)