### PR TITLE
feat(vault): add url key convention and encrypted host lookup index

### DIFF
--- a/cmd/crud/find.go
+++ b/cmd/crud/find.go
@@ -28,28 +28,57 @@ func searchWorkers(cfg *configpkg.Config) int {
 }
 
 func newFindCmd() *cobra.Command {
+	var urlFilter string
+
 	findCmd := &cobra.Command{
-		Use:               "find <query>",
+		Use:               "find [query]",
 		Aliases:           []string{"search"},
 		ValidArgsFunction: cli.EntryCompletionFunc,
 		Short:             "Search for entries",
-		Long:              `Searches entry paths and contents for the given query.`,
+		Long:              `Searches entry paths and contents for the given query, or matches entries by URL/host.`,
 		Example: `  # Search for entries containing "bank"
   symvault find bank
 
+  # Search for entries matching a URL or host
+  symvault find --url https://github.com/login
+  symvault find --url github.com
+
   # JSON output
-  symvault find bank --output json`,
-		Args: cobra.ExactArgs(1),
+  symvault find bank --output json
+  symvault find --url github.com --output json`,
+		Args: func(cmd *cobra.Command, args []string) error {
+			if urlFilter == "" && len(args) == 0 {
+				return fmt.Errorf("accepts 1 arg(s), received 0")
+			}
+			if len(args) > 1 {
+				return fmt.Errorf("accepts at most 1 arg(s), received %d", len(args))
+			}
+			return nil
+		},
 		Annotations: map[string]string{
 			cli.JSONOutputAnnotation: "true",
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if urlFilter != "" {
+				if err := vaultpkg.ValidateURL(urlFilter); err != nil {
+					return errorspkg.InvalidInput("invalid url %q: %v", urlFilter, err)
+				}
+			}
+
 			return cli.WithVault(func(v *vaultpkg.Vault, vs *cli.VaultService) error {
 				cli.MaybeAutoPull(vs.VaultDir(), v.Config)
 				cfg := v.Config
 				workers := searchWorkers(cfg)
 
-				matches, err := vs.FindEntries(args[0], vaultpkg.FindOptions{MaxWorkers: workers})
+				query := ""
+				if len(args) > 0 {
+					query = args[0]
+				}
+
+				matches, err := vs.FindEntries(query, vaultpkg.FindOptions{
+					MaxWorkers: workers,
+					URLFilter:  urlFilter,
+				})
 				if err != nil {
 					return errorspkg.ReadFailed(err, "search failed")
 				}
@@ -87,6 +116,7 @@ func newFindCmd() *cobra.Command {
 		},
 	}
 
+	findCmd.Flags().StringVar(&urlFilter, "url", "", "Search entries matching a URL or host")
 	findCmd.GroupID = cli.GroupIDEssentials
 	return findCmd
 }

--- a/cmd/crud/find_test.go
+++ b/cmd/crud/find_test.go
@@ -25,3 +25,44 @@ func TestSearchWorkersUsesConfiguredValue(t *testing.T) {
 		t.Fatalf("searchWorkers(configured) = %d, want 12", got)
 	}
 }
+
+func TestNewFindCmd_HasURLFlag(t *testing.T) {
+	cmd := newFindCmd()
+	flag := cmd.Flags().Lookup("url")
+	if flag == nil {
+		t.Fatal("newFindCmd() missing --url flag")
+	}
+	if flag.Value.Type() != "string" {
+		t.Errorf("url flag type = %s, want string", flag.Value.Type())
+	}
+}
+
+func TestNewFindCmd_ArgsValidation(t *testing.T) {
+	cmd := newFindCmd()
+
+	// No args and no --url flag -> error
+	if err := cmd.Args(cmd, []string{}); err == nil {
+		t.Error("cmd.Args with 0 args and no url flag expected error, got nil")
+	}
+
+	// 1 arg and no --url flag -> ok
+	if err := cmd.Args(cmd, []string{"search_query"}); err != nil {
+		t.Errorf("cmd.Args with 1 arg unexpected error: %v", err)
+	}
+
+	// 0 args but --url flag set -> ok
+	_ = cmd.Flags().Set("url", "github.com")
+	if err := cmd.Args(cmd, []string{}); err != nil {
+		t.Errorf("cmd.Args with 0 args and --url flag unexpected error: %v", err)
+	}
+
+	// 1 arg with --url flag set -> ok
+	if err := cmd.Args(cmd, []string{"query"}); err != nil {
+		t.Errorf("cmd.Args with 1 arg and --url flag unexpected error: %v", err)
+	}
+
+	// > 1 args -> error
+	if err := cmd.Args(cmd, []string{"arg1", "arg2"}); err == nil {
+		t.Error("cmd.Args with >1 args expected error, got nil")
+	}
+}

--- a/cmd/find_test.go
+++ b/cmd/find_test.go
@@ -79,3 +79,99 @@ func TestFind_ErrorPaths(t *testing.T) {
 		}
 	})
 }
+
+func TestCmdFind_URLFilter(t *testing.T) {
+	vaultDir, passphrase := initVault(t)
+	identity, _ := vaultpkg.OpenWithPassphrase(vaultDir, passphrase)
+	entry1 := &vaultpkg.Entry{Data: map[string]any{"url": "https://github.com/login", "username": "octocat"}}
+	_ = vaultpkg.WriteEntry(vaultDir, "work/github", entry1, identity.Identity)
+	entry2 := &vaultpkg.Entry{Data: map[string]any{"url": "http://gitlab.internal:8080/auth", "username": "gituser"}}
+	_ = vaultpkg.WriteEntry(vaultDir, "personal/gitlab", entry2, identity.Identity)
+
+	setPassEnv(t, string(passphrase))
+	defer setupVaultFlag(t, vaultDir)()
+
+	t.Run("find by bare domain", func(t *testing.T) {
+		out := execWithStdout("--vault", vaultDir, "find", "--url", "github.com")
+		if !strings.Contains(out, "work/github") {
+			t.Errorf("expected work/github in output, got: %s", out)
+		}
+		if strings.Contains(out, "personal/gitlab") {
+			t.Errorf("unexpected personal/gitlab in output: %s", out)
+		}
+	})
+
+	t.Run("find by full URL with default port and path", func(t *testing.T) {
+		out := execWithStdout("--vault", vaultDir, "find", "--url", "https://github.com:443/settings/profile")
+		if !strings.Contains(out, "work/github") {
+			t.Errorf("expected work/github in output, got: %s", out)
+		}
+	})
+
+	t.Run("find by custom port URL", func(t *testing.T) {
+		out := execWithStdout("--vault", vaultDir, "find", "--url", "http://gitlab.internal:8080")
+		if !strings.Contains(out, "personal/gitlab") {
+			t.Errorf("expected personal/gitlab in output, got: %s", out)
+		}
+	})
+
+	t.Run("custom port mismatch returns no matches", func(t *testing.T) {
+		stderr := captureStderr(func() {
+			root := NewRootCmd()
+			root.SetArgs([]string{"--vault", vaultDir, "find", "--url", "gitlab.internal"})
+			_ = root.Execute()
+		})
+		if !strings.Contains(stderr, "No matches") {
+			t.Errorf("expected No matches on port mismatch, got: %s", stderr)
+		}
+	})
+
+	t.Run("json output format", func(t *testing.T) {
+		out := execWithStdout("--vault", vaultDir, "find", "--url", "github.com", "--output", "json")
+		if !strings.Contains(out, `"path": "work/github"`) && !strings.Contains(out, `"path":"work/github"`) {
+			t.Errorf("expected JSON with work/github, got: %s", out)
+		}
+	})
+
+	t.Run("combined query and url", func(t *testing.T) {
+		out := execWithStdout("--vault", vaultDir, "find", "octocat", "--url", "github.com")
+		if !strings.Contains(out, "work/github") {
+			t.Errorf("expected work/github in output, got: %s", out)
+		}
+	})
+
+	t.Run("combined query mismatch returns no matches", func(t *testing.T) {
+		stderr := captureStderr(func() {
+			root := NewRootCmd()
+			root.SetArgs([]string{"--vault", vaultDir, "find", "nonexistent_term", "--url", "github.com"})
+			_ = root.Execute()
+		})
+		if !strings.Contains(stderr, "No matches") {
+			t.Errorf("expected No matches on query mismatch, got: %s", stderr)
+		}
+	})
+}
+
+func TestCmdFind_URLFilterErrors(t *testing.T) {
+	vaultDir, passphrase := initVault(t)
+	setPassEnv(t, string(passphrase))
+	defer setupVaultFlag(t, vaultDir)()
+
+	t.Run("invalid url format", func(t *testing.T) {
+		root := NewRootCmd()
+		root.SetArgs([]string{"--vault", vaultDir, "find", "--url", "invalid::url"})
+		err := root.Execute()
+		if err == nil || !strings.Contains(err.Error(), "invalid url") {
+			t.Errorf("expected invalid url error, got: %v", err)
+		}
+	})
+
+	t.Run("no args and no url flag", func(t *testing.T) {
+		root := NewRootCmd()
+		root.SetArgs([]string{"--vault", vaultDir, "find"})
+		err := root.Execute()
+		if err == nil {
+			t.Errorf("expected error when no args and no --url, got nil")
+		}
+	})
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -180,6 +180,21 @@ symvault profile add work --vault ~/.symvault-work
 symvault profile use work
 ```
 
+## Entry Format & Conventions
+
+Vault entry data is stored as a flexible map of key-value pairs (`map[string]any`). While keys are free-form, several well-known keys follow standard conventions across CLI commands, MCP integrations, and client extensions.
+
+### Well-Known Field: `url`
+
+The `url` key associates credentials with web services, domains, or internal network endpoints. It is used by `symvault find --url <value>` and platform integrations (such as iOS AutoFill, ADR 0006 D4) to match stored credentials to requested services.
+
+- **Validation**: URLs must be non-empty, contain no illegal whitespace or control characters, and resolve to a valid hostname or IP address.
+- **Scheme Defaulting**: If a scheme is omitted (e.g. `github.com` or `gitlab.company.internal/login`), `https://` is assumed by default.
+- **Host Lowercasing**: Hostnames are case-insensitive and normalized to lowercase (e.g. `GITHUB.COM` is stored and indexed as `github.com`).
+- **Port Handling**: Default protocol ports (`80` for `http`/`ws`, `443` for `https`/`wss`, `22` for `ssh`/`sftp`, `21` for `ftp`) are stripped during normalization (e.g. `https://github.com:443` normalizes to `github.com`). Non-standard ports (e.g. `http://localhost:3000`, `https://example.com:8443`) are preserved in host matching.
+- **Same-Host Matching**: Service lookups match against the normalized host representation, allowing scheme-insensitive and port-normalized queries to find corresponding entries.
+- **Encrypted Index**: Host mappings are indexed within the vault's encrypted search index (`.search-index`), preventing unencrypted plaintext leakage of service names on disk.
+
 ## Validation
 
 Symaira Vault validates your configuration file on load. You can also manually validate it:

--- a/docs/man/symvault-find.1
+++ b/docs/man/symvault-find.1
@@ -17,6 +17,10 @@ Searches entry paths and contents for the given query.
 \fB-h\fP, \fB--help\fP[=false]
 	help for find
 
+.PP
+\fB--url\fP=""
+	Search entries matching a URL or host
+
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 \fB--color\fP="auto"
@@ -52,8 +56,13 @@ Searches entry paths and contents for the given query.
   # Search for entries containing "bank"
   symvault find bank
 
+  # Search for entries matching a URL or host
+  symvault find --url https://github.com/login
+  symvault find --url github.com
+
   # JSON output
   symvault find bank --output json
+  symvault find --url github.com --output json
 .EE
 
 

--- a/internal/vault/search.go
+++ b/internal/vault/search.go
@@ -885,7 +885,7 @@ func filterPathsUsingHostIndex(vaultDir string, candidates []string, targetHost 
 	idx := searchIndexForVault(vaultDir)
 	if !idx.Covers(vaultDir, identity) {
 		if loadErr := idx.loadFromDisk(vaultDir, identity); loadErr != nil || !idx.Covers(vaultDir, identity) {
-			if err := idx.Build(vaultDir, identity); err != nil {
+			if buildErr := idx.Build(vaultDir, identity); buildErr != nil {
 				return scanCandidatesForHost(vaultDir, candidates, normHost, identity), nil
 			}
 		}

--- a/internal/vault/search.go
+++ b/internal/vault/search.go
@@ -595,6 +595,8 @@ type FindOptions struct {
 	// agent could probe the existence of a value in a redacted field via
 	// substring search (SEC-002).
 	RedactFieldPatterns []string
+	// URLFilter, if non-empty, matches entries by normalized host against their "url" field.
+	URLFilter string
 }
 
 // isRedactedField checks if a field name matches any redaction pattern.
@@ -637,6 +639,34 @@ func findWithOptionsIdentity(vaultDir string, query string, opts FindOptions, id
 
 	if identity == nil {
 		return nil, fmt.Errorf("no search identity available")
+	}
+
+	if opts.URLFilter != "" {
+		normHost, err := NormalizeHost(opts.URLFilter)
+		if err != nil {
+			return nil, fmt.Errorf("invalid url filter %q: %w", opts.URLFilter, err)
+		}
+
+		urlPaths, err := filterPathsUsingHostIndex(vaultDir, paths, normHost, identity)
+		if err != nil {
+			return nil, err
+		}
+
+		if query == "" {
+			var urlMatches []Match
+			for _, path := range urlPaths {
+				if opts.ScopeFilter != nil && !opts.ScopeFilter(path) {
+					continue
+				}
+				urlMatches = append(urlMatches, Match{Path: path, Fields: []string{"url"}})
+			}
+			sort.Slice(urlMatches, func(i, j int) bool {
+				return urlMatches[i].Path < urlMatches[j].Path
+			})
+			return urlMatches, nil
+		}
+
+		paths = urlPaths
 	}
 
 	needle := strings.ToLower(query)
@@ -836,6 +866,72 @@ func filterPathsUsingIndex(vaultDir string, candidates []string, needle string, 
 		result = append(result, path)
 	}
 	return result
+}
+
+// filterPathsUsingHostIndex uses the encrypted search index to find entries whose
+// "url" field matches the target host. Falls back to scanning candidate entries on
+// missing/stale index or decryption error.
+func filterPathsUsingHostIndex(vaultDir string, candidates []string, targetHost string, identity *age.X25519Identity) ([]string, error) {
+	if identity == nil {
+		return candidates, fmt.Errorf("no search identity available")
+	}
+
+	normHost, err := NormalizeHost(targetHost)
+	if err != nil {
+		return nil, err
+	}
+
+	idx := searchIndexForVault(vaultDir)
+	if !idx.Covers(vaultDir, identity) {
+		if err := idx.loadFromDisk(vaultDir, identity); err != nil || !idx.Covers(vaultDir, identity) {
+			if err := idx.Build(vaultDir, identity); err != nil {
+				return scanCandidatesForHost(vaultDir, candidates, normHost, identity), nil
+			}
+		}
+	}
+
+	matching, err := idx.MatchHost(vaultDir, identity, candidates, normHost)
+	if err != nil {
+		if buildErr := idx.Build(vaultDir, identity); buildErr != nil {
+			return scanCandidatesForHost(vaultDir, candidates, normHost, identity), nil
+		}
+		matching, err = idx.MatchHost(vaultDir, identity, candidates, normHost)
+		if err != nil {
+			return scanCandidatesForHost(vaultDir, candidates, normHost, identity), nil
+		}
+	}
+
+	if len(matching) == 0 {
+		return nil, nil
+	}
+
+	result := make([]string, 0, len(matching))
+	for path := range matching {
+		result = append(result, path)
+	}
+	sort.Strings(result)
+	return result, nil
+}
+
+// scanCandidatesForHost is the fallback for filterPathsUsingHostIndex when the index
+// is unavailable or fails to decrypt. It decrypts candidate entries to inspect their url fields.
+func scanCandidatesForHost(vaultDir string, candidates []string, targetHost string, identity *age.X25519Identity) []string {
+	var matching []string
+	for _, path := range candidates {
+		entry, err := ReadEntry(vaultDir, path, identity)
+		if err != nil {
+			continue
+		}
+		hosts := ExtractHostsFromData(entry.Data)
+		for _, h := range hosts {
+			if h == targetHost {
+				matching = append(matching, path)
+				break
+			}
+		}
+	}
+	sort.Strings(matching)
+	return matching
 }
 
 // collectStringValues recursively collects string values from a map.

--- a/internal/vault/search.go
+++ b/internal/vault/search.go
@@ -626,6 +626,7 @@ func FindWithOptions(vaultDir string, query string, opts FindOptions, identity *
 	return findWithOptionsIdentity(vaultDir, query, opts, identity)
 }
 
+//nolint:gocyclo // Search orchestration: listing, filtering, decryption, ranking
 func findWithOptionsIdentity(vaultDir string, query string, opts FindOptions, identity *age.X25519Identity) ([]Match, error) {
 	start := time.Now()
 	defer func() {
@@ -883,7 +884,7 @@ func filterPathsUsingHostIndex(vaultDir string, candidates []string, targetHost 
 
 	idx := searchIndexForVault(vaultDir)
 	if !idx.Covers(vaultDir, identity) {
-		if err := idx.loadFromDisk(vaultDir, identity); err != nil || !idx.Covers(vaultDir, identity) {
+		if loadErr := idx.loadFromDisk(vaultDir, identity); loadErr != nil || !idx.Covers(vaultDir, identity) {
 			if err := idx.Build(vaultDir, identity); err != nil {
 				return scanCandidatesForHost(vaultDir, candidates, normHost, identity), nil
 			}

--- a/internal/vault/search_index.go
+++ b/internal/vault/search_index.go
@@ -167,6 +167,10 @@ type indexDoc struct {
 	// every token in the index. May be nil in indices written before this
 	// field existed; it is rebuilt lazily on the first incremental update.
 	PathTokens map[string][]string `json:"pt,omitempty"`
+	// HostIndex maps normalized host → entry paths containing that host in their url field.
+	HostIndex map[string]map[string]struct{} `json:"hi,omitempty"`
+	// PathHosts is the reverse of HostIndex: entry path → deduplicated normalized hosts.
+	PathHosts map[string][]string `json:"ph,omitempty"`
 	// EntryCount is the number of entries in the vault when the index was built.
 	// Used for stale detection — if the count differs, the index is rebuilt.
 	EntryCount int `json:"c,omitempty"`
@@ -306,6 +310,8 @@ func (idx *EncryptedIndex) buildIndex(vaultDir string, identity *age.X25519Ident
 		Values:     make(map[string][]string, len(paths)),
 		TokenIndex: make(map[string]map[string]struct{}),
 		PathTokens: make(map[string][]string, len(paths)),
+		HostIndex:  make(map[string]map[string]struct{}),
+		PathHosts:  make(map[string][]string, len(paths)),
 		EntryCount: len(paths),
 	}
 
@@ -323,6 +329,7 @@ func (idx *EncryptedIndex) buildIndex(vaultDir string, identity *age.X25519Ident
 		i      int
 		path   string
 		values []string
+		hosts  []string
 	}
 
 	jobs := make(chan indexJob, len(paths))
@@ -354,7 +361,8 @@ func (idx *EncryptedIndex) buildIndex(vaultDir string, identity *age.X25519Ident
 				var values []string
 				collectStringValues(&values, entry.Data)
 				sort.Strings(values)
-				results <- indexResult{i: job.i, path: job.path, values: values}
+				hosts := ExtractHostsFromData(entry.Data)
+				results <- indexResult{i: job.i, path: job.path, values: values, hosts: hosts}
 			}
 		}()
 	}
@@ -375,12 +383,13 @@ func (idx *EncryptedIndex) buildIndex(vaultDir string, identity *age.X25519Ident
 	}
 
 	for _, result := range collected {
-		if len(result.values) == 0 {
-			continue
+		if len(result.values) > 0 {
+			doc.Values[result.path] = result.values
+			addToTokenIndex(doc.TokenIndex, doc.PathTokens, result.values, result.path)
 		}
-
-		doc.Values[result.path] = result.values
-		addToTokenIndex(doc.TokenIndex, doc.PathTokens, result.values, result.path)
+		if len(result.hosts) > 0 {
+			addToHostIndex(doc.HostIndex, doc.PathHosts, result.hosts, result.path)
+		}
 	}
 
 	// Refuse to commit an index that covers zero entries when the vault
@@ -389,7 +398,7 @@ func (idx *EncryptedIndex) buildIndex(vaultDir string, identity *age.X25519Ident
 	// silently look empty. Returning an error lets callers fall back to
 	// the full decrypt path (or surface the problem to the user) instead
 	// of producing misleading "no matches" results.
-	if len(paths) > 0 && len(doc.Values) == 0 {
+	if len(paths) > 0 && len(doc.Values) == 0 && len(doc.HostIndex) == 0 {
 		return ErrIndexBuildEmpty
 	}
 
@@ -514,6 +523,82 @@ func (idx *EncryptedIndex) MatchEntries(vaultDir string, identity *age.X25519Ide
 	return matching, nil
 }
 
+// MatchHost decrypts the index and returns the subset of entry paths whose
+// "url" field matches the target URL or host (normalized). If candidates is
+// non-empty, only candidates that match are returned; if candidates is empty,
+// all matching paths in the vault index are returned.
+func (idx *EncryptedIndex) MatchHost(vaultDir string, identity *age.X25519Identity, candidates []string, targetHostOrURL string) (map[string]struct{}, error) {
+	if targetHostOrURL == "" {
+		return nil, nil
+	}
+
+	targetHost, err := NormalizeHost(targetHostOrURL)
+	if err != nil {
+		return nil, err
+	}
+
+	idx.mu.RLock()
+	ct := idx.ciphertext
+	idHash := idx.idHash
+	storedSalt := idx.salt
+	storedDir := idx.vaultDir
+	idx.mu.RUnlock()
+
+	if ct == nil {
+		return nil, nil
+	}
+
+	currentHash := sha256.Sum256([]byte(identity.Recipient().String()))
+	if currentHash != idHash {
+		return nil, errors.New("identity changed")
+	}
+	if canonicalVaultDir(storedDir) != canonicalVaultDir(vaultDir) {
+		return nil, errors.New("vault directory changed")
+	}
+
+	key := deriveIndexKey(identity, storedSalt)
+	defer vaultcrypto.Wipe(key)
+
+	plaintext, err := vaultcrypto.DecryptWithKey(ct, key)
+	if err != nil {
+		return nil, err
+	}
+	defer vaultcrypto.Wipe(plaintext)
+
+	var doc indexDoc
+	if err := json.Unmarshal(plaintext, &doc); err != nil {
+		return nil, err
+	}
+
+	if doc.HostIndex == nil {
+		return make(map[string]struct{}), nil
+	}
+
+	paths, found := doc.HostIndex[targetHost]
+	if !found || len(paths) == 0 {
+		return make(map[string]struct{}), nil
+	}
+
+	matching := make(map[string]struct{}, len(paths))
+	if len(candidates) > 0 {
+		candSet := make(map[string]struct{}, len(candidates))
+		for _, c := range candidates {
+			candSet[c] = struct{}{}
+		}
+		for path := range paths {
+			if _, ok := candSet[path]; ok {
+				matching[path] = struct{}{}
+			}
+		}
+	} else {
+		for path := range paths {
+			matching[path] = struct{}{}
+		}
+	}
+
+	return matching, nil
+}
+
 // IsBuilt returns true if the index has been built (ciphertext exists).
 func (idx *EncryptedIndex) IsBuilt() bool {
 	idx.mu.RLock()
@@ -599,9 +684,14 @@ func (idx *EncryptedIndex) UpdateEntry(vaultDir, path string, identity *age.X255
 	if doc.TokenIndex == nil {
 		doc.TokenIndex = make(map[string]map[string]struct{})
 	}
+	if doc.HostIndex == nil {
+		doc.HostIndex = make(map[string]map[string]struct{})
+	}
 	ensurePathTokens(&doc)
+	ensurePathHosts(&doc)
 
 	removeFromTokenIndex(doc.TokenIndex, doc.PathTokens, path)
+	removeFromHostIndex(doc.HostIndex, doc.PathHosts, path)
 	delete(doc.Values, path)
 
 	entry, readErr := ReadEntry(vaultDir, path, identity)
@@ -611,6 +701,10 @@ func (idx *EncryptedIndex) UpdateEntry(vaultDir, path string, identity *age.X255
 		if len(values) > 0 {
 			doc.Values[path] = values
 			addToTokenIndex(doc.TokenIndex, doc.PathTokens, values, path)
+		}
+		hosts := ExtractHostsFromData(entry.Data)
+		if len(hosts) > 0 {
+			addToHostIndex(doc.HostIndex, doc.PathHosts, hosts, path)
 		}
 	}
 
@@ -689,6 +783,10 @@ func (idx *EncryptedIndex) RemoveEntry(path string, identity *age.X25519Identity
 	if doc.TokenIndex != nil {
 		ensurePathTokens(&doc)
 		removeFromTokenIndex(doc.TokenIndex, doc.PathTokens, path)
+	}
+	if doc.HostIndex != nil {
+		ensurePathHosts(&doc)
+		removeFromHostIndex(doc.HostIndex, doc.PathHosts, path)
 	}
 	// A delete removes exactly one vault entry; keep the persisted entry count
 	// in step so the on-disk index stays valid (not flagged stale) on reload.
@@ -999,4 +1097,59 @@ func removeFromTokenIndex(ti map[string]map[string]struct{}, pt map[string][]str
 		}
 	}
 	delete(pt, path)
+}
+
+// addToHostIndex associates entry path with normalized hosts in doc.HostIndex and doc.PathHosts.
+func addToHostIndex(hi map[string]map[string]struct{}, ph map[string][]string, hosts []string, path string) {
+	if len(hosts) == 0 {
+		return
+	}
+	for _, host := range hosts {
+		if hi[host] == nil {
+			hi[host] = make(map[string]struct{})
+		}
+		hi[host][path] = struct{}{}
+	}
+	if ph != nil {
+		ph[path] = hosts
+	}
+}
+
+// removeFromHostIndex removes all references to path from doc.HostIndex using doc.PathHosts.
+func removeFromHostIndex(hi map[string]map[string]struct{}, ph map[string][]string, path string) {
+	hosts, ok := ph[path]
+	if !ok {
+		return
+	}
+	for _, host := range hosts {
+		paths, found := hi[host]
+		if !found {
+			continue
+		}
+		delete(paths, path)
+		if len(paths) == 0 {
+			delete(hi, host)
+		}
+	}
+	delete(ph, path)
+}
+
+// ensurePathHosts lazily rebuilds the reverse path→hosts map from HostIndex
+// for index documents written before PathHosts existed.
+func ensurePathHosts(doc *indexDoc) {
+	if doc.PathHosts != nil || doc.HostIndex == nil {
+		if doc.HostIndex == nil {
+			doc.HostIndex = make(map[string]map[string]struct{})
+		}
+		if doc.PathHosts == nil {
+			doc.PathHosts = make(map[string][]string)
+		}
+		return
+	}
+	doc.PathHosts = make(map[string][]string)
+	for host, paths := range doc.HostIndex {
+		for path := range paths {
+			doc.PathHosts[path] = append(doc.PathHosts[path], host)
+		}
+	}
 }

--- a/internal/vault/search_index_test.go
+++ b/internal/vault/search_index_test.go
@@ -930,3 +930,169 @@ func TestFindFallbackWhenIndexUnavailable(t *testing.T) {
 		}
 	}
 }
+
+func TestEncryptedIndex_MatchHost(t *testing.T) {
+	searchIndexStore.invalidateAll()
+	t.Cleanup(searchIndexStore.invalidateAll)
+
+	vaultDir := t.TempDir()
+	identity := testutil.TempIdentity(t)
+
+	mustWriteEntry(t, vaultDir, identity, "work/github", map[string]interface{}{
+		"url":      "https://github.com/login",
+		"username": "octocat",
+	})
+	mustWriteEntry(t, vaultDir, identity, "work/gitlab", map[string]interface{}{
+		"url":      "http://gitlab.internal:8080/auth",
+		"username": "gituser",
+	})
+	mustWriteEntry(t, vaultDir, identity, "personal/multi", map[string]interface{}{
+		"url": []any{
+			"https://apple.com",
+			"https://icloud.com:443",
+		},
+		"username": "appleuser",
+	})
+	mustWriteEntry(t, vaultDir, identity, "local/dev", map[string]interface{}{
+		"url":      "http://localhost:3000/app",
+		"username": "devuser",
+	})
+
+	idx := &EncryptedIndex{}
+	if err := idx.Build(vaultDir, identity); err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+
+	tests := []struct {
+		query    string
+		wantPath string
+		wantFind bool
+	}{
+		{"github.com", "work/github", true},
+		{"HTTPS://GITHUB.COM:443/profile", "work/github", true},
+		{"http://github.com", "work/github", true},
+		{"http://gitlab.internal:8080", "work/gitlab", true},
+		{"gitlab.internal:8080", "work/gitlab", true},
+		{"gitlab.internal", "", false}, // different port
+		{"apple.com", "personal/multi", true},
+		{"icloud.com", "personal/multi", true},
+		{"https://icloud.com", "personal/multi", true},
+		{"localhost:3000", "local/dev", true},
+		{"localhost:8080", "", false},
+		{"nonexistent.org", "", false},
+	}
+
+	candidates := []string{"work/github", "work/gitlab", "personal/multi", "local/dev"}
+	for _, tc := range tests {
+		matches, err := idx.MatchHost(vaultDir, identity, candidates, tc.query)
+		if err != nil {
+			t.Errorf("MatchHost(%q) unexpected error: %v", tc.query, err)
+			continue
+		}
+		if tc.wantFind {
+			if _, ok := matches[tc.wantPath]; !ok {
+				t.Errorf("MatchHost(%q) did not find %s; matches: %v", tc.query, tc.wantPath, matches)
+			}
+		} else {
+			if len(matches) > 0 {
+				t.Errorf("MatchHost(%q) expected 0 matches, got %v", tc.query, matches)
+			}
+		}
+	}
+}
+
+func TestEncryptedIndex_MatchHostIncremental(t *testing.T) {
+	searchIndexStore.invalidateAll()
+	t.Cleanup(searchIndexStore.invalidateAll)
+
+	vaultDir := t.TempDir()
+	identity := testutil.TempIdentity(t)
+
+	mustWriteEntry(t, vaultDir, identity, "work/srv", map[string]interface{}{
+		"url":      "https://original-host.com",
+		"username": "user1",
+	})
+
+	idx := searchIndexForVault(vaultDir)
+	if err := idx.Build(vaultDir, identity); err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+
+	matches, err := idx.MatchHost(vaultDir, identity, []string{"work/srv"}, "original-host.com")
+	if err != nil || len(matches) != 1 {
+		t.Fatalf("MatchHost(original-host.com) = %v, err: %v", matches, err)
+	}
+
+	// Update the entry with a new URL
+	mustWriteEntry(t, vaultDir, identity, "work/srv", map[string]interface{}{
+		"url":      "https://updated-host.com",
+		"username": "user1",
+	})
+
+	// Old host must no longer match
+	matchesOld, err := idx.MatchHost(vaultDir, identity, []string{"work/srv"}, "original-host.com")
+	if err != nil || len(matchesOld) != 0 {
+		t.Fatalf("MatchHost(original-host.com) after update = %v (expected empty)", matchesOld)
+	}
+
+	// New host must match
+	matchesNew, err := idx.MatchHost(vaultDir, identity, []string{"work/srv"}, "updated-host.com")
+	if err != nil || len(matchesNew) != 1 {
+		t.Fatalf("MatchHost(updated-host.com) after update = %v, want [work/srv]", matchesNew)
+	}
+
+	// Delete the entry
+	idx.RemoveEntry("work/srv", identity)
+
+	matchesDeleted, err := idx.MatchHost(vaultDir, identity, []string{"work/srv"}, "updated-host.com")
+	if err != nil || len(matchesDeleted) != 0 {
+		t.Fatalf("MatchHost(updated-host.com) after delete = %v (expected empty)", matchesDeleted)
+	}
+}
+
+func TestEncryptedIndex_NoServiceLeakageOnDisk(t *testing.T) {
+	searchIndexStore.invalidateAll()
+	t.Cleanup(searchIndexStore.invalidateAll)
+
+	vaultDir := t.TempDir()
+	identity := testutil.TempIdentity(t)
+
+	const secretServiceHost = "topsecret-financial-portal-99.example.com"
+	const secretServiceName = "topsecret-financial-portal-99"
+
+	mustWriteEntry(t, vaultDir, identity, "banking/portal", map[string]interface{}{
+		"url":      "https://" + secretServiceHost + "/login",
+		"username": "secretuser",
+		"password": "secretpassword",
+	})
+
+	if err := searchIndexForVault(vaultDir).Build(vaultDir, identity); err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+
+	// Read all files in the vault directory and ensure plaintext service name does not appear anywhere
+	err := filepath.Walk(vaultDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+
+		raw, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+
+		if bytes.Contains(raw, []byte(secretServiceHost)) {
+			t.Errorf("plaintext service host %q leaked into vault file %s", secretServiceHost, path)
+		}
+		if bytes.Contains(raw, []byte(secretServiceName)) {
+			t.Errorf("plaintext service name %q leaked into vault file %s", secretServiceName, path)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Walk vault dir: %v", err)
+	}
+}

--- a/internal/vault/search_test.go
+++ b/internal/vault/search_test.go
@@ -806,3 +806,86 @@ func TestIsSensitiveCacheField_DenylistDeprecated(t *testing.T) {
 		}
 	}
 }
+
+func TestFindWithOptions_URLFilter(t *testing.T) {
+	vaultDir := t.TempDir()
+	id := testutil.TempIdentity(t)
+
+	mustWriteEntry(t, vaultDir, id, "work/github", map[string]interface{}{
+		"url":      "https://github.com/login",
+		"username": "alice",
+	})
+	mustWriteEntry(t, vaultDir, id, "personal/github", map[string]interface{}{
+		"url":      "http://github.com",
+		"username": "alice_personal",
+	})
+	mustWriteEntry(t, vaultDir, id, "work/gitlab", map[string]interface{}{
+		"url":      "https://gitlab.com",
+		"username": "alice_gitlab",
+	})
+
+	t.Run("match host by bare domain", func(t *testing.T) {
+		matches, err := FindWithOptions(vaultDir, "", FindOptions{URLFilter: "github.com"}, id)
+		if err != nil {
+			t.Fatalf("FindWithOptions() error = %v", err)
+		}
+		if len(matches) != 2 {
+			t.Fatalf("FindWithOptions() returned %d matches, want 2", len(matches))
+		}
+		if matches[0].Path != "personal/github" || matches[1].Path != "work/github" {
+			t.Errorf("matches = %v, want [personal/github, work/github]", matches)
+		}
+		if len(matches[0].Fields) != 1 || matches[0].Fields[0] != "url" {
+			t.Errorf("matches[0].Fields = %v, want [url]", matches[0].Fields)
+		}
+	})
+
+	t.Run("match host by full URL with path", func(t *testing.T) {
+		matches, err := FindWithOptions(vaultDir, "", FindOptions{URLFilter: "https://github.com/another/path"}, id)
+		if err != nil {
+			t.Fatalf("FindWithOptions() error = %v", err)
+		}
+		if len(matches) != 2 {
+			t.Fatalf("FindWithOptions() returned %d matches, want 2", len(matches))
+		}
+	})
+
+	t.Run("match with query filter", func(t *testing.T) {
+		matches, err := FindWithOptions(vaultDir, "personal", FindOptions{URLFilter: "github.com"}, id)
+		if err != nil {
+			t.Fatalf("FindWithOptions() error = %v", err)
+		}
+		if len(matches) != 1 || matches[0].Path != "personal/github" {
+			t.Fatalf("FindWithOptions(personal, github.com) = %v, want [personal/github]", matches)
+		}
+	})
+
+	t.Run("invalid url filter returns error", func(t *testing.T) {
+		_, err := FindWithOptions(vaultDir, "", FindOptions{URLFilter: "invalid::url"}, id)
+		if err == nil {
+			t.Fatal("FindWithOptions(invalid url) expected error, got nil")
+		}
+	})
+}
+
+func TestVault_FindByURL(t *testing.T) {
+	vaultDir := t.TempDir()
+	id := testutil.TempIdentity(t)
+
+	mustWriteEntry(t, vaultDir, id, "site/app", map[string]interface{}{
+		"url": "https://myapp.internal:8080/dashboard",
+	})
+
+	v := &Vault{
+		Dir:      vaultDir,
+		Identity: id,
+	}
+
+	matches, err := v.FindByURL("http://myapp.internal:8080", FindOptions{})
+	if err != nil {
+		t.Fatalf("FindByURL() error = %v", err)
+	}
+	if len(matches) != 1 || matches[0].Path != "site/app" {
+		t.Fatalf("FindByURL() = %v, want [site/app]", matches)
+	}
+}

--- a/internal/vault/url.go
+++ b/internal/vault/url.go
@@ -1,0 +1,269 @@
+package vault
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"unicode"
+)
+
+// URLKey is the well-known key in Entry.Data for associated service URLs.
+const URLKey = "url"
+
+// ErrInvalidURL indicates that a URL or host string could not be parsed or validated.
+var ErrInvalidURL = errors.New("invalid url")
+
+// ValidateURL validates that a raw URL or host string is non-empty, contains no invalid
+// whitespace or control characters, and normalizes to a valid host.
+func ValidateURL(raw string) error {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return fmt.Errorf("%w: url cannot be empty", ErrInvalidURL)
+	}
+	if strings.ContainsAny(trimmed, " \t\r\n") {
+		return fmt.Errorf("%w: url contains whitespace", ErrInvalidURL)
+	}
+	for _, r := range trimmed {
+		if unicode.IsControl(r) {
+			return fmt.Errorf("%w: url contains control character", ErrInvalidURL)
+		}
+	}
+	_, err := NormalizeHost(trimmed)
+	if err != nil {
+		return fmt.Errorf("%w: %v", ErrInvalidURL, err)
+	}
+	_, err = NormalizeURL(trimmed)
+	if err != nil {
+		return fmt.Errorf("%w: %v", ErrInvalidURL, err)
+	}
+	return nil
+}
+
+// NormalizeURL normalizes a URL by defaulting the scheme to https:// if missing,
+// lowercasing the scheme and host, and stripping default protocol ports (e.g. 443 for https, 80 for http).
+func NormalizeURL(raw string) (string, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return "", fmt.Errorf("%w: url cannot be empty", ErrInvalidURL)
+	}
+	if strings.ContainsAny(trimmed, " \t\r\n") {
+		return "", fmt.Errorf("%w: url contains whitespace", ErrInvalidURL)
+	}
+	for _, r := range trimmed {
+		if unicode.IsControl(r) {
+			return "", fmt.Errorf("%w: url contains control character", ErrInvalidURL)
+		}
+	}
+
+	rawWithScheme := trimmed
+	if !strings.Contains(rawWithScheme, "://") {
+		if strings.HasPrefix(rawWithScheme, "//") {
+			rawWithScheme = "https:" + rawWithScheme
+		} else {
+			rawWithScheme = "https://" + rawWithScheme
+		}
+	}
+
+	u, err := url.Parse(rawWithScheme)
+	if err != nil {
+		return "", fmt.Errorf("%w: %v", ErrInvalidURL, err)
+	}
+
+	if u.Host == "" {
+		return "", fmt.Errorf("%w: missing host", ErrInvalidURL)
+	}
+
+	scheme := strings.ToLower(u.Scheme)
+	normHost, err := normalizeHostPort(u.Host, scheme)
+	if err != nil {
+		return "", fmt.Errorf("%w: %v", ErrInvalidURL, err)
+	}
+
+	u.Scheme = scheme
+	u.Host = normHost
+	return u.String(), nil
+}
+
+// NormalizeHost extracts and normalizes the host (and non-default port) from a URL or host string.
+// Schemes are ignored, hosts are lowercased, and default protocol ports are stripped.
+func NormalizeHost(raw string) (string, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return "", fmt.Errorf("%w: host cannot be empty", ErrInvalidURL)
+	}
+	if strings.ContainsAny(trimmed, " \t\r\n") {
+		return "", fmt.Errorf("%w: host contains whitespace", ErrInvalidURL)
+	}
+	for _, r := range trimmed {
+		if unicode.IsControl(r) {
+			return "", fmt.Errorf("%w: host contains control character", ErrInvalidURL)
+		}
+	}
+
+	rawWithScheme := trimmed
+	scheme := ""
+	if strings.Contains(rawWithScheme, "://") {
+		u, err := url.Parse(rawWithScheme)
+		if err != nil {
+			return "", fmt.Errorf("%w: %v", ErrInvalidURL, err)
+		}
+		if u.Host == "" {
+			return "", fmt.Errorf("%w: missing host", ErrInvalidURL)
+		}
+		return normalizeHostPort(u.Host, strings.ToLower(u.Scheme))
+	}
+
+	if strings.HasPrefix(rawWithScheme, "//") {
+		rawWithScheme = "https:" + rawWithScheme
+		scheme = "https"
+	} else {
+		rawWithScheme = "//" + rawWithScheme
+	}
+
+	u, err := url.Parse(rawWithScheme)
+	if err != nil {
+		return "", fmt.Errorf("%w: %v", ErrInvalidURL, err)
+	}
+	if u.Host == "" {
+		return "", fmt.Errorf("%w: missing host", ErrInvalidURL)
+	}
+	return normalizeHostPort(u.Host, scheme)
+}
+
+// normalizeHostPort splits hostname and port, validates and lowercases the hostname,
+// strips default ports for the given scheme, and returns "hostname" or "hostname:port".
+func normalizeHostPort(hostWithPort, scheme string) (string, error) {
+	hostname, port, err := net.SplitHostPort(hostWithPort)
+	if err != nil {
+		hostname = hostWithPort
+		port = ""
+		if strings.HasPrefix(hostname, "[") && strings.HasSuffix(hostname, "]") {
+			hostname = strings.Trim(hostname, "[]")
+		}
+	} else {
+		p, portErr := strconv.Atoi(port)
+		if portErr != nil || p <= 0 || p > 65535 {
+			return "", fmt.Errorf("invalid port %q", port)
+		}
+		if isDefaultPort(scheme, p) {
+			port = ""
+		}
+	}
+
+	hostname = strings.ToLower(hostname)
+	hostname = strings.TrimSuffix(hostname, ".")
+
+	if hostname == "" {
+		return "", errors.New("empty hostname")
+	}
+
+	// Validate IP or domain name
+	ip := net.ParseIP(hostname)
+	if ip != nil {
+		if ip.To4() == nil {
+			// IPv6
+			if port != "" {
+				return fmt.Sprintf("[%s]:%s", hostname, port), nil
+			}
+			return fmt.Sprintf("[%s]", hostname), nil
+		}
+		if port != "" {
+			return fmt.Sprintf("%s:%s", hostname, port), nil
+		}
+		return hostname, nil
+	}
+
+	// Hostname validation
+	for _, r := range hostname {
+		if !unicode.IsLetter(r) && !unicode.IsDigit(r) && r != '.' && r != '-' && r != '_' {
+			return "", fmt.Errorf("invalid character %q in hostname", r)
+		}
+	}
+
+	if port != "" {
+		return fmt.Sprintf("%s:%s", hostname, port), nil
+	}
+	return hostname, nil
+}
+
+// isDefaultPort returns true if port matches the default port for the scheme.
+func isDefaultPort(scheme string, port int) bool {
+	switch strings.ToLower(scheme) {
+	case "http", "ws":
+		return port == 80
+	case "https", "wss":
+		return port == 443
+	case "ssh", "sftp":
+		return port == 22
+	case "ftp":
+		return port == 21
+	case "":
+		return port == 80 || port == 443
+	default:
+		return false
+	}
+}
+
+// SameHost reports whether two URL or host strings normalize to the same host.
+func SameHost(a, b string) bool {
+	h1, err1 := NormalizeHost(a)
+	if err1 != nil {
+		return false
+	}
+	h2, err2 := NormalizeHost(b)
+	if err2 != nil {
+		return false
+	}
+	return h1 == h2
+}
+
+// ExtractHostsFromData extracts all normalized hosts from the "url" field(s) of an entry's data map.
+func ExtractHostsFromData(data map[string]any) []string {
+	if len(data) == 0 {
+		return nil
+	}
+	val, ok := data[URLKey]
+	if !ok || val == nil {
+		return nil
+	}
+
+	seen := make(map[string]struct{})
+	var hosts []string
+
+	addHost := func(s string) {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			return
+		}
+		h, err := NormalizeHost(s)
+		if err != nil || h == "" {
+			return
+		}
+		if _, exists := seen[h]; !exists {
+			seen[h] = struct{}{}
+			hosts = append(hosts, h)
+		}
+	}
+
+	switch v := val.(type) {
+	case string:
+		addHost(v)
+	case []string:
+		for _, s := range v {
+			addHost(s)
+		}
+	case []any:
+		for _, item := range v {
+			if s, ok := item.(string); ok {
+				addHost(s)
+			}
+		}
+	}
+
+	sort.Strings(hosts)
+	return hosts
+}

--- a/internal/vault/url.go
+++ b/internal/vault/url.go
@@ -34,11 +34,11 @@ func ValidateURL(raw string) error {
 	}
 	_, err := NormalizeHost(trimmed)
 	if err != nil {
-		return fmt.Errorf("%w: %v", ErrInvalidURL, err)
+		return fmt.Errorf("%w: %w", ErrInvalidURL, err)
 	}
 	_, err = NormalizeURL(trimmed)
 	if err != nil {
-		return fmt.Errorf("%w: %v", ErrInvalidURL, err)
+		return fmt.Errorf("%w: %w", ErrInvalidURL, err)
 	}
 	return nil
 }
@@ -70,7 +70,7 @@ func NormalizeURL(raw string) (string, error) {
 
 	u, err := url.Parse(rawWithScheme)
 	if err != nil {
-		return "", fmt.Errorf("%w: %v", ErrInvalidURL, err)
+		return "", fmt.Errorf("%w: %w", ErrInvalidURL, err)
 	}
 
 	if u.Host == "" {
@@ -80,7 +80,7 @@ func NormalizeURL(raw string) (string, error) {
 	scheme := strings.ToLower(u.Scheme)
 	normHost, err := normalizeHostPort(u.Host, scheme)
 	if err != nil {
-		return "", fmt.Errorf("%w: %v", ErrInvalidURL, err)
+		return "", fmt.Errorf("%w: %w", ErrInvalidURL, err)
 	}
 
 	u.Scheme = scheme
@@ -109,7 +109,7 @@ func NormalizeHost(raw string) (string, error) {
 	if strings.Contains(rawWithScheme, "://") {
 		u, err := url.Parse(rawWithScheme)
 		if err != nil {
-			return "", fmt.Errorf("%w: %v", ErrInvalidURL, err)
+			return "", fmt.Errorf("%w: %w", ErrInvalidURL, err)
 		}
 		if u.Host == "" {
 			return "", fmt.Errorf("%w: missing host", ErrInvalidURL)
@@ -126,7 +126,7 @@ func NormalizeHost(raw string) (string, error) {
 
 	u, err := url.Parse(rawWithScheme)
 	if err != nil {
-		return "", fmt.Errorf("%w: %v", ErrInvalidURL, err)
+		return "", fmt.Errorf("%w: %w", ErrInvalidURL, err)
 	}
 	if u.Host == "" {
 		return "", fmt.Errorf("%w: missing host", ErrInvalidURL)

--- a/internal/vault/url_test.go
+++ b/internal/vault/url_test.go
@@ -1,0 +1,210 @@
+package vault
+
+import (
+	"testing"
+)
+
+func TestValidateURL(t *testing.T) {
+	valid := []string{
+		"https://github.com",
+		"http://github.com",
+		"github.com",
+		"github.com/login",
+		"https://sub.domain.example.com/path?foo=bar#frag",
+		"http://localhost:3000",
+		"http://localhost:80",
+		"https://localhost:443",
+		"127.0.0.1",
+		"http://127.0.0.1:8080",
+		"[::1]",
+		"http://[::1]:8080",
+		"https://[::1]:443",
+		"user:pass@github.com:443/repo",
+		"ssh://git@github.com:22/user/repo",
+		"ftp://files.example.com:21/pub",
+		"ws://socket.example.com:80/stream",
+		"wss://secure.example.com:443/stream",
+	}
+
+	for _, u := range valid {
+		if err := ValidateURL(u); err != nil {
+			t.Errorf("ValidateURL(%q) unexpected error: %v", u, err)
+		}
+	}
+
+	invalid := []string{
+		"",
+		"   ",
+		"http://",
+		"https://",
+		"https:///",
+		"http://[invalid-ipv6",
+		"github.com:99999",
+		"github.com:abc",
+		"github.com:0",
+		"https://bad host name.com",
+		"http://example.com/bad\x00char",
+		"http://example.com/bad\nnewline",
+	}
+
+	for _, u := range invalid {
+		if err := ValidateURL(u); err == nil {
+			t.Errorf("ValidateURL(%q) expected error, got nil", u)
+		}
+	}
+}
+
+func TestNormalizeURL(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"github.com", "https://github.com"},
+		{"github.com/login", "https://github.com/login"},
+		{"//github.com/path", "https://github.com/path"},
+		{"HTTPS://GITHUB.COM/login", "https://github.com/login"},
+		{"HTTP://GITHUB.COM:80/login", "http://github.com/login"},
+		{"https://github.com:443/login", "https://github.com/login"},
+		{"http://localhost:3000/app", "http://localhost:3000/app"},
+		{"https://sub.domain.co.uk:8443/api?key=val#tag", "https://sub.domain.co.uk:8443/api?key=val#tag"},
+		{"http://127.0.0.1:80", "http://127.0.0.1"},
+		{"http://127.0.0.1:8080", "http://127.0.0.1:8080"},
+		{"http://[::1]:80", "http://[::1]"},
+		{"http://[::1]:8080", "http://[::1]:8080"},
+	}
+
+	for _, tc := range tests {
+		got, err := NormalizeURL(tc.input)
+		if err != nil {
+			t.Errorf("NormalizeURL(%q) unexpected error: %v", tc.input, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("NormalizeURL(%q) = %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}
+
+func TestNormalizeHost(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"https://github.com/login", "github.com"},
+		{"http://github.com:80/path", "github.com"},
+		{"https://github.com:443", "github.com"},
+		{"github.com", "github.com"},
+		{"GITHUB.COM", "github.com"},
+		{"github.com:443", "github.com"},
+		{"github.com:80", "github.com"},
+		{"github.com:8080", "github.com:8080"},
+		{"https://github.com:8080/test", "github.com:8080"},
+		{"http://localhost:3000", "localhost:3000"},
+		{"http://localhost:80", "localhost"},
+		{"localhost", "localhost"},
+		{"user:pass@github.com:443/repo", "github.com"},
+		{"https://SUB.DOMAIN.CO.UK/foo?bar=1#frag", "sub.domain.co.uk"},
+		{"127.0.0.1:8000", "127.0.0.1:8000"},
+		{"http://127.0.0.1:80", "127.0.0.1"},
+		{"127.0.0.1", "127.0.0.1"},
+		{"http://[::1]:8080", "[::1]:8080"},
+		{"https://[::1]:443", "[::1]"},
+		{"[::1]", "[::1]"},
+	}
+
+	for _, tc := range tests {
+		got, err := NormalizeHost(tc.input)
+		if err != nil {
+			t.Errorf("NormalizeHost(%q) unexpected error: %v", tc.input, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("NormalizeHost(%q) = %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}
+
+func TestSameHost(t *testing.T) {
+	matches := [][2]string{
+		{"http://github.com", "https://github.com"},
+		{"http://github.com:80", "https://github.com:443"},
+		{"github.com", "GITHUB.COM"},
+		{"https://github.com/login", "github.com/profile"},
+		{"https://github.com:443", "github.com"},
+		{"http://localhost:3000/a", "http://localhost:3000/b"},
+		{"[::1]:8080", "http://[::1]:8080"},
+		{"127.0.0.1", "http://127.0.0.1:80"},
+	}
+
+	for _, pair := range matches {
+		if !SameHost(pair[0], pair[1]) {
+			t.Errorf("SameHost(%q, %q) = false, want true", pair[0], pair[1])
+		}
+	}
+
+	nonMatches := [][2]string{
+		{"github.com", "gitlab.com"},
+		{"localhost:3000", "localhost:8080"},
+		{"sub.example.com", "example.com"},
+		{"127.0.0.1:80", "127.0.0.1:8080"},
+		{"invalid::url", "github.com"},
+	}
+
+	for _, pair := range nonMatches {
+		if SameHost(pair[0], pair[1]) {
+			t.Errorf("SameHost(%q, %q) = true, want false", pair[0], pair[1])
+		}
+	}
+}
+
+func TestExtractHostsFromData(t *testing.T) {
+	t.Run("nil or empty data", func(t *testing.T) {
+		if got := ExtractHostsFromData(nil); got != nil {
+			t.Errorf("ExtractHostsFromData(nil) = %v, want nil", got)
+		}
+		if got := ExtractHostsFromData(map[string]any{}); got != nil {
+			t.Errorf("ExtractHostsFromData(empty) = %v, want nil", got)
+		}
+	})
+
+	t.Run("single string url", func(t *testing.T) {
+		data := map[string]any{
+			"url":      "https://github.com/login",
+			"username": "alice",
+		}
+		got := ExtractHostsFromData(data)
+		if len(got) != 1 || got[0] != "github.com" {
+			t.Fatalf("ExtractHostsFromData = %v, want [github.com]", got)
+		}
+	})
+
+	t.Run("slice of urls", func(t *testing.T) {
+		data := map[string]any{
+			"url": []any{
+				"https://github.com/login",
+				"http://gitlab.com:8080/auth",
+				"GITHUB.COM:443",
+			},
+		}
+		got := ExtractHostsFromData(data)
+		if len(got) != 2 {
+			t.Fatalf("ExtractHostsFromData len = %d, want 2 (%v)", len(got), got)
+		}
+		if got[0] != "github.com" || got[1] != "gitlab.com:8080" {
+			t.Errorf("ExtractHostsFromData = %v, want [github.com, gitlab.com:8080]", got)
+		}
+	})
+
+	t.Run("slice of strings", func(t *testing.T) {
+		data := map[string]any{
+			"url": []string{
+				"https://apple.com",
+				"https://icloud.com",
+			},
+		}
+		got := ExtractHostsFromData(data)
+		if len(got) != 2 || got[0] != "apple.com" || got[1] != "icloud.com" {
+			t.Errorf("ExtractHostsFromData = %v, want [apple.com, icloud.com]", got)
+		}
+	})
+}

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -609,6 +609,15 @@ func (v *Vault) FindWithOptions(query string, opts FindOptions) ([]Match, error)
 	return findWithOptionsIdentity(v.Dir, query, opts, v.Identity)
 }
 
+// FindByURL searches this vault's entries matching the specified URL or host.
+func (v *Vault) FindByURL(targetURL string, opts FindOptions) ([]Match, error) {
+	if v == nil {
+		return nil, errors.New("vault is nil")
+	}
+	opts.URLFilter = targetURL
+	return findWithOptionsIdentity(v.Dir, "", opts, v.Identity)
+}
+
 // ReadEntry reads a single entry from this vault using the vault's identity.
 func (v *Vault) ReadEntry(path string) (*Entry, error) {
 	if v == nil {


### PR DESCRIPTION
## Summary

Implements ADR 0006 decision D4: a documented `url` key convention for entries plus an encrypted host lookup index.

- `internal/vault/url.go`: URL validation + normalisation (scheme defaults, host lowercasing, default-port stripping) with full test coverage.
- `EncryptedIndex` extended with a url dimension: answers "which entries match this host" from an encrypted blob keyed by the vault identity — no whole-vault decryption at query time.
- Leakage guard: `TestEncryptedIndex_NoServiceLeakageOnDisk` asserts no plaintext service identifiers land on disk.
- CLI: `symvault find --url <value>` matches by normalised host (`cmd/crud/find.go`).
- Docs: `url` key documented in `docs/configuration.md` and `docs/man/symvault-find.1`.

Closes danieljustus/symaira-vault#865

## Checks

- make fmt-check / go vet / go build green
- go test -count=1 ./internal/vault/... ./cmd/... green (coordinator-verified)
