### PR TITLE
feat(approval): HTTP transport for approval devices on the MCP server

### DIFF
--- a/cmd/mcp/serve_deps.go
+++ b/cmd/mcp/serve_deps.go
@@ -16,20 +16,41 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/danieljustus/symaira-vault/internal/approval"
 	"github.com/danieljustus/symaira-vault/internal/config"
 	errorspkg "github.com/danieljustus/symaira-vault/internal/errors"
 	server "github.com/danieljustus/symaira-vault/internal/mcp/server"
 	"github.com/danieljustus/symaira-vault/internal/mcp/serverbootstrap"
+	"github.com/danieljustus/symaira-vault/internal/pairing"
 	"github.com/danieljustus/symaira-vault/internal/ui/cliout"
 	vaultpkg "github.com/danieljustus/symaira-vault/internal/vault"
 )
 
-var RunStdioServerFunc = func(ctx context.Context, vault *vaultpkg.Vault, agentName string) error {
-	return serverbootstrap.RunStdioServer(ctx, vault, agentName, server.New)
+// newServerWithApproval builds an MCP server and attaches the shared
+// approval queue, so approval mode "prompt" blocks on a device decision.
+func newServerWithApproval(v *vaultpkg.Vault, agentName, transport string) (*server.Server, error) {
+	srv, err := server.New(v, agentName, transport)
+	if err != nil {
+		return nil, err
+	}
+	srv.AttachApprovalQueue(ApprovalQueue)
+	return srv, nil
 }
+
+var RunStdioServerFunc = func(ctx context.Context, vault *vaultpkg.Vault, agentName string) error {
+	return serverbootstrap.RunStdioServer(ctx, vault, agentName, newServerWithApproval)
+}
+
+// ApprovalQueue is the shared pending-approval queue for the serve process.
+// It backs approval mode "prompt" (authorizer blocks until a paired device
+// decides) and is exposed to devices via the /api/v1/approvals transport.
+var ApprovalQueue = approval.NewQueue()
+
 var RunHTTPServerFunc = func(ctx context.Context, bind string, port int, vault *vaultpkg.Vault) error {
 	vaultDir, _ := cli.VaultPath()
-	return serverbootstrap.RunHTTPServer(ctx, bind, port, vault, vaultDir, Version, server.New)
+	approvalHandler := approval.NewHTTPHandler(ApprovalQueue, approval.NewPairingTokenValidator(pairing.NewTokenStore()))
+	return serverbootstrap.RunHTTPServer(ctx, bind, port, vault, vaultDir, Version, newServerWithApproval,
+		serverbootstrap.WithApprovalAPI(approvalHandler))
 }
 var FindAvailablePortFunc = cli.FindAvailablePort
 

--- a/internal/approval/http.go
+++ b/internal/approval/http.go
@@ -1,0 +1,145 @@
+// Package approval provides the HTTP transport for the pending-approval
+// queue: an enrolled approval device (mobile client) lists pending agent
+// requests and approves/denies them. Requests are authenticated with a
+// pairing token from the device enrolment, so only a paired device can
+// decide.
+package approval
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/danieljustus/symaira-vault/internal/pairing"
+)
+
+// HTTP paths served by the approval transport.
+const (
+	PathApprovals      = "/api/v1/approvals"
+	PathApprovalAction = "/api/v1/approvals/"
+)
+
+// tokenValidator is the minimal pairing-token surface the handler needs.
+type tokenValidator interface {
+	Validate(token string) (string, bool)
+}
+
+// HTTPHandler exposes the approval queue over HTTP for enrolled devices.
+type HTTPHandler struct {
+	queue  *Queue
+	tokens tokenValidator
+}
+
+// NewHTTPHandler creates the approval API handler. tokens validates device
+// pairing tokens (nil disables the device auth gate for tests/embedders).
+func NewHTTPHandler(queue *Queue, tokens tokenValidator) *HTTPHandler {
+	return &HTTPHandler{queue: queue, tokens: tokens}
+}
+
+// ServeHTTP dispatches the approval API endpoints.
+func (h *HTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	path := r.URL.Path
+	switch {
+	case r.Method == http.MethodGet && path == PathApprovals:
+		h.list(w, r)
+	case r.Method == http.MethodPost && strings.HasPrefix(path, PathApprovalAction):
+		h.decide(w, r)
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+// deviceFromRequest validates the bearer token and returns the paired device
+// id, or an empty string when unauthorized.
+func (h *HTTPHandler) deviceFromRequest(r *http.Request) string {
+	if h.tokens == nil {
+		return "test-device"
+	}
+	authz := r.Header.Get("Authorization")
+	token := strings.TrimPrefix(authz, "Bearer ")
+	if token == "" || token == authz {
+		return ""
+	}
+	deviceID, ok := h.tokens.Validate(token)
+	if !ok {
+		return ""
+	}
+	return deviceID
+}
+
+func (h *HTTPHandler) list(w http.ResponseWriter, r *http.Request) {
+	if h.deviceFromRequest(r) == "" {
+		writeApprovalError(w, http.StatusUnauthorized, "unauthorized: valid device token required")
+		return
+	}
+	entries := h.queue.Pending()
+	writeApprovalJSON(w, http.StatusOK, map[string]any{
+		"requests": entries,
+	})
+}
+
+func (h *HTTPHandler) decide(w http.ResponseWriter, r *http.Request) {
+	deviceID := h.deviceFromRequest(r)
+	if deviceID == "" {
+		writeApprovalError(w, http.StatusUnauthorized, "unauthorized: valid device token required")
+		return
+	}
+	id := strings.TrimPrefix(r.URL.Path, PathApprovalAction)
+	id = strings.TrimSuffix(id, "/")
+	if id == "" {
+		writeApprovalError(w, http.StatusBadRequest, "missing approval request id")
+		return
+	}
+
+	var out Outcome
+	var err error
+	switch {
+	case strings.HasSuffix(id, "/approve"):
+		base := strings.TrimSuffix(id, "/approve")
+		out, err = h.queue.Approve(base, deviceID)
+	case strings.HasSuffix(id, "/deny"):
+		base := strings.TrimSuffix(id, "/deny")
+		out, err = h.queue.Deny(base, deviceID)
+	default:
+		writeApprovalError(w, http.StatusNotFound, "unknown approval action")
+		return
+	}
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			writeApprovalError(w, http.StatusNotFound, err.Error())
+			return
+		}
+		writeApprovalError(w, http.StatusConflict, err.Error())
+		return
+	}
+	writeApprovalJSON(w, http.StatusOK, map[string]any{
+		"outcome": out,
+	})
+}
+
+func writeApprovalJSON(w http.ResponseWriter, status int, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	//nolint:errchkjson // response payloads are fixed structs/maps; best-effort write
+	_ = json.NewEncoder(w).Encode(payload)
+}
+
+func writeApprovalError(w http.ResponseWriter, status int, message string) {
+	writeApprovalJSON(w, status, map[string]any{"error": message})
+}
+
+// pairingTokenStore adapts *pairing.TokenStore to tokenValidator.
+type pairingTokenStore struct{ store *pairing.TokenStore }
+
+// NewPairingTokenValidator wraps a pairing token store as a validator.
+func NewPairingTokenValidator(store *pairing.TokenStore) tokenValidator {
+	if store == nil {
+		return nil
+	}
+	return &pairingTokenStore{store: store}
+}
+
+func (p *pairingTokenStore) Validate(token string) (string, bool) {
+	return p.store.Validate(token)
+}

--- a/internal/approval/http_test.go
+++ b/internal/approval/http_test.go
@@ -1,0 +1,165 @@
+package approval
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// fakeTokens implements tokenValidator for tests.
+type fakeTokens struct{ valid map[string]string }
+
+func (f *fakeTokens) Validate(token string) (string, bool) {
+	id, ok := f.valid[token]
+	return id, ok
+}
+
+func TestListRequiresDeviceToken(t *testing.T) {
+	q := NewQueue()
+	h := NewHTTPHandler(q, &fakeTokens{valid: map[string]string{"tok-1": "device-1"}})
+
+	req := httptest.NewRequest(http.MethodGet, PathApprovals, nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rec.Code)
+	}
+}
+
+func TestListReturnsPending(t *testing.T) {
+	q := NewQueue()
+	h := NewHTTPHandler(q, &fakeTokens{valid: map[string]string{"tok-1": "device-1"}})
+	if _, err := q.Enqueue(Request{AgentName: "agent-a", Path: "work/creds", Write: true, Reason: "test"}); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, PathApprovals, nil)
+	req.Header.Set("Authorization", "Bearer tok-1")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body %s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Requests []Entry `json:"requests"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Requests) != 1 || resp.Requests[0].AgentName != "agent-a" {
+		t.Fatalf("requests = %+v", resp.Requests)
+	}
+	if resp.Requests[0].Path != "work/creds" {
+		t.Fatalf("path = %q", resp.Requests[0].Path)
+	}
+}
+
+func TestApproveWakesAndRecordsDevice(t *testing.T) {
+	q := NewQueue()
+	h := NewHTTPHandler(q, &fakeTokens{valid: map[string]string{"tok-1": "device-1"}})
+	id, _ := q.Enqueue(Request{AgentName: "agent-a", Path: "p", Write: true})
+
+	req := httptest.NewRequest(http.MethodPost, PathApprovalAction+id+"/approve", nil)
+	req.Header.Set("Authorization", "Bearer tok-1")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body %s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Outcome Outcome `json:"outcome"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Outcome.Status != StatusApproved {
+		t.Fatalf("outcome = %s", resp.Outcome.Status)
+	}
+	if resp.Outcome.DecidedBy != "device-1" {
+		t.Fatalf("decided_by = %q", resp.Outcome.DecidedBy)
+	}
+}
+
+func TestDenyRecordsDevice(t *testing.T) {
+	q := NewQueue()
+	h := NewHTTPHandler(q, &fakeTokens{valid: map[string]string{"tok-1": "device-1"}})
+	id, _ := q.Enqueue(Request{AgentName: "agent-a", Path: "p", Write: true})
+
+	req := httptest.NewRequest(http.MethodPost, PathApprovalAction+id+"/deny", nil)
+	req.Header.Set("Authorization", "Bearer tok-1")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	var resp struct {
+		Outcome Outcome `json:"outcome"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Outcome.Status != StatusDenied || resp.Outcome.DecidedBy != "device-1" {
+		t.Fatalf("outcome = %+v", resp.Outcome)
+	}
+}
+
+func TestUnknownActionAndMissingID(t *testing.T) {
+	q := NewQueue()
+	h := NewHTTPHandler(q, &fakeTokens{valid: map[string]string{"tok-1": "device-1"}})
+
+	req := httptest.NewRequest(http.MethodPost, PathApprovalAction+"nonexistent/approve", nil)
+	req.Header.Set("Authorization", "Bearer tok-1")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+
+	req2 := httptest.NewRequest(http.MethodPost, PathApprovalAction, nil)
+	req2.Header.Set("Authorization", "Bearer tok-1")
+	rec2 := httptest.NewRecorder()
+	h.ServeHTTP(rec2, req2)
+	if rec2.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 (missing id)", rec2.Code)
+	}
+}
+
+func TestDoubleDecisionConflict(t *testing.T) {
+	q := NewQueue()
+	h := NewHTTPHandler(q, &fakeTokens{valid: map[string]string{"tok-1": "device-1"}})
+	id, _ := q.Enqueue(Request{AgentName: "agent-a", Path: "p", Write: true})
+
+	decide := func() int {
+		req := httptest.NewRequest(http.MethodPost, PathApprovalAction+id+"/approve", nil)
+		req.Header.Set("Authorization", "Bearer tok-1")
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		return rec.Code
+	}
+	if code := decide(); code != http.StatusOK {
+		t.Fatalf("first = %d", code)
+	}
+	if code := decide(); code != http.StatusConflict {
+		t.Fatalf("second = %d, want 409", code)
+	}
+}
+
+func TestRejectsMalformedAuthorization(t *testing.T) {
+	q := NewQueue()
+	h := NewHTTPHandler(q, &fakeTokens{valid: map[string]string{"tok-1": "device-1"}})
+	id, _ := q.Enqueue(Request{AgentName: "a", Path: "p", Write: true})
+
+	// "Bearer" without a token must be rejected.
+	req := httptest.NewRequest(http.MethodPost, PathApprovalAction+id+"/approve", nil)
+	req.Header.Set("Authorization", "Bearer ")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401 (body: %s)", rec.Code, strings.TrimSpace(rec.Body.String()))
+	}
+}

--- a/internal/mcp/server/server.go
+++ b/internal/mcp/server/server.go
@@ -85,6 +85,9 @@ type Server struct {
 	tools        []toolDefinition // per-instance tool set, populated from global registry
 
 	authorizer policy.Authorizer
+	// authorizerConfig is retained so an approval queue can be attached
+	// after construction (AttachApprovalQueue).
+	authorizerConfig policy.AuthorizerConfig
 
 	approvalCache      *approvalCache
 	approvalKeyCounter atomic.Int64
@@ -223,6 +226,7 @@ func New(v *vault.Vault, agentName string, transport string) (*Server, error) {
 		}(),
 		RedactFields: agent.RedactFields,
 	}
+	srv.authorizerConfig = authorizerConfig
 	srv.authorizer = policy.NewAuthorizer(authorizerConfig,
 		policy.WithPolicyEngine(policyEngine),
 		policy.WithAuditLog(auditLog),

--- a/internal/mcp/server/server_approval.go
+++ b/internal/mcp/server/server_approval.go
@@ -1,0 +1,27 @@
+package server
+
+import (
+	"github.com/danieljustus/symaira-vault/internal/approval"
+	"github.com/danieljustus/symaira-vault/internal/policy"
+)
+
+// AttachApprovalQueue wires a pending-approval queue into this server's
+// authorizer. In approval mode "prompt" the authorizer then enqueues write
+// requests and blocks until an enrolled approval device decides, instead of
+// degrading to an instant deny. Call once during server bootstrap, before
+// handling requests.
+func (s *Server) AttachApprovalQueue(queue *approval.Queue) {
+	if s == nil || queue == nil {
+		return
+	}
+	opts := []policy.AuthorizerOption{
+		policy.WithApprovalQueue(queue),
+	}
+	if s.policyEngine != nil {
+		opts = append(opts, policy.WithPolicyEngine(s.policyEngine))
+	}
+	if s.auditLog != nil {
+		opts = append(opts, policy.WithAuditLog(s.auditLog))
+	}
+	s.authorizer = policy.NewAuthorizer(s.authorizerConfig, opts...)
+}

--- a/internal/mcp/server/server_approval_test.go
+++ b/internal/mcp/server/server_approval_test.go
@@ -1,0 +1,136 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/danieljustus/symaira-vault/internal/approval"
+	"github.com/danieljustus/symaira-vault/internal/config"
+	"github.com/danieljustus/symaira-vault/internal/vault"
+)
+
+// deviceTokens is a test tokenValidator.
+type deviceTokens struct{ valid map[string]string }
+
+func (d *deviceTokens) Validate(token string) (string, bool) {
+	id, ok := d.valid[token]
+	return id, ok
+}
+
+// TestAttachApprovalQueueBlocksUntilDeviceDecides exercises the full loop:
+// server authorizer (prompt mode) enqueues → device lists → device approves →
+// the blocked authorize call returns nil.
+func TestAttachApprovalQueueBlocksUntilDeviceDecides(t *testing.T) {
+	dir := t.TempDir()
+	canWrite := true
+	approvalMode := "prompt"
+	identity, err := vault.InitWithPassphrase(dir, []byte("test-passphrase-123"), &config.Config{
+		Vault: &config.VaultConfig{FormatVersion: 2},
+		Agents: map[string]config.AgentProfile{
+			"approval-agent": {
+				Name:         "approval-agent",
+				AllowedPaths: []string{"*"},
+				CanWrite:     &canWrite,
+				ApprovalMode: &approvalMode,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("init vault: %v", err)
+	}
+	v, err := vault.Open(dir, identity)
+	if err != nil {
+		t.Fatalf("open vault: %v", err)
+	}
+
+	srv, err := New(v, "approval-agent", "test")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	q := approval.NewQueue()
+	srv.AttachApprovalQueue(q)
+	tokens := &deviceTokens{valid: map[string]string{"device-token-1": "device-1"}}
+	handler := approval.NewHTTPHandler(q, tokens)
+
+	// The agent (authorizer) attempts a write that requires approval.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	done := make(chan error, 1)
+	go func() {
+		done <- srv.authorizer.Authorize(ctx, "work/creds", true, false)
+	}()
+
+	// The device lists pending requests.
+	var reqID string
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		pending := q.Pending()
+		if len(pending) == 1 {
+			reqID = pending[0].ID
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if reqID == "" {
+		t.Fatal("no pending request appeared")
+	}
+
+	listReq := httptest.NewRequest(http.MethodGet, approval.PathApprovals, nil)
+	listReq.Header.Set("Authorization", "Bearer device-token-1")
+	listRec := httptest.NewRecorder()
+	handler.ServeHTTP(listRec, listReq)
+	if listRec.Code != http.StatusOK {
+		t.Fatalf("list status = %d: %s", listRec.Code, listRec.Body.String())
+	}
+	var listResp struct {
+		Requests []approval.Entry `json:"requests"`
+	}
+	if err := json.Unmarshal(listRec.Body.Bytes(), &listResp); err != nil {
+		t.Fatalf("decode list: %v", err)
+	}
+	if len(listResp.Requests) != 1 || listResp.Requests[0].Path != "work/creds" {
+		t.Fatalf("requests = %+v", listResp.Requests)
+	}
+
+	// Device approves via the transport.
+	approveReq := httptest.NewRequest(http.MethodPost, approval.PathApprovalAction+reqID+"/approve", nil)
+	approveReq.Header.Set("Authorization", "Bearer device-token-1")
+	approveRec := httptest.NewRecorder()
+	handler.ServeHTTP(approveRec, approveReq)
+	if approveRec.Code != http.StatusOK {
+		t.Fatalf("approve status = %d: %s", approveRec.Code, approveRec.Body.String())
+	}
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("authorize after device approval: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("authorize did not unblock")
+	}
+}
+
+func TestApprovalTransportRejectsUnknownDevice(t *testing.T) {
+	q := approval.NewQueue()
+	handler := approval.NewHTTPHandler(q, &deviceTokens{valid: map[string]string{"ok": "device-1"}})
+
+	req := httptest.NewRequest(http.MethodGet, approval.PathApprovals, nil)
+	req.Header.Set("Authorization", "Bearer nope")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "device token") {
+		t.Fatalf("body = %s", rec.Body.String())
+	}
+}
+
+func boolPtr(b bool) *bool { return &b }

--- a/internal/mcp/serverbootstrap/http.go
+++ b/internal/mcp/serverbootstrap/http.go
@@ -16,6 +16,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/danieljustus/symaira-vault/internal/approval"
 	auth "github.com/danieljustus/symaira-vault/internal/mcp/auth"
 	mcpserver "github.com/danieljustus/symaira-vault/internal/mcp/server"
 	transport "github.com/danieljustus/symaira-vault/internal/mcp/transport"
@@ -32,21 +33,42 @@ var bufferPool = sync.Pool{
 	},
 }
 
+// serverOptions carries optional extensions for the HTTP server.
+type serverOptions struct {
+	approvalHandler http.Handler
+}
+
+// HTTPServerOption configures an optional extension of the HTTP server.
+type HTTPServerOption func(*serverOptions)
+
+// WithApprovalAPI mounts the device-approval transport (internal/approval)
+// under /api/v1/approvals on the MCP HTTP server, so an enrolled approval
+// device can list pending agent requests and approve/deny them.
+func WithApprovalAPI(handler http.Handler) HTTPServerOption {
+	return func(o *serverOptions) {
+		o.approvalHandler = handler
+	}
+}
+
 // RunHTTPServer starts the HTTP MCP server.
-func RunHTTPServer(ctx context.Context, bind string, port int, v *vaultpkg.Vault, vaultDir string, version string, factory func(*vaultpkg.Vault, string, string) (*mcpserver.Server, error)) error {
+func RunHTTPServer(ctx context.Context, bind string, port int, v *vaultpkg.Vault, vaultDir string, version string, factory func(*vaultpkg.Vault, string, string) (*mcpserver.Server, error), opts ...HTTPServerOption) error {
 	addr := net.JoinHostPort(bind, strconv.Itoa(port))
 	listener, err := net.Listen("tcp", addr)
 	if err != nil {
 		return err
 	}
-	return RunHTTPServerOnListener(ctx, listener, v, vaultDir, version, factory)
+	return RunHTTPServerOnListener(ctx, listener, v, vaultDir, version, factory, opts...)
 }
 
 // RunHTTPServerOnListener starts the HTTP MCP server on an already-bound listener.
 // Tests and embedders can use this to bind :0 safely without a find-free-port race.
 //
 //nolint:gocyclo // Complex server initialization: auth, middleware, metrics, graceful shutdown
-func RunHTTPServerOnListener(ctx context.Context, listener net.Listener, v *vaultpkg.Vault, vaultDir string, version string, factory func(*vaultpkg.Vault, string, string) (*mcpserver.Server, error)) error {
+func RunHTTPServerOnListener(ctx context.Context, listener net.Listener, v *vaultpkg.Vault, vaultDir string, version string, factory func(*vaultpkg.Vault, string, string) (*mcpserver.Server, error), opts ...HTTPServerOption) error {
+	var options serverOptions
+	for _, opt := range opts {
+		opt(&options)
+	}
 	bind, port := listenerAddress(listener)
 	otlpEndpoint := ""
 	if v != nil && v.Config != nil && v.Config.MCP != nil {
@@ -258,6 +280,13 @@ func RunHTTPServerOnListener(ctx context.Context, listener net.Listener, v *vaul
 		mcpChain = auth.RateLimiterMiddleware(rateLimiter, mcpChain)
 	}
 	mux.Handle("/mcp", mcpChain)
+
+	// Device approval transport (optional): mounted when an approval queue
+	// and device-token validator are wired in by the caller.
+	if options.approvalHandler != nil {
+		mux.Handle(approval.PathApprovals, options.approvalHandler)
+		mux.Handle(approval.PathApprovalAction, options.approvalHandler)
+	}
 
 	timeouts := resolveServerTimeouts(v)
 	shutdownTimeout := timeouts.shutdown


### PR DESCRIPTION
Device-facing approval transport for #871, wired into the serve process.

## What
- `internal/approval` HTTP handler: `GET /api/v1/approvals` lists pending agent requests; `POST /api/v1/approvals/<id>/approve|deny` records the decision (device id captured). Authenticated via pairing device token; unauthorized requests rejected.
- `serverbootstrap.WithApprovalAPI` mounts the transport on the MCP HTTP server (optional, runs when an approval queue is wired in).
- Serve process: shared `ApprovalQueue` singleton; `newServerWithApproval` attaches it to the MCP authorizer so approval mode `prompt` blocks on a device decision instead of degrading to deny; the queue is exposed via the HTTP transport.

## Verified
- Queue/HTTP unit tests (auth rejection, list, approve/deny, double-decision conflict, malformed auth).
- Server-level E2E: authorizer (prompt) blocks → device lists via HTTP → device approves → blocked authorize returns nil.
- Full package tests green (`go test` on approval, policy, mcp/server, serverbootstrap, cmd/mcp); make lint 0.

## Remaining for #871
- Mobile UI (Face ID approve screen, pending-request list) — device-side work.
- Persistent device-token provisioning from the vault device registry (the transport is wired to a pairing TokenStore; provisioning the store from the registry is part of the device work).

Refs #871