### PR TITLE
security(mcp): validate Perplexity BaseURL against SSRF

### DIFF
--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -94,6 +94,7 @@ type PerplexityConfig struct {
 	APIKey          string `yaml:"api_key,omitempty"`
 	BaseURL         string `yaml:"base_url,omitempty"`
 	RateLimitPerMin int    `yaml:"rate_limit_per_min,omitempty"`
+	AllowPrivate    bool   `yaml:"allow_private,omitempty"`
 }
 
 // MCPConfig holds MCP server-related configuration for AI agent integration.
@@ -433,6 +434,9 @@ func MergeFromMCP(dst *MCPConfig, src MCPConfig) {
 		}
 		if src.Perplexity.RateLimitPerMin > 0 {
 			dst.Perplexity.RateLimitPerMin = src.Perplexity.RateLimitPerMin
+		}
+		if src.Perplexity.AllowPrivate {
+			dst.Perplexity.AllowPrivate = true
 		}
 	}
 }

--- a/internal/mcp/server/tools_perplexity.go
+++ b/internal/mcp/server/tools_perplexity.go
@@ -6,13 +6,16 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
 
 	mcp "github.com/danieljustus/symaira-vault/internal/mcp"
 	"github.com/danieljustus/symaira-vault/internal/metrics"
+	"github.com/danieljustus/symaira-vault/internal/ssrf"
 	vaultpkg "github.com/danieljustus/symaira-vault/internal/vault"
 )
 
@@ -25,6 +28,8 @@ const (
 	perplexityMaxTokens        = 2048
 	perplexityAPIKeyEntry      = "perplexity"
 )
+
+var newPerplexityHTTPClient = ssrf.NewHTTPClient
 
 type perplexityRateLimiter struct {
 	mu      sync.Mutex
@@ -120,6 +125,14 @@ func (s *Server) getPerplexityBaseURL() string {
 	return perplexityDefaultBaseURL
 }
 
+func (s *Server) getPerplexityAllowPrivate() bool {
+	if s.vault != nil && s.vault.Config != nil && s.vault.Config.MCP != nil &&
+		s.vault.Config.MCP.Perplexity != nil {
+		return s.vault.Config.MCP.Perplexity.AllowPrivate
+	}
+	return false
+}
+
 func (s *Server) getPerplexityRateLimit() int {
 	if s.vault != nil && s.vault.Config != nil && s.vault.Config.MCP != nil &&
 		s.vault.Config.MCP.Perplexity != nil && s.vault.Config.MCP.Perplexity.RateLimitPerMin > 0 {
@@ -128,10 +141,23 @@ func (s *Server) getPerplexityRateLimit() int {
 	return perplexityDefaultRateLimit
 }
 
-func (s *Server) callPerplexityChat(ctx context.Context, apiKey, baseURL, model string, messages []perplexityMessage) (*perplexityChatResponse, error) {
+func (s *Server) callPerplexityChat(ctx context.Context, apiKey, baseURL, model string, messages []perplexityMessage, allowPrivate bool) (*perplexityChatResponse, error) {
 	rateLimit := s.getPerplexityRateLimit()
 	if !globalPerplexityRL.Allow(rateLimit) {
 		return nil, fmt.Errorf("perplexity rate limit exceeded: max %d requests per minute", rateLimit)
+	}
+
+	// Validate the resolved BaseURL before constructing any Authorization
+	// header or sending a request. This is the SSRF-hardened entry point.
+	parsedURL, err := url.Parse(baseURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid perplexity base URL: %w", err)
+	}
+	if parsedURL.Scheme != "https" {
+		return nil, fmt.Errorf("perplexity base URL must use HTTPS, got %q", parsedURL.Scheme)
+	}
+	if targetErr := ssrf.ValidateURL(ctx, baseURL, allowPrivate, net.DefaultResolver.LookupIPAddr); targetErr != nil {
+		return nil, targetErr
 	}
 
 	reqBody := perplexityChatRequest{
@@ -153,7 +179,7 @@ func (s *Server) callPerplexityChat(ctx context.Context, apiKey, baseURL, model 
 	httpReq.Header.Set("Authorization", "Bearer "+apiKey)
 	httpReq.Header.Set("Accept", "application/json")
 
-	client := &http.Client{Timeout: perplexityDefaultTimeout * time.Second}
+	client := newPerplexityHTTPClient(time.Duration(perplexityDefaultTimeout)*time.Second, allowPrivate)
 	resp, err := client.Do(httpReq)
 	if err != nil {
 		return nil, fmt.Errorf("perplexity API call failed: %w", err)
@@ -191,13 +217,14 @@ func (s *Server) handlePerplexitySearch(ctx context.Context, req mcp.CallToolReq
 	}
 
 	baseURL := s.getPerplexityBaseURL()
+	allowPrivate := s.getPerplexityAllowPrivate()
 
 	messages := []perplexityMessage{
 		{Role: "system", Content: "You are a search assistant. Synthesize search results for the user's query. Provide accurate, up-to-date information with citations where applicable. Be concise and direct."},
 		{Role: "user", Content: query},
 	}
 
-	resp, apiErr := s.callPerplexityChat(ctx, apiKey, baseURL, perplexityDefaultModel, messages)
+	resp, apiErr := s.callPerplexityChat(ctx, apiKey, baseURL, perplexityDefaultModel, messages, allowPrivate)
 	if apiErr != nil {
 		s.logAudit(ctx, "perplexity_search", fmt.Sprintf("query=%q, error=%v", query, apiErr), false)
 		metrics.RecordMCPRequest("perplexity_search", s.agent.Name, "error", 0)
@@ -244,6 +271,7 @@ func (s *Server) handlePerplexityAsk(ctx context.Context, req mcp.CallToolReques
 	}
 
 	baseURL := s.getPerplexityBaseURL()
+	allowPrivate := s.getPerplexityAllowPrivate()
 	contextEntries := req.GetString("context", "")
 
 	systemPrompt := "You are a helpful AI assistant. Answer the user's question clearly and accurately. Provide citations for your answers where applicable."
@@ -263,7 +291,7 @@ func (s *Server) handlePerplexityAsk(ctx context.Context, req mcp.CallToolReques
 		{Role: "user", Content: userMessage},
 	}
 
-	resp, apiErr := s.callPerplexityChat(ctx, apiKey, baseURL, perplexityDefaultModel, messages)
+	resp, apiErr := s.callPerplexityChat(ctx, apiKey, baseURL, perplexityDefaultModel, messages, allowPrivate)
 	if apiErr != nil {
 		s.logAudit(ctx, "perplexity_ask", fmt.Sprintf("question=%q, error=%v", question, apiErr), false)
 		metrics.RecordMCPRequest("perplexity_ask", s.agent.Name, "error", 0)

--- a/internal/mcp/server/tools_perplexity_test.go
+++ b/internal/mcp/server/tools_perplexity_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -13,11 +14,12 @@ import (
 
 	"github.com/danieljustus/symaira-vault/internal/config"
 	mcp "github.com/danieljustus/symaira-vault/internal/mcp"
+	"github.com/danieljustus/symaira-vault/internal/ssrf"
 )
 
 func newTestPerplexityServer(t *testing.T, searchResponse bool) *httptest.Server {
 	t.Helper()
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	return httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != "POST" {
 			t.Errorf("method = %q, want POST", r.Method)
 		}
@@ -86,9 +88,16 @@ func TestHandlePerplexitySearch_Success(t *testing.T) {
 			Perplexity: &config.PerplexityConfig{
 				BaseURL:         ts.URL,
 				RateLimitPerMin: 100,
+				AllowPrivate:    true,
 			},
 		},
 	}
+
+	origNewHTTPClient := newPerplexityHTTPClient
+	newPerplexityHTTPClient = func(timeout time.Duration, allowPrivate bool) *http.Client {
+		return ssrf.NewHTTPClientWithTLSConfig(timeout, allowPrivate, &tls.Config{InsecureSkipVerify: true})
+	}
+	t.Cleanup(func() { newPerplexityHTTPClient = origNewHTTPClient })
 
 	globalPerplexityRL = &perplexityRateLimiter{}
 
@@ -223,9 +232,16 @@ func TestHandlePerplexitySearch_APIKeyFromConfig(t *testing.T) {
 				APIKey:          "test-perplexity-key",
 				BaseURL:         ts.URL,
 				RateLimitPerMin: 100,
+				AllowPrivate:    true,
 			},
 		},
 	}
+
+	origNewHTTPClient := newPerplexityHTTPClient
+	newPerplexityHTTPClient = func(timeout time.Duration, allowPrivate bool) *http.Client {
+		return ssrf.NewHTTPClientWithTLSConfig(timeout, allowPrivate, &tls.Config{InsecureSkipVerify: true})
+	}
+	t.Cleanup(func() { newPerplexityHTTPClient = origNewHTTPClient })
 
 	globalPerplexityRL = &perplexityRateLimiter{}
 
@@ -275,9 +291,16 @@ func TestHandlePerplexityAsk_Success(t *testing.T) {
 			Perplexity: &config.PerplexityConfig{
 				BaseURL:         ts.URL,
 				RateLimitPerMin: 100,
+				AllowPrivate:    true,
 			},
 		},
 	}
+
+	origNewHTTPClient := newPerplexityHTTPClient
+	newPerplexityHTTPClient = func(timeout time.Duration, allowPrivate bool) *http.Client {
+		return ssrf.NewHTTPClientWithTLSConfig(timeout, allowPrivate, &tls.Config{InsecureSkipVerify: true})
+	}
+	t.Cleanup(func() { newPerplexityHTTPClient = origNewHTTPClient })
 
 	globalPerplexityRL = &perplexityRateLimiter{}
 
@@ -336,9 +359,16 @@ func TestHandlePerplexityAsk_WithContext(t *testing.T) {
 			Perplexity: &config.PerplexityConfig{
 				BaseURL:         ts.URL,
 				RateLimitPerMin: 100,
+				AllowPrivate:    true,
 			},
 		},
 	}
+
+	origNewHTTPClient := newPerplexityHTTPClient
+	newPerplexityHTTPClient = func(timeout time.Duration, allowPrivate bool) *http.Client {
+		return ssrf.NewHTTPClientWithTLSConfig(timeout, allowPrivate, &tls.Config{InsecureSkipVerify: true})
+	}
+	t.Cleanup(func() { newPerplexityHTTPClient = origNewHTTPClient })
 
 	globalPerplexityRL = &perplexityRateLimiter{}
 
@@ -606,9 +636,16 @@ func TestPerplexitySearch_RateLimited(t *testing.T) {
 			Perplexity: &config.PerplexityConfig{
 				BaseURL:         ts.URL,
 				RateLimitPerMin: 1,
+				AllowPrivate:    true,
 			},
 		},
 	}
+
+	origNewHTTPClient := newPerplexityHTTPClient
+	newPerplexityHTTPClient = func(timeout time.Duration, allowPrivate bool) *http.Client {
+		return ssrf.NewHTTPClientWithTLSConfig(timeout, allowPrivate, &tls.Config{InsecureSkipVerify: true})
+	}
+	t.Cleanup(func() { newPerplexityHTTPClient = origNewHTTPClient })
 
 	globalPerplexityRL = &perplexityRateLimiter{}
 
@@ -645,7 +682,7 @@ func TestPerplexitySearch_RateLimited(t *testing.T) {
 }
 
 func TestPerplexityAPIError(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusUnauthorized)
 		_, _ = w.Write([]byte(`{"error": "invalid_api_key"}`))
 	}))
@@ -666,9 +703,16 @@ func TestPerplexityAPIError(t *testing.T) {
 			Perplexity: &config.PerplexityConfig{
 				BaseURL:         ts.URL,
 				RateLimitPerMin: 100,
+				AllowPrivate:    true,
 			},
 		},
 	}
+
+	origNewHTTPClient := newPerplexityHTTPClient
+	newPerplexityHTTPClient = func(timeout time.Duration, allowPrivate bool) *http.Client {
+		return ssrf.NewHTTPClientWithTLSConfig(timeout, allowPrivate, &tls.Config{InsecureSkipVerify: true})
+	}
+	t.Cleanup(func() { newPerplexityHTTPClient = origNewHTTPClient })
 
 	globalPerplexityRL = &perplexityRateLimiter{}
 
@@ -688,5 +732,246 @@ func TestPerplexityAPIError(t *testing.T) {
 	}
 	if !strings.Contains(result.Text, "401") && !strings.Contains(result.Text, "Unauthorized") {
 		t.Errorf("error = %q, want to contain error details", result.Text)
+	}
+}
+
+func TestHandlePerplexitySearch_PlainHTTPRejected(t *testing.T) {
+	called := make(chan struct{}, 1)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case called <- struct{}{}:
+		default:
+		}
+	}))
+	defer ts.Close()
+
+	vaultDir, identity := mockVaultWithEntry(t, "perplexity", map[string]any{
+		"credential": "test-perplexity-key",
+	})
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:         "test",
+		AllowedPaths: []string{"*"},
+		CanWrite:     config.BoolPtr(false),
+		ApprovalMode: config.StrPtr("none"),
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+	srv.vault.Config = &config.Config{
+		MCP: &config.MCPConfig{
+			Perplexity: &config.PerplexityConfig{
+				BaseURL:         ts.URL,
+				RateLimitPerMin: 100,
+			},
+		},
+	}
+
+	req := mcp.CallToolRequest{
+		Arguments: map[string]any{"query": "test"},
+	}
+
+	result, err := srv.handlePerplexitySearch(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handlePerplexitySearch() error = %v", err)
+	}
+	if result == nil {
+		t.Fatal("handlePerplexitySearch() returned nil result")
+	}
+	if !result.IsError {
+		t.Fatal("handlePerplexitySearch() expected error for plain HTTP BaseURL")
+	}
+	if !strings.Contains(result.Text, "HTTPS") {
+		t.Errorf("error = %q, want to contain 'HTTPS'", result.Text)
+	}
+
+	select {
+	case <-called:
+		t.Fatal("HTTP server was called for rejected plain HTTP BaseURL — credential may have been attached before rejection")
+	default:
+	}
+}
+
+func TestHandlePerplexitySearch_LoopbackBlocked(t *testing.T) {
+	called := make(chan struct{}, 1)
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case called <- struct{}{}:
+		default:
+		}
+	}))
+	defer ts.Close()
+
+	vaultDir, identity := mockVaultWithEntry(t, "perplexity", map[string]any{
+		"credential": "test-perplexity-key",
+	})
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:         "test",
+		AllowedPaths: []string{"*"},
+		CanWrite:     config.BoolPtr(false),
+		ApprovalMode: config.StrPtr("none"),
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+	srv.vault.Config = &config.Config{
+		MCP: &config.MCPConfig{
+			Perplexity: &config.PerplexityConfig{
+				BaseURL:         ts.URL,
+				RateLimitPerMin: 100,
+			},
+		},
+	}
+
+	req := mcp.CallToolRequest{
+		Arguments: map[string]any{"query": "test"},
+	}
+
+	result, err := srv.handlePerplexitySearch(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handlePerplexitySearch() error = %v", err)
+	}
+	if result == nil {
+		t.Fatal("handlePerplexitySearch() returned nil result")
+	}
+	if !result.IsError {
+		t.Fatal("handlePerplexitySearch() expected error for loopback BaseURL")
+	}
+	if !strings.Contains(result.Text, "private or local network address") {
+		t.Errorf("error = %q, want to contain 'private or local network address'", result.Text)
+	}
+
+	select {
+	case <-called:
+		t.Fatal("HTTP server was called for rejected loopback BaseURL — credential may have been attached before rejection")
+	default:
+	}
+}
+
+func TestHandlePerplexitySearch_PrivateWithOptInAllowed(t *testing.T) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":    "test-chat-id",
+			"model": "sonar-pro",
+			"choices": []map[string]any{
+				{
+					"index":         0,
+					"finish_reason": "stop",
+					"message": map[string]any{
+						"role":    "assistant",
+						"content": "The capital of France is Paris.",
+					},
+				},
+			},
+			"citations": []string{},
+			"usage": map[string]any{
+				"prompt_tokens":     50,
+				"completion_tokens": 100,
+				"total_tokens":      150,
+			},
+		})
+	}))
+	defer ts.Close()
+
+	vaultDir, identity := mockVaultWithEntry(t, "perplexity", map[string]any{
+		"credential": "test-perplexity-key",
+	})
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:         "test",
+		AllowedPaths: []string{"*"},
+		CanWrite:     config.BoolPtr(false),
+		ApprovalMode: config.StrPtr("none"),
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+	srv.vault.Config = &config.Config{
+		MCP: &config.MCPConfig{
+			Perplexity: &config.PerplexityConfig{
+				BaseURL:         ts.URL,
+				RateLimitPerMin: 100,
+				AllowPrivate:    true,
+			},
+		},
+	}
+
+	origNewHTTPClient := newPerplexityHTTPClient
+	newPerplexityHTTPClient = func(timeout time.Duration, allowPrivate bool) *http.Client {
+		return ssrf.NewHTTPClientWithTLSConfig(timeout, allowPrivate, &tls.Config{InsecureSkipVerify: true})
+	}
+	t.Cleanup(func() { newPerplexityHTTPClient = origNewHTTPClient })
+
+	globalPerplexityRL = &perplexityRateLimiter{}
+
+	req := mcp.CallToolRequest{
+		Arguments: map[string]any{"query": "What is the capital of France?"},
+	}
+
+	result, err := srv.handlePerplexitySearch(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handlePerplexitySearch() error = %v", err)
+	}
+	if result == nil {
+		t.Fatal("handlePerplexitySearch() returned nil result")
+	}
+	if result.IsError {
+		t.Fatalf("handlePerplexitySearch() returned error with allow_private: %s", result.Text)
+	}
+
+	var output perplexitySearchResult
+	if err := json.Unmarshal([]byte(result.Text), &output); err != nil {
+		t.Fatalf("parse result: %v", err)
+	}
+	if output.Answer == "" {
+		t.Error("answer should not be empty")
+	}
+}
+
+func TestHandlePerplexityAsk_PlainHTTPRejected(t *testing.T) {
+	called := make(chan struct{}, 1)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case called <- struct{}{}:
+		default:
+		}
+	}))
+	defer ts.Close()
+
+	vaultDir, identity := mockVaultWithEntry(t, "perplexity", map[string]any{
+		"credential": "test-perplexity-key",
+	})
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:         "test",
+		AllowedPaths: []string{"*"},
+		CanWrite:     config.BoolPtr(false),
+		ApprovalMode: config.StrPtr("none"),
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+	srv.vault.Config = &config.Config{
+		MCP: &config.MCPConfig{
+			Perplexity: &config.PerplexityConfig{
+				BaseURL:         ts.URL,
+				RateLimitPerMin: 100,
+			},
+		},
+	}
+
+	req := mcp.CallToolRequest{
+		Arguments: map[string]any{"question": "test"},
+	}
+
+	result, err := srv.handlePerplexityAsk(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handlePerplexityAsk() error = %v", err)
+	}
+	if result == nil {
+		t.Fatal("handlePerplexityAsk() returned nil result")
+	}
+	if !result.IsError {
+		t.Fatal("handlePerplexityAsk() expected error for plain HTTP BaseURL")
+	}
+	if !strings.Contains(result.Text, "HTTPS") {
+		t.Errorf("error = %q, want to contain 'HTTPS'", result.Text)
+	}
+
+	select {
+	case <-called:
+		t.Fatal("HTTP server was called for rejected plain HTTP BaseURL — credential may have been attached before rejection")
+	default:
 	}
 }


### PR DESCRIPTION
## Summary
- validate the resolved Perplexity BaseURL with the existing SSRF guard before sending credentials
- require HTTPS by default and thread an explicit `allow_private` configuration through the client
- use the SSRF-hardened HTTP client and add regression coverage for private and invalid endpoints

## Verification
- focused SSRF, MCP server, and config tests passed
- `go build ./...` passed with Go 1.26.6
- the change is limited to the Perplexity implementation, configuration schema, and its tests

Closes #913
