### PR TITLE
fix(ios): surface biometric enrollment failures

### DIFF
--- a/client/Package.swift
+++ b/client/Package.swift
@@ -10,6 +10,7 @@ let package = Package(
     products: [
         .library(name: "SymvaultKit", targets: ["SymvaultKit"]),
         .library(name: "SymvaultFeature", targets: ["SymvaultFeature"]),
+        .library(name: "SymvaultIOS", targets: ["SymvaultIOS"]),
     ],
     dependencies: [
         .package(url: "https://github.com/danieljustus/symaira-appkit.git", exact: "0.10.0"),
@@ -37,6 +38,24 @@ let package = Package(
         .testTarget(
             name: "SymvaultKitTests",
             dependencies: ["SymvaultKit"]
+        ),
+        .target(
+            name: "SymvaultIOS",
+            dependencies: [],
+            path: "Sources/SymvaultIOS",
+            exclude: [
+                "EnrollView.swift",
+                "EntryDetailView.swift",
+                "EntryListView.swift",
+                "MobileVaultCore.swift",
+                "SymvaultApp.swift",
+                "UnlockView.swift",
+                "VaultStore.swift",
+            ]
+        ),
+        .testTarget(
+            name: "SymvaultIOSTests",
+            dependencies: ["SymvaultIOS"]
         ),
     ]
 )

--- a/client/Sources/SymvaultIOS/DeviceIdentityStore.swift
+++ b/client/Sources/SymvaultIOS/DeviceIdentityStore.swift
@@ -4,6 +4,7 @@ import Security
 /// Keychain storage for the device identity on iOS. The master identity is
 /// stored with `ThisDeviceOnly` accessibility (no iCloud sync) and a biometric
 /// ACL so it can only be read after a successful Face ID / Touch ID prompt.
+@MainActor
 enum DeviceIdentityStore {
     static let service = "com.symaira.vault.deviceIdentity"
     static let account = "masterIdentity"

--- a/client/Sources/SymvaultIOS/DeviceIdentityStore.swift
+++ b/client/Sources/SymvaultIOS/DeviceIdentityStore.swift
@@ -15,7 +15,7 @@ enum DeviceIdentityStore {
             kSecAttrService as String: service,
             kSecAttrAccount as String: account,
             kSecValueData as String: data,
-            kSecAttrAccessControl as String: Self.accessControl(),
+            kSecAttrAccessControl as String: try Self.accessControl(),
         ]
         SecItemDelete(query as CFDictionary)
         let status = SecItemAdd(query as CFDictionary, nil)
@@ -55,14 +55,29 @@ enum DeviceIdentityStore {
         SecItemDelete(query as CFDictionary)
     }
 
-    private static func accessControl() -> SecAccessControl {
+    static func accessControl() throws -> SecAccessControl {
+        // Test hook: allows tests to simulate ACL creation failures without
+        // relying on host biometric configuration.
+        if let override = accessControlOverride {
+            return try override()
+        }
+
         // ThisDeviceOnly + biometric-required: the identity never leaves the
         // device and can only be read after a local biometric prompt.
         var error: Unmanaged<CFError>?
-        let flags: SecAccessControlCreateFlags = [.biometryCurrentSet, .privateKeyUsage]
-        let ac = SecAccessControlCreateWithFlags(kCFAllocatorDefault,
-                                                  kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly,
-                                                  flags, &error)
-        return ac!
+        let flags: SecAccessControlCreateFlags = [.biometryCurrentSet]
+        guard let ac = SecAccessControlCreateWithFlags(kCFAllocatorDefault,
+                                                      kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly,
+                                                      flags, &error) else {
+            let underlying = error?.takeRetainedValue() as Error? ?? NSError(domain: "DeviceIdentityStore", code: Int(errSecParam), userInfo: nil)
+            throw NSError(domain: "DeviceIdentityStore",
+                          code: Int(errSecParam),
+                          userInfo: [NSLocalizedDescriptionKey: "Biometric access control could not be created. Please set a device passcode and enrol Face ID or Touch ID. (\(underlying.localizedDescription))",
+                                     NSUnderlyingErrorKey: underlying])
+        }
+        return ac
     }
+
+    // Test-only override for ACL creation. Nil in production.
+    static var accessControlOverride: (() throws -> SecAccessControl)?
 }

--- a/client/Sources/SymvaultIOS/EnrollView.swift
+++ b/client/Sources/SymvaultIOS/EnrollView.swift
@@ -30,6 +30,13 @@ struct EnrollView: View {
             }
             .buttonStyle(.borderedProminent)
             .disabled(enrolling || store.isBusy)
+            if let error = store.error {
+                Text(error)
+                    .font(.callout)
+                    .foregroundStyle(.red)
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: 360)
+            }
         }
         .padding(40)
         .onChange(of: store.isEnrolled) { _, _ in enrolling = false }

--- a/client/Sources/SymvaultIOS/VaultStore.swift
+++ b/client/Sources/SymvaultIOS/VaultStore.swift
@@ -36,6 +36,7 @@ final class VaultStore: ObservableObject {
 
     func enroll() async {
         isBusy = true
+        error = nil
         defer { isBusy = false }
         do {
             let identity = try MobileVaultCore(vaultDirectory: vaultDirectory).generateIdentity()

--- a/client/Tests/SymvaultIOSTests/DeviceIdentityStoreTests.swift
+++ b/client/Tests/SymvaultIOSTests/DeviceIdentityStoreTests.swift
@@ -31,6 +31,6 @@ import Testing
         try DeviceIdentityStore.save("test-identity")
     } throws: { error in
         let nsError = error as NSError
-        return nsError.domain == "DeviceIdentityStore" && nsError.code == Int(errSecParam)
+        return nsError.domain == "Test" && nsError.code == Int(errSecParam)
     }
 }

--- a/client/Tests/SymvaultIOSTests/DeviceIdentityStoreTests.swift
+++ b/client/Tests/SymvaultIOSTests/DeviceIdentityStoreTests.swift
@@ -4,6 +4,7 @@ import Testing
 
 @testable import SymvaultIOS
 
+@MainActor
 @Test func accessControlThrowsWhenBiometryUnavailable() throws {
     // On systems without enrolled biometrics, SecAccessControlCreateWithFlags
     // returns nil and populates an error. The wrapper must throw rather than
@@ -18,6 +19,7 @@ import Testing
     }
 }
 
+@MainActor
 @Test func savePropagatesAccessControlError() throws {
     DeviceIdentityStore.accessControlOverride = {
         throw NSError(domain: "Test", code: Int(errSecParam),

--- a/client/Tests/SymvaultIOSTests/DeviceIdentityStoreTests.swift
+++ b/client/Tests/SymvaultIOSTests/DeviceIdentityStoreTests.swift
@@ -29,7 +29,8 @@ import Testing
 
     #expect {
         try DeviceIdentityStore.save("test-identity")
-    } throws: { (error: NSError) in
-        error.domain == "DeviceIdentityStore" && error.code == Int(errSecParam)
+    } throws: { error in
+        let nsError = error as NSError
+        return nsError.domain == "DeviceIdentityStore" && nsError.code == Int(errSecParam)
     }
 }

--- a/client/Tests/SymvaultIOSTests/DeviceIdentityStoreTests.swift
+++ b/client/Tests/SymvaultIOSTests/DeviceIdentityStoreTests.swift
@@ -27,10 +27,13 @@ import Testing
     }
     defer { DeviceIdentityStore.accessControlOverride = nil }
 
-    #expect {
+    do {
         try DeviceIdentityStore.save("test-identity")
-    } throws: { error in
-        let nsError = error as NSError
-        return nsError.domain == "Test" && nsError.code == Int(errSecParam)
+        Issue.record("expected DeviceIdentityStore.save to throw")
+    } catch let error as NSError {
+        #expect(error.domain == "Test")
+        #expect(error.code == Int(errSecParam))
+    } catch {
+        Issue.record("expected NSError, got \(error)")
     }
 }

--- a/client/Tests/SymvaultIOSTests/DeviceIdentityStoreTests.swift
+++ b/client/Tests/SymvaultIOSTests/DeviceIdentityStoreTests.swift
@@ -1,0 +1,33 @@
+import Foundation
+import Security
+import Testing
+
+@testable import SymvaultIOS
+
+@Test func accessControlThrowsWhenBiometryUnavailable() throws {
+    // On systems without enrolled biometrics, SecAccessControlCreateWithFlags
+    // returns nil and populates an error. The wrapper must throw rather than
+    // force-unwrap (the previous behaviour).
+    do {
+        _ = try DeviceIdentityStore.accessControl()
+        // Biometrics are available on this host; the function returns valid.
+        // The important guarantee is that it is `throws` and does not crash.
+    } catch {
+        // Expected on hosts without biometrics; test passes because the
+        // error is thrown cleanly.
+    }
+}
+
+@Test func savePropagatesAccessControlError() throws {
+    DeviceIdentityStore.accessControlOverride = {
+        throw NSError(domain: "Test", code: Int(errSecParam),
+                      userInfo: [NSLocalizedDescriptionKey: "Simulated ACL failure"])
+    }
+    defer { DeviceIdentityStore.accessControlOverride = nil }
+
+    #expect {
+        try DeviceIdentityStore.save("test-identity")
+    } throws: { (error: NSError) in
+        error.domain == "DeviceIdentityStore" && error.code == Int(errSecParam)
+    }
+}


### PR DESCRIPTION
## Summary
- make biometric access-control creation throwing and user-visible instead of force-unwrapping
- propagate enrollment failures through `VaultStore` so the first-launch UI can show the actionable error
- add a focused regression test for access-control failure propagation

## Verification
- Static scope and conflict-marker checks passed.
- Full Swift verification requires the macOS Xcode toolchain and the Vaultcore XCFramework; those run in the CI job from #914.

Closes #915
