### PR TITLE
security(device): display joining key fingerprint in device accept

### DIFF
--- a/cmd/device.go
+++ b/cmd/device.go
@@ -100,13 +100,14 @@ for the new device.`,
 				return fmt.Errorf("save pairing file: %w", err)
 			}
 
-			if err := git.AutoCommitAndPush(vaultDir, fmt.Sprintf("Pairing token %s", token), v.Config.Git.AutoPush); err != nil {
+			if err := git.AutoCommitAndPush(vaultDir, fmt.Sprintf("Pairing token %s", token), gitAutoPush(v)); err != nil {
 				cliout.Warnf("Warning: could not auto-commit/push: %v", err)
 			}
 
 			printQuietAware("\n=== Pairing Token ===\n")
 			printQuietAware("Token: %s\n\n", token)
 			printQuietAware("This device's public key: %s\n", publicKey)
+			printQuietAware("Key fingerprint:          %s (SHA-256)\n", cryptopkg.PublicKeyFingerprint(publicKey))
 			printQuietAware("\nOn the joining device, run:\n")
 			printQuietAware("  symvault device join <remote-url> %s\n\n", token)
 			printQuietAware("After the joining device has submitted its key, run:\n")
@@ -241,8 +242,10 @@ to re-encrypt all entries for this new device.`,
 			}
 
 			cliout.Hintf("=== Join Successful ===")
-			printQuietAware("\nYour public key: %s\n", myPubkey)
-			printQuietAware("Device name: %s\n\n", joinedData.Name)
+			printQuietAware("\nDevice name:     %s\n", joinedData.Name)
+			printQuietAware("Key type:        age X25519\n")
+			printQuietAware("Your public key: %s\n", myPubkey)
+			printQuietAware("Key fingerprint: %s (SHA-256)\n\n", cryptopkg.PublicKeyFingerprint(myPubkey))
 			printQuietAware("IMPORTANT: Entries cannot be decrypted yet.\n")
 			printQuietAware("On the existing device, run:\n")
 			printQuietAware("  symvault device accept %s\n\n", token)
@@ -296,6 +299,14 @@ can decrypt them.`,
 				return fmt.Errorf("parse joined file: %w", err)
 			}
 
+			fp := cryptopkg.PublicKeyFingerprint(jf.PublicKey)
+
+			printQuietAware("\n=== Joining Device Request ===\n")
+			printQuietAware("Device name:     %s\n", jf.Name)
+			printQuietAware("Key type:        age X25519\n")
+			printQuietAware("Public key:      %s\n", jf.PublicKey)
+			printQuietAware("Key fingerprint: %s (SHA-256)\n\n", fp)
+
 			cliout.Hintf("Accepting join from device: %s (public key: %s)", jf.Name, truncatePubkey(jf.PublicKey))
 
 			rm := vaultpkg.NewRecipientsManager(vaultDir)
@@ -315,7 +326,7 @@ can decrypt them.`,
 
 			_ = os.Remove(joinedPath)
 
-			if err := git.AutoCommitAndPush(vaultDir, fmt.Sprintf("Accept device join: %s", jf.Name), v.Config.Git.AutoPush); err != nil {
+			if err := git.AutoCommitAndPush(vaultDir, fmt.Sprintf("Accept device join: %s", jf.Name), gitAutoPush(v)); err != nil {
 				cliout.Warnf("Warning: could not auto-commit/push: %v", err)
 			}
 
@@ -563,8 +574,10 @@ request so the first device can accept it.`,
 			}
 
 			cliout.Hintf("=== Pairing Setup Complete ===")
+			fmt.Fprintf(os.Stderr, "Device name:     %s\n", joinedData.Name)
+			fmt.Fprintf(os.Stderr, "Key type:        age X25519\n")
 			fmt.Fprintf(os.Stderr, "Your public key: %s\n", identity.Recipient().String())
-			fmt.Fprintf(os.Stderr, "Device name: %s\n\n", joinedData.Name)
+			fmt.Fprintf(os.Stderr, "Key fingerprint: %s (SHA-256)\n\n", cryptopkg.PublicKeyFingerprint(identity.Recipient().String()))
 			fmt.Fprintf(os.Stderr, "IMPORTANT: Entries cannot be decrypted yet.\n")
 			fmt.Fprintf(os.Stderr, "On the original device, run:\n")
 			fmt.Fprintf(os.Stderr, "  symvault device accept %s\n\n", token)
@@ -665,7 +678,7 @@ access to all vault entries.`,
 			}
 
 			// Auto-commit and push
-			if err := git.AutoCommitAndPush(vaultDir, fmt.Sprintf("Revoke device: %s", deviceName), v.Config.Git.AutoPush); err != nil {
+			if err := git.AutoCommitAndPush(vaultDir, fmt.Sprintf("Revoke device: %s", deviceName), gitAutoPush(v)); err != nil {
 				cliout.Warnf("Warning: could not auto-commit/push: %v", err)
 			}
 
@@ -714,4 +727,11 @@ func truncatePubkey(pubkey string) string {
 		return pubkey[:16] + "..."
 	}
 	return pubkey
+}
+
+func gitAutoPush(v *vaultpkg.Vault) bool {
+	if v != nil && v.Config != nil && v.Config.Git != nil {
+		return v.Config.Git.AutoPush
+	}
+	return false
 }

--- a/cmd/device_test.go
+++ b/cmd/device_test.go
@@ -1,0 +1,334 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	configpkg "github.com/danieljustus/symaira-vault/internal/config"
+	cryptopkg "github.com/danieljustus/symaira-vault/internal/crypto"
+	"github.com/danieljustus/symaira-vault/internal/pairing"
+	vaultpkg "github.com/danieljustus/symaira-vault/internal/vault"
+)
+
+func TestDeviceAccept_DisplaysFingerprintAndAccepts(t *testing.T) {
+	vaultDir, passphrase := initVault(t)
+	setPassEnv(t, string(passphrase))
+	vaultFlagReset(t)
+
+	// Generate joining device identity
+	joiningIdentity, err := cryptopkg.GenerateIdentity()
+	if err != nil {
+		t.Fatalf("generate joining identity: %v", err)
+	}
+	joiningPubkey := joiningIdentity.Recipient().String()
+	expectedFingerprint := cryptopkg.PublicKeyFingerprint(joiningPubkey)
+	if expectedFingerprint == "" {
+		t.Fatal("expected fingerprint to not be empty")
+	}
+
+	token, err := pairing.GenerateToken()
+	if err != nil {
+		t.Fatalf("generate token: %v", err)
+	}
+
+	// Write joined file
+	jf := joinedFile{
+		Token:     string(token),
+		Name:      "test-phone",
+		PublicKey: joiningPubkey,
+		CreatedAt: time.Now().UTC(),
+	}
+	pairingDir := filepath.Join(vaultDir, configpkg.DefaultVaultSubdir, "pairing")
+	if err := os.MkdirAll(pairingDir, 0o700); err != nil {
+		t.Fatalf("mkdir pairing dir: %v", err)
+	}
+	jfBytes, err := json.MarshalIndent(jf, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal joined file: %v", err)
+	}
+	jfPath := filepath.Join(pairingDir, string(token)+"-joined.json")
+	if err := os.WriteFile(jfPath, jfBytes, 0o600); err != nil {
+		t.Fatalf("write joined file: %v", err)
+	}
+
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "device", "accept", string(token)})
+	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+
+	var execErr error
+	output := captureStdout(func() {
+		execErr = rootCmd.Execute()
+	})
+
+	if execErr != nil {
+		t.Fatalf("device accept execute failed: %v", execErr)
+	}
+
+	// Verify stdout output contains all expected fingerprint and device metadata
+	if !strings.Contains(output, "=== Joining Device Request ===") {
+		t.Errorf("output missing header: %q", output)
+	}
+	if !strings.Contains(output, "Device name:     test-phone") {
+		t.Errorf("output missing device name: %q", output)
+	}
+	if !strings.Contains(output, "Key type:        age X25519") {
+		t.Errorf("output missing key type: %q", output)
+	}
+	if !strings.Contains(output, "Public key:      "+joiningPubkey) {
+		t.Errorf("output missing public key: %q", output)
+	}
+	if !strings.Contains(output, "Key fingerprint: "+expectedFingerprint) {
+		t.Errorf("output missing fingerprint %q: %q", expectedFingerprint, output)
+	}
+	if !strings.Contains(output, "=== Pairing Complete ===") {
+		t.Errorf("output missing pairing complete: %q", output)
+	}
+	if !strings.Contains(output, "Device \"test-phone\" can now access all vault entries.") {
+		t.Errorf("output missing device grant confirmation: %q", output)
+	}
+
+	// Verify joining public key was added to recipients
+	rm := vaultpkg.NewRecipientsManager(vaultDir)
+	recipients, err := rm.LoadRecipientStrings()
+	if err != nil {
+		t.Fatalf("load recipients: %v", err)
+	}
+	found := false
+	for _, r := range recipients {
+		if r == joiningPubkey {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("joining public key %s not found in recipients list %v", joiningPubkey, recipients)
+	}
+
+	// Verify joined file was removed
+	if _, err := os.Stat(jfPath); !os.IsNotExist(err) {
+		t.Errorf("joined file still exists at %s", jfPath)
+	}
+}
+
+func TestDevicePair_DisplaysFingerprint(t *testing.T) {
+	vaultDir, passphrase := initVault(t)
+	setPassEnv(t, string(passphrase))
+	vaultFlagReset(t)
+
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "device", "pair"})
+	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+
+	var execErr error
+	output := captureStdout(func() {
+		execErr = rootCmd.Execute()
+	})
+
+	if execErr != nil {
+		t.Fatalf("device pair execute failed: %v", execErr)
+	}
+
+	if !strings.Contains(output, "=== Pairing Token ===") {
+		t.Errorf("output missing header: %q", output)
+	}
+	if !strings.Contains(output, "Token:") {
+		t.Errorf("output missing token: %q", output)
+	}
+	if !strings.Contains(output, "This device's public key:") {
+		t.Errorf("output missing public key: %q", output)
+	}
+	if !strings.Contains(output, "Key fingerprint:") {
+		t.Errorf("output missing key fingerprint: %q", output)
+	}
+	if !strings.Contains(output, "(SHA-256)") {
+		t.Errorf("output missing (SHA-256): %q", output)
+	}
+}
+
+func TestDeviceAccept_InvalidToken(t *testing.T) {
+	vaultDir, passphrase := initVault(t)
+	setPassEnv(t, string(passphrase))
+	vaultFlagReset(t)
+
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "device", "accept", "invalid/token"})
+	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+
+	var execErr error
+	captureStderr(func() {
+		execErr = rootCmd.Execute()
+	})
+
+	if execErr == nil {
+		t.Fatal("expected error for invalid token")
+	}
+	if !strings.Contains(execErr.Error(), "invalid pairing token") {
+		t.Errorf("unexpected error message: %v", execErr)
+	}
+}
+
+func TestDeviceAccept_NoJoinRequest(t *testing.T) {
+	vaultDir, passphrase := initVault(t)
+	setPassEnv(t, string(passphrase))
+	vaultFlagReset(t)
+
+	token, err := pairing.GenerateToken()
+	if err != nil {
+		t.Fatalf("generate token: %v", err)
+	}
+
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "device", "accept", string(token)})
+	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+
+	var execErr error
+	captureStderr(func() {
+		execErr = rootCmd.Execute()
+	})
+
+	if execErr == nil {
+		t.Fatal("expected error when no join request exists")
+	}
+	if !strings.Contains(execErr.Error(), "no join request found") {
+		t.Errorf("unexpected error message: %v", execErr)
+	}
+}
+
+func TestDeviceAccept_CorruptJoinedFile(t *testing.T) {
+	vaultDir, passphrase := initVault(t)
+	setPassEnv(t, string(passphrase))
+	vaultFlagReset(t)
+
+	token, err := pairing.GenerateToken()
+	if err != nil {
+		t.Fatalf("generate token: %v", err)
+	}
+
+	pairingDir := filepath.Join(vaultDir, configpkg.DefaultVaultSubdir, "pairing")
+	if err := os.MkdirAll(pairingDir, 0o700); err != nil {
+		t.Fatalf("mkdir pairing dir: %v", err)
+	}
+	jfPath := filepath.Join(pairingDir, string(token)+"-joined.json")
+	if err := os.WriteFile(jfPath, []byte("not-valid-json"), 0o600); err != nil {
+		t.Fatalf("write joined file: %v", err)
+	}
+
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "device", "accept", string(token)})
+	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+
+	var execErr error
+	captureStderr(func() {
+		execErr = rootCmd.Execute()
+	})
+
+	if execErr == nil {
+		t.Fatal("expected error for corrupt joined file")
+	}
+	if !strings.Contains(execErr.Error(), "parse joined file") {
+		t.Errorf("unexpected error message: %v", execErr)
+	}
+}
+
+func TestDeviceAccept_DefaultDeviceName(t *testing.T) {
+	vaultDir, passphrase := initVault(t)
+	setPassEnv(t, string(passphrase))
+	vaultFlagReset(t)
+
+	joiningIdentity, err := cryptopkg.GenerateIdentity()
+	if err != nil {
+		t.Fatalf("generate joining identity: %v", err)
+	}
+	joiningPubkey := joiningIdentity.Recipient().String()
+	expectedFingerprint := cryptopkg.PublicKeyFingerprint(joiningPubkey)
+
+	token, err := pairing.GenerateToken()
+	if err != nil {
+		t.Fatalf("generate token: %v", err)
+	}
+
+	// Write joined file with empty name
+	jf := joinedFile{
+		Token:     string(token),
+		Name:      "",
+		PublicKey: joiningPubkey,
+		CreatedAt: time.Now().UTC(),
+	}
+	pairingDir := filepath.Join(vaultDir, configpkg.DefaultVaultSubdir, "pairing")
+	if err := os.MkdirAll(pairingDir, 0o700); err != nil {
+		t.Fatalf("mkdir pairing dir: %v", err)
+	}
+	jfBytes, err := json.MarshalIndent(jf, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal joined file: %v", err)
+	}
+	jfPath := filepath.Join(pairingDir, string(token)+"-joined.json")
+	if err := os.WriteFile(jfPath, jfBytes, 0o600); err != nil {
+		t.Fatalf("write joined file: %v", err)
+	}
+
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "device", "accept", string(token)})
+	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+
+	var execErr error
+	output := captureStdout(func() {
+		execErr = rootCmd.Execute()
+	})
+
+	if execErr != nil {
+		t.Fatalf("device accept execute failed: %v", execErr)
+	}
+
+	if !strings.Contains(output, "Key fingerprint: "+expectedFingerprint) {
+		t.Errorf("output missing expected fingerprint %s: %q", expectedFingerprint, output)
+	}
+	if !strings.Contains(output, "Key type:        age X25519") {
+		t.Errorf("output missing key type: %q", output)
+	}
+}
+
+func TestDeviceAdd_DisplaysFingerprint(t *testing.T) {
+	vaultDir := t.TempDir()
+	vaultFlagReset(t)
+
+	existingIdentity, err := cryptopkg.GenerateIdentity()
+	if err != nil {
+		t.Fatalf("generate existing identity: %v", err)
+	}
+	existingPubkey := existingIdentity.Recipient().String()
+
+	token, err := pairing.GenerateToken()
+	if err != nil {
+		t.Fatalf("generate token: %v", err)
+	}
+
+	cleanupStdin := pipeStdin(t, "test-device-passphrase-123\n")
+	t.Cleanup(cleanupStdin)
+
+	rootCmd.SetArgs([]string{"--vault", vaultDir, "device", "add", "--pair", string(token) + ":" + existingPubkey, "--name", "added-device"})
+	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+
+	var execErr error
+	output := captureStderr(func() {
+		execErr = rootCmd.Execute()
+	})
+
+	if execErr != nil {
+		t.Fatalf("device add execute failed: %v, output: %s", execErr, output)
+	}
+
+	if !strings.Contains(output, "Device name:     added-device") {
+		t.Errorf("output missing device name: %q", output)
+	}
+	if !strings.Contains(output, "Key type:        age X25519") {
+		t.Errorf("output missing key type: %q", output)
+	}
+	if !strings.Contains(output, "Your public key: age1") {
+		t.Errorf("output missing public key: %q", output)
+	}
+	if !strings.Contains(output, "Key fingerprint:") {
+		t.Errorf("output missing key fingerprint: %q", output)
+	}
+	if !strings.Contains(output, "(SHA-256)") {
+		t.Errorf("output missing (SHA-256): %q", output)
+	}
+}

--- a/internal/crypto/age.go
+++ b/internal/crypto/age.go
@@ -308,7 +308,7 @@ func PublicKeyFingerprint(pubkey string) string {
 	}
 	sum := sha256.Sum256([]byte(pubkey))
 	hexStr := strings.ToUpper(hex.EncodeToString(sum[:16]))
-	var groups []string
+	groups := make([]string, 0, len(hexStr)/4)
 	for i := 0; i < len(hexStr); i += 4 {
 		groups = append(groups, hexStr[i:i+4])
 	}

--- a/internal/crypto/age.go
+++ b/internal/crypto/age.go
@@ -5,6 +5,8 @@ package crypto
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -291,4 +293,38 @@ func ParseRecipients(recipientStrs []string) ([]*age.X25519Recipient, error) {
 	}
 
 	return recipients, nil
+}
+
+// PublicKeyFingerprint computes a deterministic human-verifiable fingerprint
+// for an age public key string (or recipient string).
+// It computes the SHA-256 digest of the trimmed public key string, takes the first
+// 16 bytes (128 bits), and formats them as 8 space-separated 4-character hex groups
+// in uppercase (e.g. "AB12 CD34 EF56 7890 1234 5678 9ABC DEF0").
+// If pubkey is empty, it returns an empty string.
+func PublicKeyFingerprint(pubkey string) string {
+	pubkey = strings.TrimSpace(pubkey)
+	if pubkey == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(pubkey))
+	hexStr := strings.ToUpper(hex.EncodeToString(sum[:16]))
+	var groups []string
+	for i := 0; i < len(hexStr); i += 4 {
+		groups = append(groups, hexStr[i:i+4])
+	}
+	return strings.Join(groups, " ")
+}
+
+// Fingerprint is an alias for PublicKeyFingerprint.
+func Fingerprint(pubkey string) string {
+	return PublicKeyFingerprint(pubkey)
+}
+
+// FingerprintRecipient computes the deterministic fingerprint for an age.X25519Recipient.
+// Returns an empty string if recipient is nil.
+func FingerprintRecipient(recipient *age.X25519Recipient) string {
+	if recipient == nil {
+		return ""
+	}
+	return PublicKeyFingerprint(recipient.String())
 }

--- a/internal/crypto/crypto_test.go
+++ b/internal/crypto/crypto_test.go
@@ -745,3 +745,94 @@ func bytesEqual(a, b []byte) bool {
 	}
 	return true
 }
+
+func TestPublicKeyFingerprint(t *testing.T) {
+	t.Run("empty string returns empty", func(t *testing.T) {
+		if got := PublicKeyFingerprint(""); got != "" {
+			t.Errorf("PublicKeyFingerprint(\"\") = %q, want empty", got)
+		}
+		if got := PublicKeyFingerprint("   \n\t  "); got != "" {
+			t.Errorf("PublicKeyFingerprint(whitespace) = %q, want empty", got)
+		}
+	})
+
+	t.Run("nil recipient returns empty", func(t *testing.T) {
+		if got := FingerprintRecipient(nil); got != "" {
+			t.Errorf("FingerprintRecipient(nil) = %q, want empty", got)
+		}
+	})
+
+	t.Run("determinism - same key produces same fingerprint", func(t *testing.T) {
+		key := "age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p"
+		fp1 := PublicKeyFingerprint(key)
+		fp2 := PublicKeyFingerprint(key)
+		fp3 := Fingerprint(key)
+		if fp1 == "" {
+			t.Fatal("fingerprint should not be empty")
+		}
+		if fp1 != fp2 {
+			t.Errorf("expected deterministic fingerprint, got %q and %q", fp1, fp2)
+		}
+		if fp1 != fp3 {
+			t.Errorf("Fingerprint alias produced %q, want %q", fp3, fp1)
+		}
+
+		// Trimming whitespace
+		fpWithSpaces := PublicKeyFingerprint("  " + key + "\n")
+		if fpWithSpaces != fp1 {
+			t.Errorf("fingerprint with whitespace = %q, want %q", fpWithSpaces, fp1)
+		}
+	})
+
+	t.Run("distinct keys produce distinct fingerprints", func(t *testing.T) {
+		key1 := "age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p"
+		key2 := "age1savzx9za5xg4fvwkeq788v50esvs3ccn9sscdxevw2fev9xdyeps8z9z65"
+
+		fp1 := PublicKeyFingerprint(key1)
+		fp2 := PublicKeyFingerprint(key2)
+		if fp1 == fp2 {
+			t.Errorf("distinct keys produced same fingerprint: %q", fp1)
+		}
+	})
+
+	t.Run("format is 8 groups of 4 uppercase hex characters", func(t *testing.T) {
+		key := "age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p"
+		fp := PublicKeyFingerprint(key)
+
+		// Expected length: 8 groups * 4 chars + 7 spaces = 39 chars
+		if len(fp) != 39 {
+			t.Errorf("expected length 39, got %d for %q", len(fp), fp)
+		}
+
+		groups := strings.Split(fp, " ")
+		if len(groups) != 8 {
+			t.Fatalf("expected 8 groups, got %d", len(groups))
+		}
+		for i, g := range groups {
+			if len(g) != 4 {
+				t.Errorf("group %d length = %d, want 4 (%q)", i, len(g), g)
+			}
+			for _, ch := range g {
+				if !((ch >= '0' && ch <= '9') || (ch >= 'A' && ch <= 'F')) {
+					t.Errorf("group %d contains non-hex char: %c in %q", i, ch, g)
+				}
+			}
+		}
+	})
+
+	t.Run("FingerprintRecipient matches PublicKeyFingerprint", func(t *testing.T) {
+		id, err := GenerateIdentity()
+		if err != nil {
+			t.Fatalf("GenerateIdentity: %v", err)
+		}
+		recipient := id.Recipient()
+		fpFromRecipient := FingerprintRecipient(recipient)
+		fpFromString := PublicKeyFingerprint(recipient.String())
+		if fpFromRecipient == "" {
+			t.Fatal("FingerprintRecipient returned empty")
+		}
+		if fpFromRecipient != fpFromString {
+			t.Errorf("FingerprintRecipient = %q, want %q", fpFromRecipient, fpFromString)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
Implements the human gate in device enrolment (ADR 0006 D1): `symvault device accept` now displays the joining device's public-key fingerprint **before** adding the recipient and re-encrypting the vault.

- New `crypto.PublicKeyFingerprint`: SHA-256 over the trimmed public key, first 16 bytes, rendered as 8 space-separated uppercase hex groups (`AB12 CD34 ...`). Deterministic; covered by unit tests for determinism, distinctness and format.
- `device accept` shows device name, key type, full public key and fingerprint before granting.
- `device join`, `device pair` and `device add` print the same-format fingerprint so both ends can compare out of band.
- Small nil-guard helper (`gitAutoPush`) prevents a panic when `v.Config.Git` is unset on the touched paths — behavior-preserving otherwise.

An attacker who can write to the sync account can submit a join request, but the operator now sees exactly which key they are accepting.

Closes danieljustus/symaira-vault#866

## Checks
- go build ./... / go vet / gofmt clean
- go test -count=1 ./cmd/... ./internal/crypto/... green (new fingerprint + command tests included)