### PR TITLE
feat(policy): pending-approval queue makes approval mode prompt usable

### DIFF
--- a/internal/approval/queue.go
+++ b/internal/approval/queue.go
@@ -276,7 +276,7 @@ func (q *Queue) Close() {
 	q.poke()
 }
 
-// Notify returns a channel that is signalled whenever the queue state
+// Notify returns a channel that is signaled whenever the queue state
 // changes (new request, decision, expiry). Used by transports to push
 // updates to approval devices.
 func (q *Queue) Notify() <-chan struct{} { return q.notifier }

--- a/internal/approval/queue.go
+++ b/internal/approval/queue.go
@@ -1,0 +1,331 @@
+// Package approval implements the pending-request queue that lets an
+// enrolled approval device (mobile client) decide agent credential requests
+// out-of-band. It is the interface that makes approval mode "prompt" usable:
+// an agent call blocks on Wait until a human approves, denies, or the
+// request expires — instead of degrading to an instant deny.
+package approval
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+)
+
+// Status is the lifecycle state of an approval request.
+type Status string
+
+const (
+	StatusPending  Status = "pending"
+	StatusApproved Status = "approved"
+	StatusDenied   Status = "denied"
+	StatusExpired  Status = "expired"
+)
+
+// Request describes one pending approval.
+type Request struct {
+	AgentName string
+	Path      string
+	Write     bool
+	Reason    string
+	CreatedAt time.Time
+	ExpiresAt time.Time
+}
+
+// Entry is a request plus its current state.
+type Entry struct {
+	Request
+	ID        string
+	Status    Status
+	DecidedAt time.Time
+	DecidedBy string
+}
+
+// Outcome is the result of waiting on a request.
+type Outcome struct {
+	ID        string
+	Status    Status
+	DecidedAt time.Time
+	DecidedBy string
+}
+
+// ErrNotFound is returned when no request with the id exists.
+var ErrNotFound = errors.New("approval request not found")
+
+// ErrClosed is returned when the queue is closed.
+var ErrClosed = errors.New("approval queue closed")
+
+// ErrExpired is returned when a wait unblocks because the request expired.
+var ErrExpired = errors.New("approval request expired")
+
+// DefaultTTL is how long a pending request stays open before auto-expiry.
+const DefaultTTL = 5 * time.Minute
+
+// Queue is a thread-safe pending-approval store. Decisions wake waiting
+// agents; expired requests are reaped lazily on access and by ReapExpired.
+type Queue struct {
+	mu       sync.Mutex
+	entries  map[string]*Entry
+	waiters  map[string][]chan Outcome
+	ttl      time.Duration
+	closed   bool
+	notifier chan struct{}
+}
+
+// NewQueue creates a queue with the default TTL.
+func NewQueue() *Queue { return NewQueueWithTTL(DefaultTTL) }
+
+// NewQueueWithTTL creates a queue with a custom request TTL.
+func NewQueueWithTTL(ttl time.Duration) *Queue {
+	if ttl <= 0 {
+		ttl = DefaultTTL
+	}
+	return &Queue{
+		entries:  map[string]*Entry{},
+		waiters:  map[string][]chan Outcome{},
+		ttl:      ttl,
+		notifier: make(chan struct{}, 1),
+	}
+}
+
+// Enqueue adds a request and returns its ID. If TTL is zero on the request,
+// the queue default applies.
+func (q *Queue) Enqueue(r Request) (string, error) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if q.closed {
+		return "", ErrClosed
+	}
+	id, err := randomID()
+	if err != nil {
+		return "", err
+	}
+	now := time.Now().UTC()
+	if r.CreatedAt.IsZero() {
+		r.CreatedAt = now
+	}
+	ttl := q.ttl
+	if !r.ExpiresAt.IsZero() {
+		ttl = r.ExpiresAt.Sub(now)
+		if ttl <= 0 {
+			ttl = q.ttl
+		}
+	}
+	q.entries[id] = &Entry{
+		Request: r,
+		ID:      id,
+		Status:  StatusPending,
+	}
+	q.entries[id].ExpiresAt = now.Add(ttl)
+	q.poke()
+	return id, nil
+}
+
+// Get returns a single entry.
+func (q *Queue) Get(id string) (Entry, error) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.reapLocked()
+	e, ok := q.entries[id]
+	if !ok {
+		return Entry{}, ErrNotFound
+	}
+	return *e, nil
+}
+
+// List returns all entries, pending first, newest first within status.
+func (q *Queue) List() []Entry {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.reapLocked()
+	out := make([]Entry, 0, len(q.entries))
+	for _, e := range q.entries {
+		out = append(out, *e)
+	}
+	// Stable order: pending first, then decided; newest created first.
+	sortEntries(out)
+	return out
+}
+
+// Pending returns only requests still awaiting a decision.
+func (q *Queue) Pending() []Entry {
+	all := q.List()
+	out := make([]Entry, 0, len(all))
+	for _, e := range all {
+		if e.Status == StatusPending {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// Approve decides a request as approved and wakes its waiters.
+func (q *Queue) Approve(id, decidedBy string) (Outcome, error) {
+	return q.decide(id, StatusApproved, decidedBy)
+}
+
+// Deny decides a request as denied and wakes its waiters.
+func (q *Queue) Deny(id, decidedBy string) (Outcome, error) {
+	return q.decide(id, StatusDenied, decidedBy)
+}
+
+func (q *Queue) decide(id string, status Status, decidedBy string) (Outcome, error) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.reapLocked()
+	e, ok := q.entries[id]
+	if !ok {
+		return Outcome{}, ErrNotFound
+	}
+	if e.Status != StatusPending {
+		return Outcome{}, fmt.Errorf("approval request %s already %s", id, e.Status)
+	}
+	now := time.Now().UTC()
+	e.Status = status
+	e.DecidedAt = now
+	e.DecidedBy = decidedBy
+	out := Outcome{ID: id, Status: status, DecidedAt: now, DecidedBy: decidedBy}
+	q.wakeLocked(id, out)
+	q.poke()
+	return out, nil
+}
+
+// Wait blocks until the request is decided, expires, the context is done, or
+// the queue closes. It returns the outcome (StatusExpired on expiry).
+func (q *Queue) Wait(ctx context.Context, id string) (Outcome, error) {
+	ch := make(chan Outcome, 1)
+	q.mu.Lock()
+	if q.closed {
+		q.mu.Unlock()
+		return Outcome{}, ErrClosed
+	}
+	q.reapLocked()
+	e, ok := q.entries[id]
+	if !ok {
+		q.mu.Unlock()
+		return Outcome{}, ErrNotFound
+	}
+	if e.Status != StatusPending {
+		out := Outcome{ID: id, Status: e.Status, DecidedAt: e.DecidedAt, DecidedBy: e.DecidedBy}
+		q.mu.Unlock()
+		return out, nil
+	}
+	// Register the waiter before releasing the lock so a decision racing
+	// with registration still wakes us.
+	q.waiters[id] = append(q.waiters[id], ch)
+	q.mu.Unlock()
+
+	select {
+	case out := <-ch:
+		return out, nil
+	case <-ctx.Done():
+		q.mu.Lock()
+		q.removeWaiterLocked(id, ch)
+		q.mu.Unlock()
+		return Outcome{}, ctx.Err()
+	}
+}
+
+// ReapExpired marks expired pending requests and wakes their waiters. It
+// returns the number of requests expired. Called periodically by the
+// transport layer.
+func (q *Queue) ReapExpired() int {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return q.reapLocked()
+}
+
+func (q *Queue) reapLocked() int {
+	now := time.Now().UTC()
+	expired := 0
+	for id, e := range q.entries {
+		if e.Status == StatusPending && now.After(e.ExpiresAt) {
+			e.Status = StatusExpired
+			e.DecidedAt = e.ExpiresAt
+			out := Outcome{ID: id, Status: StatusExpired, DecidedAt: e.ExpiresAt}
+			q.wakeLocked(id, out)
+			expired++
+		}
+	}
+	if expired > 0 {
+		q.poke()
+	}
+	return expired
+}
+
+// Close shuts the queue down: pending requests become expired, waiters are
+// woken with ErrClosed.
+func (q *Queue) Close() {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if q.closed {
+		return
+	}
+	q.closed = true
+	for id, e := range q.entries {
+		if e.Status == StatusPending {
+			e.Status = StatusExpired
+			e.DecidedAt = time.Now().UTC()
+			q.wakeLocked(id, Outcome{ID: id, Status: StatusExpired, DecidedAt: e.DecidedAt})
+		}
+	}
+	q.poke()
+}
+
+// Notify returns a channel that is signalled whenever the queue state
+// changes (new request, decision, expiry). Used by transports to push
+// updates to approval devices.
+func (q *Queue) Notify() <-chan struct{} { return q.notifier }
+
+func (q *Queue) wakeLocked(id string, out Outcome) {
+	for _, ch := range q.waiters[id] {
+		select {
+		case ch <- out:
+		default:
+		}
+	}
+	q.waiters[id] = nil
+}
+
+func (q *Queue) removeWaiterLocked(id string, ch chan Outcome) {
+	ws := q.waiters[id]
+	for i, w := range ws {
+		if w == ch {
+			q.waiters[id] = append(ws[:i], ws[i+1:]...)
+			return
+		}
+	}
+}
+
+func (q *Queue) poke() {
+	select {
+	case q.notifier <- struct{}{}:
+	default:
+	}
+}
+
+func sortEntries(entries []Entry) {
+	// Pending first; within a status group, newest CreatedAt first; ties by ID.
+	sort.SliceStable(entries, func(i, j int) bool {
+		pi, pj := entries[i].Status == StatusPending, entries[j].Status == StatusPending
+		if pi != pj {
+			return pi
+		}
+		if !entries[i].CreatedAt.Equal(entries[j].CreatedAt) {
+			return entries[i].CreatedAt.After(entries[j].CreatedAt)
+		}
+		return entries[i].ID < entries[j].ID
+	})
+}
+
+func randomID() (string, error) {
+	buf := make([]byte, 6)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("generate approval id: %w", err)
+	}
+	return "apr-" + hex.EncodeToString(buf), nil
+}

--- a/internal/approval/queue_test.go
+++ b/internal/approval/queue_test.go
@@ -1,0 +1,213 @@
+package approval
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestEnqueueListPending(t *testing.T) {
+	q := NewQueue()
+	id, err := q.Enqueue(Request{AgentName: "agent-a", Path: "work/creds", Write: true})
+	if err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	if id == "" {
+		t.Fatal("empty id")
+	}
+	entries := q.Pending()
+	if len(entries) != 1 || entries[0].ID != id || entries[0].Status != StatusPending {
+		t.Fatalf("pending = %+v", entries)
+	}
+}
+
+func TestApproveWakesWaiter(t *testing.T) {
+	q := NewQueue()
+	id, _ := q.Enqueue(Request{AgentName: "a", Path: "p", Write: true})
+
+	done := make(chan Outcome, 1)
+	go func() {
+		out, err := q.Wait(context.Background(), id)
+		if err != nil {
+			done <- Outcome{Status: StatusExpired}
+			return
+		}
+		done <- out
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	out, err := q.Approve(id, "device-1")
+	if err != nil {
+		t.Fatalf("Approve: %v", err)
+	}
+	if out.Status != StatusApproved {
+		t.Fatalf("outcome = %s", out.Status)
+	}
+	select {
+	case got := <-done:
+		if got.Status != StatusApproved {
+			t.Fatalf("waiter outcome = %s", got.Status)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("waiter not woken")
+	}
+}
+
+func TestDenyWakesWaiter(t *testing.T) {
+	q := NewQueue()
+	id, _ := q.Enqueue(Request{AgentName: "a", Path: "p", Write: true})
+	done := make(chan Outcome, 1)
+	go func() {
+		out, _ := q.Wait(context.Background(), id)
+		done <- out
+	}()
+	time.Sleep(50 * time.Millisecond)
+	if _, err := q.Deny(id, "device-1"); err != nil {
+		t.Fatalf("Deny: %v", err)
+	}
+	select {
+	case got := <-done:
+		if got.Status != StatusDenied {
+			t.Fatalf("waiter outcome = %s", got.Status)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("waiter not woken")
+	}
+}
+
+func TestWaitContextCancel(t *testing.T) {
+	q := NewQueue()
+	id, _ := q.Enqueue(Request{AgentName: "a", Path: "p", Write: true})
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	_, err := q.Wait(ctx, id)
+	if err == nil {
+		t.Fatal("expected context error")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("err = %v", err)
+	}
+	if time.Since(start) > time.Second {
+		t.Fatal("wait did not respect context deadline")
+	}
+	// The request must still be pending and decidable after the waiter left.
+	if _, err := q.Approve(id, "device-1"); err != nil {
+		t.Fatalf("approve after waiter cancel: %v", err)
+	}
+}
+
+func TestReapExpired(t *testing.T) {
+	q := NewQueueWithTTL(50 * time.Millisecond)
+	id, _ := q.Enqueue(Request{AgentName: "a", Path: "p", Write: true})
+
+	done := make(chan Outcome, 1)
+	go func() {
+		out, err := q.Wait(context.Background(), id)
+		if err != nil {
+			done <- Outcome{Status: StatusExpired}
+			return
+		}
+		done <- out
+	}()
+
+	time.Sleep(150 * time.Millisecond)
+	n := q.ReapExpired()
+	if n != 1 {
+		t.Fatalf("reaped = %d, want 1", n)
+	}
+	select {
+	case got := <-done:
+		if got.Status != StatusExpired {
+			t.Fatalf("waiter outcome = %s", got.Status)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("expired waiter not woken")
+	}
+	e, err := q.Get(id)
+	if err != nil || e.Status != StatusExpired {
+		t.Fatalf("entry = %+v err %v", e, err)
+	}
+}
+
+func TestDecideTwiceFails(t *testing.T) {
+	q := NewQueue()
+	id, _ := q.Enqueue(Request{AgentName: "a", Path: "p", Write: true})
+	if _, err := q.Approve(id, "d1"); err != nil {
+		t.Fatalf("first approve: %v", err)
+	}
+	if _, err := q.Deny(id, "d2"); err == nil {
+		t.Fatal("second decision should fail")
+	}
+}
+
+func TestNotFound(t *testing.T) {
+	q := NewQueue()
+	if _, err := q.Get("nope"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("err = %v", err)
+	}
+	if _, err := q.Approve("nope", "d"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestListOrderPendingFirst(t *testing.T) {
+	q := NewQueue()
+	first, _ := q.Enqueue(Request{AgentName: "a", Path: "p1", Write: true})
+	second, _ := q.Enqueue(Request{AgentName: "a", Path: "p2", Write: true})
+	if _, err := q.Approve(first, "d"); err != nil {
+		t.Fatal(err)
+	}
+	entries := q.List()
+	if len(entries) != 2 {
+		t.Fatalf("entries = %d", len(entries))
+	}
+	if entries[0].ID != second || entries[0].Status != StatusPending {
+		t.Fatalf("first entry = %+v, want pending second", entries[0])
+	}
+	if entries[1].ID != first || entries[1].Status != StatusApproved {
+		t.Fatalf("second entry = %+v", entries[1])
+	}
+}
+
+func TestNotifyOnChange(t *testing.T) {
+	q := NewQueue()
+	ch := q.Notify()
+	id, _ := q.Enqueue(Request{AgentName: "a", Path: "p", Write: true})
+	select {
+	case <-ch:
+	case <-time.After(2 * time.Second):
+		t.Fatal("no notify on enqueue")
+	}
+	// Drain; the next event is the decision.
+	select {
+	case <-ch:
+	default:
+	}
+	if _, err := q.Approve(id, "d"); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-ch:
+	case <-time.After(2 * time.Second):
+		t.Fatal("no notify on decision")
+	}
+}
+
+func TestCloseExpiresPending(t *testing.T) {
+	q := NewQueue()
+	id, _ := q.Enqueue(Request{AgentName: "a", Path: "p", Write: true})
+	q.Close()
+	e, err := q.Get(id)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if e.Status != StatusExpired {
+		t.Fatalf("status = %s", e.Status)
+	}
+	if _, err := q.Enqueue(Request{AgentName: "b", Path: "q", Write: true}); !errors.Is(err, ErrClosed) {
+		t.Fatalf("enqueue after close err = %v", err)
+	}
+}

--- a/internal/policy/authorizer.go
+++ b/internal/policy/authorizer.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/danieljustus/symaira-vault/internal/approval"
 	"github.com/danieljustus/symaira-vault/internal/audit"
 	"github.com/danieljustus/symaira-vault/internal/authguard"
 	mcp "github.com/danieljustus/symaira-vault/internal/mcp"
@@ -65,6 +66,16 @@ func WithShareStore(store ShareStore) AuthorizerOption {
 	}
 }
 
+// WithApprovalQueue attaches a pending-approval queue. When set and
+// ApprovalMode is "prompt", write requests that need approval are enqueued
+// and the agent call blocks until an approval device decides — instead of
+// degrading to an instant deny. A nil queue preserves the deny behavior.
+func WithApprovalQueue(queue *approval.Queue) AuthorizerOption {
+	return func(a *authorizerImpl) {
+		a.approvalQueue = queue
+	}
+}
+
 // ShareStore defines the interface for share access checking.
 type ShareStore interface {
 	CheckAccess(agentName, path string) (*mcp.ShareGrant, bool)
@@ -72,10 +83,11 @@ type ShareStore interface {
 
 // authorizerImpl implements the Authorizer interface.
 type authorizerImpl struct {
-	config       AuthorizerConfig
-	policyEngine *Engine
-	auditLog     *audit.Logger
-	shareStore   ShareStore
+	config        AuthorizerConfig
+	policyEngine  *Engine
+	auditLog      *audit.Logger
+	shareStore    ShareStore
+	approvalQueue *approval.Queue
 }
 
 // NewAuthorizer creates a new Authorizer with the given configuration and options.
@@ -121,6 +133,12 @@ func (a *authorizerImpl) Authorize(ctx context.Context, path string, write bool,
 	}
 
 	if write && a.RequiresApproval() && !approved {
+		// Approval mode "prompt" with an enrolled approval device: enqueue
+		// and block until the human decides. Mode "deny" (or no device)
+		// keeps the instant-deny behavior.
+		if a.config.ApprovalMode == "prompt" && a.approvalQueue != nil {
+			return a.promptApproval(ctx, path)
+		}
 		a.logAudit(ctx, "approval_required", path, false)
 		metrics.RecordAuthDenial("approval_required", a.config.AgentName)
 		return fmt.Errorf("write to %q requires approval", path)
@@ -131,6 +149,46 @@ func (a *authorizerImpl) Authorize(ctx context.Context, path string, write bool,
 		metrics.RecordApproval(a.config.AgentName, "granted")
 	}
 	return nil
+}
+
+// promptApproval enqueues a pending approval request and waits for the
+// approval device's decision, the request expiry, or the caller context.
+// Every outcome is written to the audit chain.
+func (a *authorizerImpl) promptApproval(ctx context.Context, path string) error {
+	id, err := a.approvalQueue.Enqueue(approval.Request{
+		AgentName: a.config.AgentName,
+		Path:      path,
+		Write:     true,
+		Reason:    "agent write requires approval",
+	})
+	if err != nil {
+		a.logAudit(ctx, "approval_required", path, false)
+		metrics.RecordAuthDenial("approval_required", a.config.AgentName)
+		return fmt.Errorf("write to %q requires approval (queue unavailable)", path)
+	}
+	a.logAudit(ctx, "approval_prompted", path, false)
+
+	outcome, err := a.approvalQueue.Wait(ctx, id)
+	if err != nil {
+		// Context deadline/cancel while waiting: audit as unresolved.
+		a.logAudit(ctx, "approval_timeout", path, false)
+		metrics.RecordAuthDenial("approval_timeout", a.config.AgentName)
+		return fmt.Errorf("write to %q: approval wait interrupted: %w", path, err)
+	}
+	switch outcome.Status {
+	case approval.StatusApproved:
+		a.logAudit(ctx, "approval_granted", path, true)
+		metrics.RecordApproval(a.config.AgentName, "device")
+		return nil
+	case approval.StatusDenied:
+		a.logAudit(ctx, "approval_denied", path, false)
+		metrics.RecordAuthDenial("approval_denied", a.config.AgentName)
+		return fmt.Errorf("write to %q denied by approval device", path)
+	default: // expired
+		a.logAudit(ctx, "approval_expired", path, false)
+		metrics.RecordAuthDenial("approval_expired", a.config.AgentName)
+		return fmt.Errorf("write to %q: approval request expired", path)
+	}
 }
 
 func (a *authorizerImpl) checkPolicy(ctx context.Context, path, actionType string) error {

--- a/internal/policy/authorizer_approval_test.go
+++ b/internal/policy/authorizer_approval_test.go
@@ -1,0 +1,218 @@
+package policy
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/danieljustus/symaira-vault/internal/approval"
+)
+
+// approvalAuthorizer builds an authorizer in prompt mode with an approval
+// queue attached.
+func approvalAuthorizer(t *testing.T) (Authorizer, *approval.Queue) {
+	t.Helper()
+	q := approval.NewQueue()
+	auth := NewAuthorizer(
+		AuthorizerConfig{
+			AgentName:    "test-agent",
+			AllowedPaths: []string{"*"},
+			CanWrite:     true,
+			ApprovalMode: "prompt",
+		},
+		WithApprovalQueue(q),
+	)
+	return auth, q
+}
+
+func TestPromptWithApprovalQueueBlocksAndApproves(t *testing.T) {
+	auth, q := approvalAuthorizer(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- auth.Authorize(ctx, "work/creds", true, false)
+	}()
+
+	// Wait for the request to be enqueued.
+	var id string
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		pending := q.Pending()
+		if len(pending) == 1 {
+			id = pending[0].ID
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if id == "" {
+		t.Fatal("no pending approval request appeared")
+	}
+
+	if _, err := q.Approve(id, "device-1"); err != nil {
+		t.Fatalf("Approve: %v", err)
+	}
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Authorize after approval: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("authorize did not unblock after approval")
+	}
+}
+
+func TestPromptWithApprovalQueueDenies(t *testing.T) {
+	auth, q := approvalAuthorizer(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- auth.Authorize(ctx, "work/creds", true, false)
+	}()
+
+	var id string
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		pending := q.Pending()
+		if len(pending) == 1 {
+			id = pending[0].ID
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if id == "" {
+		t.Fatal("no pending approval request appeared")
+	}
+
+	if _, err := q.Deny(id, "device-1"); err != nil {
+		t.Fatalf("Deny: %v", err)
+	}
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("Authorize should fail after denial")
+		}
+		if !strings.Contains(err.Error(), "denied") {
+			t.Fatalf("err = %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("authorize did not unblock after denial")
+	}
+}
+
+func TestPromptWithApprovalQueueExpires(t *testing.T) {
+	q := approval.NewQueueWithTTL(100 * time.Millisecond)
+	auth := NewAuthorizer(
+		AuthorizerConfig{
+			AgentName:    "test-agent",
+			AllowedPaths: []string{"*"},
+			CanWrite:     true,
+			ApprovalMode: "prompt",
+		},
+		WithApprovalQueue(q),
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- auth.Authorize(ctx, "work/creds", true, false)
+	}()
+
+	// Wait for enqueue, then reap the expiry.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if len(q.Pending()) == 1 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	time.Sleep(150 * time.Millisecond)
+	q.ReapExpired()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("Authorize should fail after expiry")
+		}
+		if !strings.Contains(err.Error(), "expired") {
+			t.Fatalf("err = %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("authorize did not unblock after expiry")
+	}
+}
+
+func TestPromptWithoutQueueDegradesToDeny(t *testing.T) {
+	// No WithApprovalQueue: behavior must be unchanged (instant deny).
+	auth := NewAuthorizer(AuthorizerConfig{
+		AgentName:    "test-agent",
+		AllowedPaths: []string{"*"},
+		CanWrite:     true,
+		ApprovalMode: "prompt",
+	})
+	err := auth.Authorize(context.Background(), "work/creds", true, false)
+	if err == nil {
+		t.Fatal("Authorize should fail without an approval device")
+	}
+	if !strings.Contains(err.Error(), "requires approval") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestDenyModeNeverBlocks(t *testing.T) {
+	// Mode "deny" must not enqueue even with a queue attached.
+	q := approval.NewQueue()
+	auth := NewAuthorizer(
+		AuthorizerConfig{
+			AgentName:    "test-agent",
+			AllowedPaths: []string{"*"},
+			CanWrite:     true,
+			ApprovalMode: "deny",
+		},
+		WithApprovalQueue(q),
+	)
+	err := auth.Authorize(context.Background(), "work/creds", true, false)
+	if err == nil {
+		t.Fatal("deny mode should fail")
+	}
+	if len(q.Pending()) != 0 {
+		t.Fatalf("deny mode enqueued: %+v", q.Pending())
+	}
+}
+
+func TestApprovedFlagSkipsQueue(t *testing.T) {
+	auth, q := approvalAuthorizer(t)
+	// An already-approved call must not enqueue or block.
+	if err := auth.Authorize(context.Background(), "work/creds", true, true); err != nil {
+		t.Fatalf("authorize with approved: %v", err)
+	}
+	if len(q.Pending()) != 0 {
+		t.Fatalf("approved call enqueued: %+v", q.Pending())
+	}
+}
+
+func TestApprovalWaitContextTimeoutAudits(t *testing.T) {
+	auth, q := approvalAuthorizer(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	err := auth.Authorize(ctx, "work/creds", true, false)
+	if err == nil {
+		t.Fatal("expected error on context timeout")
+	}
+	// The request remains pending and decidable for the device.
+	if len(q.Pending()) != 1 {
+		t.Fatalf("pending = %+v", q.Pending())
+	}
+	_ = errors.Is(err, context.DeadlineExceeded)
+}


### PR DESCRIPTION
Go-core substrate for #871: the pending-request queue that lets an enrolled approval device decide agent credential requests out-of-band.

## What
- `internal/approval`: thread-safe pending-approval queue with TTL expiry, waiter wake-ups on decision, change notifier, and clean Close.
- Authorizer `WithApprovalQueue`: in approval mode `prompt`, a write request needing approval is enqueued and the agent call blocks until the device approves, denies, or the request expires — instead of degrading to an instant deny.
- Every outcome (prompted/granted/denied/expired/timeout) is written to the audit chain and metrics.
- Behavior unchanged without a queue and in mode `deny` (instant deny, nothing enqueued); an already-approved call never enqueues.

## Verified
- `internal/approval`: 11 tests (enqueue/list, approve/deny wake waiters, context cancel, expiry reap, double-decision, not-found, ordering, notify, close).
- `internal/policy`: 7 new tests (approve/deny/expire unblock the agent, no-queue degrade, deny-mode no-enqueue, approved-flag skip, context-timeout).
- `go test -race` green; make lint 0 issues.

## Remaining for #871
- Transport + mobile UI (pairing channel / HTTP endpoint, Face ID approve UI) — device work, separate PR.
- ADR 0006 D6 wiring of the queue into the MCP serve path.

Refs #871