### PR TITLE
docs: clear stale notarization blocker, drop Pro-edition contradictions, align README

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -76,6 +76,28 @@ builds:
       - -X main.builtBy=goreleaser
     mod_timestamp: "{{ .CommitTimestamp }}"
 
+# macOS code signing and notarization
+# Requires Apple Developer ID (Team ID: M4744F3TAA) and App Store Connect API keys.
+# Kept commented out until repository secrets are configured in GitHub Actions:
+# - APPLE_DEVELOPER_ID_CERTIFICATE
+# - APPLE_DEVELOPER_ID_CERTIFICATE_PASSWORD
+# - APPLE_API_KEY_ID
+# - APPLE_API_ISSUER_ID
+# - APPLE_API_KEY_BASE64
+# (See docs/macos-notarization.md)
+#
+# notarize:
+#   macos:
+#     - enabled: true
+#       sign:
+#         certificate: "{{ .Env.APPLE_DEVELOPER_ID_CERTIFICATE }}"
+#         password: "{{ .Env.APPLE_DEVELOPER_ID_CERTIFICATE_PASSWORD }}"
+#       issuer_id: "{{ .Env.APPLE_API_ISSUER_ID }}"
+#       key_id: "{{ .Env.APPLE_API_KEY_ID }}"
+#       key: "{{ .Env.APPLE_API_KEY_BASE64 }}"
+#       wait: true
+#       timeout: 20m
+
 archives:
   - id: symvault
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# Symaira Vault (symvault)
+# Symaira Vault
 
 [![CI](https://github.com/danieljustus/symaira-vault/actions/workflows/ci.yml/badge.svg)](https://github.com/danieljustus/symaira-vault/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/danieljustus/symaira-vault)](https://github.com/danieljustus/symaira-vault/releases/latest)
-[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![License](https://img.shields.io/github/license/danieljustus/symaira-vault)](https://opensource.org/licenses/Apache-2.0)
 [![Go Reference](https://pkg.go.dev/badge/github.com/danieljustus/symaira-vault.svg)](https://pkg.go.dev/github.com/danieljustus/symaira-vault)
 
 ![Symaira Vault hero](docs/assets/symvault-hero.png)
 
-A modern, secure command-line password manager written in Go. Uses [age](https://age-encryption.org/) for encryption with built-in MCP server support for AI agent integration.
+A modern, secure command-line password manager (`symvault`) written in Go. Uses [age](https://age-encryption.org/) for encryption with built-in MCP server support for AI agent integration.
 
 ![Symaira Vault demo](docs/assets/symvault-demo.gif)
 
@@ -99,7 +99,9 @@ xcodegen generate
 xcodebuild -project Symvault.xcodeproj -scheme Symvault -scmProvider system build
 ```
 
-## Quick Start
+## Usage
+
+### Quick start
 
 ```bash
 # Initialize vault
@@ -167,23 +169,7 @@ symvault restore ~/backups/symvault-20260427.tar.gz
 
 Backup archives contain encrypted vault files, identity material, config, and MCP tokens. Protect them like the vault itself and test restore before relying on backups.
 
-## Migration from other managers
-
-Symaira Vault can import from 1Password, Bitwarden, pass, CSV exports, FIDO Credential Exchange Format (CXF) archives, and browser CSV exports (Apple Passwords, Chrome, Firefox). `otpauth://` TOTP URIs in imports are normalized into structured TOTP data:
-
-```bash
-symvault import <format> <source>
-symvault import bitwarden ~/exports/bitwarden.json
-symvault import pass ~/.password-store
-symvault import cxf ~/exports/passkeys.cxf
-symvault import apple ~/exports/apple-passwords.csv
-symvault import chrome ~/exports/chrome-passwords.csv
-symvault import firefox ~/exports/firefox-logins.csv
-```
-
-See [docs/migration.md](docs/migration.md) for export steps, format details, and verification guidance.
-
-## Configuration templates
+### Configuration templates
 
 Generate configuration files from vault secrets without exposing values in shell history or intermediate files. Templates support positional `KEY=ref` arguments and the `--prefix` flag to auto-select every entry under a vault path.
 
@@ -206,28 +192,25 @@ symvault template generate --type docker-compose --prefix work/ --output docker-
 
 Supported template types: `env`, `docker-compose`, `k8s-secret`, `github-actions`, and `terraform`. Custom templates can be added in `$HOME/.config/symvault/templates`.
 
-## Egress credential broker
+### Migration from other managers
 
-`symvault broker` is an opt-in loopback MITM forward proxy that attaches vault credentials to an agent's outbound HTTPS/HTTP requests **server-side** — a brokered secret never enters the agent's process environment, argv or process listing:
+Symaira Vault can import from 1Password, Bitwarden, pass, CSV exports, FIDO Credential Exchange Format (CXF) archives, and browser CSV exports (Apple Passwords, Chrome, Firefox). `otpauth://` TOTP URIs in imports are normalized into structured TOTP data:
 
 ```bash
-# One-shot: run a child command with the broker in-process
-symvault run --broker -- gh pr create
-
-# Standalone broker on a fixed port, strict mode
-symvault broker --addr 127.0.0.1:8080 --strict
-
-# Passthrough for certificate-pinning clients
-symvault broker --passthrough corporate.internal,legacy.example.com
+symvault import <format> <source>
+symvault import bitwarden ~/exports/bitwarden.json
+symvault import pass ~/.password-store
+symvault import cxf ~/exports/passkeys.cxf
+symvault import apple ~/exports/apple-passwords.csv
+symvault import chrome ~/exports/chrome-passwords.csv
+symvault import firefox ~/exports/firefox-logins.csv
 ```
 
-Strict mode rejects requests for hosts without a matching API template; passthrough hosts are tunneled without TLS interception. Every brokered request produces a tamper-evident audit record. See [docs/egress-broker.md](docs/egress-broker.md) for details.
+See [docs/migration.md](docs/migration.md) for export steps, format details, and verification guidance.
 
-## MCP API templates
+## MCP & Agent Integration
 
-`symvault` can call external APIs on an agent's behalf through the `execute_api_request` MCP tool. Each call is shaped by an **API template** — a small YAML file declaring the base URL, auth shape, and allowed endpoints. Built-in templates ship for Anthropic, GitHub, OpenAI, Stripe, Telegram, and more; credentials are resolved from a vault entry at request time and never enter the agent's environment, argv, logs or audit trail. See [docs/api-templates.md](docs/api-templates.md) for the catalog and custom-template guide.
-
-## MCP Server
+### MCP Server
 
 Symaira Vault exposes an MCP server for AI agent integration:
 
@@ -259,6 +242,35 @@ symvault agent token hermes revoke <token-id>
 ```
 
 For detailed agent setup, profiles, token management, and observability, see [docs/agent-integration.md](docs/agent-integration.md).
+
+### MCP API templates
+
+`symvault` can call external APIs on an agent's behalf through the `execute_api_request` MCP tool. Each call is shaped by an **API template** — a small YAML file declaring the base URL, auth shape, and allowed endpoints. Built-in templates ship for Anthropic, GitHub, OpenAI, Stripe, Telegram, and more; credentials are resolved from a vault entry at request time and never enter the agent's environment, argv, logs or audit trail. See [docs/api-templates.md](docs/api-templates.md) for the catalog and custom-template guide.
+
+### Egress credential broker
+
+`symvault broker` is an opt-in loopback MITM forward proxy that attaches vault credentials to an agent's outbound HTTPS/HTTP requests **server-side** — a brokered secret never enters the agent's process environment, argv or process listing:
+
+```bash
+# One-shot: run a child command with the broker in-process
+symvault run --broker -- gh pr create
+
+# Standalone broker on a fixed port, strict mode
+symvault broker --addr 127.0.0.1:8080 --strict
+
+# Passthrough for certificate-pinning clients
+symvault broker --passthrough corporate.internal,legacy.example.com
+```
+
+Strict mode rejects requests for hosts without a matching API template; passthrough hosts are tunneled without TLS interception. Every brokered request produces a tamper-evident audit record. See [docs/egress-broker.md](docs/egress-broker.md) for details.
+
+## Ecosystem
+
+Symaira Vault (`symvault`) serves as the credential management and secret-resolution layer for the Symaira tool suite:
+
+- **AI Agents & MCP Clients**: Connect directly to `symvault` via the Model Context Protocol (`symvault serve`), using tools such as `get_entry`, `execute_with_secret`, `execute_api_request`, and `generate_totp` with scoped access tokens and tamper-evident audit logging.
+- **Symaira Hub & Desktop Clients**: Integrate vault functionality via `SymvaultKit` and `SymvaultFeature` to manage and unlock local vaults with native macOS security and biometrics.
+- **CLI & Automation Workflows**: Resolve secrets dynamically across shell scripts and pipelines via `symvault run` (environment injection), `symvault broker` (transparent egress credential proxying), or `symvault template` (configuration file generation).
 
 ## Configuration
 

--- a/docs/macos-notarization.md
+++ b/docs/macos-notarization.md
@@ -1,37 +1,39 @@
 # macOS Notarization Setup Guide
 
-## Status: BLOCKED — Apple Developer ID Required
+## Status: In Progress — Apple Developer Account Active (Team ID: M4744F3TAA)
 
 This document outlines the steps needed to enable macOS notarization for Symaira Vault releases.
 
 ## Prerequisites
 
-1. **Apple Developer Program Membership** ($99/year)
-   - Enroll at: https://developer.apple.com/programs/
-   - Required for: Developer ID Application certificate + notarization access
+1. **Apple Developer Program Membership**
+   - Active Apple Developer account (Team ID: `M4744F3TAA`).
+   - Required for: Developer ID Application certificate + notarization access.
 
 2. **Developer ID Application Certificate**
-   - Create in Apple Developer Portal → Certificates, Identifiers & Profiles
-   - Download and install in Keychain
-   - Export as .p12 file for CI use
+   - Create in Apple Developer Portal → Certificates, Identifiers & Profiles.
+   - Download and install in Keychain.
+   - Export as `.p12` file for CI use.
 
 3. **App Store Connect API Key**
    - Create at: https://appstoreconnect.apple.com/access/api
-   - Needs "Developer" role
-   - Download .p8 private key file
-   - Note the Key ID and Issuer ID
+   - Role: "Developer"
+   - Download `.p8` private key file.
+   - Note the Key ID and Issuer ID.
 
 ## GitHub Secrets Required
 
-Add these secrets to the Symaira Vault repository:
+Configure the following secrets in the Symaira Vault repository settings (`Settings` → `Secrets and variables` → `Actions`):
 
-| Secret Name | Value |
-|-------------|-------|
-| `APPLE_DEVELOPER_ID_CERTIFICATE` | Base64-encoded .p12 certificate |
-| `APPLE_DEVELOPER_ID_CERTIFICATE_PASSWORD` | Password for the .p12 file |
-| `APPLE_API_KEY_ID` | App Store Connect API Key ID |
-| `APPLE_API_ISSUER_ID` | App Store Connect API Issuer ID |
-| `APPLE_API_KEY_BASE64` | Base64-encoded .p8 private key |
+| Secret Name | Description / Format | CI Usage |
+|-------------|----------------------|----------|
+| `APPLE_DEVELOPER_ID_CERTIFICATE` | Base64-encoded `.p12` certificate | Code signing (`Developer ID Application`) |
+| `APPLE_DEVELOPER_ID_CERTIFICATE_PASSWORD` | Password for the `.p12` file | Unlocking imported CI keychain |
+| `APPLE_API_KEY_ID` | App Store Connect API Key ID (10 alphanumeric characters) | Notarization service authentication |
+| `APPLE_API_ISSUER_ID` | App Store Connect API Issuer ID (UUID format) | Notarization service authentication |
+| `APPLE_API_KEY_BASE64` | Base64-encoded `.p8` private key | Notarization service authentication |
+
+> **Credential Status:** While the paid Apple Developer account (Team ID: `M4744F3TAA`) is active, repository secrets must be configured in GitHub Secrets before automated notarization in GoReleaser can run. Until these secrets are provisioned, the GoReleaser notarization block remains commented out.
 
 ## GoReleaser Configuration
 
@@ -45,7 +47,7 @@ Add the following to `.goreleaser.yml` after the `builds:` section:
 # macos:
 #   signing:
 #     enabled: true
-#     identity: "Developer ID Application: Your Name (TEAM_ID)"
+#     identity: "Developer ID Application: Your Name (M4744F3TAA)"
 #   notarize:
 #     enabled: true
 #     issuer_id: "{{ .Env.APPLE_API_ISSUER_ID }}"
@@ -78,10 +80,10 @@ After setting up, verify notarization with:
 
 ```bash
 # Check notarization status
-spctl -a -t exec -vv /path/to/openpass
+spctl -a -t exec -vv /path/to/symvault
 
 # Expected output:
-# /path/to/openpass: accepted
+# /path/to/symvault: accepted
 # source=Notarized Developer ID
 ```
 
@@ -91,6 +93,6 @@ spctl -a -t exec -vv /path/to/openpass
 - [Apple Notarization Guide](https://developer.apple.com/documentation/security/notarizing-macos-software-before-distribution)
 - Code-Audit §10.1
 
-## Current Blocker
+## Current Status
 
-**As of 2026-05-07**: Apple Developer ID not available. This item is prepared but cannot be activated until credentials are obtained.
+**As of 2026-08**: Apple Developer account is available (Team ID: `M4744F3TAA`). Automated notarization is prepared and pending repository secrets configuration (`APPLE_DEVELOPER_ID_CERTIFICATE`, `APPLE_DEVELOPER_ID_CERTIFICATE_PASSWORD`, `APPLE_API_KEY_ID`, `APPLE_API_ISSUER_ID`, `APPLE_API_KEY_BASE64`).

--- a/docs/research-handoff-eu-commercialization.md
+++ b/docs/research-handoff-eu-commercialization.md
@@ -8,7 +8,7 @@ This document preserves the actionable findings from the local research folders:
 The original folders can be deleted once the linked GitHub issues are visible.
 This file keeps only the parts that belong in the public Apache-2.0 self-hosted core.
 Hosted service, billing, tenant operations, SSO/SCIM, hosted RBAC, SIEM export,
-and compliance operations are out of scope: there is no Pro edition and no hosted
+and compliance operations are out of scope: there is no commercial edition and no hosted
 counterpart to hand them to.
 
 ## Current Public-Core Status
@@ -50,13 +50,13 @@ counterpart to hand them to.
    German/EU regulated buyers will ask for a documented post-quantum transition
    plan before long-term procurement decisions. The plan now exists at
    `docs/adr/0005-post-quantum-transition-plan.md`.
-4. Hardware-backed unlock and FIDO2/WebAuthn are enterprise-relevant, but hosted
-   MFA enforcement belongs to Pro. Public core may later evaluate local
-   hardware-key unlock without creating paid gates.
-5. The old OpenPass commercialization advice is now partially obsolete: the repo
-   has been renamed and substantially hardened, and Pro has its own private
-   service layer. The still-useful part is the positioning around AI-agent
-   credentials and local-first trust.
+4. Hardware-backed unlock and FIDO2/WebAuthn remain enterprise-relevant. Symaira
+   Vault may evaluate local hardware-key unlock (e.g. YubiKey/FIDO2) for the
+   self-hosted tool without introducing hosted MFA services or paid tiers.
+5. The old OpenPass commercialization advice is obsolete: the project is focused
+   entirely on the single Apache-2.0 open-source product without a hosted
+   counterpart. The lasting takeaway is the strong positioning around AI-agent
+   credentials, local-first trust, and zero-telemetry operational security.
 
 ## GitHub Tracking
 


### PR DESCRIPTION
## Summary
Documentation cleanup across three issues:

- **macos-notarization.md**: removes the stale BLOCKED status — the Apple Developer Program membership now exists (Team ID M4744F3TAA). The GoReleaser signing/notarization block stays commented out until the required repository secrets are configured; the exact missing secret list is documented.
- **research-handoff-eu-commercialization.md**: rewrites research takeaways that still referenced a Pro edition / private service layer, contradicting docs/commercial-boundary.md. Hardware-backed unlock and FIDO2/WebAuthn remain enterprise-relevant takeaways.
- **README.md**: H1 simplified to "Symaira Vault", dynamic license badge, sections regrouped so the first screen reads Why → Install → Quick start, and a new Ecosystem section describing how other Symaira tools resolve secrets through symvault.

Closes danieljustus/symaira-vault#873
Closes danieljustus/symaira-vault#874
Closes danieljustus/symaira-vault#878

## Checks
- Content greps clean (no BLOCKED status, no Pro-edition references)
- Section count reduced 18 → 15 by grouping under Usage / MCP & Agent integration headings