### PR TITLE
refactor(vault): decouple core from git, metrics, and terminal UI

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -16,11 +16,22 @@ import (
 	agentctx "github.com/danieljustus/symaira-vault/internal/agentctx"
 	configpkg "github.com/danieljustus/symaira-vault/internal/config"
 	errorspkg "github.com/danieljustus/symaira-vault/internal/errors"
+	"github.com/danieljustus/symaira-vault/internal/git"
 	"github.com/danieljustus/symaira-vault/internal/i18n"
+	"github.com/danieljustus/symaira-vault/internal/metrics"
 	"github.com/danieljustus/symaira-vault/internal/session"
 	"github.com/danieljustus/symaira-vault/internal/ui/cliout"
 	"github.com/danieljustus/symaira-vault/internal/ui/theme"
+	vaultpkg "github.com/danieljustus/symaira-vault/internal/vault"
 )
+
+func init() {
+	configpkg.SetWarnFunc(func(msg string) {
+		cliout.Warnf("%s", msg)
+	})
+	vaultpkg.SetDefaultGitSyncer(git.NewSyncer())
+	vaultpkg.SetMetricsHooks(metrics.RecordVaultOperationDuration, metrics.RecordVaultEntryCount)
+}
 
 var OsExit = os.Exit
 

--- a/internal/config/config_load.go
+++ b/internal/config/config_load.go
@@ -11,7 +11,6 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/danieljustus/symaira-vault/internal/fsutil"
-	"github.com/danieljustus/symaira-vault/internal/ui/cliout"
 )
 
 func validateConfigPath(path string) error {
@@ -167,7 +166,7 @@ func Load(path string) (*Config, error) {
 	}
 
 	if raw.EnvWhitelist != nil {
-		cliout.Warnf("envWhitelist is deprecated and will be removed in a future version; use envAllowlist instead")
+		warnf("envWhitelist is deprecated and will be removed in a future version; use envAllowlist instead")
 	}
 
 	mergeTopLevel(cfg, raw)

--- a/internal/config/config_merge.go
+++ b/internal/config/config_merge.go
@@ -4,8 +4,6 @@ import (
 	"encoding/json"
 	"sync/atomic"
 	"time"
-
-	"github.com/danieljustus/symaira-vault/internal/ui/cliout"
 )
 
 var clipboardPrintByDefaultWarningEmitted atomic.Bool
@@ -335,7 +333,7 @@ func mergeGitConfig(raw *GitConfig, sf map[string]bool) *GitConfig {
 func mergeMCPConfig(raw *MCPConfig, sf, oaf, ppf map[string]bool) *MCPConfig {
 	defaults := defaultMCPConfig()
 	if raw.ApprovalRequired {
-		cliout.Warnf("approval_required is deprecated and will be removed in a future version")
+		warnf("approval_required is deprecated and will be removed in a future version")
 	}
 	if sf["port"] {
 		defaults.Port = raw.Port
@@ -436,7 +434,7 @@ func mergeClipboardConfig(raw *ClipboardConfig, sf map[string]bool) *ClipboardCo
 		defaults.CopyByDefault = raw.CopyByDefault
 	} else if sf["printByDefault"] {
 		if !clipboardPrintByDefaultWarningEmitted.Swap(true) {
-			cliout.Warnf("clipboard.printByDefault is deprecated; use clipboard.copyByDefault instead")
+			warnf("clipboard.printByDefault is deprecated; use clipboard.copyByDefault instead")
 		}
 		defaults.CopyByDefault = raw.PrintByDefault
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -3630,5 +3631,28 @@ func TestValidate_Argon2idParamsBounds(t *testing.T) {
 				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
+	}
+}
+
+func TestSetWarnFunc(t *testing.T) {
+	var captured []string
+	SetWarnFunc(func(msg string) {
+		captured = append(captured, msg)
+	})
+	t.Cleanup(func() {
+		SetWarnFunc(func(msg string) {
+			fmt.Fprintln(os.Stderr, msg)
+		})
+	})
+
+	warnf("test warning %d", 42)
+	if len(captured) != 1 || captured[0] != "test warning 42" {
+		t.Fatalf("expected captured warning 'test warning 42', got %v", captured)
+	}
+
+	SetWarnFunc(nil)
+	warnf("suppressed warning")
+	if len(captured) != 1 {
+		t.Fatalf("expected nil warnFunc to suppress warning, got %v", captured)
 	}
 }

--- a/internal/config/warn.go
+++ b/internal/config/warn.go
@@ -1,0 +1,34 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"sync"
+)
+
+// WarnFunc is the function signature for deprecation and configuration warnings.
+type WarnFunc func(string)
+
+var (
+	warnMu   sync.RWMutex
+	warnFunc = func(msg string) {
+		fmt.Fprintln(os.Stderr, msg)
+	}
+)
+
+// SetWarnFunc sets the warning callback used when deprecation warnings are encountered.
+// If fn is nil, warnings are suppressed.
+func SetWarnFunc(fn WarnFunc) {
+	warnMu.Lock()
+	defer warnMu.Unlock()
+	warnFunc = fn
+}
+
+func warnf(format string, args ...any) {
+	warnMu.RLock()
+	fn := warnFunc
+	warnMu.RUnlock()
+	if fn != nil {
+		fn(fmt.Sprintf(format, args...))
+	}
+}

--- a/internal/git/syncer.go
+++ b/internal/git/syncer.go
@@ -1,0 +1,29 @@
+package git
+
+import (
+	"github.com/danieljustus/symaira-vault/internal/vault"
+)
+
+// Syncer implements vault.GitSyncer using local git operations.
+type Syncer struct{}
+
+// NewSyncer returns a new Syncer instance.
+func NewSyncer() *Syncer {
+	return &Syncer{}
+}
+
+// CreateGitignore creates or updates the .gitignore file in the vault directory.
+func (s *Syncer) CreateGitignore(vaultDir string) error {
+	return CreateGitignore(vaultDir)
+}
+
+// AutoCommitAndPushWithOptions creates a commit and optionally pushes to the remote.
+func (s *Syncer) AutoCommitAndPushWithOptions(vaultDir string, opts vault.GitCommitOptions, autoPush bool) error {
+	return AutoCommitAndPushWithOptions(vaultDir, CommitOptions{
+		Message:       opts.Message,
+		Template:      opts.Template,
+		Author:        opts.Author,
+		Email:         opts.Email,
+		AffectedPaths: opts.AffectedPaths,
+	}, autoPush)
+}

--- a/internal/git/vault_autocommit_test.go
+++ b/internal/git/vault_autocommit_test.go
@@ -1,4 +1,4 @@
-package vault
+package git_test
 
 import (
 	"os"
@@ -8,9 +8,17 @@ import (
 
 	gogit "github.com/go-git/go-git/v5"
 
+	"github.com/danieljustus/symaira-vault/internal/config"
 	"github.com/danieljustus/symaira-vault/internal/git"
 	"github.com/danieljustus/symaira-vault/internal/testutil"
+	"github.com/danieljustus/symaira-vault/internal/vault"
 )
+
+func testConfig(vaultDir string) *config.Config {
+	cfg := config.Default()
+	cfg.VaultDir = vaultDir
+	return cfg
+}
 
 // TestAutoCommitEntryCommitsManifestWithEntry verifies that an entry write +
 // auto-commit captures both the entry and manifest.age in the same commit, so
@@ -23,16 +31,21 @@ func TestAutoCommitEntryCommitsManifestWithEntry(t *testing.T) {
 	}
 	vaultDir := t.TempDir()
 	id := testutil.TempIdentity(t)
-	if _, err := InitWithPassphrase(vaultDir, []byte("test-passphrase"), testConfig(vaultDir)); err != nil {
+	if _, err := vault.InitWithPassphrase(vaultDir, []byte("test-passphrase"), testConfig(vaultDir)); err != nil {
 		t.Fatalf("init: %v", err)
 	}
 	if err := git.Init(vaultDir); err != nil {
 		t.Fatalf("git init: %v", err)
 	}
-	v := &Vault{Dir: vaultDir, Identity: id, Config: testConfig(vaultDir)}
+	v := &vault.Vault{
+		Dir:       vaultDir,
+		Identity:  id,
+		Config:    testConfig(vaultDir),
+		GitSyncer: git.NewSyncer(),
+	}
 
 	// Entry write + auto-commit (the real write path used by CRUD commands).
-	if err := WriteEntry(vaultDir, "alpha", &Entry{Data: map[string]any{"user": "alice"}}, id); err != nil {
+	if err := vault.WriteEntry(vaultDir, "alpha", &vault.Entry{Data: map[string]any{"user": "alice"}}, id); err != nil {
 		t.Fatalf("write entry: %v", err)
 	}
 	if err := v.AutoCommitEntry("Update alpha", "alpha"); err != nil {
@@ -56,7 +69,7 @@ func TestAutoCommitEntryCommitsManifestWithEntry(t *testing.T) {
 	if _, err := commit.File("entries/alpha.age"); err != nil {
 		t.Fatalf("commit missing entries/alpha.age: %v", err)
 	}
-	manifestFile, err := commit.File(manifestFileName)
+	manifestFile, err := commit.File("manifest.age")
 	if err != nil {
 		t.Fatalf("commit missing manifest.age: %v", err)
 	}
@@ -66,7 +79,7 @@ func TestAutoCommitEntryCommitsManifestWithEntry(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read committed manifest: %v", err)
 	}
-	diskManifest, err := os.ReadFile(filepath.Join(vaultDir, manifestFileName))
+	diskManifest, err := os.ReadFile(filepath.Join(vaultDir, "manifest.age"))
 	if err != nil {
 		t.Fatalf("read manifest on disk: %v", err)
 	}
@@ -85,7 +98,7 @@ func TestAutoCommitEntryCommitsManifestWithEntry(t *testing.T) {
 	}
 	// Note: status.File() would insert a fake Untracked entry for clean files,
 	// so check the map directly.
-	if fs, ok := status[manifestFileName]; ok && (fs.Worktree != gogit.Unmodified || fs.Staging != gogit.Unmodified) {
+	if fs, ok := status["manifest.age"]; ok && (fs.Worktree != gogit.Unmodified || fs.Staging != gogit.Unmodified) {
 		t.Errorf("manifest.age dirty after auto-commit: %+v", fs)
 	}
 	if fs, ok := status["entries/alpha.age"]; ok && fs.Worktree != gogit.Unmodified {
@@ -93,7 +106,7 @@ func TestAutoCommitEntryCommitsManifestWithEntry(t *testing.T) {
 	}
 
 	// A doctor-style integrity check must not flag the written entry as tampered.
-	result, err := VerifyManifestIntegrity(vaultDir, id)
+	result, err := vault.VerifyManifestIntegrity(vaultDir, id)
 	if err != nil {
 		t.Fatalf("VerifyManifestIntegrity: %v", err)
 	}

--- a/internal/vault/coverage_test.go
+++ b/internal/vault/coverage_test.go
@@ -516,15 +516,49 @@ func TestOpenCreatesGitignore(t *testing.T) {
 	gitDir := filepath.Join(vaultDir, ".git")
 	os.MkdirAll(gitDir, 0o700)
 
+	created := false
+	mock := &mockGitSyncerFn{
+		createGitignore: func(dir string) error {
+			created = true
+			return os.WriteFile(filepath.Join(dir, ".gitignore"), []byte("identity.age\n"), 0o600)
+		},
+	}
+	SetDefaultGitSyncer(mock)
+	t.Cleanup(func() {
+		SetDefaultGitSyncer(nil)
+	})
+
 	_, err := Open(vaultDir, identity)
 	if err != nil {
 		t.Fatalf("Open() error = %v", err)
 	}
 
+	if !created {
+		t.Errorf("GitSyncer.CreateGitignore was not called")
+	}
 	gitignorePath := filepath.Join(vaultDir, ".gitignore")
 	if _, statErr := os.Stat(gitignorePath); statErr != nil {
 		t.Errorf(".gitignore not created: %v", statErr)
 	}
+}
+
+type mockGitSyncerFn struct {
+	createGitignore func(dir string) error
+	autoCommit      func(dir string, opts GitCommitOptions, autoPush bool) error
+}
+
+func (m *mockGitSyncerFn) CreateGitignore(dir string) error {
+	if m.createGitignore != nil {
+		return m.createGitignore(dir)
+	}
+	return nil
+}
+
+func (m *mockGitSyncerFn) AutoCommitAndPushWithOptions(dir string, opts GitCommitOptions, autoPush bool) error {
+	if m.autoCommit != nil {
+		return m.autoCommit(dir, opts, autoPush)
+	}
+	return nil
 }
 
 func TestGetEntryMetadataFileNotFound(t *testing.T) {

--- a/internal/vault/decoupling_test.go
+++ b/internal/vault/decoupling_test.go
@@ -1,0 +1,65 @@
+package vault_test
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// TestVaultDecoupling guards against regressions where internal/vault
+// re-introduces forbidden dependencies (internal/git, internal/metrics, internal/ui, or os/exec).
+// This ensures that internal/vault remains buildable for headless / non-desktop targets like iOS (ADR 0006 D2).
+func TestVaultDecoupling(t *testing.T) {
+	cmd := exec.Command("go", "list", "-deps", "github.com/danieljustus/symaira-vault/internal/vault")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go list failed: %v\nOutput: %s", err, string(out))
+	}
+
+	forbidden := []string{
+		"internal/git",
+		"internal/metrics",
+		"internal/ui",
+		"os/exec",
+	}
+
+	lines := strings.Split(string(out), "\n")
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		for _, f := range forbidden {
+			if strings.Contains(trimmed, f) || trimmed == f {
+				t.Errorf("forbidden dependency %q detected in internal/vault: %s", f, trimmed)
+			}
+		}
+	}
+}
+
+// TestConfigDecoupling guards against regressions where internal/config
+// re-introduces terminal UI dependencies (internal/ui).
+func TestConfigDecoupling(t *testing.T) {
+	cmd := exec.Command("go", "list", "-deps", "github.com/danieljustus/symaira-vault/internal/config")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go list failed: %v\nOutput: %s", err, string(out))
+	}
+
+	forbidden := []string{
+		"internal/ui",
+	}
+
+	lines := strings.Split(string(out), "\n")
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		for _, f := range forbidden {
+			if strings.Contains(trimmed, f) || trimmed == f {
+				t.Errorf("forbidden dependency %q detected in internal/config: %s", f, trimmed)
+			}
+		}
+	}
+}

--- a/internal/vault/entry_readwrite.go
+++ b/internal/vault/entry_readwrite.go
@@ -1,7 +1,6 @@
 package vault
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -10,12 +9,9 @@ import (
 	"time"
 
 	"filippo.io/age"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/codes"
 
 	vaultconfig "github.com/danieljustus/symaira-vault/internal/config"
 	vaultcrypto "github.com/danieljustus/symaira-vault/internal/crypto"
-	"github.com/danieljustus/symaira-vault/internal/metrics"
 	"github.com/danieljustus/symaira-vault/internal/vault/taint"
 )
 
@@ -55,44 +51,33 @@ func ReadEntry(vaultDir, path string, identity *age.X25519Identity) (*Entry, err
 	if identity == nil {
 		return nil, errors.New("nil identity")
 	}
-	_, span := metrics.StartSpan(context.Background(), "vault.ReadEntry",
-		attribute.String("operation", "read"),
-		attribute.String("vault.entry.path", metrics.HashEntryPath(path)),
-	)
-	defer span.End()
 	if err := validateEntryPath(vaultDir, path); err != nil {
-		span.SetStatus(codes.Error, err.Error())
 		return nil, err
 	}
 	cfg, err := loadVaultConfig(vaultDir)
 	if err != nil {
-		span.SetStatus(codes.Error, err.Error())
 		return nil, err
 	}
 	filePath := entryStoragePath(vaultDir, path, identity, cfg)
 	raw, err := SafeReadFile(filePath)
 	if os.IsNotExist(err) && canUseLegacyEntryPath(path) {
 		if legacyErr := validateLegacyEntryPath(vaultDir, path); legacyErr != nil {
-			span.SetStatus(codes.Error, legacyErr.Error())
 			return nil, legacyErr
 		}
 		raw, err = SafeReadFile(legacyEntryFilePath(vaultDir, path))
 	}
 	if err != nil {
-		span.SetStatus(codes.Error, err.Error())
 		return nil, err
 	}
 	start := time.Now()
 	plaintext, err := vaultcrypto.Decrypt(raw, identity)
-	metrics.RecordVaultOperationDuration("decrypt", time.Since(start))
+	recordDuration("decrypt", time.Since(start))
 	if err != nil {
-		span.SetStatus(codes.Error, err.Error())
 		return nil, err
 	}
 	var entry Entry
 	if err := json.Unmarshal(plaintext, &entry); err != nil {
 		vaultcrypto.Wipe(plaintext)
-		span.SetStatus(codes.Error, err.Error())
 		return nil, err
 	}
 	vaultcrypto.Wipe(plaintext)
@@ -108,20 +93,12 @@ func readEntryInner(vaultDir, path string, identity *age.X25519Identity, pseudoK
 		return nil, errors.New("nil identity")
 	}
 
-	_, span := metrics.StartSpan(context.Background(), "vault.ReadEntry",
-		attribute.String("operation", "read"),
-		attribute.String("vault.entry.path", metrics.HashEntryPath(path)),
-	)
-	defer span.End()
-
 	if err := validateEntryPath(vaultDir, path); err != nil {
-		span.SetStatus(codes.Error, err.Error())
 		return nil, err
 	}
 
 	cfg, err := loadVaultConfig(vaultDir)
 	if err != nil {
-		span.SetStatus(codes.Error, err.Error())
 		return nil, err
 	}
 
@@ -134,27 +111,23 @@ func readEntryInner(vaultDir, path string, identity *age.X25519Identity, pseudoK
 	raw, err := SafeReadFile(filePath)
 	if os.IsNotExist(err) && canUseLegacyEntryPath(path) {
 		if legacyErr := validateLegacyEntryPath(vaultDir, path); legacyErr != nil {
-			span.SetStatus(codes.Error, legacyErr.Error())
 			return nil, legacyErr
 		}
 		raw, err = SafeReadFile(legacyEntryFilePath(vaultDir, path))
 	}
 	if err != nil {
-		span.SetStatus(codes.Error, err.Error())
 		return nil, err
 	}
 
 	start := time.Now()
 	plaintext, err := vaultcrypto.Decrypt(raw, identity)
-	metrics.RecordVaultOperationDuration("decrypt", time.Since(start))
+	recordDuration("decrypt", time.Since(start))
 	if err != nil {
-		span.SetStatus(codes.Error, err.Error())
 		return nil, err
 	}
 	var entry Entry
 	if err := json.Unmarshal(plaintext, &entry); err != nil {
 		vaultcrypto.Wipe(plaintext)
-		span.SetStatus(codes.Error, err.Error())
 		return nil, err
 	}
 	vaultcrypto.Wipe(plaintext)
@@ -226,7 +199,7 @@ func writeEntryLocked(vaultDir, path string, entry *Entry, identity *age.X25519I
 	defer vaultcrypto.Wipe(plaintext)
 	start := time.Now()
 	ciphertext, err := vaultcrypto.Encrypt(plaintext, identity.Recipient())
-	metrics.RecordVaultOperationDuration("encrypt", time.Since(start))
+	recordDuration("encrypt", time.Since(start))
 	if err != nil {
 		return nil, err
 	}
@@ -248,23 +221,15 @@ func WriteEntry(vaultDir, path string, entry *Entry, identity *age.X25519Identit
 	if identity == nil {
 		return errors.New("nil identity")
 	}
-	_, span := metrics.StartSpan(context.Background(), "vault.WriteEntry",
-		attribute.String("operation", "write"),
-		attribute.String("vault.entry.path", metrics.HashEntryPath(path)),
-	)
-	defer span.End()
 	if err := validateEntryPath(vaultDir, path); err != nil {
-		span.SetStatus(codes.Error, err.Error())
 		return err
 	}
 	cfg, err := loadVaultConfig(vaultDir)
 	if err != nil {
-		span.SetStatus(codes.Error, err.Error())
 		return err
 	}
 	lockFile, err := AcquireWriteLock(vaultDir, 0)
 	if err != nil {
-		span.SetStatus(codes.Error, err.Error())
 		return err
 	}
 	defer func() {
@@ -274,7 +239,6 @@ func WriteEntry(vaultDir, path string, entry *Entry, identity *age.X25519Identit
 	}()
 	ciphertext, err := writeEntryLocked(vaultDir, path, entry, identity, cfg)
 	if err != nil {
-		span.SetStatus(codes.Error, err.Error())
 		return err
 	}
 	queueManifestUpdate(vaultDir, path, ciphertext, identity)
@@ -283,36 +247,25 @@ func WriteEntry(vaultDir, path string, entry *Entry, identity *age.X25519Identit
 	}
 	FlushManifestUpdates()
 	if err := ReleaseLock(lockFile); err != nil {
-		span.SetStatus(codes.Error, err.Error())
 		return err
 	}
 	lockFile = nil
-	if err := searchIndexForVault(vaultDir).UpdateEntry(vaultDir, path, identity); err != nil {
-		span.SetStatus(codes.Error, err.Error())
-	}
+	_ = searchIndexForVault(vaultDir).UpdateEntry(vaultDir, path, identity)
 	listCacheFor(vaultDir).Invalidate()
 	return nil
 }
 
 // DeleteEntry removes an entry from the vault
 func DeleteEntry(vaultDir, path string, identity *age.X25519Identity) error {
-	_, span := metrics.StartSpan(context.Background(), "vault.DeleteEntry",
-		attribute.String("operation", "delete"),
-		attribute.String("vault.entry.path", metrics.HashEntryPath(path)),
-	)
-	defer span.End()
 	if err := validateEntryPath(vaultDir, path); err != nil {
-		span.SetStatus(codes.Error, err.Error())
 		return err
 	}
 	cfg, err := loadVaultConfig(vaultDir)
 	if err != nil {
-		span.SetStatus(codes.Error, err.Error())
 		return err
 	}
 	lockFile, err := AcquireWriteLock(vaultDir, 0)
 	if err != nil {
-		span.SetStatus(codes.Error, err.Error())
 		return err
 	}
 	defer func() {
@@ -323,15 +276,12 @@ func DeleteEntry(vaultDir, path string, identity *age.X25519Identity) error {
 	filePath := entryStoragePath(vaultDir, path, identity, cfg)
 	if err := SafeRemove(filePath); err != nil {
 		if !os.IsNotExist(err) || !canUseLegacyEntryPath(path) {
-			span.SetStatus(codes.Error, err.Error())
 			return err
 		}
 		if legacyErr := validateLegacyEntryPath(vaultDir, path); legacyErr != nil {
-			span.SetStatus(codes.Error, legacyErr.Error())
 			return legacyErr
 		}
 		if err := SafeRemove(legacyEntryFilePath(vaultDir, path)); err != nil {
-			span.SetStatus(codes.Error, err.Error())
 			return err
 		}
 		queueManifestRemove(vaultDir, path, identity)
@@ -340,7 +290,6 @@ func DeleteEntry(vaultDir, path string, identity *age.X25519Identity) error {
 		}
 		FlushManifestUpdates()
 		if err := ReleaseLock(lockFile); err != nil {
-			span.SetStatus(codes.Error, err.Error())
 			return err
 		}
 		lockFile = nil
@@ -350,11 +299,9 @@ func DeleteEntry(vaultDir, path string, identity *age.X25519Identity) error {
 	}
 	if canUseLegacyEntryPath(path) {
 		if legacyErr := validateLegacyEntryPath(vaultDir, path); legacyErr != nil {
-			span.SetStatus(codes.Error, legacyErr.Error())
 			return legacyErr
 		}
 		if err := SafeRemove(legacyEntryFilePath(vaultDir, path)); err != nil && !os.IsNotExist(err) {
-			span.SetStatus(codes.Error, err.Error())
 			return err
 		}
 	}
@@ -364,7 +311,6 @@ func DeleteEntry(vaultDir, path string, identity *age.X25519Identity) error {
 	}
 	FlushManifestUpdates()
 	if err := ReleaseLock(lockFile); err != nil {
-		span.SetStatus(codes.Error, err.Error())
 		return err
 	}
 	lockFile = nil
@@ -375,14 +321,8 @@ func DeleteEntry(vaultDir, path string, identity *age.X25519Identity) error {
 
 // MergeEntry merges partial data into an existing entry.
 func MergeEntry(vaultDir, path string, partialData map[string]any, identity *age.X25519Identity) (*Entry, error) {
-	_, span := metrics.StartSpan(context.Background(), "vault.MergeEntry",
-		attribute.String("operation", "merge"),
-		attribute.String("vault.entry.path", metrics.HashEntryPath(path)),
-	)
-	defer span.End()
 	lockFile, err := AcquireWriteLock(vaultDir, 0)
 	if err != nil {
-		span.SetStatus(codes.Error, err.Error())
 		return nil, err
 	}
 	defer func() {
@@ -392,7 +332,6 @@ func MergeEntry(vaultDir, path string, partialData map[string]any, identity *age
 	}()
 	entry, err := ReadEntry(vaultDir, path, identity)
 	if err != nil {
-		span.SetStatus(codes.Error, err.Error())
 		return nil, err
 	}
 	if entry.Data == nil {
@@ -401,23 +340,18 @@ func MergeEntry(vaultDir, path string, partialData map[string]any, identity *age
 	mergeMaps(entry.Data, partialData)
 	cfg, err := loadVaultConfig(vaultDir)
 	if err != nil {
-		span.SetStatus(codes.Error, err.Error())
 		return nil, err
 	}
 	ciphertext, err := writeEntryLocked(vaultDir, path, entry, identity, cfg)
 	if err != nil {
-		span.SetStatus(codes.Error, err.Error())
 		return nil, err
 	}
 	if err := ReleaseLock(lockFile); err != nil {
-		span.SetStatus(codes.Error, err.Error())
 		return nil, err
 	}
 	lockFile = nil
 	queueManifestUpdate(vaultDir, path, ciphertext, identity)
-	if err := searchIndexForVault(vaultDir).UpdateEntry(vaultDir, path, identity); err != nil {
-		span.SetStatus(codes.Error, err.Error())
-	}
+	_ = searchIndexForVault(vaultDir).UpdateEntry(vaultDir, path, identity)
 	listCacheFor(vaultDir).Invalidate()
 	return ReadEntry(vaultDir, path, identity)
 }
@@ -446,7 +380,7 @@ func GetEntryMetadata(vaultDir, path string, identity *age.X25519Identity) (*Ent
 	}
 	start := time.Now()
 	plaintext, err := vaultcrypto.Decrypt(raw, identity)
-	metrics.RecordVaultOperationDuration("decrypt", time.Since(start))
+	recordDuration("decrypt", time.Since(start))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/vault/git.go
+++ b/internal/vault/git.go
@@ -1,0 +1,41 @@
+package vault
+
+import (
+	"sync"
+)
+
+// GitCommitOptions holds options for an automatic git commit.
+type GitCommitOptions struct {
+	Message       string
+	Template      string
+	Author        string
+	Email         string
+	AffectedPaths []string
+}
+
+// GitSyncer abstracts git version control operations for a vault.
+type GitSyncer interface {
+	CreateGitignore(vaultDir string) error
+	AutoCommitAndPushWithOptions(vaultDir string, opts GitCommitOptions, autoPush bool) error
+}
+
+var (
+	gitSyncerMu      sync.RWMutex
+	defaultGitSyncer GitSyncer
+)
+
+// SetDefaultGitSyncer configures the default GitSyncer used by vaults when none is explicitly set on the Vault instance.
+func SetDefaultGitSyncer(syncer GitSyncer) {
+	gitSyncerMu.Lock()
+	defer gitSyncerMu.Unlock()
+	defaultGitSyncer = syncer
+}
+
+func (v *Vault) getGitSyncer() GitSyncer {
+	if v != nil && v.GitSyncer != nil {
+		return v.GitSyncer
+	}
+	gitSyncerMu.RLock()
+	defer gitSyncerMu.RUnlock()
+	return defaultGitSyncer
+}

--- a/internal/vault/metrics.go
+++ b/internal/vault/metrics.go
@@ -1,0 +1,44 @@
+package vault
+
+import (
+	"sync"
+	"time"
+)
+
+var (
+	metricsMu               sync.RWMutex
+	recordOperationDuration = func(op string, duration time.Duration) {}
+	recordEntryCount        = func(vaultDir string, count int) {}
+)
+
+// SetMetricsHooks configures the metric observation callbacks for vault operations.
+func SetMetricsHooks(onDuration func(op string, duration time.Duration), onCount func(vaultDir string, count int)) {
+	metricsMu.Lock()
+	defer metricsMu.Unlock()
+	if onDuration == nil {
+		onDuration = func(string, time.Duration) {}
+	}
+	if onCount == nil {
+		onCount = func(string, int) {}
+	}
+	recordOperationDuration = onDuration
+	recordEntryCount = onCount
+}
+
+func recordDuration(op string, duration time.Duration) {
+	metricsMu.RLock()
+	fn := recordOperationDuration
+	metricsMu.RUnlock()
+	if fn != nil {
+		fn(op, duration)
+	}
+}
+
+func recordCount(vaultDir string, count int) {
+	metricsMu.RLock()
+	fn := recordEntryCount
+	metricsMu.RUnlock()
+	if fn != nil {
+		fn(vaultDir, count)
+	}
+}

--- a/internal/vault/search.go
+++ b/internal/vault/search.go
@@ -165,7 +165,6 @@ import (
 	"golang.org/x/exp/slices"
 
 	vaultcrypto "github.com/danieljustus/symaira-vault/internal/crypto"
-	"github.com/danieljustus/symaira-vault/internal/metrics"
 )
 
 type Match struct {
@@ -238,7 +237,7 @@ func List(vaultDir string, prefix string, identity *age.X25519Identity) ([]strin
 	// Check cache when listing the entire vault (prefix == "").
 	if prefix == "" {
 		if cached := listCacheFor(vaultDir).cachedList(vaultDir); cached != nil {
-			metrics.RecordVaultOperationDuration("list_cached", 0)
+			recordDuration("list_cached", 0)
 			return cached, nil
 		}
 	}
@@ -275,8 +274,8 @@ func List(vaultDir string, prefix string, identity *age.X25519Identity) ([]strin
 		paths = append(paths, path)
 	}
 	sort.Strings(paths)
-	metrics.RecordVaultOperationDuration("list", time.Since(start))
-	metrics.RecordVaultEntryCount(vaultDir, len(paths))
+	recordDuration("list", time.Since(start))
+	recordCount(vaultDir, len(paths))
 
 	if prefix == "" {
 		listCacheFor(vaultDir).storeListCache(vaultDir, paths)
@@ -304,7 +303,7 @@ func listPseudonymizedWithIdentity(vaultDir, prefix string, identity *age.X25519
 	// Check cache for full-vault listings (prefix == "").
 	if prefix == "" {
 		if paths := listCacheFor(vaultDir).cachedPseudonymizedList(vaultDir, identity); paths != nil {
-			metrics.RecordVaultOperationDuration("list_pseudonymized_cached", 0)
+			recordDuration("list_pseudonymized_cached", 0)
 			return paths, nil
 		}
 	}
@@ -332,8 +331,8 @@ func listPseudonymizedWithIdentity(vaultDir, prefix string, identity *age.X25519
 	}
 
 	if len(filePaths) == 0 {
-		metrics.RecordVaultOperationDuration("list_pseudonymized", time.Since(start))
-		metrics.RecordVaultEntryCount(vaultDir, 0)
+		recordDuration("list_pseudonymized", time.Since(start))
+		recordCount(vaultDir, 0)
 		if prefix == "" {
 			listCacheFor(vaultDir).storePseudonymizedListCache(vaultDir, identity, nil, nil)
 		}
@@ -426,8 +425,8 @@ func listPseudonymizedWithIdentity(vaultDir, prefix string, identity *age.X25519
 		listCacheFor(vaultDir).storePseudonymizedListCache(vaultDir, identity, paths, cachedEntries)
 	}
 
-	metrics.RecordVaultOperationDuration("list_pseudonymized", time.Since(start))
-	metrics.RecordVaultEntryCount(vaultDir, len(paths))
+	recordDuration("list_pseudonymized", time.Since(start))
+	recordCount(vaultDir, len(paths))
 	return paths, nil
 }
 
@@ -548,7 +547,7 @@ func listViaManifest(vaultDir string, identity *age.X25519Identity) []string {
 		paths = append(paths, path)
 	}
 	sort.Strings(paths)
-	metrics.RecordVaultEntryCount(vaultDir, len(paths))
+	recordCount(vaultDir, len(paths))
 	return paths
 }
 
@@ -628,7 +627,7 @@ func FindWithOptions(vaultDir string, query string, opts FindOptions, identity *
 func findWithOptionsIdentity(vaultDir string, query string, opts FindOptions, identity *age.X25519Identity) ([]Match, error) {
 	start := time.Now()
 	defer func() {
-		metrics.RecordVaultOperationDuration("search", time.Since(start))
+		recordDuration("search", time.Since(start))
 	}()
 
 	paths, err := List(vaultDir, "", identity)

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -13,7 +13,6 @@ import (
 	vaultconfig "github.com/danieljustus/symaira-vault/internal/config"
 	vaultcrypto "github.com/danieljustus/symaira-vault/internal/crypto"
 	"github.com/danieljustus/symaira-vault/internal/fsutil"
-	"github.com/danieljustus/symaira-vault/internal/git"
 )
 
 const vaultFormatVersion2 = 2
@@ -47,7 +46,8 @@ type Vault struct {
 	// warning.
 	HealedFromZeroKey bool
 
-	Cache *VaultCache
+	Cache     *VaultCache
+	GitSyncer GitSyncer
 
 	searchIdentity atomic.Pointer[age.X25519Identity]
 }
@@ -143,11 +143,6 @@ func Open(vaultDir string, identity *age.X25519Identity) (*Vault, error) {
 	} else if unknown, oobErr := DetectOutOfBandEntries(vaultDir, identity, cfg); oobErr == nil && len(unknown) > 0 {
 		_ = RebuildManifest(vaultDir, identity) // best-effort
 	}
-	if _, err := os.Stat(filepath.Join(vaultDir, ".git")); err == nil {
-		if err := git.CreateGitignore(vaultDir); err != nil {
-			return nil, fmt.Errorf("update gitignore: %w", err)
-		}
-	}
 	cache := NewVaultCache(VaultCacheConfig{})
 	if cfg != nil && cfg.Vault != nil {
 		if cfg.Vault.ConfigCacheEntries > 0 {
@@ -159,6 +154,13 @@ func Open(vaultDir string, identity *age.X25519Identity) (*Vault, error) {
 	}
 	v := &Vault{Dir: vaultDir, Identity: identity, Config: cfg, Cache: cache}
 	v.searchIdentity.Store(identity)
+	if syncer := v.getGitSyncer(); syncer != nil {
+		if _, err := os.Stat(filepath.Join(vaultDir, ".git")); err == nil {
+			if err := syncer.CreateGitignore(vaultDir); err != nil {
+				return nil, fmt.Errorf("update gitignore: %w", err)
+			}
+		}
+	}
 	registerVaultCache(vaultDir, cache)
 	v.WarmSearchIndex()
 	return v, nil
@@ -499,6 +501,10 @@ func (v *Vault) AutoCommitPaths(message string, affectedPaths ...string) error {
 	if v == nil {
 		return errors.New("vault is nil")
 	}
+	syncer := v.getGitSyncer()
+	if syncer == nil {
+		return nil
+	}
 	commitMessage := message
 	autoPush := false
 	if v.Config != nil && v.Config.Git != nil {
@@ -510,7 +516,7 @@ func (v *Vault) AutoCommitPaths(message string, affectedPaths ...string) error {
 	if commitMessage == "" {
 		commitMessage = "Update from Symaira Vault"
 	}
-	return git.AutoCommitAndPushWithOptions(v.Dir, git.CommitOptions{
+	return syncer.AutoCommitAndPushWithOptions(v.Dir, GitCommitOptions{
 		Message:       commitMessage,
 		AffectedPaths: affectedPaths,
 	}, autoPush)

--- a/internal/vault/vault_test.go
+++ b/internal/vault/vault_test.go
@@ -322,6 +322,28 @@ func TestCollectFieldMatches(t *testing.T) {
 	}
 }
 
+type mockGitSyncer struct {
+	createGitignoreCalled bool
+	autoCommitCalled      bool
+	lastVaultDir          string
+	lastOpts              GitCommitOptions
+	lastAutoPush          bool
+}
+
+func (m *mockGitSyncer) CreateGitignore(vaultDir string) error {
+	m.createGitignoreCalled = true
+	m.lastVaultDir = vaultDir
+	return nil
+}
+
+func (m *mockGitSyncer) AutoCommitAndPushWithOptions(vaultDir string, opts GitCommitOptions, autoPush bool) error {
+	m.autoCommitCalled = true
+	m.lastVaultDir = vaultDir
+	m.lastOpts = opts
+	m.lastAutoPush = autoPush
+	return nil
+}
+
 func TestAutoCommitCreatesGitCommit(t *testing.T) {
 	vaultDir := t.TempDir()
 	identity := testutil.TempIdentity(t)
@@ -336,13 +358,25 @@ func TestAutoCommitCreatesGitCommit(t *testing.T) {
 		t.Fatalf("Init() error = %v", err)
 	}
 
+	mock := &mockGitSyncer{}
 	v, err := Open(vaultDir, identity)
 	if err != nil {
 		t.Fatalf("Open() error = %v", err)
 	}
+	v.GitSyncer = mock
+	v.Config.Git.AutoPush = false
 
 	if err := v.AutoCommit("test commit"); err != nil {
 		t.Fatalf("AutoCommit() error = %v", err)
+	}
+	if !mock.autoCommitCalled {
+		t.Fatal("expected AutoCommitAndPushWithOptions to be called")
+	}
+	if mock.lastOpts.Message != "test commit" {
+		t.Fatalf("expected message %q, got %q", "test commit", mock.lastOpts.Message)
+	}
+	if mock.lastAutoPush != false {
+		t.Fatalf("expected autoPush false, got %v", mock.lastAutoPush)
 	}
 }
 
@@ -369,13 +403,21 @@ func TestAutoCommitUsesTemplate(t *testing.T) {
 		t.Fatalf("Init() error = %v", err)
 	}
 
+	mock := &mockGitSyncer{}
 	v, err := Open(vaultDir, identity)
 	if err != nil {
 		t.Fatalf("Open() error = %v", err)
 	}
+	v.GitSyncer = mock
 
 	if err := v.AutoCommit(""); err != nil {
 		t.Fatalf("AutoCommit() error = %v", err)
+	}
+	if !mock.autoCommitCalled {
+		t.Fatal("expected AutoCommitAndPushWithOptions to be called")
+	}
+	if mock.lastOpts.Message != "Custom template message" {
+		t.Fatalf("expected message %q, got %q", "Custom template message", mock.lastOpts.Message)
 	}
 }
 
@@ -393,13 +435,55 @@ func TestAutoCommitWithAutoPush(t *testing.T) {
 		t.Fatalf("Init() error = %v", err)
 	}
 
+	mock := &mockGitSyncer{}
 	v, err := Open(vaultDir, identity)
 	if err != nil {
 		t.Fatalf("Open() error = %v", err)
 	}
+	v.GitSyncer = mock
 
 	if err := v.AutoCommit("test with push"); err != nil {
 		t.Fatalf("AutoCommit() error = %v", err)
+	}
+	if !mock.autoCommitCalled {
+		t.Fatal("expected AutoCommitAndPushWithOptions to be called")
+	}
+	if mock.lastAutoPush != true {
+		t.Fatalf("expected autoPush true, got %v", mock.lastAutoPush)
+	}
+}
+
+func TestDefaultGitSyncerAndOpenGitignore(t *testing.T) {
+	vaultDir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(vaultDir, ".git"), 0o700); err != nil {
+		t.Fatalf("mkdir .git: %v", err)
+	}
+	identity := testutil.TempIdentity(t)
+	cfg := config.Default()
+	cfg.VaultDir = vaultDir
+	if err := Init(vaultDir, identity, cfg); err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+
+	mock := &mockGitSyncer{}
+	SetDefaultGitSyncer(mock)
+	t.Cleanup(func() {
+		SetDefaultGitSyncer(nil)
+	})
+
+	v, err := Open(vaultDir, identity)
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	if !mock.createGitignoreCalled {
+		t.Fatal("expected CreateGitignore to be called on Open when .git exists")
+	}
+
+	if err := v.AutoCommit("via default syncer"); err != nil {
+		t.Fatalf("AutoCommit error = %v", err)
+	}
+	if !mock.autoCommitCalled || mock.lastOpts.Message != "via default syncer" {
+		t.Fatalf("expected default syncer auto-commit, got %+v", mock.lastOpts)
 	}
 }
 


### PR DESCRIPTION
## Summary
Makes a headless vault core buildable for non-desktop targets (ADR 0006 D2) by removing the transitive `os/exec` reachability of `internal/vault` and the UI/metrics entanglement:

- `internal/vault`: new narrow `GitSyncer` interface (`internal/vault/git.go`) replaces direct `internal/git` calls; metrics spans replaced by an injectable hooks seam (`SetMetricsHooks`, no-op default).
- `internal/config`: direct `cliout.Warnf` calls replaced by injectable `WarnFunc` (defaults to stderr), wired at the composition root.
- `internal/cli/cli.go` wires the concrete implementations back in (`config.SetWarnFunc`, `vault.SetDefaultGitSyncer(git.NewSyncer())`, `vault.SetMetricsHooks(...)`) — CLI behavior unchanged.
- `internal/git/syncer.go`: adapter implementing the vault-side interface.
- Guard tests (`decoupling_test.go`) fail if `internal/vault`/`internal/config` ever depend on `internal/git`, `internal/metrics`, `internal/ui` or `os/exec` again.

Closes danieljustus/symaira-vault#864

## Checks
- gofmt clean, go vet ./..., go build ./... green
- go test -count=1 ./... full suite green (coordinator-verified)