### PR TITLE
Git-sync treats every dirty file as a conflict after a failed pull, instead of actual unmerged paths

### DIFF
--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -67,11 +67,13 @@ func newSyncCmd() *cobra.Command {
 			}
 
 			if result.Success {
-				printlnQuietAware("Pulled from remote")
 				if err := git.SetLastSyncTime(vaultDir); err != nil {
 					cliout.Warnf("Warning: could not record sync time: %v", err)
 				}
+			}
 
+			if result.Updated {
+				printlnQuietAware("Pulled from remote")
 				if err := git.ResolveConflicts(vaultDir, git.DeviceIdentity(vaultDir)); err != nil {
 					cliout.Warnf("Warning: conflict resolution failed: %v", err)
 				}

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -33,10 +33,15 @@ func MaybeAutoPull(vaultDir string, cfg *configpkg.Config) {
 	}
 
 	result := git.PullWithResult(vaultDir)
+
+	// Record the attempt regardless of outcome: ShouldAutoPull throttles how
+	// often a pull is attempted, not whether it succeeded. Recording only on
+	// success left a failing pull retried on every single CLI invocation.
+	if err := git.SetLastSyncTime(vaultDir); err != nil {
+		cliout.Warnf("Warning: could not record sync time: %v", err)
+	}
+
 	if result.Error != nil {
-		if git.IsOfflineError(result.Error) {
-			return
-		}
 		return
 	}
 
@@ -44,12 +49,10 @@ func MaybeAutoPull(vaultDir string, cfg *configpkg.Config) {
 		return
 	}
 
-	if err := git.SetLastSyncTime(vaultDir); err != nil {
-		cliout.Warnf("Warning: could not record sync time: %v", err)
-	}
-
-	if err := git.ResolveConflicts(vaultDir, git.DeviceIdentity(vaultDir)); err != nil {
-		cliout.Warnf("Warning: conflict resolution failed: %v", err)
+	if result.Updated {
+		if err := git.ResolveConflicts(vaultDir, git.DeviceIdentity(vaultDir)); err != nil {
+			cliout.Warnf("Warning: conflict resolution failed: %v", err)
+		}
 	}
 
 	conflictFiles := findConflictFiles(vaultDir)

--- a/internal/cli/sync_test.go
+++ b/internal/cli/sync_test.go
@@ -4,7 +4,12 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
+	gogit "github.com/go-git/go-git/v5"
+	gogitconfig "github.com/go-git/go-git/v5/config"
+
+	configpkg "github.com/danieljustus/symaira-vault/internal/config"
 	"github.com/danieljustus/symaira-vault/internal/git"
 )
 
@@ -130,6 +135,107 @@ func TestFindConflictFiles_NestedConflicts(t *testing.T) {
 	if got != want {
 		t.Errorf("conflict file = %q, want %q", got, want)
 	}
+}
+
+// TestMaybeAutoPullRecordsAttemptOnFailure is the regression test for
+// acceptance criterion 4 of #831: a failed pull must still record enough
+// state that the next invocation does not repeat the identical pull attempt.
+// Before the fix, MaybeAutoPull returned on any pull error before ever
+// calling SetLastSyncTime, so ShouldAutoPull kept firing on every command.
+func TestMaybeAutoPullRecordsAttemptOnFailure(t *testing.T) {
+	localDir, remoteBareDir := autoPullVaultPair(t)
+	_ = remoteBareDir
+
+	cfg := &configpkg.Config{Git: &configpkg.GitConfig{
+		AutoPull:         true,
+		AutoPullInterval: time.Hour,
+	}}
+
+	if git.ShouldAutoPull(localDir, time.Hour) != true {
+		t.Fatalf("expected ShouldAutoPull to be true before any attempt")
+	}
+
+	MaybeAutoPull(localDir, cfg)
+
+	lastSync, err := git.LastSyncTime(localDir)
+	if err != nil {
+		t.Fatalf("LastSyncTime: %v", err)
+	}
+	if lastSync.IsZero() {
+		t.Fatal("SetLastSyncTime was not recorded although the pull attempt completed (with a failure)")
+	}
+	if git.ShouldAutoPull(localDir, time.Hour) {
+		t.Error("ShouldAutoPull is still true immediately after a failed attempt — the retry loop is not fixed")
+	}
+}
+
+// autoPullVaultPair builds a local vault clone whose next pull is guaranteed
+// to fail with a non-fast-forward error: the local and remote histories have
+// independently committed different content for the same tracked file.
+func autoPullVaultPair(t *testing.T) (localDir, remoteBareDir string) {
+	t.Helper()
+	remoteBareDir = t.TempDir()
+	if _, err := gogit.PlainInit(remoteBareDir, true); err != nil {
+		t.Fatalf("PlainInit bare remote: %v", err)
+	}
+
+	seedDir := t.TempDir()
+	if err := git.Init(seedDir); err != nil {
+		t.Fatalf("Init seed: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(seedDir, "entries"), 0o700); err != nil {
+		t.Fatalf("mkdir entries: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(seedDir, "entries", "a.age"), []byte("v1"), 0o600); err != nil {
+		t.Fatalf("write seed entry: %v", err)
+	}
+	if err := git.AutoCommit(seedDir, "initial"); err != nil {
+		t.Fatalf("AutoCommit seed: %v", err)
+	}
+	seedRepo, err := gogit.PlainOpen(seedDir)
+	if err != nil {
+		t.Fatalf("PlainOpen seed: %v", err)
+	}
+	if _, err := seedRepo.CreateRemote(&gogitconfig.RemoteConfig{
+		Name: "origin",
+		URLs: []string{remoteBareDir},
+	}); err != nil {
+		t.Fatalf("CreateRemote: %v", err)
+	}
+	if err := seedRepo.Push(&gogit.PushOptions{RemoteName: "origin"}); err != nil {
+		t.Fatalf("push seed: %v", err)
+	}
+
+	localDir = t.TempDir()
+	if _, err := gogit.PlainClone(localDir, false, &gogit.CloneOptions{URL: remoteBareDir}); err != nil {
+		t.Fatalf("PlainClone local: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(localDir, "entries", "a.age"), []byte("local-version"), 0o600); err != nil {
+		t.Fatalf("write local entry: %v", err)
+	}
+	if err := git.AutoCommit(localDir, "local edit"); err != nil {
+		t.Fatalf("AutoCommit local: %v", err)
+	}
+
+	otherDir := t.TempDir()
+	if _, err := gogit.PlainClone(otherDir, false, &gogit.CloneOptions{URL: remoteBareDir}); err != nil {
+		t.Fatalf("PlainClone other device: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(otherDir, "entries", "a.age"), []byte("remote-version"), 0o600); err != nil {
+		t.Fatalf("write remote entry: %v", err)
+	}
+	if err := git.AutoCommit(otherDir, "remote edit"); err != nil {
+		t.Fatalf("AutoCommit other device: %v", err)
+	}
+	otherRepo, err := gogit.PlainOpen(otherDir)
+	if err != nil {
+		t.Fatalf("PlainOpen other device: %v", err)
+	}
+	if err := otherRepo.Push(&gogit.PushOptions{RemoteName: "origin"}); err != nil {
+		t.Fatalf("push other device: %v", err)
+	}
+
+	return localDir, remoteBareDir
 }
 
 // testError is a simple error implementation for testing

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -41,6 +41,11 @@ type PullResult struct {
 	Error     error
 	RemoteURL string
 	Success   bool
+	// Updated is true only when the pull actually merged new commits from
+	// the remote. Success is also true for a no-op "already up to date"
+	// pull, but nothing was fetched in that case, so there is nothing a
+	// post-pull conflict sweep could meaningfully find.
+	Updated   bool
 	Skipped   bool
 	HasRemote bool
 	Conflicts []string

--- a/internal/git/git_pull.go
+++ b/internal/git/git_pull.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	gogit "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
 )
 
@@ -72,8 +73,19 @@ func PullWithResult(vaultDir string) PullResult {
 		return result
 	}
 
+	// Captured before the pull attempt: a failed pull can still advance the
+	// local branch ref as a side effect of go-git's internal fetch-then-merge
+	// sequence (Pull moves HEAD before Reset checks for unstaged changes), so
+	// HEAD read after the fact is not a reliable "before" snapshot.
+	preHead := headCommit(repo)
+
 	pullErr := pullWithSSHAuth(w, originRemote.Config().URLs[0])
-	if pullErr == nil || errors.Is(pullErr, gogit.NoErrAlreadyUpToDate) {
+	if pullErr == nil {
+		result.Success = true
+		result.Updated = true
+		return result
+	}
+	if errors.Is(pullErr, gogit.NoErrAlreadyUpToDate) {
 		result.Success = true
 		return result
 	}
@@ -102,7 +114,7 @@ func PullWithResult(vaultDir string) PullResult {
 	}
 
 	deviceName := DeviceIdentity(vaultDir)
-	resolveErr := ResolveConflicts(vaultDir, deviceName)
+	resolveErr := resolveDivergedConflicts(repo, vaultDir, deviceName, preHead, "origin")
 	if resolveErr == nil {
 		w2, wtErr := repo.Worktree()
 		if wtErr == nil {
@@ -117,10 +129,25 @@ func PullWithResult(vaultDir string) PullResult {
 	}
 
 	result.Error = &PushError{
-		Message: "pull failed",
+		Message: classifyPullFailure(pullErr),
 		Cause:   pullErr,
 	}
 	return result
+}
+
+// classifyPullFailure turns a pull error into a short, actionable cause. A
+// dirty worktree or a diverged history are not by themselves proof of a
+// merge conflict (see resolveDivergedConflicts) — this only labels *why*
+// the pull itself could not proceed.
+func classifyPullFailure(err error) string {
+	switch {
+	case errors.Is(err, gogit.ErrNonFastForwardUpdate):
+		return "pull failed: local and remote history have diverged"
+	case errors.Is(err, gogit.ErrUnstagedChanges), errors.Is(err, gogit.ErrWorktreeNotClean):
+		return "pull failed: local changes would be overwritten by the incoming update"
+	default:
+		return "pull failed"
+	}
 }
 
 // Sync performs a pull followed by an optional push.
@@ -160,25 +187,127 @@ func ResolveConflicts(vaultDir string, deviceName string) error {
 		if fileStatus.Staging != gogit.Unmodified || fileStatus.Worktree == gogit.Unmodified {
 			continue
 		}
-		if !strings.HasSuffix(path, ".age") && path != "config.yaml" {
-			continue
-		}
-		if strings.Contains(path, ConflictMarker) {
-			continue
-		}
-		fullPath := filepath.Join(vaultDir, path)
-		if path == "identity.age" || isProtectedRuntimePath(path) {
-			continue
-		}
-		ext := filepath.Ext(path)
-		base := strings.TrimSuffix(path, ext)
-		conflictName := base + ConflictMarker + deviceName + ext
-		conflictPath := filepath.Join(vaultDir, conflictName)
-		if err := writeConflictCopy(fullPath, conflictPath, head, path); err != nil {
-			return fmt.Errorf("save conflict file %s: %w", conflictName, err)
+		if err := preserveConflictCandidate(vaultDir, deviceName, path, head); err != nil {
+			return err
 		}
 	}
 	return nil
+}
+
+// isConflictCandidatePath reports whether path is one this package ever
+// snapshots as a conflict copy: a tracked vault entry or config.yaml, never
+// an already-written conflict copy or a protected runtime file.
+func isConflictCandidatePath(path string) bool {
+	if !strings.HasSuffix(path, ".age") && path != "config.yaml" {
+		return false
+	}
+	if strings.Contains(path, ConflictMarker) {
+		return false
+	}
+	if path == "identity.age" || isProtectedRuntimePath(path) {
+		return false
+	}
+	return true
+}
+
+// preserveConflictCandidate writes a conflict copy for path, comparing its
+// current on-disk content against baseline to decide whether it actually
+// diverged (see writeConflictCopy). Non-candidate paths are silently skipped.
+func preserveConflictCandidate(vaultDir, deviceName, path string, baseline *object.Commit) error {
+	if !isConflictCandidatePath(path) {
+		return nil
+	}
+	fullPath := filepath.Join(vaultDir, path)
+	ext := filepath.Ext(path)
+	base := strings.TrimSuffix(path, ext)
+	conflictName := base + ConflictMarker + deviceName + ext
+	conflictPath := filepath.Join(vaultDir, conflictName)
+	if err := writeConflictCopy(fullPath, conflictPath, baseline, path); err != nil {
+		return fmt.Errorf("save conflict file %s: %w", conflictName, err)
+	}
+	return nil
+}
+
+// resolveDivergedConflicts is the failure-path counterpart to ResolveConflicts:
+// it only preserves a file when the fetched remote tip genuinely changed that
+// path since the two histories' common ancestor. A file that merely happens
+// to be dirty in the worktree — but that the remote never touched — is left
+// alone even though the pull failed, because that dirt did not cause the
+// failure and is not a conflict (see issue #831).
+//
+// go-git's own fetch step, run internally by Pull before it attempts any
+// merge, updates the "<remoteName>/<branch>" remote-tracking ref regardless
+// of whether the merge itself succeeds — that is what makes this comparison
+// possible without a second network round trip. preHead must be the local
+// HEAD captured *before* Pull was called: a failed pull can still advance
+// the local branch ref as a side effect (Pull moves HEAD before Reset checks
+// for unstaged changes), so HEAD read after the fact cannot serve as the
+// "before" snapshot.
+func resolveDivergedConflicts(repo *gogit.Repository, vaultDir, deviceName string, preHead *object.Commit, remoteName string) error {
+	renameConflictsForDevice(vaultDir, deviceName)
+
+	if preHead == nil {
+		return nil
+	}
+	head, err := repo.Head()
+	if err != nil || !head.Name().IsBranch() {
+		return nil
+	}
+	remoteRef, err := repo.Reference(plumbing.NewRemoteReferenceName(remoteName, head.Name().Short()), true)
+	if err != nil {
+		return nil
+	}
+	remoteHead, err := repo.CommitObject(remoteRef.Hash())
+	if err != nil || remoteHead.Hash == preHead.Hash {
+		return nil
+	}
+
+	ancestor := preHead
+	if bases, mbErr := preHead.MergeBase(remoteHead); mbErr == nil && len(bases) > 0 {
+		ancestor = bases[0]
+	}
+
+	changed, err := changedPaths(ancestor, remoteHead)
+	if err != nil {
+		return err
+	}
+	for _, path := range changed {
+		if err := preserveConflictCandidate(vaultDir, deviceName, path, ancestor); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// changedPaths returns the file paths whose content differs between two
+// commits' trees, deduplicated (a rename touches both a From and a To entry).
+func changedPaths(from, to *object.Commit) ([]string, error) {
+	fromTree, err := from.Tree()
+	if err != nil {
+		return nil, err
+	}
+	toTree, err := to.Tree()
+	if err != nil {
+		return nil, err
+	}
+	changes, err := fromTree.Diff(toTree)
+	if err != nil {
+		return nil, err
+	}
+	seen := make(map[string]bool, len(changes))
+	paths := make([]string, 0, len(changes))
+	for _, ch := range changes {
+		name := ch.To.Name
+		if name == "" {
+			name = ch.From.Name
+		}
+		if name == "" || seen[name] {
+			continue
+		}
+		seen[name] = true
+		paths = append(paths, name)
+	}
+	return paths, nil
 }
 
 // writeConflictCopy preserves the working-tree content of src as a conflict

--- a/internal/git/git_pull_divergence_test.go
+++ b/internal/git/git_pull_divergence_test.go
@@ -1,0 +1,182 @@
+package git
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	gogit "github.com/go-git/go-git/v5"
+	gogitconfig "github.com/go-git/go-git/v5/config"
+)
+
+// remoteVaultPair creates a bare "remote" repository and a "local" vault
+// clone of it, both starting from one commit that has entries/a.age = "v1"
+// and config.yaml = "cfg1".
+func remoteVaultPair(t *testing.T) (localDir, remoteBareDir string) {
+	t.Helper()
+	remoteBareDir = t.TempDir()
+	if _, err := gogit.PlainInit(remoteBareDir, true); err != nil {
+		t.Fatalf("PlainInit bare remote: %v", err)
+	}
+
+	seedDir := t.TempDir()
+	if err := Init(seedDir); err != nil {
+		t.Fatalf("Init seed: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(seedDir, "entries"), 0o700); err != nil {
+		t.Fatalf("mkdir entries: %v", err)
+	}
+	writeFile(t, seedDir, "entries/a.age", []byte("v1"))
+	writeFile(t, seedDir, "config.yaml", []byte("cfg1"))
+	if err := AutoCommit(seedDir, "initial"); err != nil {
+		t.Fatalf("AutoCommit seed: %v", err)
+	}
+	seedRepo, err := openRepo(seedDir)
+	if err != nil {
+		t.Fatalf("openRepo seed: %v", err)
+	}
+	if _, err := seedRepo.CreateRemote(&gogitconfig.RemoteConfig{
+		Name: "origin",
+		URLs: []string{remoteBareDir},
+	}); err != nil {
+		t.Fatalf("CreateRemote: %v", err)
+	}
+	if err := seedRepo.Push(&gogit.PushOptions{RemoteName: "origin"}); err != nil {
+		t.Fatalf("push seed: %v", err)
+	}
+
+	localDir = t.TempDir()
+	if _, err := gogit.PlainClone(localDir, false, &gogit.CloneOptions{URL: remoteBareDir}); err != nil {
+		t.Fatalf("PlainClone local: %v", err)
+	}
+	return localDir, remoteBareDir
+}
+
+// pushFromFreshClone clones remoteBareDir into a scratch directory, applies
+// mutate, commits and pushes — simulating another device syncing a change.
+func pushFromFreshClone(t *testing.T, remoteBareDir, message string, mutate func(dir string)) {
+	t.Helper()
+	dir := t.TempDir()
+	if _, err := gogit.PlainClone(dir, false, &gogit.CloneOptions{URL: remoteBareDir}); err != nil {
+		t.Fatalf("PlainClone other device: %v", err)
+	}
+	mutate(dir)
+	if err := AutoCommit(dir, message); err != nil {
+		t.Fatalf("AutoCommit other device: %v", err)
+	}
+	repo, err := openRepo(dir)
+	if err != nil {
+		t.Fatalf("openRepo other device: %v", err)
+	}
+	if err := repo.Push(&gogit.PushOptions{RemoteName: "origin"}); err != nil {
+		t.Fatalf("push other device: %v", err)
+	}
+}
+
+func conflictCopyPath(vaultDir, path string) string {
+	ext := filepath.Ext(path)
+	base := path[:len(path)-len(ext)]
+	return filepath.Join(vaultDir, base+ConflictMarker+DeviceIdentity(vaultDir)+ext)
+}
+
+// TestPullWithResultDirtyUnrelatedFileWritesNoConflictCopy is the regression
+// test for acceptance criterion 1 of #831: a failed pull whose only local
+// change is an unrelated dirty file (the remote never touched it) must not
+// produce a conflict copy for that file, even though the pull itself failed.
+func TestPullWithResultDirtyUnrelatedFileWritesNoConflictCopy(t *testing.T) {
+	localDir, remoteBareDir := remoteVaultPair(t)
+
+	// config.yaml is dirty locally but the remote never touches it — only a
+	// different tracked file changes on the remote side, which is what
+	// makes the incoming pull fail with "worktree contains unstaged changes"
+	// (go-git's Pull moves HEAD before it discovers the worktree is dirty).
+	writeFile(t, localDir, "config.yaml", []byte("cfg1-local-edit"))
+	pushFromFreshClone(t, remoteBareDir, "add b", func(dir string) {
+		writeFile(t, dir, "entries/b.age", []byte("new-entry"))
+	})
+
+	result := PullWithResult(localDir)
+	if result.Error == nil {
+		t.Fatalf("expected the pull to fail (dirty worktree blocks the incoming merge), got success")
+	}
+
+	copyPath := conflictCopyPath(localDir, "config.yaml")
+	if _, err := os.Stat(copyPath); !os.IsNotExist(err) {
+		t.Errorf("conflict copy written for config.yaml although the remote never touched it (stat error = %v)", err)
+	}
+	if len(result.Conflicts) != 0 {
+		t.Errorf("result.Conflicts = %v, want empty", result.Conflicts)
+	}
+}
+
+// TestPullWithResultGenuineConflictPreservesLocalVersion is the regression
+// test for acceptance criterion 2 of #831: when the same entry is changed
+// both locally (auto-committed, as symvault does for every entry write) and
+// on the remote, the failed pull must still preserve exactly one conflict
+// copy holding the local version.
+func TestPullWithResultGenuineConflictPreservesLocalVersion(t *testing.T) {
+	localDir, remoteBareDir := remoteVaultPair(t)
+
+	writeFile(t, localDir, "entries/a.age", []byte("local-version"))
+	if err := AutoCommit(localDir, "local edit"); err != nil {
+		t.Fatalf("AutoCommit local: %v", err)
+	}
+	pushFromFreshClone(t, remoteBareDir, "remote edit", func(dir string) {
+		writeFile(t, dir, "entries/a.age", []byte("remote-version"))
+	})
+
+	result := PullWithResult(localDir)
+	if result.Error == nil {
+		t.Fatalf("expected the pull to fail (diverged history), got success")
+	}
+
+	copyPath := conflictCopyPath(localDir, "entries/a.age")
+	data, err := os.ReadFile(copyPath)
+	if err != nil {
+		t.Fatalf("expected a conflict copy at %s: %v", copyPath, err)
+	}
+	if string(data) != "local-version" {
+		t.Errorf("conflict copy content = %q, want %q", data, "local-version")
+	}
+	if len(result.Conflicts) != 1 {
+		t.Errorf("result.Conflicts = %v, want exactly one entry", result.Conflicts)
+	}
+}
+
+// TestPullWithResultNoopSuccessIsNotMarkedUpdated guards the Updated flag a
+// caller relies on to decide whether a conflict sweep is even meaningful: a
+// pull that fetched nothing new (already up to date) must not report Updated,
+// otherwise a permanently dirty config.yaml (never staged by AutoCommit)
+// would still be swept and copied on every trivial no-op sync.
+func TestPullWithResultNoopSuccessIsNotMarkedUpdated(t *testing.T) {
+	localDir, _ := remoteVaultPair(t)
+	writeFile(t, localDir, "config.yaml", []byte("cfg1-local-edit"))
+
+	result := PullWithResult(localDir)
+	if result.Error != nil {
+		t.Fatalf("PullWithResult: unexpected error %v", result.Error)
+	}
+	if !result.Success {
+		t.Fatalf("expected Success=true for an already-up-to-date pull")
+	}
+	if result.Updated {
+		t.Errorf("Updated=true for a no-op pull that fetched nothing new")
+	}
+}
+
+// TestPullWithResultRealUpdateIsMarkedUpdated is the positive counterpart:
+// a pull that actually fast-forwards must report Updated=true.
+func TestPullWithResultRealUpdateIsMarkedUpdated(t *testing.T) {
+	localDir, remoteBareDir := remoteVaultPair(t)
+	pushFromFreshClone(t, remoteBareDir, "add b", func(dir string) {
+		writeFile(t, dir, "entries/b.age", []byte("new-entry"))
+	})
+
+	result := PullWithResult(localDir)
+	if result.Error != nil {
+		t.Fatalf("PullWithResult: unexpected error %v", result.Error)
+	}
+	if !result.Updated {
+		t.Errorf("Updated=false for a pull that fast-forwarded new commits")
+	}
+}


### PR DESCRIPTION
Bundles fixes for multiple open issues. The list below grows as commits land; every linked issue will close automatically on merge.

<!-- closes-list-start -->
- Closes #831 Git-sync treats every dirty file as a conflict after a failed pull, instead of actual unmerged paths
<!-- closes-list-end -->
