### PR TITLE
fix(git): sanitize drive-letter colons in external git dir key

### DIFF
--- a/internal/git/separate_gitdir.go
+++ b/internal/git/separate_gitdir.go
@@ -20,6 +20,10 @@ import (
 func ExternalGitDirPath(vaultDir string) string {
 	if dir := config.XDGDataHome(); dir != "" {
 		key := strings.ReplaceAll(filepath.Clean(vaultDir), string(filepath.Separator), "_")
+		// Windows drive letters (and any other colon in the path) are not
+		// valid in directory names; strip them so the derived key is usable
+		// as a directory component on every platform.
+		key = strings.ReplaceAll(key, ":", "_")
 		key = strings.TrimPrefix(key, "_")
 		return filepath.Join(dir, "symaira-vault-git", key+".git")
 	}


### PR DESCRIPTION
EnsureGitOutside derives the external git directory path from the vault path with separators replaced by underscores. On Windows the drive-letter colon survives that transform (`C:_Users_...`), which is invalid in a directory name and makes filesystem-sync relocation fail.

The coverage tests added for the sync/reconciliation paths (PR #902) exposed the failure on the Windows CI matrix; this fixes the production code so the derived key is a valid directory component on every platform.