### PR TITLE
Bump symaira-corekit to v0.14.0

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
           src = ./.;
 
           # Resolved via `go mod vendor; nix hash path --sri vendor/`
-          vendorHash = "sha256-JM0LYghLrMLO7cnP9nZ3zsJ4++0rPtgsUVH3+liy1qg=";
+          vendorHash = "sha256-pQ/AbbGRJe3EZk2BgXO7doWphMydYE1sJSn/0SBUETM=";
 
           # Disable CGO for Linux — reduces distributability and is not needed
           # (keyring integration requires CGO only on darwin).

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/creack/pty v1.1.24
-	github.com/danieljustus/symaira-corekit v0.13.0
+	github.com/danieljustus/symaira-corekit v0.14.0
 	github.com/go-git/go-billy/v5 v5.9.0
 	github.com/go-git/go-git/v5 v5.19.2
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -92,8 +92,8 @@ github.com/cyphar/filepath-securejoin v0.6.1 h1:5CeZ1jPXEiYt3+Z6zqprSAgSWiggmpVy
 github.com/cyphar/filepath-securejoin v0.6.1/go.mod h1:A8hd4EnAeyujCJRrICiOWqjS1AX0a9kM5XL+NwKoYSc=
 github.com/danieljoos/wincred v1.2.3 h1:v7dZC2x32Ut3nEfRH+vhoZGvN72+dQ/snVXo/vMFLdQ=
 github.com/danieljoos/wincred v1.2.3/go.mod h1:6qqX0WNrS4RzPZ1tnroDzq9kY3fu1KwE7MRLQK4X0bs=
-github.com/danieljustus/symaira-corekit v0.13.0 h1:5ob0guNL9y43hLLZCWhJdIJZXQ8rDfd+nltCBD4W0O4=
-github.com/danieljustus/symaira-corekit v0.13.0/go.mod h1:fza/0RvUl5ODDdjic2scDinTBhRBK79+aILmXCshqxg=
+github.com/danieljustus/symaira-corekit v0.14.0 h1:RWN3LRYxF/b5P176LlXHa0T8ziZBvLkMeu3geHe9vyQ=
+github.com/danieljustus/symaira-corekit v0.14.0/go.mod h1:fza/0RvUl5ODDdjic2scDinTBhRBK79+aILmXCshqxg=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
Updates the pinned shared library to the new minor release. No breaking API changes (verified by apidiff on the corekit repo); the release includes the new shared llmkit provider layer, which is not yet consumed here.