### PR TITLE
feat(app): align macOS bundle name, identifier and DMG asset with the naming convention

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -353,7 +353,7 @@ jobs:
       - name: Code sign .app and embedded binary
         if: steps.signing.outputs.signed == 'true'
         run: |
-          APP_PATH="client/Symvault.xcarchive/Products/Applications/Symvault.app"
+          APP_PATH="client/Symvault.xcarchive/Products/Applications/Symaira Vault.app"
           RESOURCES="$APP_PATH/Contents/Resources"
           # Sign embedded symvault binary first. Notarization requires hardened
           # runtime on every executable in the bundle, not just the top-level .app.
@@ -370,8 +370,8 @@ jobs:
       - name: Create DMG
         run: |
           TAG="${GITHUB_REF#refs/tags/}"
-          APP_PATH="client/Symvault.xcarchive/Products/Applications/Symvault.app"
-          DMG_PATH="SymairaVault_${TAG}_macos.dmg"
+          APP_PATH="client/Symvault.xcarchive/Products/Applications/Symaira Vault.app"
+          DMG_PATH="Symaira-Vault-${TAG}-macos.dmg"
           ./scripts/create-symaira-dmg.sh \
             "$APP_PATH" \
             "$DMG_PATH" \
@@ -406,7 +406,7 @@ jobs:
       - name: Staple notarization ticket
         if: steps.signing.outputs.signed == 'true'
         run: |
-          APP_PATH="client/Symvault.xcarchive/Products/Applications/Symvault.app"
+          APP_PATH="client/Symvault.xcarchive/Products/Applications/Symaira Vault.app"
           xcrun stapler staple "$APP_PATH" || echo "::warning::Stapling .app failed"
           xcrun stapler staple "${{ env.DMG_PATH }}" || echo "::warning::Stapling .dmg failed"
 

--- a/client/project.yml
+++ b/client/project.yml
@@ -1,6 +1,6 @@
 name: Symvault
 options:
-  bundleIdPrefix: dev.symaira
+  bundleIdPrefix: com.symaira
   deploymentTarget:
     macOS: "14.0"
   xcodeVersion: "16.0"
@@ -32,8 +32,8 @@ targets:
       path: Symvault.entitlements
     settings:
       base:
-        PRODUCT_BUNDLE_IDENTIFIER: dev.symaira.Symvault
-        PRODUCT_NAME: Symvault
+        PRODUCT_BUNDLE_IDENTIFIER: com.symaira.vault
+        PRODUCT_NAME: Symaira Vault
         CODE_SIGN_IDENTITY: "-"
         CODE_SIGN_STYLE: Manual
         ENABLE_HARDENED_RUNTIME: true


### PR DESCRIPTION
## Summary
Aligns three layers of the macOS app with the workspace naming convention (decided 2026-08-25):

- `client/project.yml`: `PRODUCT_NAME` → `Symaira Vault`, `PRODUCT_BUNDLE_IDENTIFIER` → `com.symaira.vault`, `bundleIdPrefix: com.symaira`
- Xcode project regenerated with xcodegen (the .xcodeproj is generated and gitignored; verified locally that it now produces "Symaira Vault.app" with identifier com.symaira.vault)
- `.github/workflows/release.yml`: archive paths now point at `Symaira Vault.app`; DMG asset renamed to `Symaira-Vault-<tag>-macos.dmg`

Not touched: Go binary name `symvault`, SPM target names (`SymvaultClient`, `SymvaultFeature`), Go module path.

Closes danieljustus/symaira-vault#875

## Checks
- grep clean for dev.symaira.Symvault / Symvault.app / SymairaVault_ in tracked files (CHANGELOG.md historical entries intentionally preserved)