### PR TITLE
Fix chunked attachment reads, add secret metadata flags, reject empty sensitive values, audit plaintext exposure

### DIFF
--- a/cmd/crud/add.go
+++ b/cmd/crud/add.go
@@ -32,6 +32,7 @@ var (
 	AddTOTPIssuer  string
 	AddTOTPAccount string
 	AddForce       bool
+	AddAllowEmpty  bool
 	AddType        string
 	AddUsageHint   string
 	AddAutoRotate  bool
@@ -52,7 +53,7 @@ func runAdd(cmd *cobra.Command, args []string) error {
 
 		warnArgvExposure(AddValue, AddTOTPSecret, AddStdinTOTP)
 
-		data, secretMeta, cleanup, err := buildEntryData(name)
+		data, secretMeta, cleanup, err := buildEntryData(cmd, name)
 		if err != nil {
 			return err
 		}
@@ -151,7 +152,7 @@ func warnArgvExposure(value string, totpSecret string, stdinTOTP bool) {
 // It handles five paths: explicit --value, --generate, interactive form,
 // non-interactive stdin, and defaults.
 // The returned cleanup function must be called after the entry is persisted.
-func buildEntryData(name string) (map[string]any, vaultpkg.SecretMetadata, func(), error) {
+func buildEntryData(cmd *cobra.Command, name string) (map[string]any, vaultpkg.SecretMetadata, func(), error) {
 	data := map[string]any{}
 	var secretMeta vaultpkg.SecretMetadata
 	var cleanup func()
@@ -161,13 +162,16 @@ func buildEntryData(name string) (map[string]any, vaultpkg.SecretMetadata, func(
 	}
 
 	switch {
-	case AddValue != "":
+	case AddValue != "" || AddStdinValue || (cmd != nil && cmd.Flags().Changed("value")):
 		if AddType == "" {
 			AddType = string(vaultpkg.InferSecretType(name, "", AddValue, ""))
 		}
 		fieldName := vaultpkg.PrimaryFieldForType(vaultpkg.SecretTypeFromString(AddType))
+		if AddValue == "" && isSensitiveField(fieldName) && !AddAllowEmpty {
+			return nil, secretMeta, nil, errorspkg.NewCLIError(errorspkg.ExitInvalidInput, fmt.Sprintf("cannot set empty value for sensitive field %q (use --allow-empty to override)", fieldName), nil)
+		}
 		data[fieldName] = AddValue
-		if !AddForce {
+		if !AddForce && AddValue != "" {
 			if err := cryptopkg.ValidatePasswordStrength(AddValue); err != nil {
 				return nil, secretMeta, nil, err
 			}
@@ -353,6 +357,7 @@ Interactive mode prompts for username, password, and URL.`,
 	addCmd.Flags().StringVar(&AddTOTPIssuer, "totp-issuer", "", "TOTP issuer/service name")
 	addCmd.Flags().StringVar(&AddTOTPAccount, "totp-account", "", "TOTP account name/username")
 	addCmd.Flags().BoolVar(&AddForce, "force", false, "Skip password strength validation")
+	addCmd.Flags().BoolVar(&AddAllowEmpty, "allow-empty", false, "Allow empty value for sensitive fields")
 	addCmd.Flags().StringVar(&AddType, "type", "", "Secret type (api_key, bearer_token, basic_auth, ssh_key, password, certificate, database_url, totp_seed, custom). Auto-detected if not specified.")
 	addCmd.Flags().StringVar(&AddUsageHint, "usage-hint", "", "Usage hint for AI agents")
 	addCmd.Flags().BoolVar(&AddAutoRotate, "auto-rotate", false, "Enable automatic rotation reminder")

--- a/cmd/crud/add_test.go
+++ b/cmd/crud/add_test.go
@@ -3,6 +3,7 @@ package crud
 import (
 	"io"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/danieljustus/symaira-vault/internal/vault"
@@ -16,20 +17,20 @@ func resetAddFlags(t *testing.T) {
 		length                              int
 		username, url, notes                string
 		totpSecret, totpIssuer, totpAccount string
-		force                               bool
+		force, allowEmpty                   bool
 		typ, usageHint, expiresAt           string
 		autoRotate                          bool
 	}{
 		AddValue, AddStdinValue, AddStdinTOTP, AddGenerate,
 		AddLength, AddUsername, AddURL, AddNotes,
 		AddTOTPSecret, AddTOTPIssuer, AddTOTPAccount,
-		AddForce, AddType, AddUsageHint, AddExpiresAt, AddAutoRotate,
+		AddForce, AddAllowEmpty, AddType, AddUsageHint, AddExpiresAt, AddAutoRotate,
 	}
 	t.Cleanup(func() {
 		AddValue, AddStdinValue, AddStdinTOTP, AddGenerate = old.value, old.stdinValue, old.stdinTOTP, old.generate
 		AddLength, AddUsername, AddURL, AddNotes = old.length, old.username, old.url, old.notes
 		AddTOTPSecret, AddTOTPIssuer, AddTOTPAccount = old.totpSecret, old.totpIssuer, old.totpAccount
-		AddForce, AddType, AddUsageHint, AddExpiresAt, AddAutoRotate = old.force, old.typ, old.usageHint, old.expiresAt, old.autoRotate
+		AddForce, AddAllowEmpty, AddType, AddUsageHint, AddExpiresAt, AddAutoRotate = old.force, old.allowEmpty, old.typ, old.usageHint, old.expiresAt, old.autoRotate
 	})
 }
 
@@ -171,6 +172,40 @@ func TestReadStdinValues_AcceptsEOFWithData(t *testing.T) {
 			}
 			if AddTOTPSecret != tt.wantTOTP {
 				t.Errorf("AddTOTPSecret = %q, want %q", AddTOTPSecret, tt.wantTOTP)
+			}
+		})
+	}
+}
+
+func TestAddCommand_EmptySensitiveValues(t *testing.T) {
+	setupTestVault(t)
+
+	tests := []struct {
+		name       string
+		args       []string
+		allowEmpty bool
+		wantErr    bool
+	}{
+		{name: "add empty password no-allow", args: []string{"account1", "--value", ""}, allowEmpty: false, wantErr: true},
+		{name: "add empty password allow", args: []string{"account2", "--value", ""}, allowEmpty: true, wantErr: false},
+		{name: "add non-empty password no-allow", args: []string{"account3", "--value", "ValidPass123!"}, allowEmpty: false, wantErr: false},
+		{name: "add empty token type no-allow", args: []string{"account4", "--type", "bearer_token", "--value", ""}, allowEmpty: false, wantErr: true},
+		{name: "add empty token type allow", args: []string{"account5", "--type", "bearer_token", "--value", ""}, allowEmpty: true, wantErr: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetAddFlags(t)
+			cmd := newAddCmd()
+			args := append([]string{}, tt.args...)
+			if tt.allowEmpty {
+				args = append(args, "--allow-empty")
+			}
+			cmd.SetArgs(args)
+			cmd.SetOut(&strings.Builder{})
+			err := cmd.Execute()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("add %v returned err = %v, wantErr = %v", args, err, tt.wantErr)
 			}
 		})
 	}

--- a/cmd/crud/get.go
+++ b/cmd/crud/get.go
@@ -1,6 +1,9 @@
 package crud
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -24,6 +27,9 @@ import (
 
 var (
 	GetPrint                 bool
+	GetLength                bool
+	GetDigest                bool
+	GetMetadata              bool
 	GetClipboard             = clipboardapp.DefaultClipboard
 	GetAutoClearDurationFunc = GetAutoClearDuration
 	StartAutoClear           = clipboardapp.StartAutoClear
@@ -69,6 +75,23 @@ func newGetCmd() *cobra.Command {
 			cli.JSONOutputAnnotation: "true",
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			flagsCount := 0
+			if GetPrint {
+				flagsCount++
+			}
+			if GetLength {
+				flagsCount++
+			}
+			if GetDigest {
+				flagsCount++
+			}
+			if GetMetadata {
+				flagsCount++
+			}
+			if flagsCount > 1 {
+				return errorspkg.NewCLIError(errorspkg.ExitInvalidInput, "--print, --length, --digest, and --metadata are mutually exclusive", nil)
+			}
+
 			unlockVault := cli.WithVault
 			if !cli.IsTerminalFunc(int(os.Stdin.Fd())) {
 				unlockVault = cli.WithVaultForScripting
@@ -87,6 +110,10 @@ func newGetCmd() *cobra.Command {
 						path = candidatePath
 						field = candidateField
 					}
+				}
+
+				if (GetLength || GetDigest || GetMetadata) && field == "" {
+					return errorspkg.NewCLIError(errorspkg.ExitInvalidInput, "field is required for --length, --digest, or --metadata", nil)
 				}
 
 				value, err := vs.GetField(path, field)
@@ -136,6 +163,31 @@ func newGetCmd() *cobra.Command {
 
 				if field != "" {
 					strValue := fmt.Sprintf("%v", value)
+
+					if GetLength {
+						cli.PrintlnQuietAware(fmt.Sprintf("%d", len(strValue)))
+						return nil
+					}
+					if GetDigest {
+						h := sha256.Sum256([]byte(strValue))
+						hexStr := hex.EncodeToString(h[:])
+						cli.PrintlnQuietAware(fmt.Sprintf("sha256:%s", hexStr[:12]))
+						return nil
+					}
+					if GetMetadata {
+						h := sha256.Sum256([]byte(strValue))
+						hexStr := hex.EncodeToString(h[:])
+						type metaOut struct {
+							Length   int    `json:"length"`
+							SHA25612 string `json:"sha256_12"`
+						}
+						metaBytes, _ := json.Marshal(metaOut{
+							Length:   len(strValue),
+							SHA25612: hexStr[:12],
+						})
+						cli.PrintlnQuietAware(string(metaBytes))
+						return nil
+					}
 
 					// Determine if we should copy to clipboard:
 					// 1. --output json: never clipboard, always print as JSON
@@ -277,6 +329,9 @@ func newGetCmd() *cobra.Command {
 	}
 
 	getCmd.Flags().BoolVarP(&GetPrint, "print", "p", false, "Print value to stdout instead of copying to clipboard")
+	getCmd.Flags().BoolVar(&GetLength, "length", false, "Print byte length of the stored string value only")
+	getCmd.Flags().BoolVar(&GetDigest, "digest", false, "Print sha256 digest (first 12 hex chars) of the value only")
+	getCmd.Flags().BoolVar(&GetMetadata, "metadata", false, "Print JSON metadata (length and sha256_12) of the value only")
 	getCmd.GroupID = cli.GroupIDEssentials
 	return getCmd
 }

--- a/cmd/crud/get.go
+++ b/cmd/crud/get.go
@@ -361,7 +361,7 @@ func emitExposureAudit(vaultDir string, identity *age.X25519Identity, path, fiel
 		cliout.Warnf("Warning: audit log open failed: %v", err)
 		return
 	}
-	defer auditLog.Close()
+	defer func() { _ = auditLog.Close() }() //nolint:errcheck // best-effort close; audit failures must not fail get
 
 	entry := audit.LogEntry{
 		Timestamp: time.Now().UTC().Format(time.RFC3339),

--- a/cmd/crud/get.go
+++ b/cmd/crud/get.go
@@ -13,8 +13,10 @@ import (
 
 	cli "github.com/danieljustus/symaira-vault/internal/cli"
 
+	"filippo.io/age"
 	"github.com/spf13/cobra"
 
+	"github.com/danieljustus/symaira-vault/internal/audit"
 	clipboardapp "github.com/danieljustus/symaira-vault/internal/clipboard"
 	configpkg "github.com/danieljustus/symaira-vault/internal/config"
 	vaultcrypto "github.com/danieljustus/symaira-vault/internal/crypto"
@@ -197,6 +199,9 @@ func newGetCmd() *cobra.Command {
 					// 5. Config override: clipboard.copyByDefault=false restores old behavior
 
 					if cli.OutputFormat != "text" {
+						if GetPrint {
+							emitExposureAudit(vs.VaultDir(), v.Identity, path, field)
+						}
 						if printErr := cli.PrintResult(strValue); printErr != nil {
 							return printErr
 						}
@@ -247,6 +252,9 @@ func newGetCmd() *cobra.Command {
 						return nil
 					}
 
+					if GetPrint {
+						emitExposureAudit(vs.VaultDir(), v.Identity, path, field)
+					}
 					cli.PrintlnQuietAware(strValue)
 					return nil
 				}
@@ -292,6 +300,10 @@ func newGetCmd() *cobra.Command {
 					return nil
 				}
 
+				if GetPrint {
+					emitExposureAudit(vs.VaultDir(), v.Identity, path, "")
+				}
+
 				cli.PrintQuietAware("Path: %s\n", render.ForTerminal(taint.Wrap(path, taint.Provenance{Source: "cli.path"})))
 				cli.PrintQuietAware("Modified: %s\n", entry.Metadata.Updated.Format("2006-01-02 15:04"))
 				cli.PrintlnQuietAware()
@@ -334,6 +346,34 @@ func newGetCmd() *cobra.Command {
 	getCmd.Flags().BoolVar(&GetMetadata, "metadata", false, "Print JSON metadata (length and sha256_12) of the value only")
 	getCmd.GroupID = cli.GroupIDEssentials
 	return getCmd
+}
+
+func emitExposureAudit(vaultDir string, identity *age.X25519Identity, path, field string) {
+	if vaultDir == "" {
+		return
+	}
+	rawArgv := strings.Join(os.Args, " ")
+	h := sha256.Sum256([]byte(rawArgv))
+	argvHash := hex.EncodeToString(h[:])[:16]
+
+	auditLog, err := audit.New("symvault", vaultDir, identity)
+	if err != nil {
+		cliout.Warnf("Warning: audit log open failed: %v", err)
+		return
+	}
+	defer auditLog.Close()
+
+	entry := audit.LogEntry{
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+		Action:    audit.ActionExposePlaintext,
+		Path:      path,
+		Field:     field,
+		ArgvHash:  argvHash,
+		OK:        true,
+	}
+	if err := auditLog.LogEntry(entry); err != nil {
+		cliout.Warnf("Warning: audit log write failed: %v", err)
+	}
 }
 
 func GetAutoClearDuration() int {

--- a/cmd/crud/get_test.go
+++ b/cmd/crud/get_test.go
@@ -5,9 +5,11 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 
+	"github.com/danieljustus/symaira-vault/internal/audit"
 	cli "github.com/danieljustus/symaira-vault/internal/cli"
 )
 
@@ -234,6 +236,80 @@ func TestGetCommand_MetadataFlags_RequireField(t *testing.T) {
 		err := cmd.Execute()
 		if err == nil {
 			t.Errorf("Execute(service/api %s) = nil, want error requiring field", flag)
+		}
+	}
+}
+
+func TestGetCommand_ExposePlaintextAudit(t *testing.T) {
+	setupTestVault(t)
+	resetGetCmdFlags(t)
+	secret := "secret-to-be-exposed-123"
+	addTestEntry(t, "prod/database", map[string]any{"password": secret})
+
+	cmd := newGetCmd()
+	cmd.SetArgs([]string{"prod/database.password", "--print"})
+	out := captureStdout(t, func() {
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+	})
+
+	if !strings.Contains(out, secret) {
+		t.Fatalf("output %q does not contain secret %q", out, secret)
+	}
+
+	vaultDir := cli.Vault
+	entries, err := audit.LoadAuditLogFiles("symvault", vaultDir, 0)
+	if err != nil {
+		t.Fatalf("LoadAuditLogFiles: %v", err)
+	}
+
+	var exposeEntries []audit.LogEntry
+	for _, e := range entries {
+		if e.Action == audit.ActionExposePlaintext {
+			exposeEntries = append(exposeEntries, e)
+		}
+	}
+
+	if len(exposeEntries) != 1 {
+		t.Fatalf("expected 1 expose_plaintext audit entry, found %d (all entries: %+v)", len(exposeEntries), entries)
+	}
+
+	entry := exposeEntries[0]
+	if entry.Path != "prod/database" {
+		t.Errorf("audit entry Path = %q, want prod/database", entry.Path)
+	}
+	if entry.Field != "password" {
+		t.Errorf("audit entry Field = %q, want password", entry.Field)
+	}
+	if !entry.OK {
+		t.Errorf("audit entry OK = %v, want true", entry.OK)
+	}
+	if len(entry.ArgvHash) != 16 {
+		t.Errorf("audit entry ArgvHash length = %d (%q), want 16 hex chars", len(entry.ArgvHash), entry.ArgvHash)
+	}
+	rawArgv := strings.Join(os.Args, " ")
+	if entry.ArgvHash == rawArgv {
+		t.Errorf("audit entry ArgvHash leaked raw argv %q", entry.ArgvHash)
+	}
+}
+
+func TestGetCommand_NoExposeAuditWhenNotPrinted(t *testing.T) {
+	setupTestVault(t)
+	resetGetCmdFlags(t)
+	addTestEntry(t, "prod/database", map[string]any{"password": "secretpassword"})
+
+	cmd := newGetCmd()
+	cmd.SetArgs([]string{"prod/database.password", "--length"})
+	_ = captureStdout(t, func() {
+		_ = cmd.Execute()
+	})
+
+	vaultDir := cli.Vault
+	entries, _ := audit.LoadAuditLogFiles("symvault", vaultDir, 0)
+	for _, e := range entries {
+		if e.Action == audit.ActionExposePlaintext {
+			t.Errorf("found unexpected expose_plaintext audit entry when --print was not used: %+v", e)
 		}
 	}
 }

--- a/cmd/crud/get_test.go
+++ b/cmd/crud/get_test.go
@@ -1,6 +1,10 @@
 package crud
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -85,7 +89,151 @@ func TestNewGetCmd_Flags(t *testing.T) {
 	if cmd.Flags().Lookup("print") == nil {
 		t.Error("--print flag missing")
 	}
+	if cmd.Flags().Lookup("length") == nil {
+		t.Error("--length flag missing")
+	}
+	if cmd.Flags().Lookup("digest") == nil {
+		t.Error("--digest flag missing")
+	}
+	if cmd.Flags().Lookup("metadata") == nil {
+		t.Error("--metadata flag missing")
+	}
 	if cmd.GroupID != cli.GroupIDEssentials {
 		t.Errorf("GroupID = %q, want %q", cmd.GroupID, cli.GroupIDEssentials)
+	}
+}
+
+func resetGetCmdFlags(t *testing.T) {
+	t.Helper()
+	origPrint := GetPrint
+	origLength := GetLength
+	origDigest := GetDigest
+	origMetadata := GetMetadata
+	t.Cleanup(func() {
+		GetPrint = origPrint
+		GetLength = origLength
+		GetDigest = origDigest
+		GetMetadata = origMetadata
+	})
+}
+
+func TestGetCommand_Length(t *testing.T) {
+	setupTestVault(t)
+	resetGetCmdFlags(t)
+	secret := "supersecretvalue123"
+	addTestEntry(t, "service/api", map[string]any{"token": secret})
+
+	cmd := newGetCmd()
+	cmd.SetArgs([]string{"service/api.token", "--length"})
+	out := captureStdout(t, func() {
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+	})
+
+	want := "19\n"
+	if out != want {
+		t.Errorf("output = %q, want %q", out, want)
+	}
+	if strings.Contains(out, secret) {
+		t.Errorf("plaintext secret leaked in output: %q", out)
+	}
+}
+
+func TestGetCommand_Digest(t *testing.T) {
+	setupTestVault(t)
+	resetGetCmdFlags(t)
+	secret := "supersecretvalue123"
+	addTestEntry(t, "service/api", map[string]any{"token": secret})
+
+	h := sha256.Sum256([]byte(secret))
+	expectedDigest := fmt.Sprintf("sha256:%s\n", hex.EncodeToString(h[:])[:12])
+
+	cmd := newGetCmd()
+	cmd.SetArgs([]string{"service/api.token", "--digest"})
+	out := captureStdout(t, func() {
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+	})
+
+	if out != expectedDigest {
+		t.Errorf("output = %q, want %q", out, expectedDigest)
+	}
+	if strings.Contains(out, secret) {
+		t.Errorf("plaintext secret leaked in output: %q", out)
+	}
+}
+
+func TestGetCommand_Metadata(t *testing.T) {
+	setupTestVault(t)
+	resetGetCmdFlags(t)
+	secret := "supersecretvalue123"
+	addTestEntry(t, "service/api", map[string]any{"token": secret})
+
+	h := sha256.Sum256([]byte(secret))
+	expectedSHA := hex.EncodeToString(h[:])[:12]
+
+	cmd := newGetCmd()
+	cmd.SetArgs([]string{"service/api.token", "--metadata"})
+	out := captureStdout(t, func() {
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+	})
+
+	var parsed struct {
+		Length   int    `json:"length"`
+		SHA25612 string `json:"sha256_12"`
+	}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &parsed); err != nil {
+		t.Fatalf("unmarshal metadata json %q: %v", out, err)
+	}
+	if parsed.Length != 19 || parsed.SHA25612 != expectedSHA {
+		t.Errorf("metadata = %+v, want length=19, sha256_12=%s", parsed, expectedSHA)
+	}
+	if strings.Contains(out, secret) {
+		t.Errorf("plaintext secret leaked in output: %q", out)
+	}
+}
+
+func TestGetCommand_MutualExclusion(t *testing.T) {
+	setupTestVault(t)
+	resetGetCmdFlags(t)
+	addTestEntry(t, "service/api", map[string]any{"token": "secret"})
+
+	cases := [][]string{
+		{"service/api.token", "--length", "--print"},
+		{"service/api.token", "--digest", "--print"},
+		{"service/api.token", "--metadata", "--print"},
+		{"service/api.token", "--length", "--digest"},
+		{"service/api.token", "--length", "--metadata"},
+		{"service/api.token", "--digest", "--metadata"},
+	}
+
+	for _, args := range cases {
+		cmd := newGetCmd()
+		cmd.SetArgs(args)
+		cmd.SetOut(&strings.Builder{})
+		err := cmd.Execute()
+		if err == nil {
+			t.Errorf("Execute(%v) = nil, want error for mutually exclusive flags", args)
+		}
+	}
+}
+
+func TestGetCommand_MetadataFlags_RequireField(t *testing.T) {
+	setupTestVault(t)
+	resetGetCmdFlags(t)
+	addTestEntry(t, "service/api", map[string]any{"token": "secret"})
+
+	for _, flag := range []string{"--length", "--digest", "--metadata"} {
+		cmd := newGetCmd()
+		cmd.SetArgs([]string{"service/api", flag})
+		cmd.SetOut(&strings.Builder{})
+		err := cmd.Execute()
+		if err == nil {
+			t.Errorf("Execute(service/api %s) = nil, want error requiring field", flag)
+		}
 	}
 }

--- a/cmd/crud/set.go
+++ b/cmd/crud/set.go
@@ -38,6 +38,39 @@ func isSensitiveField(fieldName string) bool {
 	return false
 }
 
+// readConfirmedFieldValue prompts for a hidden field value and, for sensitive
+// fields, requires a non-empty confirmation that matches. Empty sensitive
+// values are rejected unless --allow-empty is set.
+func readConfirmedFieldValue(reader *bufio.Reader, field string) (string, error) {
+	prompt := fmt.Sprintf("Enter value for %s: ", field)
+	valueBytes, err := cliinput.ReadHiddenInputFn(prompt, reader)
+	if err != nil && len(valueBytes) == 0 {
+		return "", errorspkg.ReadFailed(err, "read value")
+	}
+	defer cryptopkg.Wipe(valueBytes)
+
+	if isSensitiveField(field) {
+		if len(valueBytes) == 0 && !SetAllowEmpty {
+			return "", errorspkg.NewCLIError(errorspkg.ExitInvalidInput, fmt.Sprintf("cannot set empty value for sensitive field %q (use --allow-empty to override)", field), nil)
+		}
+		if len(valueBytes) > 0 {
+			confirmPrompt := fmt.Sprintf("Confirm value for %s: ", field)
+			confirmBytes, err := cliinput.ReadHiddenInputFn(confirmPrompt, reader)
+			if err != nil && len(confirmBytes) == 0 {
+				return "", errorspkg.ReadFailed(err, "read confirmation")
+			}
+			defer cryptopkg.Wipe(confirmBytes)
+			if len(confirmBytes) == 0 {
+				return "", errorspkg.NewCLIError(errorspkg.ExitInvalidInput, "confirmation cannot be empty", nil)
+			}
+			if string(confirmBytes) != string(valueBytes) {
+				return "", errorspkg.NewCLIError(errorspkg.ExitInvalidInput, "values do not match", nil)
+			}
+		}
+	}
+	return string(valueBytes), nil
+}
+
 func newSetCmd() *cobra.Command {
 	setCmd := &cobra.Command{
 		Use:   "set <path[.field]>",
@@ -94,32 +127,9 @@ func newSetCmd() *cobra.Command {
 			} else {
 				reader := bufio.NewReader(os.Stdin)
 				if field != "" {
-					prompt := fmt.Sprintf("Enter value for %s: ", field)
-					valueBytes, err := cliinput.ReadHiddenInputFn(prompt, reader)
-					if err != nil && len(valueBytes) == 0 {
-						return errorspkg.ReadFailed(err, "read value")
-					}
-					defer cryptopkg.Wipe(valueBytes)
-					valueStr := string(valueBytes)
-
-					if isSensitiveField(field) {
-						if len(valueBytes) == 0 && !SetAllowEmpty {
-							return errorspkg.NewCLIError(errorspkg.ExitInvalidInput, fmt.Sprintf("cannot set empty value for sensitive field %q (use --allow-empty to override)", field), nil)
-						}
-						if len(valueBytes) > 0 {
-							confirmPrompt := fmt.Sprintf("Confirm value for %s: ", field)
-							confirmBytes, err := cliinput.ReadHiddenInputFn(confirmPrompt, reader)
-							if err != nil && len(confirmBytes) == 0 {
-								return errorspkg.ReadFailed(err, "read confirmation")
-							}
-							defer cryptopkg.Wipe(confirmBytes)
-							if len(confirmBytes) == 0 {
-								return errorspkg.NewCLIError(errorspkg.ExitInvalidInput, "confirmation cannot be empty", nil)
-							}
-							if string(confirmBytes) != valueStr {
-								return errorspkg.NewCLIError(errorspkg.ExitInvalidInput, "values do not match", nil)
-							}
-						}
+					valueStr, err := readConfirmedFieldValue(reader, field)
+					if err != nil {
+						return err
 					}
 					data[field] = valueStr
 				} else {

--- a/cmd/crud/set.go
+++ b/cmd/crud/set.go
@@ -19,11 +19,24 @@ import (
 var (
 	SetValue       string
 	SetStdinValue  bool
+	SetAllowEmpty  bool
 	SetTOTPSecret  string
 	SetTOTPIssuer  string
 	SetTOTPAccount string
 	SetForce       bool
 )
+
+// isSensitiveField reports whether fieldName contains any sensitive substring:
+// "password", "token", "secret", "key", "passwd", or "pwd" (case-insensitive).
+func isSensitiveField(fieldName string) bool {
+	lower := strings.ToLower(fieldName)
+	for _, sub := range []string{"password", "token", "secret", "key", "passwd", "pwd"} {
+		if strings.Contains(lower, sub) {
+			return true
+		}
+	}
+	return false
+}
 
 func newSetCmd() *cobra.Command {
 	setCmd := &cobra.Command{
@@ -49,6 +62,11 @@ func newSetCmd() *cobra.Command {
 				field = query[idx+1:]
 			}
 
+			targetField := field
+			if targetField == "" {
+				targetField = "password"
+			}
+
 			if SetStdinValue {
 				stdinReader := bufio.NewReader(os.Stdin)
 				line, err := stdinReader.ReadString('\n')
@@ -61,13 +79,14 @@ func newSetCmd() *cobra.Command {
 			warnArgvExposure(SetValue, SetTOTPSecret, false)
 
 			data := map[string]any{}
-			if SetValue != "" {
-				if field != "" {
-					data[field] = SetValue
-				} else {
-					data["password"] = SetValue
+			isExplicitValue := cmd.Flags().Changed("value") || SetStdinValue
+
+			if isExplicitValue {
+				if SetValue == "" && isSensitiveField(targetField) && !SetAllowEmpty {
+					return errorspkg.NewCLIError(errorspkg.ExitInvalidInput, fmt.Sprintf("cannot set empty value for sensitive field %q (use --allow-empty to override)", targetField), nil)
 				}
-				if !SetForce && (field == "" || field == "password") {
+				data[targetField] = SetValue
+				if !SetForce && (targetField == "password") && SetValue != "" {
 					if err := cryptopkg.ValidatePasswordStrength(SetValue); err != nil {
 						return err
 					}
@@ -81,7 +100,28 @@ func newSetCmd() *cobra.Command {
 						return errorspkg.ReadFailed(err, "read value")
 					}
 					defer cryptopkg.Wipe(valueBytes)
-					data[field] = string(valueBytes)
+					valueStr := string(valueBytes)
+
+					if isSensitiveField(field) {
+						if len(valueBytes) == 0 && !SetAllowEmpty {
+							return errorspkg.NewCLIError(errorspkg.ExitInvalidInput, fmt.Sprintf("cannot set empty value for sensitive field %q (use --allow-empty to override)", field), nil)
+						}
+						if len(valueBytes) > 0 {
+							confirmPrompt := fmt.Sprintf("Confirm value for %s: ", field)
+							confirmBytes, err := cliinput.ReadHiddenInputFn(confirmPrompt, reader)
+							if err != nil && len(confirmBytes) == 0 {
+								return errorspkg.ReadFailed(err, "read confirmation")
+							}
+							defer cryptopkg.Wipe(confirmBytes)
+							if len(confirmBytes) == 0 {
+								return errorspkg.NewCLIError(errorspkg.ExitInvalidInput, "confirmation cannot be empty", nil)
+							}
+							if string(confirmBytes) != valueStr {
+								return errorspkg.NewCLIError(errorspkg.ExitInvalidInput, "values do not match", nil)
+							}
+						}
+					}
+					data[field] = valueStr
 				} else {
 					collected, err := cli.CollectEntryData(reader, cli.EntryFlags{
 						TOTPSecret:      SetTOTPSecret,
@@ -129,6 +169,7 @@ func newSetCmd() *cobra.Command {
 
 	setCmd.Flags().StringVar(&SetValue, "value", "", "Value to set (non-interactive, visible in process listings)")
 	setCmd.Flags().BoolVar(&SetStdinValue, "stdin-value", false, "Read value from stdin (prevents argv leak)")
+	setCmd.Flags().BoolVar(&SetAllowEmpty, "allow-empty", false, "Allow setting empty values on sensitive fields")
 	setCmd.Flags().StringVar(&SetTOTPSecret, "totp-secret", "", "TOTP secret key (base32 encoded, visible in process listings)")
 	setCmd.Flags().StringVar(&SetTOTPIssuer, "totp-issuer", "", "TOTP issuer/service name")
 	setCmd.Flags().StringVar(&SetTOTPAccount, "totp-account", "", "TOTP account name/username")

--- a/cmd/crud/set_test.go
+++ b/cmd/crud/set_test.go
@@ -90,29 +90,168 @@ func TestSetStdinValue_ReadsFromStdin(t *testing.T) {
 	}
 }
 
-func TestSetInteractiveHiddenPrompt(t *testing.T) {
-	// Verify that ReadHiddenInputFn gets invoked on field prompt
+func resetSetFlags(t *testing.T) {
+	t.Helper()
+	oldValue := SetValue
+	oldStdinValue := SetStdinValue
+	oldAllowEmpty := SetAllowEmpty
+	oldTOTPSecret := SetTOTPSecret
+	oldTOTPIssuer := SetTOTPIssuer
+	oldTOTPAccount := SetTOTPAccount
+	oldForce := SetForce
+	t.Cleanup(func() {
+		SetValue = oldValue
+		SetStdinValue = oldStdinValue
+		SetAllowEmpty = oldAllowEmpty
+		SetTOTPSecret = oldTOTPSecret
+		SetTOTPIssuer = oldTOTPIssuer
+		SetTOTPAccount = oldTOTPAccount
+		SetForce = oldForce
+	})
+}
+
+func TestSetCommand_EmptySensitiveValues(t *testing.T) {
+	setupTestVault(t)
+
+	tests := []struct {
+		name       string
+		query      string
+		value      string
+		allowEmpty bool
+		wantErr    bool
+	}{
+		// Sensitive fields with empty value and allowEmpty = false -> error
+		{name: "sensitive password empty no-allow", query: "svc.password", value: "", allowEmpty: false, wantErr: true},
+		{name: "sensitive token empty no-allow", query: "svc.api_token", value: "", allowEmpty: false, wantErr: true},
+		{name: "sensitive secret empty no-allow", query: "svc.client_secret", value: "", allowEmpty: false, wantErr: true},
+		{name: "sensitive key empty no-allow", query: "svc.private_key", value: "", allowEmpty: false, wantErr: true},
+		{name: "sensitive passwd empty no-allow", query: "svc.db_passwd", value: "", allowEmpty: false, wantErr: true},
+		{name: "sensitive pwd empty no-allow", query: "svc.user_pwd", value: "", allowEmpty: false, wantErr: true},
+		{name: "sensitive uppercase PASSWORD empty no-allow", query: "svc.MY_PASSWORD", value: "", allowEmpty: false, wantErr: true},
+		{name: "sensitive default password empty no-allow", query: "svc", value: "", allowEmpty: false, wantErr: true},
+
+		// Sensitive fields with empty value and allowEmpty = true -> success
+		{name: "sensitive password empty allow", query: "svc.password", value: "", allowEmpty: true, wantErr: false},
+		{name: "sensitive token empty allow", query: "svc.api_token", value: "", allowEmpty: true, wantErr: false},
+		{name: "sensitive secret empty allow", query: "svc.client_secret", value: "", allowEmpty: true, wantErr: false},
+		{name: "sensitive key empty allow", query: "svc.private_key", value: "", allowEmpty: true, wantErr: false},
+		{name: "sensitive passwd empty allow", query: "svc.db_passwd", value: "", allowEmpty: true, wantErr: false},
+		{name: "sensitive pwd empty allow", query: "svc.user_pwd", value: "", allowEmpty: true, wantErr: false},
+		{name: "sensitive default password empty allow", query: "svc", value: "", allowEmpty: true, wantErr: false},
+
+		// Sensitive fields with non-empty value and allowEmpty = false -> success
+		{name: "sensitive password non-empty no-allow", query: "svc.password", value: "StrongPass123!", allowEmpty: false, wantErr: false},
+		{name: "sensitive token non-empty no-allow", query: "svc.api_token", value: "tok-123456", allowEmpty: false, wantErr: false},
+		{name: "sensitive secret non-empty no-allow", query: "svc.client_secret", value: "sec-123456", allowEmpty: false, wantErr: false},
+		{name: "sensitive key non-empty no-allow", query: "svc.private_key", value: "key-123456", allowEmpty: false, wantErr: false},
+
+		// Sensitive fields with non-empty value and allowEmpty = true -> success
+		{name: "sensitive password non-empty allow", query: "svc.password", value: "StrongPass123!", allowEmpty: true, wantErr: false},
+
+		// Non-sensitive fields with empty value and allowEmpty = false -> success
+		{name: "non-sensitive username empty no-allow", query: "svc.username", value: "", allowEmpty: false, wantErr: false},
+		{name: "non-sensitive url empty no-allow", query: "svc.url", value: "", allowEmpty: false, wantErr: false},
+		{name: "non-sensitive notes empty no-allow", query: "svc.notes", value: "", allowEmpty: false, wantErr: false},
+		{name: "non-sensitive custom empty no-allow", query: "svc.custom_field", value: "", allowEmpty: false, wantErr: false},
+
+		// Non-sensitive fields with empty value and allowEmpty = true -> success
+		{name: "non-sensitive username empty allow", query: "svc.username", value: "", allowEmpty: true, wantErr: false},
+
+		// Non-sensitive fields with non-empty value and allowEmpty = false -> success
+		{name: "non-sensitive username non-empty no-allow", query: "svc.username", value: "octocat", allowEmpty: false, wantErr: false},
+		{name: "non-sensitive url non-empty no-allow", query: "svc.url", value: "https://example.com", allowEmpty: false, wantErr: false},
+
+		// Non-sensitive fields with non-empty value and allowEmpty = true -> success
+		{name: "non-sensitive username non-empty allow", query: "svc.username", value: "octocat", allowEmpty: true, wantErr: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetSetFlags(t)
+			cmd := newSetCmd()
+			args := []string{tt.query, "--value", tt.value}
+			if tt.allowEmpty {
+				args = append(args, "--allow-empty")
+			}
+			cmd.SetArgs(args)
+			cmd.SetOut(&strings.Builder{})
+			err := cmd.Execute()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("set %v returned err = %v, wantErr = %v", args, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestSetInteractivePrompt_RetypeMatch(t *testing.T) {
+	setupTestVault(t)
+	resetSetFlags(t)
+
 	oldHiddenInputFn := cliinput.ReadHiddenInputFn
 	defer func() { cliinput.ReadHiddenInputFn = oldHiddenInputFn }()
 
-	calledPrompt := ""
+	calls := 0
 	cliinput.ReadHiddenInputFn = func(prompt string, reader *bufio.Reader) ([]byte, error) {
-		calledPrompt = prompt
+		calls++
 		return []byte("secretinput"), nil
 	}
 
-	reader := bufio.NewReader(strings.NewReader(""))
-	field := "password"
-	prompt := "Enter value for " + field + ": "
-	valueBytes, err := cliinput.ReadHiddenInputFn(prompt, reader)
-	if err != nil {
+	cmd := newSetCmd()
+	cmd.SetArgs([]string{"service.password"})
+	cmd.SetOut(&strings.Builder{})
+	if err := cmd.Execute(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-
-	if string(valueBytes) != "secretinput" {
-		t.Errorf("expected secretinput, got %s", string(valueBytes))
+	if calls != 2 {
+		t.Errorf("expected 2 prompts (value + confirm), got %d", calls)
 	}
-	if calledPrompt != prompt {
-		t.Errorf("expected prompt %q, got %q", prompt, calledPrompt)
+	entry := getTestEntry(t, "service")
+	if got, _ := entry.GetField("password"); got != "secretinput" {
+		t.Errorf("expected password secretinput, got %v", got)
+	}
+}
+
+func TestSetInteractivePrompt_RetypeMismatch(t *testing.T) {
+	setupTestVault(t)
+	resetSetFlags(t)
+
+	oldHiddenInputFn := cliinput.ReadHiddenInputFn
+	defer func() { cliinput.ReadHiddenInputFn = oldHiddenInputFn }()
+
+	call := 0
+	cliinput.ReadHiddenInputFn = func(prompt string, reader *bufio.Reader) ([]byte, error) {
+		call++
+		if call == 1 {
+			return []byte("secretinput1"), nil
+		}
+		return []byte("secretinput2"), nil
+	}
+
+	cmd := newSetCmd()
+	cmd.SetArgs([]string{"service.password"})
+	cmd.SetOut(&strings.Builder{})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error on retype mismatch, got nil")
+	}
+}
+
+func TestSetInteractivePrompt_EmptySensitiveRejected(t *testing.T) {
+	setupTestVault(t)
+	resetSetFlags(t)
+
+	oldHiddenInputFn := cliinput.ReadHiddenInputFn
+	defer func() { cliinput.ReadHiddenInputFn = oldHiddenInputFn }()
+
+	cliinput.ReadHiddenInputFn = func(prompt string, reader *bufio.Reader) ([]byte, error) {
+		return []byte(""), nil
+	}
+
+	cmd := newSetCmd()
+	cmd.SetArgs([]string{"service.password"})
+	cmd.SetOut(&strings.Builder{})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error on empty sensitive interactive prompt, got nil")
 	}
 }

--- a/cmd/file/field.go
+++ b/cmd/file/field.go
@@ -1,8 +1,10 @@
 package file
 
 import (
+	"encoding/base64"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 
 	errorspkg "github.com/danieljustus/symaira-vault/internal/errors"
@@ -48,4 +50,80 @@ func resolveAttachmentField(entry *vaultpkg.Entry, explicitField string) (field 
 	sort.Strings(names)
 	return "", nil, errorspkg.NewCLIError(errorspkg.ExitInvalidInput,
 		fmt.Sprintf("entry has multiple attachment fields (%s); specify --field", strings.Join(names, ", ")), nil)
+}
+
+// decodeAttachmentContent extracts and decodes binary attachment content from an entry's field.
+// If the stored value is a "chunked-v1:" manifest, the chunks listed are resolved from
+// the same entry's Data map, concatenated in order, and decoded from base64.
+func decodeAttachmentContent(entry *vaultpkg.Entry, resolvedField string) ([]byte, error) {
+	raw, ok := entry.Data[resolvedField]
+	if !ok {
+		if entry.Path != "" {
+			return nil, errorspkg.NewCLIError(errorspkg.ExitNotFound, fmt.Sprintf("field %q not found in entry %q", resolvedField, entry.Path), nil)
+		}
+		return nil, errorspkg.NewCLIError(errorspkg.ExitNotFound, fmt.Sprintf("field %q not found in entry", resolvedField), nil)
+	}
+	encoded, ok := raw.(string)
+	if !ok {
+		return nil, errorspkg.NewCLIError(errorspkg.ExitGeneralError, fmt.Sprintf("field %q is not string-encoded content", resolvedField), nil)
+	}
+
+	if strings.HasPrefix(encoded, "chunked-v1:") {
+		manifest := strings.TrimPrefix(encoded, "chunked-v1:")
+		if manifest == "" {
+			return nil, errorspkg.NewCLIError(errorspkg.ExitGeneralError, fmt.Sprintf("invalid chunk manifest in field %q: no chunks specified", resolvedField), nil)
+		}
+		chunkNames := strings.Split(manifest, ",")
+
+		for _, countKey := range []string{resolvedField + "_chunk_count", "chunk_count"} {
+			if countRaw, ok := entry.Data[countKey]; ok {
+				var expectedCount int
+				switch v := countRaw.(type) {
+				case int:
+					expectedCount = v
+				case int64:
+					expectedCount = int(v)
+				case float64:
+					expectedCount = int(v)
+				case string:
+					if p, err := strconv.Atoi(v); err == nil {
+						expectedCount = p
+					}
+				}
+				if expectedCount > 0 && expectedCount != len(chunkNames) {
+					return nil, errorspkg.NewCLIError(errorspkg.ExitGeneralError,
+						fmt.Sprintf("chunk count mismatch for field %q: manifest lists %d chunks, entry specifies %d", resolvedField, len(chunkNames), expectedCount), nil)
+				}
+			}
+		}
+
+		var sb strings.Builder
+		for _, chunkName := range chunkNames {
+			chunkName = strings.TrimSpace(chunkName)
+			if chunkName == "" {
+				return nil, errorspkg.NewCLIError(errorspkg.ExitGeneralError, fmt.Sprintf("invalid chunk manifest in field %q: empty chunk name", resolvedField), nil)
+			}
+			chunkRaw, ok := entry.Data[chunkName]
+			if !ok {
+				return nil, errorspkg.NewCLIError(errorspkg.ExitNotFound, fmt.Sprintf("chunk field %q not found in entry", chunkName), nil)
+			}
+			chunkStr, ok := chunkRaw.(string)
+			if !ok {
+				return nil, errorspkg.NewCLIError(errorspkg.ExitGeneralError, fmt.Sprintf("chunk field %q is not string-encoded content", chunkName), nil)
+			}
+			sb.WriteString(chunkStr)
+		}
+
+		content, decErr := base64.StdEncoding.DecodeString(sb.String())
+		if decErr != nil {
+			return nil, errorspkg.Wrap(errorspkg.ExitGeneralError, errorspkg.ErrKindNone, decErr, "decode attachment content")
+		}
+		return content, nil
+	}
+
+	content, decErr := base64.StdEncoding.DecodeString(encoded)
+	if decErr != nil {
+		return nil, errorspkg.Wrap(errorspkg.ExitGeneralError, errorspkg.ErrKindNone, decErr, "decode attachment content")
+	}
+	return content, nil
 }

--- a/cmd/file/get.go
+++ b/cmd/file/get.go
@@ -1,8 +1,6 @@
 package file
 
 import (
-	"encoding/base64"
-	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -56,18 +54,9 @@ func runFileGet(cmd *cobra.Command, args []string) error {
 			return resolveErr
 		}
 
-		raw, ok := entry.Data[resolvedField]
-		if !ok {
-			return errorspkg.NewCLIError(errorspkg.ExitNotFound, fmt.Sprintf("field %q not found in entry %q", resolvedField, path), nil)
-		}
-		encoded, ok := raw.(string)
-		if !ok {
-			return errorspkg.NewCLIError(errorspkg.ExitGeneralError, fmt.Sprintf("field %q is not string-encoded content", resolvedField), nil)
-		}
-
-		content, decErr := base64.StdEncoding.DecodeString(encoded)
+		content, decErr := decodeAttachmentContent(entry, resolvedField)
 		if decErr != nil {
-			return errorspkg.Wrap(errorspkg.ExitGeneralError, errorspkg.ErrKindNone, decErr, "decode attachment content")
+			return decErr
 		}
 
 		if attachment != nil {

--- a/cmd/file/get_test.go
+++ b/cmd/file/get_test.go
@@ -122,6 +122,11 @@ func TestRunFileGet_EntryNotFound(t *testing.T) {
 	}
 }
 
+// writeChunkedTestEntry writes an entry with chunked fields. field is kept as a
+// parameter even though current tests only exercise one field name, so future
+// multi-field cases can reuse the helper.
+//
+//nolint:unparam
 func writeChunkedTestEntry(t *testing.T, path, field string, data map[string]any, info *vaultpkg.AttachmentInfo) {
 	t.Helper()
 	err := cli.WithVaultRaw(func(_ *vaultpkg.Vault, vs *cli.VaultService) error {

--- a/cmd/file/get_test.go
+++ b/cmd/file/get_test.go
@@ -1,9 +1,13 @@
 package file
 
 import (
+	"encoding/base64"
 	"os"
 	"path/filepath"
 	"testing"
+
+	cli "github.com/danieljustus/symaira-vault/internal/cli"
+	vaultpkg "github.com/danieljustus/symaira-vault/internal/vault"
 )
 
 func resetGetFlags(t *testing.T) {
@@ -115,5 +119,121 @@ func TestRunFileGet_EntryNotFound(t *testing.T) {
 
 	if err := runFileGet(nil, []string{"does/not-exist#field"}); err == nil {
 		t.Fatal("expected error for missing entry, got nil")
+	}
+}
+
+func writeChunkedTestEntry(t *testing.T, path, field string, data map[string]any, info *vaultpkg.AttachmentInfo) {
+	t.Helper()
+	err := cli.WithVaultRaw(func(_ *vaultpkg.Vault, vs *cli.VaultService) error {
+		entry := &vaultpkg.Entry{
+			Path: path,
+			Data: data,
+		}
+		if info != nil {
+			entry.SecretMetadata.Attachments = map[string]vaultpkg.AttachmentInfo{
+				field: *info,
+			}
+		}
+		return vs.WriteEntry(path, entry)
+	})
+	if err != nil {
+		t.Fatalf("write chunked test entry %q: %v", path, err)
+	}
+}
+
+func TestRunFileGet_ChunkedV1_Success(t *testing.T) {
+	setupTestVault(t)
+	content := []byte("known-binary-content-for-chunked-v1-test-1234567890")
+	fullB64 := base64.StdEncoding.EncodeToString(content)
+	splitIdx := len(fullB64) / 2
+	chunk0 := fullB64[:splitIdx]
+	chunk1 := fullB64[splitIdx:]
+
+	path := "apple-developer/certificate-p12"
+	field := "cert_p12"
+	data := map[string]any{
+		field:               "chunked-v1:cert_p12_b64_0000,cert_p12_b64_0001",
+		"cert_p12_b64_0000": chunk0,
+		"cert_p12_b64_0001": chunk1,
+	}
+	info := &vaultpkg.AttachmentInfo{
+		Filename: "certificate.p12",
+		Size:     int64(len(content)),
+		SHA256:   vaultpkg.HashAttachmentSHA256(content),
+	}
+	writeChunkedTestEntry(t, path, field, data, info)
+
+	resetGetFlags(t)
+	outPath := filepath.Join(t.TempDir(), "out.p12")
+	GetField = ""
+	GetOut = outPath
+
+	if err := runFileGet(nil, []string{path + "#" + field}); err != nil {
+		t.Fatalf("runFileGet on chunked entry: %v", err)
+	}
+
+	got, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("read exported file: %v", err)
+	}
+	if string(got) != string(content) {
+		t.Errorf("got %q, want %q", got, content)
+	}
+}
+
+func TestRunFileGet_ChunkedV1_MissingChunk(t *testing.T) {
+	setupTestVault(t)
+	path := "apple-developer/missing-chunk"
+	field := "cert_p12"
+	data := map[string]any{
+		field:               "chunked-v1:cert_p12_b64_0000,cert_p12_b64_0001",
+		"cert_p12_b64_0000": "c29tZS1kYXRh",
+		// cert_p12_b64_0001 is missing
+	}
+	writeChunkedTestEntry(t, path, field, data, nil)
+
+	resetGetFlags(t)
+	GetOut = filepath.Join(t.TempDir(), "out.p12")
+
+	if err := runFileGet(nil, []string{path + "#" + field}); err == nil {
+		t.Fatal("expected error for missing chunk field, got nil")
+	}
+}
+
+func TestRunFileGet_ChunkedV1_ChunkCountMismatch(t *testing.T) {
+	setupTestVault(t)
+	path := "apple-developer/count-mismatch"
+	field := "cert_p12"
+	data := map[string]any{
+		field:               "chunked-v1:cert_p12_b64_0000,cert_p12_b64_0001",
+		"cert_p12_b64_0000": "c29tZS1kYXRh",
+		"cert_p12_b64_0001": "bW9yZS1kYXRh",
+		"chunk_count":       3, // Mismatch: manifest has 2, entry specifies 3
+	}
+	writeChunkedTestEntry(t, path, field, data, nil)
+
+	resetGetFlags(t)
+	GetOut = filepath.Join(t.TempDir(), "out.p12")
+
+	if err := runFileGet(nil, []string{path + "#" + field}); err == nil {
+		t.Fatal("expected error for chunk count mismatch, got nil")
+	}
+}
+
+func TestRunFileGet_ChunkedV1_InvalidBase64Chunk(t *testing.T) {
+	setupTestVault(t)
+	path := "apple-developer/invalid-b64"
+	field := "cert_p12"
+	data := map[string]any{
+		field:               "chunked-v1:cert_p12_b64_0000",
+		"cert_p12_b64_0000": "not-valid-base64!@#$",
+	}
+	writeChunkedTestEntry(t, path, field, data, nil)
+
+	resetGetFlags(t)
+	GetOut = filepath.Join(t.TempDir(), "out.p12")
+
+	if err := runFileGet(nil, []string{path + "#" + field}); err == nil {
+		t.Fatal("expected error for invalid base64 in chunk, got nil")
 	}
 }

--- a/cmd/file/use.go
+++ b/cmd/file/use.go
@@ -1,7 +1,6 @@
 package file
 
 import (
-	"encoding/base64"
 	"fmt"
 	"os"
 	"strings"
@@ -59,18 +58,9 @@ func runFileUse(cmd *cobra.Command, args []string) error {
 			return resolveErr
 		}
 
-		raw, ok := entry.Data[resolvedField]
-		if !ok {
-			return errorspkg.NewCLIError(errorspkg.ExitNotFound, fmt.Sprintf("field %q not found in entry %q", resolvedField, path), nil)
-		}
-		encoded, ok := raw.(string)
-		if !ok {
-			return errorspkg.NewCLIError(errorspkg.ExitGeneralError, fmt.Sprintf("field %q is not string-encoded content", resolvedField), nil)
-		}
-
-		content, decErr := base64.StdEncoding.DecodeString(encoded)
+		content, decErr := decodeAttachmentContent(entry, resolvedField)
 		if decErr != nil {
-			return errorspkg.Wrap(errorspkg.ExitGeneralError, errorspkg.ErrKindNone, decErr, "decode attachment content")
+			return decErr
 		}
 
 		name := UseAs

--- a/cmd/file/use_test.go
+++ b/cmd/file/use_test.go
@@ -1,10 +1,13 @@
 package file
 
 import (
+	"encoding/base64"
 	"runtime"
 	"strings"
 	"testing"
 	"time"
+
+	vaultpkg "github.com/danieljustus/symaira-vault/internal/vault"
 )
 
 func resetUseFlags(t *testing.T) {
@@ -95,5 +98,41 @@ func TestRunFileUse_EntryNotFound(t *testing.T) {
 	args := []string{"does/not-exist#field", "true"}
 	if err := runFileUse(nil, args); err == nil {
 		t.Fatal("expected error for missing entry, got nil")
+	}
+}
+
+func TestRunFileUse_ChunkedV1(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows: relies on a POSIX shell")
+	}
+	setupTestVault(t)
+	content := []byte("chunked-v1-test-bytes-for-use")
+	fullB64 := base64.StdEncoding.EncodeToString(content)
+	splitIdx := len(fullB64) / 2
+	chunk0 := fullB64[:splitIdx]
+	chunk1 := fullB64[splitIdx:]
+
+	path := "apple-developer/certificate-p12"
+	field := "cert_p12"
+	data := map[string]any{
+		field:               "chunked-v1:cert_p12_b64_0000,cert_p12_b64_0001",
+		"cert_p12_b64_0000": chunk0,
+		"cert_p12_b64_0001": chunk1,
+	}
+	info := &vaultpkg.AttachmentInfo{
+		Filename: "certificate.p12",
+		Size:     int64(len(content)),
+		SHA256:   vaultpkg.HashAttachmentSHA256(content),
+	}
+	writeChunkedTestEntry(t, path, field, data, info)
+
+	resetUseFlags(t)
+	UseField = ""
+	UseAs = ""
+	UseTimeout = 5 * time.Second
+
+	args := []string{path + "#" + field, "sh", "-c", `test "$(cat "$SYMVAULT_FILE_CERT_P12")" = "chunked-v1-test-bytes-for-use"`}
+	if err := runFileUse(nil, args); err != nil {
+		t.Fatalf("runFileUse with chunked attachment: %v", err)
 	}
 }

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -134,6 +134,9 @@ type ErrorInfo struct {
 	OK        bool   `json:"ok"`
 }
 
+// ActionExposePlaintext is the audit action recorded when secret plaintext is printed to stdout.
+const ActionExposePlaintext = "expose_plaintext"
+
 type LogEntry struct {
 	Timestamp   string `json:"ts"`
 	Agent       string `json:"agent"`
@@ -152,7 +155,24 @@ type LogEntry struct {
 	SessionID   string `json:"sess_id,omitempty"`
 	Kid         string `json:"kid,omitempty"`
 	HMAC        string `json:"hmac,omitempty"`
+	ArgvHash    string `json:"argv_hash,omitempty"`
 	OK          bool   `json:"ok"`
+}
+
+// CountPlaintextExposures counts how many times the entry at entryPath has been
+// exposed in plaintext across all audit log files for the agent in auditDir.
+func CountPlaintextExposures(agent string, auditDir string, entryPath string) (int, error) {
+	entries, err := LoadAuditLogFiles(agent, auditDir, 0)
+	if err != nil {
+		return 0, err
+	}
+	count := 0
+	for _, e := range entries {
+		if e.Action == ActionExposePlaintext && e.Path == entryPath {
+			count++
+		}
+	}
+	return count, nil
 }
 
 // VerifyResult reports the outcome of audit log integrity verification.

--- a/internal/audit/audit_test.go
+++ b/internal/audit/audit_test.go
@@ -2251,3 +2251,64 @@ func TestHealthCheckNeedsRotationBySize_Symvault(t *testing.T) {
 		t.Fatal("expected NeedsRotation=true for oversized file")
 	}
 }
+
+func TestCountPlaintextExposures(t *testing.T) {
+	auditDir := t.TempDir()
+	logger, err := New("symvault", auditDir, nil)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	_ = logger.LogEntry(LogEntry{
+		Action:   ActionExposePlaintext,
+		Path:     "prod/database",
+		Field:    "password",
+		ArgvHash: "0123456789abcdef",
+		OK:       true,
+	})
+	_ = logger.LogEntry(LogEntry{
+		Action:   ActionExposePlaintext,
+		Path:     "prod/database",
+		Field:    "password",
+		ArgvHash: "0123456789abcdef",
+		OK:       true,
+	})
+	_ = logger.LogEntry(LogEntry{
+		Action: "read",
+		Path:   "prod/database",
+		Field:  "password",
+		OK:     true,
+	})
+	_ = logger.LogEntry(LogEntry{
+		Action:   ActionExposePlaintext,
+		Path:     "other/secret",
+		Field:    "key",
+		ArgvHash: "0123456789abcdef",
+		OK:       true,
+	})
+	_ = logger.Close()
+
+	count, err := CountPlaintextExposures("symvault", auditDir, "prod/database")
+	if err != nil {
+		t.Fatalf("CountPlaintextExposures error: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("CountPlaintextExposures = %d, want 2", count)
+	}
+
+	countOther, err := CountPlaintextExposures("symvault", auditDir, "other/secret")
+	if err != nil {
+		t.Fatalf("CountPlaintextExposures error: %v", err)
+	}
+	if countOther != 1 {
+		t.Errorf("CountPlaintextExposures = %d, want 1", countOther)
+	}
+
+	countNone, err := CountPlaintextExposures("symvault", auditDir, "nonexistent")
+	if err != nil {
+		t.Fatalf("CountPlaintextExposures error: %v", err)
+	}
+	if countNone != 0 {
+		t.Errorf("CountPlaintextExposures = %d, want 0", countNone)
+	}
+}


### PR DESCRIPTION
## Summary

Implements four related vault-CLI improvements:

- **#850** — `file get` / `file use` now recognize `chunked-v1:` manifests on attachment fields, resolve each listed `<field>_NNNN` chunk from the same entry, concatenate in order, and decode. Previously the manifest string itself was fed to the base64 decoder (`illegal base64 data at input byte 7`).
- **#851** — `get` gains `--length`, `--digest` (sha256, first 12 hex chars) and `--metadata` (JSON `{length, sha256_12}`) for verifying stored secrets without ever printing plaintext. Mutually exclusive with each other and with `--print`.
- **#852** — `set`/`add` reject empty values on sensitive fields (`password`, `token`, `secret`, `key`, …) with a non-zero exit unless `--allow-empty` is passed; interactive confirm prompts fail loudly on empty or mismatched retyped input instead of storing silently.
- **#853** — `get --print` emits an `expose_plaintext` audit entry (path, field, argv hash — never raw argv) so incident response can answer "was this value ever printed?"; plus a `CountPlaintextExposures` query helper.

Closes #850
Closes #851
Closes #852
Closes #853

## Issue-to-change mapping

| Issue | Production files | Test files |
|---|---|---|
| #850 | `cmd/file/field.go` (new `decodeAttachmentContent`), `cmd/file/get.go`, `cmd/file/use.go` | `cmd/file/get_test.go`, `cmd/file/use_test.go` |
| #851 | `cmd/crud/get.go` | `cmd/crud/get_test.go` |
| #852 | `cmd/crud/set.go`, `cmd/crud/add.go` | `cmd/crud/set_test.go`, `cmd/crud/add_test.go` |
| #853 | `cmd/crud/get.go` (+`emitExposureAudit`), `internal/audit/audit.go` | `cmd/crud/get_test.go`, `internal/audit/audit_test.go` |

## Verification

Local checks at head `11404c5bf253566bdfe282209a0076c7a7fe33ba` (base `dc3864b`):

- `go build ./...` ✅
- `go vet ./...` ✅
- `go test -count=1 ./cmd/... ./internal/audit/...` ✅ (all packages pass)
- `gofmt -l cmd internal` clean ✅
- Staged-diff secret scan: clean ✅

Draft until CI confirms.