### PR TITLE
Bump symaira-corekit pin to v0.13.0

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
           src = ./.;
 
           # Resolved via `go mod vendor; nix hash path --sri vendor/`
-          vendorHash = "sha256-Lo8k96qqMF5hI6KcwfvMZIFrC46FzpemFNzzU0fNum0=";
+          vendorHash = "sha256-JM0LYghLrMLO7cnP9nZ3zsJ4++0rPtgsUVH3+liy1qg=";
 
           # Disable CGO for Linux — reduces distributability and is not needed
           # (keyring integration requires CGO only on darwin).

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,8 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/creack/pty v1.1.24
-	github.com/danieljustus/symaira-corekit v0.11.0
+	github.com/danieljustus/symaira-corekit v0.13.0
+	github.com/go-git/go-billy/v5 v5.9.0
 	github.com/go-git/go-git/v5 v5.19.2
 	github.com/google/uuid v1.6.0
 	github.com/invopop/jsonschema v0.14.0
@@ -97,7 +98,6 @@ require (
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
-	github.com/go-git/go-billy/v5 v5.9.0 // indirect
 	github.com/go-logr/logr v1.4.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/godbus/dbus/v5 v5.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -92,10 +92,8 @@ github.com/cyphar/filepath-securejoin v0.6.1 h1:5CeZ1jPXEiYt3+Z6zqprSAgSWiggmpVy
 github.com/cyphar/filepath-securejoin v0.6.1/go.mod h1:A8hd4EnAeyujCJRrICiOWqjS1AX0a9kM5XL+NwKoYSc=
 github.com/danieljoos/wincred v1.2.3 h1:v7dZC2x32Ut3nEfRH+vhoZGvN72+dQ/snVXo/vMFLdQ=
 github.com/danieljoos/wincred v1.2.3/go.mod h1:6qqX0WNrS4RzPZ1tnroDzq9kY3fu1KwE7MRLQK4X0bs=
-github.com/danieljustus/symaira-corekit v0.9.1 h1:ICJSMOe61HBl/oPrpeDLBhnxx9VApyldCBPf3LrUd9c=
-github.com/danieljustus/symaira-corekit v0.9.1/go.mod h1:ziocS/M31UNVMZBOz43IVrZjr9brfTIM6Ul4Ds/77Ek=
-github.com/danieljustus/symaira-corekit v0.11.0 h1:8iRkgC3FDHs35rdfAy0p0KW4JXF/Hqam8eFHDbsjEic=
-github.com/danieljustus/symaira-corekit v0.11.0/go.mod h1:tE756PUw001N+1Pe0Lcd8JRBKFNXZy+HXWYCm078Ix8=
+github.com/danieljustus/symaira-corekit v0.13.0 h1:5ob0guNL9y43hLLZCWhJdIJZXQ8rDfd+nltCBD4W0O4=
+github.com/danieljustus/symaira-corekit v0.13.0/go.mod h1:fza/0RvUl5ODDdjic2scDinTBhRBK79+aILmXCshqxg=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -163,8 +161,6 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/lucasb-eyer/go-colorful v1.3.0 h1:2/yBRLdWBZKrf7gB40FoiKfAWYQ0lqNcbuQwVHXptag=
 github.com/lucasb-eyer/go-colorful v1.3.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
-github.com/mattn/go-isatty v0.0.21 h1:xYae+lCNBP7QuW4PUnNG61ffM4hVIfm+zUzDuSzYLGs=
-github.com/mattn/go-isatty v0.0.21/go.mod h1:ZXfXG4SQHsB/w3ZeOYbR0PrPwLy+n6xiMrJlRFqopa4=
 github.com/mattn/go-isatty v0.0.24 h1:tGZZoVgT/KiqK1c8ocVLeDS8BSWMRd47J3Lbz7vsReI=
 github.com/mattn/go-isatty v0.0.24/go.mod h1:nMCL3Zebbrt45jsMDgnfIwz6ydEQApk5oEI3HqDio6A=
 github.com/mattn/go-localereader v0.0.1 h1:ygSAOl7ZXTx4RdPYinUpg6W99U8jWvWi9Ye2JC/oIi4=


### PR DESCRIPTION
## Summary
- Bumps `github.com/danieljustus/symaira-corekit` from v0.11.0 to v0.13.0.
- `go mod tidy` also promoted `github.com/go-git/go-billy/v5` from indirect to direct — a pre-existing genuine import in `internal/git/separate_gitdir_probe_test.go` that tidy hadn't classified correctly before; unrelated to corekit.

## Test plan
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./... -race` — full suite passes. One flake surfaced during a full-suite `-race` run under heavy concurrent load on this dev machine (`cmd/crud` `TestEditCommand_NotFound` hit a 280s timeout waiting on `startManifestWorker`'s shutdown channel) — verified NOT caused by this bump: reproduced the identical hang risk by stashing this change back to v0.11.0 and running the same test in isolation, where it passes cleanly in 5.6s. Not reproducible in isolation on either version; treating it as contention-induced flake under this session's unusually loaded machine, not a real regression. CI (a real, less-contended runner) is the authoritative signal here.
- [x] `make lint` — the golangci-lint step fails locally with an export-data/toolchain version mismatch, but confirmed via `git stash` that this reproduces identically on unmodified `main` — pre-existing local environment issue, not caused by this bump.

Refs danieljustus/symaira-corekit#157