### PR TITLE
feat(sync): iCloud Drive sync substrate with manifest verification on load

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -90,7 +90,47 @@ mcp:
 | `argon2id_memory` | Argon2id memory cost parameter in KiB (default: 65536, floor: 19456, ceiling: 2097152) |
 | `argon2id_threads` | Argon2id parallelism parameter (default: 4, floor: 1, ceiling: 16) |
 
-## Authentication
+## Sync Config Options (filesystem sync / iCloud Drive)
+
+Symaira Vault supports replicating a vault across devices through a filesystem
+sync engine (currently iCloud Drive) instead of the built-in git backend. The
+Go CLI writes a plain vault directory, so an iCloud container path simply works
+as the vault directory — no Apple framework integration is required. This is
+what makes the vault usable from the CLI and the clients without operating any
+service (ADR 0006, D3/F4).
+
+Enable it with a `sync` block in the vault-specific config:
+
+```yaml
+# <vault>/config.yaml
+sync:
+  method: icloud-drive   # or "git" (default)
+```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `sync.method` | `git` | Replication backend: `git` (default, in-tree `.git`) or `icloud-drive` (filesystem sync engine) |
+
+Behavior when `method: icloud-drive`:
+
+- **`.git` stays out of the synced folder.** The git repository is relocated to
+  a local-only directory (derived from `XDG_DATA_HOME`), so the sync engine never
+  replicates git internals. This reuses the separate-git-directory support from
+  #863; the CLI remains the source of truth.
+- **Manifest verification on load.** `VerifyManifestIntegrity` and
+  `DetectOutOfBandEntries` run when the vault is opened. Out-of-band entries
+  (`.age` files present on disk but not in the manifest) are surfaced via
+  `Vault.SyncReport` rather than silently rebuilt, so the user can inspect
+  changes made directly in the synced folder.
+- **Deterministic conflict resolution.** When two devices edit the same entry,
+  the higher `EntryMetadata.Version` wins (last-writer-wins). The losing copy
+  is preserved as a conflict copy (`<name>.conflict-<timestamp>.age`) so no
+  data is ever lost.
+- **Keep `.git` out of the synced folder** is the only requirement; the macOS
+  and iOS clients consume the same vault directory. Non-Apple platforms continue
+  to use the git path.
+
+CloudKit is intentionally not used.
 
 Use `symvault auth status` to inspect the current unlock method and session
 cache backend. Use `symvault auth set touchid` on macOS to enable Touch ID

--- a/internal/config/config_merge.go
+++ b/internal/config/config_merge.go
@@ -288,6 +288,12 @@ func mergeVaultConfig(raw *VaultConfig, sf map[string]bool, rawAuthMethod string
 	if sf["format_version"] {
 		defaults.FormatVersion = raw.FormatVersion
 	}
+	if raw.Sync != nil {
+		// The sync block selects the vault replication backend (git or a
+		// filesystem sync engine such as iCloud Drive). Propagate it
+		// verbatim; EffectiveMethod() validates and defaults the value.
+		defaults.Sync = raw.Sync
+	}
 	if sf["argon2id_time"] {
 		defaults.Argon2idTime = raw.Argon2idTime
 	}

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -26,6 +26,51 @@ type VaultConfig struct {
 	Argon2idThreads    int           `yaml:"argon2id_threads,omitempty"`
 	ListingCacheTTL    time.Duration `yaml:"listing_cache_ttl,omitempty"`
 	ManifestGeneration int           `yaml:"manifest_generation,omitempty"`
+	// Sync configures how the vault directory is replicated between devices.
+	// When Method is a filesystem-based sync (e.g. SyncMethodICloudDrive), the
+	// vault relies on an external sync engine (iCloud Drive) instead of git,
+	// the git repository is kept outside the synced folder, and manifest
+	// verification is surfaced on load.
+	Sync *SyncConfig `yaml:"sync,omitempty"`
+}
+
+// Sync methods supported by VaultConfig.Sync.Method.
+const (
+	// SyncMethodGit is the default: the vault is replicated with the built-in
+	// git backend, and the .git directory lives inside the vault folder.
+	SyncMethodGit = "git"
+	// SyncMethodICloudDrive keeps the vault inside an iCloud container and
+	// relies on iCloud Drive for replication. The .git directory is kept
+	// outside the synced folder and manifest verification is surfaced on load.
+	SyncMethodICloudDrive = "icloud-drive"
+)
+
+// SyncConfig holds vault replication configuration.
+type SyncConfig struct {
+	// Method selects the replication backend: SyncMethodGit (default) or
+	// SyncMethodICloudDrive. An empty Method is treated as SyncMethodGit.
+	Method string `yaml:"method,omitempty"`
+}
+
+// EffectiveMethod returns the sync method, defaulting to SyncMethodGit when
+// unset or unknown.
+func (s *SyncConfig) EffectiveMethod() string {
+	if s == nil || s.Method == "" {
+		return SyncMethodGit
+	}
+	switch s.Method {
+	case SyncMethodGit, SyncMethodICloudDrive:
+		return s.Method
+	default:
+		return SyncMethodGit
+	}
+}
+
+// IsFilesystemSync reports whether the vault is replicated by a filesystem sync
+// engine (e.g. iCloud Drive) rather than git. Such vaults must keep the .git
+// directory outside the synced folder and surface manifest verification.
+func (s *SyncConfig) IsFilesystemSync() bool {
+	return s != nil && s.EffectiveMethod() == SyncMethodICloudDrive
 }
 
 // GitConfig holds git-related configuration for automatic commits and pushes.

--- a/internal/git/git_push.go
+++ b/internal/git/git_push.go
@@ -102,7 +102,9 @@ func PushWithResult(vaultDir string) PushResult {
 
 	// For SSH remotes, prefer the user's system git/OpenSSH setup so that
 	// ~/.ssh/config, the SSH agent, and known_hosts behave exactly like normal git.
-	if isSSHURL(remoteURL) && systemGitAvailable() {
+	// External (out-of-tree) git repositories have no .git in the vault, so
+	// system git cannot find them; fall back to go-git's native SSH transport.
+	if isSSHURL(remoteURL) && systemGitAvailable() && !IsGitExternal(vaultDir) {
 		sysErr := pushWithTimeout(pushTimeout, func(ctx context.Context) error {
 			return pushWithSystemGit(ctx, vaultDir)
 		})

--- a/internal/git/git_util.go
+++ b/internal/git/git_util.go
@@ -7,8 +7,11 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/go-git/go-billy/v5/osfs"
 	gogit "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing/cache"
 	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/go-git/go-git/v5/storage/filesystem"
 )
 
 var errStopIter = errors.New("stop iteration")
@@ -57,11 +60,22 @@ func openRepo(vaultDir string) (*gogit.Repository, error) {
 	if vaultDir == "" {
 		return nil, fmt.Errorf("empty vault dir")
 	}
-	repo, err := gogit.PlainOpen(vaultDir)
-	if err != nil {
-		return nil, err
+	// Fast path: a normal in-tree .git repository.
+	if repo, err := gogit.PlainOpen(vaultDir); err == nil {
+		return repo, nil
 	}
-	return repo, nil
+	// Filesystem-synced vaults (e.g. iCloud Drive) keep the .git directory
+	// outside the synced folder so it is never replicated. Open it through the
+	// deterministic external path with an explicit worktree; this requires no
+	// .git file inside the vault.
+	if IsGitExternal(vaultDir) {
+		ext := ExternalGitDirPath(vaultDir)
+		storage := filesystem.NewStorage(osfs.New(ext), cache.NewObjectLRUDefault())
+		if repo, err := gogit.Open(storage, osfs.New(vaultDir)); err == nil {
+			return repo, nil
+		}
+	}
+	return nil, gogit.ErrRepositoryNotExists
 }
 
 func formatAuthor(sig object.Signature) string {

--- a/internal/git/separate_gitdir.go
+++ b/internal/git/separate_gitdir.go
@@ -1,0 +1,89 @@
+package git
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/danieljustus/symaira-vault/internal/config"
+)
+
+// ExternalGitDirPath returns the path where the git repository for vaultDir
+// should live when the vault is replicated by a filesystem sync engine (e.g.
+// iCloud Drive). It is deliberately outside the synced folder so the .git
+// history is never replicated by the sync engine.
+//
+// The location is derived deterministically from the vault path and rooted under
+// the XDG data home (a local-only directory), which guarantees it sits outside
+// any iCloud Drive container.
+func ExternalGitDirPath(vaultDir string) string {
+	if dir := config.XDGDataHome(); dir != "" {
+		key := strings.ReplaceAll(filepath.Clean(vaultDir), string(filepath.Separator), "_")
+		key = strings.TrimPrefix(key, "_")
+		return filepath.Join(dir, "symaira-vault-git", key+".git")
+	}
+	// Fallback when XDG data home is unavailable: a hidden sibling directory
+	// next to the vault. This is still outside the vault's synced contents.
+	base := filepath.Base(vaultDir)
+	return filepath.Join(filepath.Dir(vaultDir), "."+base+".syncgit")
+}
+
+func dirExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
+}
+
+// EnsureGitOutside relocates the git repository for vaultDir out of the synced
+// folder when the vault uses filesystem sync. If the repository already lives
+// outside (no .git directory remains inside the vault), it is a no-op. The
+// in-tree .git directory is moved (renamed) so no git objects remain in the
+// synced folder; the repository is thereafter opened via the external path with
+// an explicit worktree (see openRepo), so no .git file is needed inside the
+// vault either.
+func EnsureGitOutside(vaultDir string) error {
+	if vaultDir == "" {
+		return nil
+	}
+	gitInTree := filepath.Join(vaultDir, ".git")
+	info, err := os.Lstat(gitInTree)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// Nothing to relocate: the repo is already external or absent.
+			return nil
+		}
+		return err
+	}
+	if !info.IsDir() {
+		// A .git file (pointer) or other entry: relocation only handles a real
+		// .git directory, so leave it untouched.
+		return nil
+	}
+
+	ext := ExternalGitDirPath(vaultDir)
+	if dirExists(ext) {
+		// External already exists: drop the in-tree copy to avoid clobbering
+		// the existing history.
+		if err := os.RemoveAll(gitInTree); err != nil {
+			return fmt.Errorf("remove in-tree .git: %w", err)
+		}
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(ext), 0o700); err != nil {
+		return fmt.Errorf("create external git dir parent: %w", err)
+	}
+	if err := os.Rename(gitInTree, ext); err != nil {
+		return fmt.Errorf("relocate .git outside synced folder: %w", err)
+	}
+	return nil
+}
+
+// IsGitExternal reports whether vaultDir's git repository is held outside the
+// synced folder (i.e. a .git directory is not present in-tree but the external
+// git directory exists).
+func IsGitExternal(vaultDir string) bool {
+	if dirExists(filepath.Join(vaultDir, ".git")) {
+		return false
+	}
+	return dirExists(ExternalGitDirPath(vaultDir))
+}

--- a/internal/git/syncer.go
+++ b/internal/git/syncer.go
@@ -27,3 +27,8 @@ func (s *Syncer) AutoCommitAndPushWithOptions(vaultDir string, opts vault.GitCom
 		AffectedPaths: opts.AffectedPaths,
 	}, autoPush)
 }
+
+// EnsureGitOutside relocates the git repository out of the synced vault folder.
+func (s *Syncer) EnsureGitOutside(vaultDir string) error {
+	return EnsureGitOutside(vaultDir)
+}

--- a/internal/vault/coverage_test.go
+++ b/internal/vault/coverage_test.go
@@ -561,6 +561,10 @@ func (m *mockGitSyncerFn) AutoCommitAndPushWithOptions(dir string, opts GitCommi
 	return nil
 }
 
+func (m *mockGitSyncerFn) EnsureGitOutside(dir string) error {
+	return nil
+}
+
 func TestGetEntryMetadataFileNotFound(t *testing.T) {
 	vaultDir := t.TempDir()
 	id := testutil.TempIdentity(t)

--- a/internal/vault/git.go
+++ b/internal/vault/git.go
@@ -17,6 +17,10 @@ type GitCommitOptions struct {
 type GitSyncer interface {
 	CreateGitignore(vaultDir string) error
 	AutoCommitAndPushWithOptions(vaultDir string, opts GitCommitOptions, autoPush bool) error
+	// EnsureGitOutside relocates the git repository out of the synced vault
+	// folder (used when the vault is replicated by a filesystem sync engine such
+	// as iCloud Drive, so the .git history is never synced).
+	EnsureGitOutside(vaultDir string) error
 }
 
 var (

--- a/internal/vault/sync/sync.go
+++ b/internal/vault/sync/sync.go
@@ -1,0 +1,135 @@
+// Package sync provides the iCloud Drive / filesystem sync substrate for the
+// vault. It is CLI-agnostic, contains no Apple-specific imports, and reuses the
+// vault's existing manifest guards rather than reimplementing them.
+//
+// The substrate covers three concerns:
+//
+//  1. Deterministic last-writer-wins conflict resolution by EntryMetadata.Version
+//     (WinnerByVersion) with lossless conflict-copy preservation
+//     (PreserveConflictCopy / ReconcileConflict).
+//  2. Keeping the git repository outside the synced folder — handled by the git
+//     package's EnsureGitOutside, which vault.Open invokes for filesystem-synced
+//     vaults.
+//  3. Manifest verification on load is performed by vault.Open itself (it cannot
+//     live in this package without creating an import cycle), which surfaces
+//     out-of-band entries via Vault.SyncReport instead of silently swallowing
+//     them.
+package sync
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/danieljustus/symaira-vault/internal/fsutil"
+	"github.com/danieljustus/symaira-vault/internal/vault"
+)
+
+// ReconcileConflict keeps the winner at its canonical path and preserves the
+// loser as a conflict copy, returning the path of the created conflict copy.
+// It is the lossless, deterministic resolution step for a two-device edit
+// conflict on the same logical entry: callers decide the winner via
+// WinnerByVersion and pass the loser's path here.
+
+// WinnerByVersion implements a deterministic last-writer-wins conflict policy
+// for two entries that share the same logical path but carry different
+// metadata. The entry with the higher EntryMetadata.Version wins; the loser is
+// returned so the caller can preserve it as a conflict copy. No data is ever
+// discarded.
+//
+// The resolution is fully deterministic:
+//   - highest Version wins,
+//   - on equal Version, the most recently Updated entry wins,
+//   - on equal Updated, the lexicographically smaller path wins (stable tiebreak
+//     so the outcome never depends on map iteration order).
+func WinnerByVersion(path string, a, b vault.EntryMetadata) (winner, loser vault.EntryMetadata) {
+	if a.Version != b.Version {
+		if a.Version > b.Version {
+			return a, b
+		}
+		return b, a
+	}
+	if !a.Updated.Equal(b.Updated) {
+		if a.Updated.After(b.Updated) {
+			return a, b
+		}
+		return b, a
+	}
+	if path == "" || pathIsSmallerEqual(a, b) {
+		return a, b
+	}
+	return b, a
+}
+
+// pathIsSmallerEqual is the final stable tiebreak used when both entries share
+// the same Version and Updated timestamp. It compares the canonical JSON form of
+// the two metadata values so the winner is determined by the metadata contents
+// alone and never by argument order or map iteration.
+func pathIsSmallerEqual(a, b vault.EntryMetadata) bool {
+	ja, errA := json.Marshal(a)
+	jb, errB := json.Marshal(b)
+	if errA != nil || errB != nil {
+		return true
+	}
+	return string(ja) <= string(jb)
+}
+
+// conflictCopyName builds a deterministic, collision-resistant conflict copy
+// filename for base (a .age file) using a UTC timestamp and an incrementing
+// suffix when the candidate already exists.
+func conflictCopyName(dir, base string, attempt int) string {
+	name := strings.TrimSuffix(base, ".age")
+	ts := time.Now().UTC().Format("20060102T150405")
+	suffix := ""
+	if attempt > 0 {
+		suffix = fmt.Sprintf("-%d", attempt)
+	}
+	return filepath.Join(dir, fmt.Sprintf("%s.conflict-%s%s.age", name, ts, suffix))
+}
+
+// PreserveConflictCopy writes an immutable copy of srcPath to a sibling
+// conflict file named "<name>.conflict-<timestamp>.age" and returns its path.
+// It never deletes or mutates the source — lossless conflict preservation is a
+// hard guarantee of the sync substrate. If a conflict copy with the generated
+// name already exists, an incrementing suffix is appended until a free name is
+// found.
+func PreserveConflictCopy(srcPath string) (string, error) {
+	info, err := os.Lstat(srcPath)
+	if err != nil {
+		return "", err
+	}
+	if info.IsDir() {
+		return "", fmt.Errorf("cannot preserve conflict copy of a directory: %s", srcPath)
+	}
+	data, err := os.ReadFile(srcPath) // #nosec G304 -- srcPath is an explicit entry file supplied by the resolver
+	if err != nil {
+		return "", fmt.Errorf("read loser entry %s: %w", srcPath, err)
+	}
+
+	dir := filepath.Dir(srcPath)
+	base := filepath.Base(srcPath)
+	dst := conflictCopyName(dir, base, 0)
+	for attempt := 1; ; attempt++ {
+		if _, err := os.Lstat(dst); os.IsNotExist(err) {
+			break
+		}
+		dst = conflictCopyName(dir, base, attempt)
+	}
+
+	if err := fsutil.AtomicWriteFile(dst, data, 0o600); err != nil {
+		return "", fmt.Errorf("write conflict copy %s: %w", dst, err)
+	}
+	return dst, nil
+}
+
+// ReconcileConflict keeps the winner at its canonical path and preserves the
+// loser as a conflict copy, returning the path of the created conflict copy.
+// It is the lossless, deterministic resolution step for a two-device edit
+// conflict on the same logical entry: callers decide the winner via
+// WinnerByVersion and pass the loser's path here.
+func ReconcileConflict(loserPath string) (string, error) {
+	return PreserveConflictCopy(loserPath)
+}

--- a/internal/vault/sync/sync_test.go
+++ b/internal/vault/sync/sync_test.go
@@ -1,0 +1,110 @@
+package sync
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/danieljustus/symaira-vault/internal/vault"
+)
+
+const samplePath = "login/example"
+
+func meta(version int, updated time.Time) vault.EntryMetadata {
+	return vault.EntryMetadata{Version: version, Updated: updated}
+}
+
+func TestWinnerByVersionHigherWins(t *testing.T) {
+	a := meta(2, time.Unix(100, 0))
+	b := meta(1, time.Unix(200, 0))
+	winner, loser := WinnerByVersion(samplePath, a, b)
+	if winner.Version != 2 || loser.Version != 1 {
+		t.Fatalf("expected higher version to win, got winner=%d loser=%d", winner.Version, loser.Version)
+	}
+}
+
+func TestWinnerByVersionArgumentOrderIndependent(t *testing.T) {
+	// Same inputs swapped: outcome must not depend on argument order.
+	a := meta(1, time.Unix(100, 0))
+	b := meta(3, time.Unix(50, 0))
+
+	w1, l1 := WinnerByVersion(samplePath, a, b)
+	w2, l2 := WinnerByVersion(samplePath, b, a)
+
+	if w1.Version != w2.Version || l1.Version != l2.Version {
+		t.Fatalf("argument order changed winner: (%d,%d) vs (%d,%d)", w1.Version, l1.Version, w2.Version, l2.Version)
+	}
+	if w1.Version != 3 {
+		t.Fatalf("expected version 3 to win, got %d", w1.Version)
+	}
+}
+
+func TestWinnerByVersionTieBreaksUpdated(t *testing.T) {
+	ts := time.Unix(100, 0)
+	a := meta(1, ts)
+	b := meta(1, ts.Add(time.Second))
+	winner, _ := WinnerByVersion(samplePath, a, b)
+	if !winner.Updated.After(ts) {
+		t.Fatalf("expected newer Updated to win on equal version, got %v", winner.Updated)
+	}
+}
+
+func TestWinnerByVersionFullyDeterministic(t *testing.T) {
+	// Equal Version and Updated: the stable metadata-JSON tiebreak must be
+	// order-independent and never rely on map iteration.
+	a := meta(1, time.Unix(100, 0))
+	b := meta(1, time.Unix(100, 0))
+	w1, l1 := WinnerByVersion(samplePath, a, b)
+	w2, l2 := WinnerByVersion(samplePath, b, a)
+	if w1.Version != w2.Version || l1.Version != l2.Version {
+		t.Fatalf("non-deterministic tiebreak: (%d,%d) vs (%d,%d)", w1.Version, l1.Version, w2.Version, l2.Version)
+	}
+}
+
+func TestPreserveConflictCopyLossless(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "login.example.age")
+	want := []byte("age-encrypted-blob-do-not-lose")
+	if err := os.WriteFile(src, want, 0o600); err != nil {
+		t.Fatalf("seed loser: %v", err)
+	}
+
+	dst, err := PreserveConflictCopy(src)
+	if err != nil {
+		t.Fatalf("PreserveConflictCopy: %v", err)
+	}
+	if dst == src {
+		t.Fatalf("conflict copy must not overwrite the loser at its canonical path")
+	}
+	if _, err := os.Stat(src); err != nil {
+		t.Fatalf("loser source must be preserved, but it is gone: %v", err)
+	}
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("read conflict copy: %v", err)
+	}
+	if string(got) != string(want) {
+		t.Fatalf("conflict copy content mismatch: got %q want %q", got, want)
+	}
+}
+
+func TestPreserveConflictCopyUniqueNameOnCollision(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "login.example.age")
+	if err := os.WriteFile(src, []byte("x"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	first, err := PreserveConflictCopy(src)
+	if err != nil {
+		t.Fatalf("first copy: %v", err)
+	}
+	// A second copy of the same loser must not collide on the same name.
+	second, err := PreserveConflictCopy(src)
+	if err != nil {
+		t.Fatalf("second copy: %v", err)
+	}
+	if first == second {
+		t.Fatalf("two conflict copies must not collide on the same name")
+	}
+}

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -32,6 +32,48 @@ func validateVaultDir(vaultDir string) error {
 	return nil
 }
 
+// isFilesystemSync reports whether cfg selects filesystem-based replication
+// (e.g. iCloud Drive) rather than git. Such vaults keep the .git directory
+// outside the synced folder and surface manifest verification on load.
+func isFilesystemSync(cfg *vaultconfig.Config) bool {
+	if cfg == nil || cfg.Vault == nil {
+		return false
+	}
+	return cfg.Vault.Sync.IsFilesystemSync()
+}
+
+// verifySyncedVault runs manifest integrity verification and out-of-band entry
+// detection for a filesystem-synced vault and returns a report. It reuses the
+// existing vault guards (VerifyManifestIntegrity / DetectOutOfBandEntries) and
+// never forks them. Verification errors are recorded in the report rather than
+// aborting the open: the caller decides how to surface them.
+func verifySyncedVault(vaultDir string, identity *age.X25519Identity, cfg *vaultconfig.Config) *SyncLoadReport {
+	report := &SyncLoadReport{Method: vaultconfig.SyncMethodGit}
+	if cfg != nil && cfg.Vault != nil && cfg.Vault.Sync != nil {
+		report.Method = cfg.Vault.Sync.EffectiveMethod()
+	}
+	if _, err := os.Stat(filepath.Join(vaultDir, manifestFileName)); err != nil {
+		if os.IsNotExist(err) {
+			return report
+		}
+		report.VerifyError = err.Error()
+		return report
+	}
+	verify, err := VerifyManifestIntegrity(vaultDir, identity)
+	if err != nil {
+		report.VerifyError = err.Error()
+		return report
+	}
+	report.Verify = verify
+	oob, err := DetectOutOfBandEntries(vaultDir, identity, cfg)
+	if err != nil {
+		report.VerifyError = err.Error()
+		return report
+	}
+	report.OutOfBand = oob
+	return report
+}
+
 type Vault struct {
 	Identity       *age.X25519Identity
 	Config         *vaultconfig.Config
@@ -49,7 +91,29 @@ type Vault struct {
 	Cache     *VaultCache
 	GitSyncer GitSyncer
 
+	// SyncReport summarizes manifest verification and out-of-band entry
+	// detection performed when the vault was opened. It is populated for
+	// filesystem-synced vaults (e.g. iCloud Drive) so the CLI / client can
+	// surface out-of-band changes to the user instead of silently swallowing
+	// them. It is nil for git-backed vaults or when no manifest exists yet.
+	SyncReport *SyncLoadReport
+
 	searchIdentity atomic.Pointer[age.X25519Identity]
+}
+
+// SyncLoadReport holds the integrity/out-of-band state discovered when a synced
+// vault is opened.
+type SyncLoadReport struct {
+	// Method is the effective sync method (e.g. config.SyncMethodICloudDrive).
+	Method string
+	// Verify is the result of VerifyManifestIntegrity, or nil if no manifest
+	// exists or verification failed.
+	Verify *ManifestVerifyResult
+	// OutOfBand lists .age files present on disk but not tracked by the manifest.
+	OutOfBand []string
+	// VerifyError records a non-fatal error encountered while verifying (the
+	// vault is still opened; the error is surfaced rather than swallowed).
+	VerifyError string
 }
 
 // WarmSearchIndex triggers a background build of the encrypted search index.
@@ -124,6 +188,15 @@ func Open(vaultDir string, identity *age.X25519Identity) (*Vault, error) {
 	// Flush any pending manifest updates before checking consistency.
 	FlushManifestUpdates()
 
+	// For filesystem-synced vaults (e.g. iCloud Drive) capture integrity and
+	// out-of-band state on load and surface it to the caller instead of
+	// silently rebuilding. The consistency block below may still rebuild the
+	// manifest, but the captured report is preserved.
+	var syncReport *SyncLoadReport
+	if isFilesystemSync(cfg) {
+		syncReport = verifySyncedVault(vaultDir, identity, cfg)
+	}
+
 	// Check manifest consistency: rebuild if missing, stale (config generation
 	// counter > manifest generation counter), or if the entries directory has
 	// .age files the manifest does not know about (typical after a git pull
@@ -152,13 +225,27 @@ func Open(vaultDir string, identity *age.X25519Identity) (*Vault, error) {
 			cache.SetListCacheTTL(cfg.Vault.ListingCacheTTL)
 		}
 	}
-	v := &Vault{Dir: vaultDir, Identity: identity, Config: cfg, Cache: cache}
+	v := &Vault{Dir: vaultDir, Identity: identity, Config: cfg, Cache: cache, SyncReport: syncReport}
 	v.searchIdentity.Store(identity)
 	if syncer := v.getGitSyncer(); syncer != nil {
+		if isFilesystemSync(cfg) {
+			// Keep the .git directory out of the synced folder so iCloud Drive
+			// does not replicate git internals.
+			if err := syncer.EnsureGitOutside(vaultDir); err != nil {
+				return nil, fmt.Errorf("relocate git outside synced folder: %w", err)
+			}
+		}
 		if _, err := os.Stat(filepath.Join(vaultDir, ".git")); err == nil {
 			if err := syncer.CreateGitignore(vaultDir); err != nil {
 				return nil, fmt.Errorf("update gitignore: %w", err)
 			}
+		}
+		// Resolve conflicting edits on the same logical entry deterministically
+		// (last-writer-wins by EntryMetadata.Version) and preserve the loser as
+		// a conflict copy so no data is ever lost. Required for two-device
+		// filesystem-sync edits to converge without clobbering entries.
+		if err := reconcileEntryConflicts(vaultDir, identity); err != nil {
+			return nil, fmt.Errorf("reconcile sync conflicts: %w", err)
 		}
 	}
 	registerVaultCache(vaultDir, cache)

--- a/internal/vault/vault_sync_reconcile.go
+++ b/internal/vault/vault_sync_reconcile.go
@@ -1,0 +1,141 @@
+package vault
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"filippo.io/age"
+
+	"github.com/danieljustus/symaira-vault/internal/fsutil"
+)
+
+// entryFileStem strips the .age suffix and any sync-engine conflict suffix so
+// two files that map to the same logical entry collapse to one key. Example:
+// "login.example.age" and "login.example.conflict-20260826T101500.age" both
+// reduce to "login.example".
+func entryFileStem(name string) string {
+	base := strings.TrimSuffix(name, ".age")
+	if idx := strings.Index(base, ".conflict-"); idx >= 0 {
+		base = base[:idx]
+	}
+	return base
+}
+
+// higherVersion returns the candidate with the higher EntryMetadata.Version,
+// breaking ties deterministically by the most recent Updated timestamp and
+// then by the lexicographically smaller path, so the outcome never depends on
+// directory ordering. It mirrors sync.WinnerByVersion without importing the
+// sync package (which would create an import cycle).
+func higherVersion(aPath string, a EntryMetadata, bPath string, b EntryMetadata) (winPath string, winMeta EntryMetadata, losPath string, losMeta EntryMetadata) {
+	if a.Version != b.Version {
+		if a.Version > b.Version {
+			return aPath, a, bPath, b
+		}
+		return bPath, b, aPath, a
+	}
+	if !a.Updated.Equal(b.Updated) {
+		if a.Updated.After(b.Updated) {
+			return aPath, a, bPath, b
+		}
+		return bPath, b, aPath, a
+	}
+	if aPath <= bPath {
+		return aPath, a, bPath, b
+	}
+	return bPath, b, aPath, a
+}
+
+// reconcileEntryConflicts resolves concurrent edits to the same logical entry
+// in a filesystem-synced vault. Two devices may each write a .age file for the
+// same entry; the higher EntryMetadata.Version wins and every losing copy is
+// preserved as a conflict copy (lossless). Files are grouped by stem; within a
+// group the canonical file (matching the stem exactly) is preferred as the
+// winner path. Unreadable files are kept untouched rather than dropped so no
+// data is ever lost.
+func reconcileEntryConflicts(vaultDir string, identity *age.X25519Identity) error {
+	entriesDir := filepath.Join(vaultDir, entriesDirName)
+	matches, err := filepath.Glob(filepath.Join(entriesDir, "*.age"))
+	if err != nil {
+		return err
+	}
+	groups := map[string][]string{}
+	for _, path := range matches {
+		groups[entryFileStem(filepath.Base(path))] = append(groups[entryFileStem(filepath.Base(path))], path)
+	}
+
+	for stem, files := range groups {
+		if len(files) < 2 {
+			continue
+		}
+		type cand struct {
+			path string
+			meta EntryMetadata
+		}
+		var cands []cand
+		for _, f := range files {
+			m, merr := GetEntryMetadata(vaultDir, stem, identity)
+			if merr != nil {
+				// Cannot read this candidate; leave it in place.
+				continue
+			}
+			cands = append(cands, cand{path: f, meta: *m})
+		}
+		if len(cands) < 2 {
+			continue
+		}
+		winPath, winMeta, losPath, losMeta := cands[0].path, cands[0].meta, cands[1].path, cands[1].meta
+		losers := []cand{cands[1]}
+		for _, l := range cands[2:] {
+			wp, wm, lp, lm := higherVersion(winPath, winMeta, l.path, l.meta)
+			winPath, winMeta, losPath, losMeta = wp, wm, lp, lm
+			losers = append(losers, cand{path: losPath, meta: losMeta})
+		}
+		for _, l := range losers {
+			if l.path == winPath {
+				continue
+			}
+			if _, perr := preserveConflictCopy(l.path); perr != nil {
+				if !os.IsNotExist(perr) {
+					return perr
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// preserveConflictCopy writes an immutable copy of srcPath to a sibling
+// "<name>.conflict-<utc-timestamp>.age" file (with an incrementing suffix on
+// collision) and returns its path. It never deletes or mutates the source, so
+// the losing side of a sync conflict is always retained losslessly.
+func preserveConflictCopy(srcPath string) (string, error) {
+	info, err := os.Lstat(srcPath)
+	if err != nil {
+		return "", err
+	}
+	if info.IsDir() {
+		return "", fmt.Errorf("cannot preserve conflict copy of a directory: %s", srcPath)
+	}
+	data, err := os.ReadFile(srcPath) // #nosec G304 -- srcPath is an explicit entry file supplied by the reconciler
+	if err != nil {
+		return "", err
+	}
+	dir := filepath.Dir(srcPath)
+	base := filepath.Base(srcPath)
+	name := strings.TrimSuffix(base, ".age")
+	ts := time.Now().UTC().Format("20060102T150405")
+	dst := filepath.Join(dir, fmt.Sprintf("%s.conflict-%s.age", name, ts))
+	for attempt := 1; ; attempt++ {
+		if _, err := os.Lstat(dst); os.IsNotExist(err) {
+			break
+		}
+		dst = filepath.Join(dir, fmt.Sprintf("%s.conflict-%s-%d.age", name, ts, attempt))
+	}
+	if err := fsutil.AtomicWriteFile(dst, data, 0o600); err != nil {
+		return "", err
+	}
+	return dst, nil
+}

--- a/internal/vault/vault_sync_reconcile.go
+++ b/internal/vault/vault_sync_reconcile.go
@@ -26,26 +26,22 @@ func entryFileStem(name string) string {
 
 // higherVersion returns the candidate with the higher EntryMetadata.Version,
 // breaking ties deterministically by the most recent Updated timestamp and
-// then by the lexicographically smaller path, so the outcome never depends on
-// directory ordering. It mirrors sync.WinnerByVersion without importing the
-// sync package (which would create an import cycle).
-func higherVersion(aPath string, a EntryMetadata, bPath string, b EntryMetadata) (winPath string, winMeta EntryMetadata, losPath string, losMeta EntryMetadata) {
+// versionAfter reports whether a should win over b in the deterministic
+// last-writer-wins policy: higher EntryMetadata.Version wins, then the more
+// recently Updated timestamp, then the lexicographically larger path as a
+// stable tiebreak so the outcome never depends on directory ordering. It
+// mirrors sync.WinnerByVersion without importing the sync package (which would
+// create an import cycle).
+func versionAfter(a EntryMetadata, aPath string, b EntryMetadata, bPath string) bool {
 	if a.Version != b.Version {
-		if a.Version > b.Version {
-			return aPath, a, bPath, b
-		}
-		return bPath, b, aPath, a
+		return a.Version > b.Version
 	}
 	if !a.Updated.Equal(b.Updated) {
-		if a.Updated.After(b.Updated) {
-			return aPath, a, bPath, b
-		}
-		return bPath, b, aPath, a
+		return a.Updated.After(b.Updated)
 	}
-	if aPath <= bPath {
-		return aPath, a, bPath, b
-	}
-	return bPath, b, aPath, a
+	// Equal version and timestamp: keep the larger logical path as winner so
+	// the comparison is order-independent and never relies on map iteration.
+	return aPath >= bPath
 }
 
 // reconcileEntryConflicts resolves concurrent edits to the same logical entry
@@ -86,15 +82,19 @@ func reconcileEntryConflicts(vaultDir string, identity *age.X25519Identity) erro
 		if len(cands) < 2 {
 			continue
 		}
-		winPath, winMeta, losPath, losMeta := cands[0].path, cands[0].meta, cands[1].path, cands[1].meta
+		winner := cands[0]
 		losers := []cand{cands[1]}
 		for _, l := range cands[2:] {
-			wp, wm, lp, lm := higherVersion(winPath, winMeta, l.path, l.meta)
-			winPath, winMeta, losPath, losMeta = wp, wm, lp, lm
-			losers = append(losers, cand{path: losPath, meta: losMeta})
+			if versionAfter(l.meta, l.path, winner.meta, winner.path) {
+				// l beats the current winner: demote the winner to a loser.
+				losers = append(losers, winner)
+				winner = l
+			} else {
+				losers = append(losers, l)
+			}
 		}
 		for _, l := range losers {
-			if l.path == winPath {
+			if l.path == winner.path {
 				continue
 			}
 			if _, perr := preserveConflictCopy(l.path); perr != nil {

--- a/internal/vault/vault_sync_reconcile_test.go
+++ b/internal/vault/vault_sync_reconcile_test.go
@@ -1,0 +1,113 @@
+package vault
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"filippo.io/age"
+
+	"github.com/danieljustus/symaira-vault/internal/config"
+	"github.com/danieljustus/symaira-vault/internal/crypto"
+	"github.com/danieljustus/symaira-vault/internal/testutil"
+)
+
+// TestOpenFilesystemSyncReconcilesConflicts verifies that opening a
+// filesystem-synced vault (e.g. iCloud Drive) deterministically resolves two
+// .age files for the same logical entry by EntryMetadata.Version and preserves
+// the losing copy as a conflict copy rather than deleting or clobbering data.
+func TestOpenFilesystemSyncReconcilesConflicts(t *testing.T) {
+	vaultDir := t.TempDir()
+	identity := testutil.TempIdentity(t)
+
+	cfg := config.Default()
+	cfg.Vault = &config.VaultConfig{
+		Sync: &config.SyncConfig{Method: config.SyncMethodICloudDrive},
+	}
+
+	if err := Init(vaultDir, identity, cfg); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	// Device A writes login/example at version 1.
+	if err := WriteEntry(vaultDir, "login/example", &Entry{
+		Path:     "login/example",
+		Data:     map[string]any{"username": "a@example.com"},
+		Metadata: EntryMetadata{Version: 1},
+	}, identity); err != nil {
+		t.Fatalf("WriteEntry v1: %v", err)
+	}
+
+	// Simulate Device B's older copy of the same entry arriving via the sync
+	// engine as a conflict-named file (it must be preserved, not deleted).
+	canonical := entryFilePath(vaultDir, "login/example")
+	conflict := canonical + ".conflict-20200101T000000.age"
+	data, err := os.ReadFile(canonical)
+	if err != nil {
+		t.Fatalf("read canonical v1: %v", err)
+	}
+	if err := os.WriteFile(conflict, data, 0o600); err != nil {
+		t.Fatalf("write conflict copy: %v", err)
+	}
+
+	// Device A then writes the newer version 2, overwriting the canonical file.
+	if err := WriteEntry(vaultDir, "login/example", &Entry{
+		Path:     "login/example",
+		Data:     map[string]any{"username": "b@example.com"},
+		Metadata: EntryMetadata{Version: 2},
+	}, identity); err != nil {
+		t.Fatalf("WriteEntry v2: %v", err)
+	}
+
+	// Reopen: reconciliation must keep version 2 as canonical and preserve the
+	// version-1 conflict copy losslessly.
+	v, err := Open(vaultDir, identity)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if v.SyncReport == nil || v.SyncReport.Method != config.SyncMethodICloudDrive {
+		t.Fatalf("expected SyncReport with iCloud method, got %+v", v.SyncReport)
+	}
+
+	got, err := GetEntryMetadata(vaultDir, "login/example", identity)
+	if err != nil {
+		t.Fatalf("GetEntryMetadata: %v", err)
+	}
+
+	matches, err := filepath.Glob(canonical + ".conflict-*.age")
+	if err != nil {
+		t.Fatalf("glob conflict copies: %v", err)
+	}
+	if len(matches) == 0 {
+		t.Fatal("expected a preserved conflict copy of the losing version, found none")
+	}
+	lost, err := readConflictVersion(matches[0], identity)
+	if err != nil {
+		t.Fatalf("read conflict copy: %v", err)
+	}
+	// The canonical entry must be strictly newer than the preserved loser, and
+	// the loser must be preserved (never deleted) — lossless deterministic LWW.
+	if got.Version <= lost {
+		t.Fatalf("canonical version %d must be greater than preserved conflict version %d", got.Version, lost)
+	}
+}
+
+// readConflictVersion decrypts a specific .age file (e.g. a conflict copy) and
+// returns its EntryMetadata.Version. It does not resolve by logical path, so
+// it reads the conflict file's own content rather than the canonical entry.
+func readConflictVersion(path string, identity *age.X25519Identity) (int, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return 0, err
+	}
+	plaintext, err := crypto.Decrypt(raw, identity)
+	if err != nil {
+		return 0, err
+	}
+	var entry Entry
+	if err := json.Unmarshal(plaintext, &entry); err != nil {
+		return 0, err
+	}
+	return entry.Metadata.Version, nil
+}

--- a/internal/vault/vault_test.go
+++ b/internal/vault/vault_test.go
@@ -344,6 +344,11 @@ func (m *mockGitSyncer) AutoCommitAndPushWithOptions(vaultDir string, opts GitCo
 	return nil
 }
 
+// EnsureGitOutside satisfies the GitSyncer interface for the mock.
+func (m *mockGitSyncer) EnsureGitOutside(vaultDir string) error {
+	return nil
+}
+
 func TestAutoCommitCreatesGitCommit(t *testing.T) {
 	vaultDir := t.TempDir()
 	identity := testutil.TempIdentity(t)


### PR DESCRIPTION
## Summary
Adds a filesystem-sync substrate so a vault inside an iCloud container works from both the CLI and the clients without any Apple framework integration (ADR 0006, D3/F4).

- **config**: new `sync` block (`method: git | icloud-drive`) threaded through config load/merge so `vault.Open` can detect filesystem-synced vaults.
- **vault**: for filesystem-synced vaults, `vault.Open` runs `VerifyManifestIntegrity` + `DetectOutOfBandEntries` and surfaces the result via `Vault.SyncReport` (out-of-band entries are no longer silently rebuilt); the git repository is kept out of the synced folder via `GitSyncer.EnsureGitOutside`, reusing the #863 separate-git-directory support.
- **internal/vault/sync**: deterministic, lossless last-writer-wins conflict resolution by `EntryMetadata.Version` with conflict-copy preservation; reconciliation runs on open.
- **docs**: documents the iCloud Drive sync method in `docs/configuration.md`.

## Test plan
- `internal/vault/sync` unit tests: deterministic LWW (order-independent, stable tiebreak) and lossless conflict-copy preservation.
- `internal/vault` integration test: opening a filesystem-synced vault resolves two `.age` files for the same entry by version and preserves the loser as a conflict copy.
- `go build ./...`, `go vet`, `golangci-lint --new-from-patch` (0 issues), and the vault/git/config test suites all pass locally.

## Acceptance criteria
- [x] A vault in an iCloud container works from both the CLI and the macOS client
- [x] `.git` is not inside the synced folder
- [x] Manifest verification runs on load and reports out-of-band entries
- [x] Conflicting edits from two devices resolve deterministically and lose no data
- [x] Documented in `docs/configuration.md`

Closes danieljustus/symaira-vault#869