### PR TITLE
perf(broker): evict expired leaf certificates

### DIFF
--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -169,6 +169,33 @@ func TestCA_LeafForIPHost(t *testing.T) {
 	}
 }
 
+func TestCA_LeafForHostSweepsExpiredEntries(t *testing.T) {
+	ca, err := NewCA()
+	if err != nil {
+		t.Fatalf("NewCA: %v", err)
+	}
+	now := time.Now()
+	ca.now = func() time.Time { return now }
+
+	if _, err := ca.LeafForHost("expired.example.com"); err != nil {
+		t.Fatalf("LeafForHost: %v", err)
+	}
+	if len(ca.leaves) != 1 {
+		t.Fatalf("leaf cache size = %d, want 1", len(ca.leaves))
+	}
+
+	now = now.Add(leafTTL + time.Second)
+	if _, err := ca.LeafForHost("fresh.example.com"); err != nil {
+		t.Fatalf("LeafForHost after expiry: %v", err)
+	}
+	if _, ok := ca.leaves["expired.example.com"]; ok {
+		t.Fatal("expired leaf remained in cache after an insertion")
+	}
+	if len(ca.leaves) != 1 {
+		t.Fatalf("leaf cache size after sweep = %d, want 1", len(ca.leaves))
+	}
+}
+
 func TestProxy_PlainHTTPInjection(t *testing.T) {
 	const token = "broker-token-1"
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/broker/ca.go
+++ b/internal/broker/ca.go
@@ -31,7 +31,7 @@ const (
 
 // CA is an ephemeral leaf-signing certificate authority. It generates a
 // self-signed CA on start and mints per-host leaf certificates with a bounded
-// TTL, cached in an LRU map keyed by hostname.
+// TTL. Expired cached leaves are swept whenever a new leaf is inserted.
 type CA struct {
 	mu     sync.Mutex
 	caCert *x509.Certificate
@@ -90,15 +90,27 @@ func (c *CA) LeafForHost(host string) (*tls.Certificate, error) {
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if entry, ok := c.leaves[host]; ok && c.now().Before(entry.exp) {
+	now := c.now()
+	if entry, ok := c.leaves[host]; ok && now.Before(entry.exp) {
 		return entry.cert, nil
 	}
+	c.sweepExpiredLocked(now)
 	cert, err := c.mintLeaf(host)
 	if err != nil {
 		return nil, err
 	}
-	c.leaves[host] = leafEntry{cert: cert, exp: c.now().Add(leafTTL)}
+	c.leaves[host] = leafEntry{cert: cert, exp: now.Add(leafTTL)}
 	return cert, nil
+}
+
+// sweepExpiredLocked releases expired leaves and their private keys. The
+// caller must hold c.mu.
+func (c *CA) sweepExpiredLocked(now time.Time) {
+	for host, entry := range c.leaves {
+		if !now.Before(entry.exp) {
+			delete(c.leaves, host)
+		}
+	}
 }
 
 // CertPEM returns the CA certificate in PEM form, for export via


### PR DESCRIPTION
## Summary
- sweep expired leaf certificates before inserting a fresh host entry
- update the CA documentation to describe the implemented expiry cleanup
- add a deterministic regression test proving expired entries are released

## Verification
- focused CA tests passed
- full `internal/broker` package tests passed
- `git diff --check` passed

Closes #919
