### PR TITLE
test(health): cover orphaned conflict-file detection and --fix guard paths (#841)

### DIFF
--- a/internal/health/doctor_conflicts.go
+++ b/internal/health/doctor_conflicts.go
@@ -42,10 +42,7 @@ func findConflictCopies(vaultDir string) ([]conflictFile, error) {
 		if !ok {
 			return nil
 		}
-		rel, relErr := filepath.Rel(vaultDir, path)
-		if relErr != nil {
-			rel = d.Name()
-		}
+		rel, _ := filepath.Rel(vaultDir, path)
 		found = append(found, conflictFile{
 			path:      path,
 			rel:       rel,

--- a/internal/health/doctor_conflicts_test.go
+++ b/internal/health/doctor_conflicts_test.go
@@ -135,3 +135,196 @@ func TestCheckVaultOrphanedConflictFilesDryRunKeepsFiles(t *testing.T) {
 		t.Errorf("dry run must not remove %s: %v", filepath.Base(orphan), err)
 	}
 }
+
+func TestCheckVaultOrphanedConflictFilesUnreadableDir(t *testing.T) {
+	t.Run("NonexistentDir", func(t *testing.T) {
+		nonexistent := filepath.Join(t.TempDir(), "does-not-exist")
+		r := checkVaultOrphanedConflictFiles(nonexistent, Options{})
+		if r.Status != StatusWarn {
+			t.Fatalf("status = %q, want %q", r.Status, StatusWarn)
+		}
+		if !strings.Contains(r.Message, "cannot inspect conflict files:") {
+			t.Errorf("message = %q, want 'cannot inspect conflict files:'", r.Message)
+		}
+		if r.Fixable {
+			t.Error("unreadable directory check must not be fixable")
+		}
+	})
+
+	t.Run("UnreadableSubdir", func(t *testing.T) {
+		vaultDir := t.TempDir()
+		unreadable := filepath.Join(vaultDir, "locked")
+		if err := os.Mkdir(unreadable, 0o700); err != nil {
+			t.Fatalf("Mkdir: %v", err)
+		}
+		if err := os.Chmod(unreadable, 0000); err != nil {
+			t.Fatalf("Chmod: %v", err)
+		}
+		t.Cleanup(func() { _ = os.Chmod(unreadable, 0o700) })
+
+		r := checkVaultOrphanedConflictFiles(vaultDir, Options{})
+		if r.Status != StatusWarn {
+			t.Fatalf("status = %q, want %q", r.Status, StatusWarn)
+		}
+		if !strings.Contains(r.Message, "cannot inspect conflict files:") {
+			t.Errorf("message = %q, want 'cannot inspect conflict files:'", r.Message)
+		}
+	})
+}
+
+func TestCheckVaultOrphanedConflictFilesUnreadableConflictFile(t *testing.T) {
+	vaultDir := t.TempDir()
+	writeConflictTestFile(t, filepath.Join(vaultDir, "secret.yaml"), "local")
+	conflictPath := filepath.Join(vaultDir, "secret.conflict-macbook-2.yaml")
+	writeConflictTestFile(t, conflictPath, "local")
+
+	if err := os.Chmod(conflictPath, 0000); err != nil {
+		t.Fatalf("Chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(conflictPath, 0o600) })
+
+	r := checkVaultOrphanedConflictFiles(vaultDir, Options{})
+	if r.Status != StatusWarn {
+		t.Fatalf("status = %q, want %q", r.Status, StatusWarn)
+	}
+	if !strings.Contains(r.Message, "1 conflict file(s) with unmerged content") {
+		t.Errorf("message = %q, want 1 unmerged conflict file", r.Message)
+	}
+	if r.Fixable || r.Fix != nil {
+		t.Error("unreadable conflict file must not be fixable or auto-removable")
+	}
+}
+
+func TestCheckVaultOrphanedConflictFilesFixDataLossGuard(t *testing.T) {
+	vaultDir := t.TempDir()
+	// 1. Redundant orphan: identical to original file -> should be removed by --fix
+	writeConflictTestFile(t, filepath.Join(vaultDir, "config.yaml"), "vault: 1")
+	orphanRedundant := filepath.Join(vaultDir, "config.conflict-macbook-1.yaml")
+	writeConflictTestFile(t, orphanRedundant, "vault: 1")
+
+	// 2. Orphan without source: original file is gone -> must NOT be removed by --fix
+	orphanNoSource := filepath.Join(vaultDir, "entries", "gone.conflict-macbook-2.age")
+	writeConflictTestFile(t, orphanNoSource, "original deleted")
+
+	// 3. Unmerged copy: original file exists but content differs -> must NOT be removed by --fix
+	writeConflictTestFile(t, filepath.Join(vaultDir, "entries", "note.age"), "local content")
+	orphanDiffering := filepath.Join(vaultDir, "entries", "note.conflict-macbook-3.age")
+	writeConflictTestFile(t, orphanDiffering, "remote content")
+
+	r := checkVaultOrphanedConflictFiles(vaultDir, Options{})
+	if r.Status != StatusWarn {
+		t.Fatalf("status = %q, want %q", r.Status, StatusWarn)
+	}
+	if !strings.Contains(r.Message, "1 orphaned conflict file(s) identical to the file they shadow") {
+		t.Errorf("message = %q, want 1 orphaned copy reported", r.Message)
+	}
+	if !strings.Contains(r.Message, "2 conflict file(s) with unmerged content") {
+		t.Errorf("message = %q, want 2 unmerged copies reported", r.Message)
+	}
+	if !r.Fixable || r.Fix == nil {
+		t.Fatal("expected check to be fixable for the 1 orphaned copy")
+	}
+	wantHint := "run `symvault doctor --fix` to remove the orphaned copies; compare the remaining ones by hand before deleting them"
+	if r.Hint != wantHint {
+		t.Errorf("hint = %q, want %q", r.Hint, wantHint)
+	}
+
+	if err := r.Fix(); err != nil {
+		t.Fatalf("Fix(): %v", err)
+	}
+
+	// Assert the redundant orphan was removed
+	if _, err := os.Stat(orphanRedundant); !os.IsNotExist(err) {
+		t.Errorf("redundant conflict copy %s must be removed, stat error = %v", orphanRedundant, err)
+	}
+
+	// Assert data loss guard: neither the copy without source nor the copy with differing content was deleted
+	if _, err := os.Stat(orphanNoSource); err != nil {
+		t.Errorf("conflict copy without source %s must be kept, stat error = %v", orphanNoSource, err)
+	}
+	if _, err := os.Stat(orphanDiffering); err != nil {
+		t.Errorf("conflict copy with differing content %s must be kept, stat error = %v", orphanDiffering, err)
+	}
+
+	// Assert original files remain intact
+	if _, err := os.Stat(filepath.Join(vaultDir, "config.yaml")); err != nil {
+		t.Errorf("config.yaml must be kept, stat error = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(vaultDir, "entries", "note.age")); err != nil {
+		t.Errorf("note.age must be kept, stat error = %v", err)
+	}
+}
+
+func TestCheckVaultOrphanedConflictFilesFixErrors(t *testing.T) {
+	t.Run("RescanFails", func(t *testing.T) {
+		vaultDir := t.TempDir()
+		writeConflictTestFile(t, filepath.Join(vaultDir, "config.yaml"), "vault: 1")
+		writeConflictTestFile(t, filepath.Join(vaultDir, "config.conflict-macbook-1.yaml"), "vault: 1")
+
+		r := checkVaultOrphanedConflictFiles(vaultDir, Options{})
+		if !r.Fixable || r.Fix == nil {
+			t.Fatal("expected check to be fixable")
+		}
+
+		// Make directory unreadable before Fix() rescans
+		locked := filepath.Join(vaultDir, "locked")
+		if err := os.Mkdir(locked, 0o700); err != nil {
+			t.Fatalf("Mkdir: %v", err)
+		}
+		if err := os.Chmod(locked, 0000); err != nil {
+			t.Fatalf("Chmod: %v", err)
+		}
+		t.Cleanup(func() { _ = os.Chmod(locked, 0o700) })
+
+		if err := r.Fix(); err == nil {
+			t.Fatal("expected Fix() to return error when rescan fails")
+		}
+	})
+
+	t.Run("RemoveFailsPermissionDenied", func(t *testing.T) {
+		vaultDir := t.TempDir()
+		subDir := filepath.Join(vaultDir, "sub")
+		writeConflictTestFile(t, filepath.Join(subDir, "config.yaml"), "vault: 1")
+		writeConflictTestFile(t, filepath.Join(subDir, "config.conflict-macbook-1.yaml"), "vault: 1")
+
+		r := checkVaultOrphanedConflictFiles(vaultDir, Options{})
+		if !r.Fixable || r.Fix == nil {
+			t.Fatal("expected check to be fixable")
+		}
+
+		// Make parent directory read-only (0500) so os.Remove fails
+		if err := os.Chmod(subDir, 0o500); err != nil {
+			t.Fatalf("Chmod: %v", err)
+		}
+		t.Cleanup(func() { _ = os.Chmod(subDir, 0o700) })
+
+		err := r.Fix()
+		if err == nil {
+			t.Fatal("expected Fix() to fail when removing from read-only dir")
+		}
+		if !strings.Contains(err.Error(), "remove ") {
+			t.Errorf("error = %v, want substring 'remove '", err)
+		}
+	})
+
+	t.Run("ConcurrentRemovalIgnored", func(t *testing.T) {
+		vaultDir := t.TempDir()
+		writeConflictTestFile(t, filepath.Join(vaultDir, "config.yaml"), "vault: 1")
+		orphan := filepath.Join(vaultDir, "config.conflict-macbook-1.yaml")
+		writeConflictTestFile(t, orphan, "vault: 1")
+
+		r := checkVaultOrphanedConflictFiles(vaultDir, Options{})
+		if !r.Fixable || r.Fix == nil {
+			t.Fatal("expected check to be fixable")
+		}
+
+		// Remove orphan file between check and Fix() execution
+		if err := os.Remove(orphan); err != nil {
+			t.Fatalf("os.Remove: %v", err)
+		}
+
+		if err := r.Fix(); err != nil {
+			t.Fatalf("Fix() failed on concurrently removed file: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
Cover the orphaned conflict-file detection and `--fix` data-loss guard paths in `internal/health/doctor_conflicts.go`.

## Problem

The conflict-copy detector shipped with 16 uncovered changed lines. The unreadable-directory and stat-failure branches in `findConflictCopies`, the read-failure branch in `sameContent`, and the reporting plus `--fix` removal branches in `checkVaultOrphanedConflictFiles` were untested. The `--fix` path deletes files, so an untested skip decision there risks destroying user data that was never backed up.

## Changes

Tests added to `doctor_conflicts_test.go`:

- Unreadable/missing vault directories: reported by `findConflictCopies` and `checkVaultOrphanedConflictFiles`.
- Unreadable conflict files: read failures handled through `sameContent`.
- Data-loss guard: conflict copies whose original is gone and copies whose content still differs are reported as unmerged and **never** deleted by `--fix`; only redundant copies are pruned.
- `--fix` error paths: rescan failure propagation, removal failure on read-only folders, graceful handling of concurrently removed files.

One production simplification: removed an unreachable `filepath.Rel` error branch in `findConflictCopies` — paths yielded by `filepath.WalkDir` over `vaultDir` are always its strict descendants, so the fallback was dead code. Behavior is unchanged; the issue explicitly permits removing branches proven unreachable.

## Verification

- `gofmt -l internal/` — clean
- `go vet ./internal/...` — pass
- `go test -count=1 ./internal/health/` — pass
- Coverage: `findConflictCopies`, `sameContent`, and `checkVaultOrphanedConflictFiles` at 100% statement coverage

Closes #841
