### PR TITLE
refactor(cmd): remove root command compatibility shim

### DIFF
--- a/cmd/add_test.go
+++ b/cmd/add_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestAddCommand_HiddenPassword(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	setPassEnv(t, string(passphrase))
 	defer setupVaultFlag(t, vaultDir)()
@@ -21,11 +22,11 @@ func TestAddCommand_HiddenPassword(t *testing.T) {
 	restore := pipeStdin(t, "myuser\nsecret-password\n\n\n\n")
 	defer restore()
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "add", "test-entry"})
-	defer rootCmd.SetArgs(nil)
+	root.SetArgs([]string{"--vault", vaultDir, "add", "test-entry"})
+	defer root.SetArgs(nil)
 
 	output := captureStdout(func() {
-		if err := rootCmd.Execute(); err != nil {
+		if err := root.Execute(); err != nil {
 			t.Fatalf("add command failed: %v", err)
 		}
 	})
@@ -36,15 +37,16 @@ func TestAddCommand_HiddenPassword(t *testing.T) {
 }
 
 func TestAddCommand_InvalidTOTPSecretRejected(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	setPassEnv(t, string(passphrase))
 	defer setupVaultFlag(t, vaultDir)()
 
 	stderr := captureStderr(func() {
-		rootCmd.SetArgs([]string{"--vault", vaultDir, "add", "bad-totp-entry",
+		root.SetArgs([]string{"--vault", vaultDir, "add", "bad-totp-entry",
 			"--value", "StrongP@ssw0rd123", "--totp-secret", "not-valid-base32!!!"})
-		_ = rootCmd.Execute()
-		rootCmd.SetArgs(nil)
+		_ = root.Execute()
+		root.SetArgs(nil)
 	})
 
 	if !strings.Contains(stderr, "TOTP secret must be Base32-encoded") {
@@ -80,15 +82,16 @@ func TestAddCommand_TOTPSecretWithSpacesAccepted(t *testing.T) {
 }
 
 func TestAddCommand_GenerateWithLength(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	setPassEnv(t, string(passphrase))
 	defer setupVaultFlag(t, vaultDir)()
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "add", "generated-entry", "--generate", "--length", "24"})
-	defer rootCmd.SetArgs(nil)
+	root.SetArgs([]string{"--vault", vaultDir, "add", "generated-entry", "--generate", "--length", "24"})
+	defer root.SetArgs(nil)
 
 	output := captureStdout(func() {
-		if err := rootCmd.Execute(); err != nil {
+		if err := root.Execute(); err != nil {
 			t.Fatalf("add command failed: %v", err)
 		}
 	})
@@ -114,16 +117,17 @@ func TestAddCommand_GenerateWithLength(t *testing.T) {
 }
 
 func TestCmdAdd_Interactive(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	setPassEnv(t, string(passphrase))
 	defer setupVaultFlag(t, vaultDir)()
 	restore := pipeStdin(t, "myuser\nStrongP@ssw0rd123\n")
 	defer restore()
 	output := captureStdout(func() {
-		rootCmd.SetArgs([]string{"--vault", vaultDir, "add", "interactive-entry",
+		root.SetArgs([]string{"--vault", vaultDir, "add", "interactive-entry",
 			"--url", "https://example.com", "--notes", "some notes", "--totp-secret", "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ"})
-		_ = rootCmd.Execute()
-		rootCmd.SetArgs(nil)
+		_ = root.Execute()
+		root.SetArgs(nil)
 	})
 	if !strings.Contains(output, "Entry created") {
 		t.Errorf("expected Entry created, got: %s", output)
@@ -131,15 +135,16 @@ func TestCmdAdd_Interactive(t *testing.T) {
 }
 
 func TestCmdAdd_InteractiveStdinError(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	setPassEnv(t, string(passphrase))
 	defer setupVaultFlag(t, vaultDir)()
 	restore := pipeStdin(t, "myuser\n")
 	defer restore()
 	stderr := captureStderr(func() {
-		rootCmd.SetArgs([]string{"--vault", vaultDir, "add", "add-stdin-err"})
-		_ = rootCmd.Execute()
-		rootCmd.SetArgs(nil)
+		root.SetArgs([]string{"--vault", vaultDir, "add", "add-stdin-err"})
+		_ = root.Execute()
+		root.SetArgs(nil)
 	})
 	if !strings.Contains(stderr, "read password") {
 		t.Errorf("expected read password error, got: %s", stderr)
@@ -179,14 +184,15 @@ func TestCmdAdd_WithTOTPFlags(t *testing.T) {
 }
 
 func TestCmdAdd_Uninitialized(t *testing.T) {
+	root := NewRootCmd()
 	resetCmdFlags()
 	t.Cleanup(resetCmdFlags)
 	vaultDir := t.TempDir()
 	defer setupVaultFlag(t, vaultDir)()
 	stderr := captureStderr(func() {
-		rootCmd.SetArgs([]string{"--vault", vaultDir, "add", "x", "--value", "v"})
-		_ = rootCmd.Execute()
-		rootCmd.SetArgs(nil)
+		root.SetArgs([]string{"--vault", vaultDir, "add", "x", "--value", "v"})
+		_ = root.Execute()
+		root.SetArgs(nil)
 	})
 	if !strings.Contains(stderr, "vault not initialized") && !strings.Contains(stderr, "Error") {
 		t.Errorf("expected vault not initialized error, got: %s", stderr)
@@ -194,6 +200,7 @@ func TestCmdAdd_Uninitialized(t *testing.T) {
 }
 
 func TestCmdAdd_AlreadyExists(t *testing.T) {
+	root := NewRootCmd()
 	if runtime.GOOS == "windows" {
 		t.Skip("skipping on windows: LockFileEx access violation in AcquireWriteLock")
 	}
@@ -204,9 +211,9 @@ func TestCmdAdd_AlreadyExists(t *testing.T) {
 	setPassEnv(t, string(passphrase))
 	defer setupVaultFlag(t, vaultDir)()
 	stderr := captureStderr(func() {
-		rootCmd.SetArgs([]string{"--vault", vaultDir, "add", "exists", "--value", "v"})
-		_ = rootCmd.Execute()
-		rootCmd.SetArgs(nil)
+		root.SetArgs([]string{"--vault", vaultDir, "add", "exists", "--value", "v"})
+		_ = root.Execute()
+		root.SetArgs(nil)
 	})
 	if !strings.Contains(stderr, "already exists") && !strings.Contains(stderr, "Error") {
 		t.Errorf("expected already exists error, got: %s", stderr)
@@ -225,17 +232,18 @@ func TestCmdAdd_Notes(t *testing.T) {
 }
 
 func TestCmdAdd_InteractiveFull(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	setPassEnv(t, string(passphrase))
 	defer setupVaultFlag(t, vaultDir)()
 	restore := pipeStdin(t, "myuser\nStrongP@ssw0rd123\n")
 	defer restore()
 	output := captureStdout(func() {
-		rootCmd.SetArgs([]string{"--vault", vaultDir, "add", "full-interactive",
+		root.SetArgs([]string{"--vault", vaultDir, "add", "full-interactive",
 			"--url", "https://example.com", "--notes", "important notes",
 			"--totp-secret", "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ", "--totp-issuer", "GitHub", "--totp-account", "alice"})
-		_ = rootCmd.Execute()
-		rootCmd.SetArgs(nil)
+		_ = root.Execute()
+		root.SetArgs(nil)
 	})
 	if !strings.Contains(output, "Entry created") {
 		t.Errorf("expected Entry created, got: %s", output)
@@ -273,16 +281,17 @@ func TestCmdAdd_InteractiveFull(t *testing.T) {
 }
 
 func TestCmdAdd_InteractiveURLPrompt(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	setPassEnv(t, string(passphrase))
 	defer setupVaultFlag(t, vaultDir)()
 	restore := pipeStdin(t, "testuser\nStrongP@ssw0rd123\n")
 	defer restore()
 	output := captureStdout(func() {
-		rootCmd.SetArgs([]string{"--vault", vaultDir, "add", "url-prompt-entry",
+		root.SetArgs([]string{"--vault", vaultDir, "add", "url-prompt-entry",
 			"--url", "https://mysite.com", "--totp-secret", "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ"})
-		_ = rootCmd.Execute()
-		rootCmd.SetArgs(nil)
+		_ = root.Execute()
+		root.SetArgs(nil)
 	})
 	if !strings.Contains(output, "Entry created") {
 		t.Errorf("expected Entry created, got: %s", output)
@@ -301,6 +310,7 @@ func TestCmdAdd_InteractiveURLPrompt(t *testing.T) {
 }
 
 func TestCmdAdd_AutoCommitError(t *testing.T) {
+	root := NewRootCmd()
 	if runtime.GOOS == "windows" {
 		t.Skip("skipping on windows: stderr capture not reliable")
 	}
@@ -310,9 +320,9 @@ func TestCmdAdd_AutoCommitError(t *testing.T) {
 	defer setupVaultFlag(t, vaultDir)()
 
 	stderr := captureStderr(func() {
-		rootCmd.SetArgs([]string{"--vault", vaultDir, "add", "autocommit-add", "--value", "StrongP@ssw0rd123"})
-		_ = rootCmd.Execute()
-		rootCmd.SetArgs(nil)
+		root.SetArgs([]string{"--vault", vaultDir, "add", "autocommit-add", "--value", "StrongP@ssw0rd123"})
+		_ = root.Execute()
+		root.SetArgs(nil)
 	})
 	if !strings.Contains(stderr, "auto-commit failed") {
 		t.Errorf("expected auto-commit warning in stderr: %s", stderr)
@@ -320,6 +330,7 @@ func TestCmdAdd_AutoCommitError(t *testing.T) {
 }
 
 func TestAdd_ErrorPaths(t *testing.T) {
+	root := NewRootCmd()
 	resetVaultState(t)
 	tests := []struct {
 		setupFunc  func()
@@ -369,10 +380,10 @@ func TestAdd_ErrorPaths(t *testing.T) {
 				cli.VaultFlag.Changed = false
 			}
 
-			rootCmd.SetArgs(tt.args)
-			defer rootCmd.SetArgs(nil)
+			root.SetArgs(tt.args)
+			defer root.SetArgs(nil)
 
-			err := rootCmd.Execute()
+			err := root.Execute()
 			if tt.wantErr {
 				if err == nil {
 					t.Errorf("expected error, got nil")
@@ -387,6 +398,7 @@ func TestAdd_ErrorPaths(t *testing.T) {
 }
 
 func TestAdd_InteractiveMode(t *testing.T) {
+	root := NewRootCmd()
 	resetVaultState(t)
 
 	tmpDir := t.TempDir()
@@ -436,11 +448,11 @@ func TestAdd_InteractiveMode(t *testing.T) {
 		_ = w.Close()
 	}()
 
-	rootCmd.SetArgs([]string{"--vault", tmpDir, "add", "interactive-test"})
-	defer rootCmd.SetArgs(nil)
+	root.SetArgs([]string{"--vault", tmpDir, "add", "interactive-test"})
+	defer root.SetArgs(nil)
 
 	output := captureStdout(func() {
-		_ = rootCmd.Execute()
+		_ = root.Execute()
 	})
 
 	os.Stdin = oldStdin
@@ -452,6 +464,7 @@ func TestAdd_InteractiveMode(t *testing.T) {
 }
 
 func TestAdd_InteractiveReadErrors(t *testing.T) {
+	root := NewRootCmd()
 	resetVaultState(t)
 
 	tmpDir := t.TempDir()
@@ -473,10 +486,10 @@ func TestAdd_InteractiveReadErrors(t *testing.T) {
 	os.Stdin = r
 	_ = w.Close()
 
-	rootCmd.SetArgs([]string{"--vault", tmpDir, "add", "test"})
-	defer rootCmd.SetArgs(nil)
+	root.SetArgs([]string{"--vault", tmpDir, "add", "test"})
+	defer root.SetArgs(nil)
 
-	err := rootCmd.Execute()
+	err := root.Execute()
 	os.Stdin = oldStdin
 	_ = r.Close()
 

--- a/cmd/audit_test.go
+++ b/cmd/audit_test.go
@@ -298,6 +298,7 @@ func TestOutputAuditTable_Empty(t *testing.T) {
 }
 
 func TestAuditCommand_JSON(t *testing.T) {
+	root := NewRootCmd()
 	resetCommandTestState()
 	t.Cleanup(resetCommandTestState)
 
@@ -320,12 +321,12 @@ func TestAuditCommand_JSON(t *testing.T) {
 		t.Fatalf("write log: %v", err)
 	}
 
-	buf := prepareRootCommandOutput(t)
-	rootCmd.SetArgs([]string{"audit", "--json"})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	buf := prepareRootCommandOutput(t, root)
+	root.SetArgs([]string{"audit", "--json"})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
-	if err := rootCmd.Execute(); err != nil {
-		t.Fatalf("Execute() error = %v", err)
+	if err := root.Execute(); err != nil {
+		t.Fatalf("ExecuteRoot(root) error = %v", err)
 	}
 
 	var result []audit.LogEntry
@@ -338,6 +339,7 @@ func TestAuditCommand_JSON(t *testing.T) {
 }
 
 func TestAuditCommand_Table(t *testing.T) {
+	root := NewRootCmd()
 	resetCommandTestState()
 	t.Cleanup(resetCommandTestState)
 
@@ -360,12 +362,12 @@ func TestAuditCommand_Table(t *testing.T) {
 		t.Fatalf("write log: %v", err)
 	}
 
-	buf := prepareRootCommandOutput(t)
-	rootCmd.SetArgs([]string{"audit"})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	buf := prepareRootCommandOutput(t, root)
+	root.SetArgs([]string{"audit"})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
-	if err := rootCmd.Execute(); err != nil {
-		t.Fatalf("Execute() error = %v", err)
+	if err := root.Execute(); err != nil {
+		t.Fatalf("ExecuteRoot(root) error = %v", err)
 	}
 
 	output := buf.String()
@@ -375,6 +377,7 @@ func TestAuditCommand_Table(t *testing.T) {
 }
 
 func TestAuditCommand_SinceFilter(t *testing.T) {
+	root := NewRootCmd()
 	resetCommandTestState()
 	t.Cleanup(resetCommandTestState)
 
@@ -403,12 +406,12 @@ func TestAuditCommand_SinceFilter(t *testing.T) {
 	}
 	f.Close()
 
-	buf := prepareRootCommandOutput(t)
-	rootCmd.SetArgs([]string{"audit", "--since", "10m"})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	buf := prepareRootCommandOutput(t, root)
+	root.SetArgs([]string{"audit", "--since", "10m"})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
-	if err := rootCmd.Execute(); err != nil {
-		t.Fatalf("Execute() error = %v", err)
+	if err := root.Execute(); err != nil {
+		t.Fatalf("ExecuteRoot(root) error = %v", err)
 	}
 
 	output := buf.String()
@@ -421,6 +424,7 @@ func TestAuditCommand_SinceFilter(t *testing.T) {
 }
 
 func TestAuditCommand_FailedFilter(t *testing.T) {
+	root := NewRootCmd()
 	resetCommandTestState()
 	t.Cleanup(resetCommandTestState)
 
@@ -448,12 +452,12 @@ func TestAuditCommand_FailedFilter(t *testing.T) {
 	}
 	f.Close()
 
-	buf := prepareRootCommandOutput(t)
-	rootCmd.SetArgs([]string{"audit", "--failed"})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	buf := prepareRootCommandOutput(t, root)
+	root.SetArgs([]string{"audit", "--failed"})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
-	if err := rootCmd.Execute(); err != nil {
-		t.Fatalf("Execute() error = %v", err)
+	if err := root.Execute(); err != nil {
+		t.Fatalf("ExecuteRoot(root) error = %v", err)
 	}
 
 	output := buf.String()

--- a/cmd/audit_test.go
+++ b/cmd/audit_test.go
@@ -15,12 +15,10 @@ import (
 )
 
 func TestAuditLogPath(t *testing.T) {
+	origHome := os.Getenv("HOME")
 	home := t.TempDir()
 	_ = os.Setenv("HOME", home)
-	defer func() {
-		h, _ := os.UserHomeDir()
-		_ = os.Setenv("HOME", h)
-	}()
+	defer func() { _ = os.Setenv("HOME", origHome) }()
 
 	path, err := admin.AuditLogPath("default")
 	if err != nil {
@@ -57,12 +55,10 @@ func TestAuditLogPath_NoHomeDir(t *testing.T) {
 }
 
 func TestLoadAuditEntries(t *testing.T) {
+	origHome := os.Getenv("HOME")
 	home := t.TempDir()
 	_ = os.Setenv("HOME", home)
-	defer func() {
-		h, _ := os.UserHomeDir()
-		_ = os.Setenv("HOME", h)
-	}()
+	defer func() { _ = os.Setenv("HOME", origHome) }()
 
 	auditDir := filepath.Join(home, configpkg.DefaultVaultSubdir)
 	if err := os.MkdirAll(auditDir, 0o700); err != nil {
@@ -95,12 +91,10 @@ func TestLoadAuditEntries(t *testing.T) {
 }
 
 func TestLoadAuditEntries_MissingFile(t *testing.T) {
+	origHome := os.Getenv("HOME")
 	home := t.TempDir()
 	_ = os.Setenv("HOME", home)
-	defer func() {
-		h, _ := os.UserHomeDir()
-		_ = os.Setenv("HOME", h)
-	}()
+	defer func() { _ = os.Setenv("HOME", origHome) }()
 
 	entries, err := admin.LoadAuditEntries("nonexistent", 10)
 	if err != nil {
@@ -112,12 +106,10 @@ func TestLoadAuditEntries_MissingFile(t *testing.T) {
 }
 
 func TestLoadAuditEntries_Limit(t *testing.T) {
+	origHome := os.Getenv("HOME")
 	home := t.TempDir()
 	_ = os.Setenv("HOME", home)
-	defer func() {
-		h, _ := os.UserHomeDir()
-		_ = os.Setenv("HOME", h)
-	}()
+	defer func() { _ = os.Setenv("HOME", origHome) }()
 
 	auditDir := filepath.Join(home, configpkg.DefaultVaultSubdir)
 	if err := os.MkdirAll(auditDir, 0o700); err != nil {
@@ -302,12 +294,10 @@ func TestAuditCommand_JSON(t *testing.T) {
 	resetCommandTestState()
 	t.Cleanup(resetCommandTestState)
 
+	origHome := os.Getenv("HOME")
 	home := t.TempDir()
 	_ = os.Setenv("HOME", home)
-	defer func() {
-		h, _ := os.UserHomeDir()
-		_ = os.Setenv("HOME", h)
-	}()
+	defer func() { _ = os.Setenv("HOME", origHome) }()
 
 	auditDir := filepath.Join(home, configpkg.DefaultVaultSubdir)
 	if err := os.MkdirAll(auditDir, 0o700); err != nil {
@@ -343,12 +333,10 @@ func TestAuditCommand_Table(t *testing.T) {
 	resetCommandTestState()
 	t.Cleanup(resetCommandTestState)
 
+	origHome := os.Getenv("HOME")
 	home := t.TempDir()
 	_ = os.Setenv("HOME", home)
-	defer func() {
-		h, _ := os.UserHomeDir()
-		_ = os.Setenv("HOME", h)
-	}()
+	defer func() { _ = os.Setenv("HOME", origHome) }()
 
 	auditDir := filepath.Join(home, configpkg.DefaultVaultSubdir)
 	if err := os.MkdirAll(auditDir, 0o700); err != nil {
@@ -381,12 +369,10 @@ func TestAuditCommand_SinceFilter(t *testing.T) {
 	resetCommandTestState()
 	t.Cleanup(resetCommandTestState)
 
+	origHome := os.Getenv("HOME")
 	home := t.TempDir()
 	_ = os.Setenv("HOME", home)
-	defer func() {
-		h, _ := os.UserHomeDir()
-		_ = os.Setenv("HOME", h)
-	}()
+	defer func() { _ = os.Setenv("HOME", origHome) }()
 
 	auditDir := filepath.Join(home, configpkg.DefaultVaultSubdir)
 	if err := os.MkdirAll(auditDir, 0o700); err != nil {
@@ -428,12 +414,10 @@ func TestAuditCommand_FailedFilter(t *testing.T) {
 	resetCommandTestState()
 	t.Cleanup(resetCommandTestState)
 
+	origHome := os.Getenv("HOME")
 	home := t.TempDir()
 	_ = os.Setenv("HOME", home)
-	defer func() {
-		h, _ := os.UserHomeDir()
-		_ = os.Setenv("HOME", h)
-	}()
+	defer func() { _ = os.Setenv("HOME", origHome) }()
 
 	auditDir := filepath.Join(home, configpkg.DefaultVaultSubdir)
 	if err := os.MkdirAll(auditDir, 0o700); err != nil {

--- a/cmd/auth_rotate_test.go
+++ b/cmd/auth_rotate_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestAuthRotate_ValidatesLengthBeforeConfirmation(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	defer setupVaultFlag(t, vaultDir)()
 
@@ -24,8 +25,8 @@ func TestAuthRotate_ValidatesLengthBeforeConfirmation(t *testing.T) {
 		w.Write([]byte("short\n"))
 	}()
 
-	rootCmd.SetArgs([]string{"auth", "rotate-passphrase"})
-	err = rootCmd.Execute()
+	root.SetArgs([]string{"auth", "rotate-passphrase"})
+	err = root.Execute()
 	os.Stdin = oldStdin
 
 	if err == nil {

--- a/cmd/backup_test.go
+++ b/cmd/backup_test.go
@@ -295,6 +295,7 @@ func TestComputeSHA256_MissingFile(t *testing.T) {
 }
 
 func TestBackupCommand(t *testing.T) {
+	root := NewRootCmd()
 	resetCommandTestState()
 	t.Cleanup(resetCommandTestState)
 
@@ -307,12 +308,12 @@ func TestBackupCommand(t *testing.T) {
 
 	archivePath := filepath.Join(t.TempDir(), "backup")
 
-	prepareRootCommandOutput(t)
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "backup", archivePath})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	prepareRootCommandOutput(t, root)
+	root.SetArgs([]string{"--vault", vaultDir, "backup", archivePath})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
-	if err := rootCmd.Execute(); err != nil {
-		t.Fatalf("Execute() error = %v", err)
+	if err := root.Execute(); err != nil {
+		t.Fatalf("ExecuteRoot(root) error = %v", err)
 	}
 
 	if _, err := os.Stat(archivePath + ".tar.gz"); err != nil {
@@ -321,6 +322,7 @@ func TestBackupCommand(t *testing.T) {
 }
 
 func TestRestoreCommand(t *testing.T) {
+	root := NewRootCmd()
 	resetCommandTestState()
 	t.Cleanup(resetCommandTestState)
 
@@ -338,12 +340,12 @@ func TestRestoreCommand(t *testing.T) {
 
 	restoreDir := t.TempDir()
 
-	prepareRootCommandOutput(t)
-	rootCmd.SetArgs([]string{"--vault", restoreDir, "restore", archivePath})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	prepareRootCommandOutput(t, root)
+	root.SetArgs([]string{"--vault", restoreDir, "restore", archivePath})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
-	if err := rootCmd.Execute(); err != nil {
-		t.Fatalf("Execute() error = %v", err)
+	if err := root.Execute(); err != nil {
+		t.Fatalf("ExecuteRoot(root) error = %v", err)
 	}
 
 	if _, err := os.Stat(filepath.Join(restoreDir, "identity.age")); err != nil {
@@ -352,36 +354,39 @@ func TestRestoreCommand(t *testing.T) {
 }
 
 func TestBackupCommand_UninitializedVault(t *testing.T) {
+	root := NewRootCmd()
 	resetCommandTestState()
 	t.Cleanup(resetCommandTestState)
 
 	vaultDir := t.TempDir()
 
-	prepareRootCommandOutput(t)
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "backup", "/tmp/backup.tar.gz"})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	prepareRootCommandOutput(t, root)
+	root.SetArgs([]string{"--vault", vaultDir, "backup", "/tmp/backup.tar.gz"})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
-	if err := rootCmd.Execute(); err == nil {
+	if err := root.Execute(); err == nil {
 		t.Fatal("expected error for uninitialized vault")
 	}
 }
 
 func TestRestoreCommand_MissingArchive(t *testing.T) {
+	root := NewRootCmd()
 	resetCommandTestState()
 	t.Cleanup(resetCommandTestState)
 
 	vaultDir := t.TempDir()
 
-	prepareRootCommandOutput(t)
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "restore", "/nonexistent/backup.tar.gz"})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	prepareRootCommandOutput(t, root)
+	root.SetArgs([]string{"--vault", vaultDir, "restore", "/nonexistent/backup.tar.gz"})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
-	if err := rootCmd.Execute(); err == nil {
+	if err := root.Execute(); err == nil {
 		t.Fatal("expected error for missing archive")
 	}
 }
 
 func TestRestoreCommand_CorruptArchive(t *testing.T) {
+	root := NewRootCmd()
 	resetCommandTestState()
 	t.Cleanup(resetCommandTestState)
 
@@ -392,11 +397,11 @@ func TestRestoreCommand_CorruptArchive(t *testing.T) {
 
 	vaultDir := t.TempDir()
 
-	prepareRootCommandOutput(t)
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "restore", archivePath})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	prepareRootCommandOutput(t, root)
+	root.SetArgs([]string{"--vault", vaultDir, "restore", archivePath})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
-	if err := rootCmd.Execute(); err == nil {
+	if err := root.Execute(); err == nil {
 		t.Fatal("expected error for corrupt archive")
 	}
 }
@@ -551,6 +556,7 @@ func TestRestoreBackup_ModeClamping(t *testing.T) {
 }
 
 func TestBackupCommand_ExcludeGit(t *testing.T) {
+	root := NewRootCmd()
 	resetCommandTestState()
 	t.Cleanup(resetCommandTestState)
 
@@ -571,12 +577,12 @@ func TestBackupCommand_ExcludeGit(t *testing.T) {
 
 	archivePath := filepath.Join(t.TempDir(), "backup")
 
-	prepareRootCommandOutput(t)
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "backup", archivePath, "--exclude-git"})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	prepareRootCommandOutput(t, root)
+	root.SetArgs([]string{"--vault", vaultDir, "backup", archivePath, "--exclude-git"})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
-	if err := rootCmd.Execute(); err != nil {
-		t.Fatalf("Execute() error = %v", err)
+	if err := root.Execute(); err != nil {
+		t.Fatalf("ExecuteRoot(root) error = %v", err)
 	}
 
 	if _, err := os.Stat(archivePath + ".tar.gz"); err != nil {

--- a/cmd/broker.go
+++ b/cmd/broker.go
@@ -26,10 +26,6 @@ var (
 // BrokerSignalNotify is a seam for tests; production uses signal.Notify.
 var BrokerSignalNotify = signal.Notify
 
-// brokerCmd is retained for API compatibility; NewRootCmd() uses
-// newBrokerCmd() so every call gets a fresh command.
-var brokerCmd = newBrokerCmd()
-
 func newBrokerCmd() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "broker",

--- a/cmd/cmd_reg_test.go
+++ b/cmd/cmd_reg_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	admin "github.com/danieljustus/symaira-vault/cmd/admin"
-	mcpcmd "github.com/danieljustus/symaira-vault/cmd/mcp"
 	cli "github.com/danieljustus/symaira-vault/internal/cli"
 	"github.com/danieljustus/symaira-vault/internal/config"
 	server "github.com/danieljustus/symaira-vault/internal/mcp/server"
@@ -18,6 +17,7 @@ import (
 )
 
 func TestCommandRegistration(t *testing.T) {
+	root := NewRootCmd()
 	commands := []string{
 		"add",
 		"delete",
@@ -48,7 +48,7 @@ func TestCommandRegistration(t *testing.T) {
 
 	for _, cmd := range commands {
 		found := false
-		for _, c := range rootCmd.Commands() {
+		for _, c := range root.Commands() {
 			if c.Name() == cmd {
 				found = true
 				break
@@ -61,14 +61,15 @@ func TestCommandRegistration(t *testing.T) {
 }
 
 func TestAllTopLevelCommandsHaveGroup(t *testing.T) {
+	root := NewRootCmd()
 	validGroups := map[string]bool{}
-	for _, g := range rootCmd.Groups() {
+	for _, g := range root.Groups() {
 		validGroups[g.ID] = true
 	}
 	if len(validGroups) == 0 {
 		t.Fatal("no command groups declared on root command")
 	}
-	for _, c := range rootCmd.Commands() {
+	for _, c := range root.Commands() {
 		if c.Name() == "help" || c.Name() == "completion" || c.Name() == "version" {
 			continue
 		}
@@ -83,9 +84,11 @@ func TestAllTopLevelCommandsHaveGroup(t *testing.T) {
 }
 
 func TestSubcommandRegistration(t *testing.T) {
+	root := NewRootCmd()
 	recipientsSubcommands := []string{"list", "add", "remove"}
 	for _, sub := range recipientsSubcommands {
 		found := false
+		recipientsCmd, _, _ := NewRootCmd().Find([]string{"recipients"})
 		for _, c := range recipientsCmd.Commands() {
 			if c.Name() == sub {
 				found = true
@@ -112,7 +115,7 @@ func TestSubcommandRegistration(t *testing.T) {
 	}
 
 	found := false
-	for _, c := range rootCmd.Commands() {
+	for _, c := range root.Commands() {
 		if c.Name() == "git" {
 			found = true
 			break
@@ -125,6 +128,7 @@ func TestSubcommandRegistration(t *testing.T) {
 	remoteSubcommands := []string{"init", "status"}
 	for _, sub := range remoteSubcommands {
 		found := false
+		remoteCmd, _, _ := NewRootCmd().Find([]string{"remote"})
 		for _, c := range remoteCmd.Commands() {
 			if c.Name() == sub {
 				found = true
@@ -139,6 +143,7 @@ func TestSubcommandRegistration(t *testing.T) {
 	deviceSubcommands := []string{"pair", "join", "accept", "list", "revoke"}
 	for _, sub := range deviceSubcommands {
 		found := false
+		deviceCmd, _, _ := NewRootCmd().Find([]string{"device"})
 		for _, c := range deviceCmd.Commands() {
 			if c.Name() == sub {
 				found = true
@@ -153,7 +158,8 @@ func TestSubcommandRegistration(t *testing.T) {
 	mcpSubcommands := []string{"install", "uninstall", "status"}
 	for _, sub := range mcpSubcommands {
 		found := false
-		for _, c := range mcpcmd.McpCmd.Commands() {
+		mcpCmd, _, _ := root.Find([]string{"mcp"})
+		for _, c := range mcpCmd.Commands() {
 			if c.Name() == sub {
 				found = true
 				break
@@ -167,7 +173,8 @@ func TestSubcommandRegistration(t *testing.T) {
 	serveSubcommands := []string{"install", "uninstall", "status"}
 	for _, sub := range serveSubcommands {
 		found := false
-		for _, c := range mcpcmd.ServeCmd.Commands() {
+		serveCmd, _, _ := root.Find([]string{"serve"})
+		for _, c := range serveCmd.Commands() {
 			if c.Name() == sub {
 				found = true
 				break
@@ -195,6 +202,7 @@ func TestSubcommandRegistration(t *testing.T) {
 	dynamicSubcommands := []string{"generate"}
 	for _, sub := range dynamicSubcommands {
 		found := false
+		dynamicCmd, _, _ := NewRootCmd().Find([]string{"dynamic"})
 		for _, c := range dynamicCmd.Commands() {
 			if c.Name() == sub {
 				found = true
@@ -209,6 +217,7 @@ func TestSubcommandRegistration(t *testing.T) {
 	templateSubcommands := []string{"generate"}
 	for _, sub := range templateSubcommands {
 		found := false
+		templateCmd, _, _ := NewRootCmd().Find([]string{"template"})
 		for _, c := range templateCmd.Commands() {
 			if c.Name() == sub {
 				found = true
@@ -223,6 +232,7 @@ func TestSubcommandRegistration(t *testing.T) {
 	policySubcommands := []string{"validate", "apply", "list", "remove"}
 	for _, sub := range policySubcommands {
 		found := false
+		policyCmd, _, _ := NewRootCmd().Find([]string{"policy"})
 		for _, c := range policyCmd.Commands() {
 			if c.Name() == sub {
 				found = true
@@ -440,6 +450,7 @@ func TestRecipientsCmd_Add_Success(t *testing.T) {
 		cli.VaultFlag.Changed = false
 	}
 
+	recipientsAddCmd, _, _ := NewRootCmd().Find([]string{"recipients", "add"})
 	recipientsAddCmd.SetArgs([]string{"age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p"})
 
 	err := recipientsAddCmd.Execute()
@@ -477,6 +488,7 @@ func TestRecipientsCmd_List_WithRecipients(t *testing.T) {
 		cli.VaultFlag.Changed = false
 	}
 
+	recipientsListCmd, _, _ := NewRootCmd().Find([]string{"recipients", "list"})
 	err = recipientsListCmd.Execute()
 	if err != nil {
 		t.Errorf("recipients list failed: %v", err)
@@ -514,6 +526,7 @@ func TestRecipientsCmd_Remove_Success(t *testing.T) {
 		cli.VaultFlag.Changed = false
 	}
 
+	recipientsRemoveCmd, _, _ := NewRootCmd().Find([]string{"recipients", "remove"})
 	recipientsRemoveCmd.SetArgs([]string{testRecipient, "--yes"})
 
 	err = recipientsRemoveCmd.Execute()
@@ -523,6 +536,7 @@ func TestRecipientsCmd_Remove_Success(t *testing.T) {
 }
 
 func TestGenerateCmd_StoreToExistingEntry(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir := t.TempDir()
 	passphrase := []byte("test-passphrase")
 	identity, _ := vaultpkg.InitWithPassphrase(vaultDir, passphrase, config.Default())
@@ -547,6 +561,7 @@ func TestGenerateCmd_StoreToExistingEntry(t *testing.T) {
 		cli.VaultFlag.Changed = false
 	}
 
+	generateCmd, _, _ := root.Find([]string{"generate"})
 	generateCmd.SetArgs([]string{"--store", "existing.pass", "--length", "16"})
 
 	err := generateCmd.Execute()
@@ -556,6 +571,7 @@ func TestGenerateCmd_StoreToExistingEntry(t *testing.T) {
 }
 
 func TestGenerateCmd_StoreNewEntry(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir := t.TempDir()
 	passphrase := []byte("test-passphrase")
 	_, _ = vaultpkg.InitWithPassphrase(vaultDir, passphrase, config.Default())
@@ -578,6 +594,7 @@ func TestGenerateCmd_StoreNewEntry(t *testing.T) {
 		cli.VaultFlag.Changed = false
 	}
 
+	generateCmd, _, _ := root.Find([]string{"generate"})
 	generateCmd.SetArgs([]string{"--store", "new.pass", "--length", "16"})
 
 	err := generateCmd.Execute()
@@ -587,6 +604,7 @@ func TestGenerateCmd_StoreNewEntry(t *testing.T) {
 }
 
 func TestOutputHTTPConfigMCP(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir := t.TempDir()
 	identity := testutil.TempIdentity(t)
 	cfg := config.Default()
@@ -617,10 +635,10 @@ func TestOutputHTTPConfigMCP(t *testing.T) {
 		cli.VaultFlag.Changed = false
 	}
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "mcp-config", "claude-code"})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	root.SetArgs([]string{"--vault", vaultDir, "mcp-config", "claude-code"})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
-	err := rootCmd.Execute()
+	err := root.Execute()
 	if err == nil {
 		t.Fatal("expected deprecation error")
 	}

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestConfigSetCommand_Basic(t *testing.T) {
+	root := NewRootCmd()
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "config.yaml")
 	if err := os.WriteFile(cfgPath, []byte("vaultDir: /old\n"), 0o600); err != nil {
@@ -20,11 +21,11 @@ func TestConfigSetCommand_Basic(t *testing.T) {
 	}
 
 	resetCmdFlags()
-	rootCmd.SetArgs([]string{"config", "set", "vaultDir", "/new", "--file", cfgPath})
-	defer rootCmd.SetArgs(nil)
+	root.SetArgs([]string{"config", "set", "vaultDir", "/new", "--file", cfgPath})
+	defer root.SetArgs(nil)
 
 	output := captureStdout(func() {
-		if err := rootCmd.Execute(); err != nil {
+		if err := root.Execute(); err != nil {
 			t.Fatalf("config set failed: %v", err)
 		}
 	})
@@ -43,6 +44,7 @@ func TestConfigSetCommand_Basic(t *testing.T) {
 }
 
 func TestConfigSetCommand_BoolValue(t *testing.T) {
+	root := NewRootCmd()
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "config.yaml")
 	if err := os.WriteFile(cfgPath, []byte("agents:\n  test:\n    canWrite: false\n"), 0o600); err != nil {
@@ -50,10 +52,10 @@ func TestConfigSetCommand_BoolValue(t *testing.T) {
 	}
 
 	resetCmdFlags()
-	rootCmd.SetArgs([]string{"config", "set", "agents.test.canWrite", "true", "--file", cfgPath})
-	defer rootCmd.SetArgs(nil)
+	root.SetArgs([]string{"config", "set", "agents.test.canWrite", "true", "--file", cfgPath})
+	defer root.SetArgs(nil)
 
-	if err := rootCmd.Execute(); err != nil {
+	if err := root.Execute(); err != nil {
 		t.Fatalf("config set failed: %v", err)
 	}
 
@@ -87,6 +89,7 @@ func TestConfigSetCommand_BoolValue(t *testing.T) {
 }
 
 func TestConfigSetCommand_CreateNestedKey(t *testing.T) {
+	root := NewRootCmd()
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "config.yaml")
 	if err := os.WriteFile(cfgPath, []byte("{}\n"), 0o600); err != nil {
@@ -94,10 +97,10 @@ func TestConfigSetCommand_CreateNestedKey(t *testing.T) {
 	}
 
 	resetCmdFlags()
-	rootCmd.SetArgs([]string{"config", "set", "agents.custom.canWrite", "true", "--file", cfgPath})
-	defer rootCmd.SetArgs(nil)
+	root.SetArgs([]string{"config", "set", "agents.custom.canWrite", "true", "--file", cfgPath})
+	defer root.SetArgs(nil)
 
-	if err := rootCmd.Execute(); err != nil {
+	if err := root.Execute(); err != nil {
 		t.Fatalf("config set failed: %v", err)
 	}
 
@@ -108,6 +111,7 @@ func TestConfigSetCommand_CreateNestedKey(t *testing.T) {
 }
 
 func TestConfigSetCommand_InvalidatesConfig(t *testing.T) {
+	root := NewRootCmd()
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "config.yaml")
 	if err := os.WriteFile(cfgPath, []byte("vaultDir: /test\nsessionTimeout: 15m\n"), 0o600); err != nil {
@@ -115,10 +119,10 @@ func TestConfigSetCommand_InvalidatesConfig(t *testing.T) {
 	}
 
 	resetCmdFlags()
-	rootCmd.SetArgs([]string{"config", "set", "sessionTimeout", "invalid", "--file", cfgPath})
-	defer rootCmd.SetArgs(nil)
+	root.SetArgs([]string{"config", "set", "sessionTimeout", "invalid", "--file", cfgPath})
+	defer root.SetArgs(nil)
 
-	err := rootCmd.Execute()
+	err := root.Execute()
 	if err == nil {
 		t.Fatal("expected error for invalid sessionTimeout value")
 	}
@@ -128,19 +132,21 @@ func TestConfigSetCommand_InvalidatesConfig(t *testing.T) {
 }
 
 func TestConfigSetCommand_MissingFile(t *testing.T) {
+	root := NewRootCmd()
 	cfgPath := filepath.Join(t.TempDir(), "nonexistent.yaml")
 
 	resetCmdFlags()
-	rootCmd.SetArgs([]string{"config", "set", "vaultDir", "/new", "--file", cfgPath})
-	defer rootCmd.SetArgs(nil)
+	root.SetArgs([]string{"config", "set", "vaultDir", "/new", "--file", cfgPath})
+	defer root.SetArgs(nil)
 
-	err := rootCmd.Execute()
+	err := root.Execute()
 	if err == nil {
 		t.Fatal("expected error for missing config file")
 	}
 }
 
 func TestConfigGetCommand_ExistingKey(t *testing.T) {
+	root := NewRootCmd()
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "config.yaml")
 	if err := os.WriteFile(cfgPath, []byte("vaultDir: /my/vault\n"), 0o600); err != nil {
@@ -148,11 +154,11 @@ func TestConfigGetCommand_ExistingKey(t *testing.T) {
 	}
 
 	resetCmdFlags()
-	rootCmd.SetArgs([]string{"config", "get", "vaultDir", "--file", cfgPath})
-	defer rootCmd.SetArgs(nil)
+	root.SetArgs([]string{"config", "get", "vaultDir", "--file", cfgPath})
+	defer root.SetArgs(nil)
 
 	output := captureStdout(func() {
-		if err := rootCmd.Execute(); err != nil {
+		if err := root.Execute(); err != nil {
 			t.Fatalf("config get failed: %v", err)
 		}
 	})
@@ -163,6 +169,7 @@ func TestConfigGetCommand_ExistingKey(t *testing.T) {
 }
 
 func TestConfigGetCommand_NestedKey(t *testing.T) {
+	root := NewRootCmd()
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "config.yaml")
 	if err := os.WriteFile(cfgPath, []byte("agents:\n  claude:\n    canWrite: true\n"), 0o600); err != nil {
@@ -170,11 +177,11 @@ func TestConfigGetCommand_NestedKey(t *testing.T) {
 	}
 
 	resetCmdFlags()
-	rootCmd.SetArgs([]string{"config", "get", "agents.claude.canWrite", "--file", cfgPath})
-	defer rootCmd.SetArgs(nil)
+	root.SetArgs([]string{"config", "get", "agents.claude.canWrite", "--file", cfgPath})
+	defer root.SetArgs(nil)
 
 	output := captureStdout(func() {
-		if err := rootCmd.Execute(); err != nil {
+		if err := root.Execute(); err != nil {
 			t.Fatalf("config get failed: %v", err)
 		}
 	})
@@ -185,6 +192,7 @@ func TestConfigGetCommand_NestedKey(t *testing.T) {
 }
 
 func TestConfigGetCommand_MissingKey(t *testing.T) {
+	root := NewRootCmd()
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "config.yaml")
 	if err := os.WriteFile(cfgPath, []byte("vaultDir: /test\n"), 0o600); err != nil {
@@ -192,29 +200,31 @@ func TestConfigGetCommand_MissingKey(t *testing.T) {
 	}
 
 	resetCmdFlags()
-	rootCmd.SetArgs([]string{"config", "get", "nonexistent.key", "--file", cfgPath})
-	defer rootCmd.SetArgs(nil)
+	root.SetArgs([]string{"config", "get", "nonexistent.key", "--file", cfgPath})
+	defer root.SetArgs(nil)
 
-	err := rootCmd.Execute()
+	err := root.Execute()
 	if err == nil {
 		t.Fatal("expected error for missing key")
 	}
 }
 
 func TestConfigGetCommand_MissingFile(t *testing.T) {
+	root := NewRootCmd()
 	cfgPath := filepath.Join(t.TempDir(), "nonexistent.yaml")
 
 	resetCmdFlags()
-	rootCmd.SetArgs([]string{"config", "get", "vaultDir", "--file", cfgPath})
-	defer rootCmd.SetArgs(nil)
+	root.SetArgs([]string{"config", "get", "vaultDir", "--file", cfgPath})
+	defer root.SetArgs(nil)
 
-	err := rootCmd.Execute()
+	err := root.Execute()
 	if err == nil {
 		t.Fatal("expected error for missing config file")
 	}
 }
 
 func TestConfigListCommand(t *testing.T) {
+	root := NewRootCmd()
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "config.yaml")
 	if err := os.WriteFile(cfgPath, []byte("vaultDir: /test\nagents:\n  a:\n    canWrite: true\n"), 0o600); err != nil {
@@ -222,11 +232,11 @@ func TestConfigListCommand(t *testing.T) {
 	}
 
 	resetCmdFlags()
-	rootCmd.SetArgs([]string{"config", "list", "--file", cfgPath})
-	defer rootCmd.SetArgs(nil)
+	root.SetArgs([]string{"config", "list", "--file", cfgPath})
+	defer root.SetArgs(nil)
 
 	output := captureStdout(func() {
-		if err := rootCmd.Execute(); err != nil {
+		if err := root.Execute(); err != nil {
 			t.Fatalf("config list failed: %v", err)
 		}
 	})
@@ -240,19 +250,21 @@ func TestConfigListCommand(t *testing.T) {
 }
 
 func TestConfigListCommand_MissingFile(t *testing.T) {
+	root := NewRootCmd()
 	cfgPath := filepath.Join(t.TempDir(), "nonexistent.yaml")
 
 	resetCmdFlags()
-	rootCmd.SetArgs([]string{"config", "list", "--file", cfgPath})
-	defer rootCmd.SetArgs(nil)
+	root.SetArgs([]string{"config", "list", "--file", cfgPath})
+	defer root.SetArgs(nil)
 
-	err := rootCmd.Execute()
+	err := root.Execute()
 	if err == nil {
 		t.Fatal("expected error for missing config file")
 	}
 }
 
 func TestConfigListCommand_EmptyConfig(t *testing.T) {
+	root := NewRootCmd()
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "config.yaml")
 	if err := os.WriteFile(cfgPath, []byte("{}\n"), 0o600); err != nil {
@@ -260,11 +272,11 @@ func TestConfigListCommand_EmptyConfig(t *testing.T) {
 	}
 
 	resetCmdFlags()
-	rootCmd.SetArgs([]string{"config", "list", "--file", cfgPath})
-	defer rootCmd.SetArgs(nil)
+	root.SetArgs([]string{"config", "list", "--file", cfgPath})
+	defer root.SetArgs(nil)
 
 	output := captureStdout(func() {
-		if err := rootCmd.Execute(); err != nil {
+		if err := root.Execute(); err != nil {
 			t.Fatalf("config list failed: %v", err)
 		}
 	})

--- a/cmd/delete_test.go
+++ b/cmd/delete_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestCmdDelete_Cancel(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	identity, _ := vaultpkg.OpenWithPassphrase(vaultDir, passphrase)
 	entry := &vaultpkg.Entry{Data: map[string]any{"password": "keep"}}
@@ -27,9 +28,9 @@ func TestCmdDelete_Cancel(t *testing.T) {
 	_, _ = w.WriteString("n\n")
 	_ = w.Close()
 	stderr := captureStderr(func() {
-		rootCmd.SetArgs([]string{"--vault", vaultDir, "delete", "keep-me"})
-		_ = rootCmd.Execute()
-		rootCmd.SetArgs(nil)
+		root.SetArgs([]string{"--vault", vaultDir, "delete", "keep-me"})
+		_ = root.Execute()
+		root.SetArgs(nil)
 	})
 	os.Stdin = oldStdin
 	_ = r.Close()
@@ -39,6 +40,7 @@ func TestCmdDelete_Cancel(t *testing.T) {
 }
 
 func TestCmdDelete_StdinError(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	identity, _ := vaultpkg.OpenWithPassphrase(vaultDir, passphrase)
 	entry := &vaultpkg.Entry{Data: map[string]any{"password": "keep"}}
@@ -48,9 +50,9 @@ func TestCmdDelete_StdinError(t *testing.T) {
 	restore := pipeStdin(t, "")
 	defer restore()
 	stderr := captureStderr(func() {
-		rootCmd.SetArgs([]string{"--vault", vaultDir, "delete", "keep-me"})
-		_ = rootCmd.Execute()
-		rootCmd.SetArgs(nil)
+		root.SetArgs([]string{"--vault", vaultDir, "delete", "keep-me"})
+		_ = root.Execute()
+		root.SetArgs(nil)
 	})
 	if !strings.Contains(stderr, "read confirmation") {
 		t.Errorf("expected read confirmation error, got: %s", stderr)
@@ -59,6 +61,7 @@ func TestCmdDelete_StdinError(t *testing.T) {
 }
 
 func TestCmdDelete_NotFound(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	setPassEnv(t, string(passphrase))
 	defer setupVaultFlag(t, vaultDir)()
@@ -68,9 +71,9 @@ func TestCmdDelete_NotFound(t *testing.T) {
 	_, _ = w.WriteString("y\n")
 	_ = w.Close()
 	stderr := captureStderr(func() {
-		rootCmd.SetArgs([]string{"--vault", vaultDir, "delete", "ghost"})
-		_ = rootCmd.Execute()
-		rootCmd.SetArgs(nil)
+		root.SetArgs([]string{"--vault", vaultDir, "delete", "ghost"})
+		_ = root.Execute()
+		root.SetArgs(nil)
 	})
 	os.Stdin = oldStdin
 	_ = r.Close()
@@ -80,6 +83,7 @@ func TestCmdDelete_NotFound(t *testing.T) {
 }
 
 func TestCmdDelete_YesJSON(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	identity, _ := vaultpkg.OpenWithPassphrase(vaultDir, passphrase)
 	entry := &vaultpkg.Entry{Data: map[string]any{"password": "secret"}}
@@ -92,9 +96,9 @@ func TestCmdDelete_YesJSON(t *testing.T) {
 	})
 
 	output := captureStdout(func() {
-		rootCmd.SetArgs([]string{"--vault", vaultDir, "delete", "delete-json", "--yes", "--output", "json"})
-		_ = rootCmd.Execute()
-		rootCmd.SetArgs(nil)
+		root.SetArgs([]string{"--vault", vaultDir, "delete", "delete-json", "--yes", "--output", "json"})
+		_ = root.Execute()
+		root.SetArgs(nil)
 	})
 
 	var result map[string]any
@@ -107,6 +111,7 @@ func TestCmdDelete_YesJSON(t *testing.T) {
 }
 
 func TestCmdDelete_Uninitialized(t *testing.T) {
+	root := NewRootCmd()
 	resetCmdFlags()
 	t.Cleanup(resetCmdFlags)
 	vaultDir := t.TempDir()
@@ -114,9 +119,9 @@ func TestCmdDelete_Uninitialized(t *testing.T) {
 	restore := pipeStdin(t, "y\n")
 	defer restore()
 	stderr := captureStderr(func() {
-		rootCmd.SetArgs([]string{"--vault", vaultDir, "delete", "x"})
-		_ = rootCmd.Execute()
-		rootCmd.SetArgs(nil)
+		root.SetArgs([]string{"--vault", vaultDir, "delete", "x"})
+		_ = root.Execute()
+		root.SetArgs(nil)
 	})
 	if !strings.Contains(stderr, "vault not initialized") && !strings.Contains(stderr, "Error") {
 		t.Errorf("expected vault not initialized, got: %s", stderr)
@@ -124,6 +129,7 @@ func TestCmdDelete_Uninitialized(t *testing.T) {
 }
 
 func TestCmdDelete_EmptyConfirm(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	identity, _ := vaultpkg.OpenWithPassphrase(vaultDir, passphrase)
 	entry := &vaultpkg.Entry{Data: map[string]any{"password": "x"}}
@@ -135,9 +141,9 @@ func TestCmdDelete_EmptyConfirm(t *testing.T) {
 	os.Stdin = r
 	_ = w.Close()
 	captureStderr(func() {
-		rootCmd.SetArgs([]string{"--vault", vaultDir, "delete", "del-empty"})
-		_ = rootCmd.Execute()
-		rootCmd.SetArgs(nil)
+		root.SetArgs([]string{"--vault", vaultDir, "delete", "del-empty"})
+		_ = root.Execute()
+		root.SetArgs(nil)
 	})
 	os.Stdin = oldStdin
 	_ = r.Close()
@@ -145,6 +151,7 @@ func TestCmdDelete_EmptyConfirm(t *testing.T) {
 }
 
 func TestCmdDelete_AutoCommitError(t *testing.T) {
+	root := NewRootCmd()
 	if runtime.GOOS == "windows" {
 		t.Skip("skipping on windows: stderr capture not reliable")
 	}
@@ -166,9 +173,9 @@ func TestCmdDelete_AutoCommitError(t *testing.T) {
 	_ = w.Close()
 
 	stderr := captureStderr(func() {
-		rootCmd.SetArgs([]string{"--vault", vaultDir, "delete", "autocommit-del"})
-		_ = rootCmd.Execute()
-		rootCmd.SetArgs(nil)
+		root.SetArgs([]string{"--vault", vaultDir, "delete", "autocommit-del"})
+		_ = root.Execute()
+		root.SetArgs(nil)
 	})
 	os.Stdin = oldStdin
 	_ = r.Close()
@@ -179,16 +186,17 @@ func TestCmdDelete_AutoCommitError(t *testing.T) {
 }
 
 func TestDelete_ErrorPaths(t *testing.T) {
+	root := NewRootCmd()
 	resetVaultState(t)
 	t.Run("uninitialized vault", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		_ = os.Setenv("SYMVAULT_VAULT", tmpDir)
 		defer func() { _ = os.Unsetenv("SYMVAULT_VAULT") }()
 
-		rootCmd.SetArgs([]string{"--vault", tmpDir, "delete", "test"})
-		defer rootCmd.SetArgs(nil)
+		root.SetArgs([]string{"--vault", tmpDir, "delete", "test"})
+		defer root.SetArgs(nil)
 
-		err := rootCmd.Execute()
+		err := root.Execute()
 		if err == nil || !strings.Contains(err.Error(), "not initialized") {
 			t.Errorf("expected 'not initialized' error, got: %v", err)
 		}
@@ -210,10 +218,10 @@ func TestDelete_ErrorPaths(t *testing.T) {
 		_, _ = w.WriteString("n\n")
 		_ = w.Close()
 
-		rootCmd.SetArgs([]string{"--vault", tmpDir, "delete", "nonexistent"})
-		defer rootCmd.SetArgs(nil)
+		root.SetArgs([]string{"--vault", tmpDir, "delete", "nonexistent"})
+		defer root.SetArgs(nil)
 
-		_ = rootCmd.Execute()
+		_ = root.Execute()
 		os.Stdin = oldStdin
 		_ = r.Close()
 	})

--- a/cmd/device.go
+++ b/cmd/device.go
@@ -30,10 +30,6 @@ var (
 	joinPairingFile   string
 )
 
-// deviceCmd is retained for API compatibility; NewCommands() uses
-// newDeviceCmd() so every call gets a fresh command.
-var deviceCmd = newDeviceCmd()
-
 func newDeviceCmd() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "device",

--- a/cmd/device_test.go
+++ b/cmd/device_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestDeviceAccept_DisplaysFingerprintAndAccepts(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	setPassEnv(t, string(passphrase))
 	vaultFlagReset(t)
@@ -55,12 +56,12 @@ func TestDeviceAccept_DisplaysFingerprintAndAccepts(t *testing.T) {
 		t.Fatalf("write joined file: %v", err)
 	}
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "device", "accept", string(token)})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	root.SetArgs([]string{"--vault", vaultDir, "device", "accept", string(token)})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
 	var execErr error
 	output := captureStdout(func() {
-		execErr = rootCmd.Execute()
+		execErr = root.Execute()
 	})
 
 	if execErr != nil {
@@ -116,6 +117,7 @@ func TestDeviceAccept_DisplaysFingerprintAndAccepts(t *testing.T) {
 // ===== Transport-independent pairing handshake (#867) =====
 
 func TestDeviceJoin_PairingFile_FullFlow(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	_ = vaultDir
 	setPassEnv(t, string(passphrase)) // not used by join; join reads the passphrase from stdin
@@ -149,13 +151,13 @@ func TestDeviceJoin_PairingFile_FullFlow(t *testing.T) {
 	restore := pipeStdin(t, "test-passphrase-for-joined-device\n")
 	t.Cleanup(restore)
 
-	rootCmd.SetArgs([]string{"--vault", joinDir, "device", "join", "--name", "file-phone",
+	root.SetArgs([]string{"--vault", joinDir, "device", "join", "--name", "file-phone",
 		"--pairing-file", pairingFilePath, string(token)})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	t.Cleanup(func() { root.SetArgs(nil) })
 
 	var execErr error
 	output := captureStdout(func() {
-		execErr = rootCmd.Execute()
+		execErr = root.Execute()
 	})
 
 	if execErr != nil {
@@ -197,6 +199,7 @@ func TestDeviceJoin_PairingFile_FullFlow(t *testing.T) {
 }
 
 func TestDeviceJoin_PairingFile_TokenMismatchRejected(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	_ = vaultDir
 	setPassEnv(t, string(passphrase))
@@ -231,13 +234,13 @@ func TestDeviceJoin_PairingFile_TokenMismatchRejected(t *testing.T) {
 
 	joinDir := t.TempDir()
 
-	rootCmd.SetArgs([]string{"--vault", joinDir, "device", "join",
+	root.SetArgs([]string{"--vault", joinDir, "device", "join",
 		"--pairing-file", pairingFilePath, string(token)})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	t.Cleanup(func() { root.SetArgs(nil) })
 
 	var execErr error
 	captureStderr(func() {
-		execErr = rootCmd.Execute()
+		execErr = root.Execute()
 	})
 
 	if execErr == nil {
@@ -249,6 +252,7 @@ func TestDeviceJoin_PairingFile_TokenMismatchRejected(t *testing.T) {
 }
 
 func TestDeviceAccept_AcceptsResponseArtefact(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	setPassEnv(t, string(passphrase))
 	vaultFlagReset(t)
@@ -283,12 +287,12 @@ func TestDeviceAccept_AcceptsResponseArtefact(t *testing.T) {
 		t.Fatalf("write join response: %v", err)
 	}
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "device", "accept", string(token)})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	root.SetArgs([]string{"--vault", vaultDir, "device", "accept", string(token)})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
 	var execErr error
 	output := captureStdout(func() {
-		execErr = rootCmd.Execute()
+		execErr = root.Execute()
 	})
 
 	if execErr != nil {
@@ -319,16 +323,17 @@ func TestDeviceAccept_AcceptsResponseArtefact(t *testing.T) {
 }
 
 func TestDevicePair_DisplaysFingerprint(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	setPassEnv(t, string(passphrase))
 	vaultFlagReset(t)
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "device", "pair"})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	root.SetArgs([]string{"--vault", vaultDir, "device", "pair"})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
 	var execErr error
 	output := captureStdout(func() {
-		execErr = rootCmd.Execute()
+		execErr = root.Execute()
 	})
 
 	if execErr != nil {
@@ -353,16 +358,17 @@ func TestDevicePair_DisplaysFingerprint(t *testing.T) {
 }
 
 func TestDeviceAccept_InvalidToken(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	setPassEnv(t, string(passphrase))
 	vaultFlagReset(t)
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "device", "accept", "invalid/token"})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	root.SetArgs([]string{"--vault", vaultDir, "device", "accept", "invalid/token"})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
 	var execErr error
 	captureStderr(func() {
-		execErr = rootCmd.Execute()
+		execErr = root.Execute()
 	})
 
 	if execErr == nil {
@@ -374,6 +380,7 @@ func TestDeviceAccept_InvalidToken(t *testing.T) {
 }
 
 func TestDeviceAccept_NoJoinRequest(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	setPassEnv(t, string(passphrase))
 	vaultFlagReset(t)
@@ -383,12 +390,12 @@ func TestDeviceAccept_NoJoinRequest(t *testing.T) {
 		t.Fatalf("generate token: %v", err)
 	}
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "device", "accept", string(token)})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	root.SetArgs([]string{"--vault", vaultDir, "device", "accept", string(token)})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
 	var execErr error
 	captureStderr(func() {
-		execErr = rootCmd.Execute()
+		execErr = root.Execute()
 	})
 
 	if execErr == nil {
@@ -400,6 +407,7 @@ func TestDeviceAccept_NoJoinRequest(t *testing.T) {
 }
 
 func TestDeviceAccept_CorruptJoinedFile(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	setPassEnv(t, string(passphrase))
 	vaultFlagReset(t)
@@ -418,12 +426,12 @@ func TestDeviceAccept_CorruptJoinedFile(t *testing.T) {
 		t.Fatalf("write joined file: %v", err)
 	}
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "device", "accept", string(token)})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	root.SetArgs([]string{"--vault", vaultDir, "device", "accept", string(token)})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
 	var execErr error
 	captureStderr(func() {
-		execErr = rootCmd.Execute()
+		execErr = root.Execute()
 	})
 
 	if execErr == nil {
@@ -435,6 +443,7 @@ func TestDeviceAccept_CorruptJoinedFile(t *testing.T) {
 }
 
 func TestDeviceAccept_DefaultDeviceName(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	setPassEnv(t, string(passphrase))
 	vaultFlagReset(t)
@@ -471,12 +480,12 @@ func TestDeviceAccept_DefaultDeviceName(t *testing.T) {
 		t.Fatalf("write joined file: %v", err)
 	}
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "device", "accept", string(token)})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	root.SetArgs([]string{"--vault", vaultDir, "device", "accept", string(token)})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
 	var execErr error
 	output := captureStdout(func() {
-		execErr = rootCmd.Execute()
+		execErr = root.Execute()
 	})
 
 	if execErr != nil {
@@ -492,6 +501,7 @@ func TestDeviceAccept_DefaultDeviceName(t *testing.T) {
 }
 
 func TestDeviceAdd_DisplaysFingerprint(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir := t.TempDir()
 	vaultFlagReset(t)
 
@@ -509,12 +519,12 @@ func TestDeviceAdd_DisplaysFingerprint(t *testing.T) {
 	cleanupStdin := pipeStdin(t, "test-device-passphrase-123\n")
 	t.Cleanup(cleanupStdin)
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "device", "add", "--pair", string(token) + ":" + existingPubkey, "--name", "added-device"})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	root.SetArgs([]string{"--vault", vaultDir, "device", "add", "--pair", string(token) + ":" + existingPubkey, "--name", "added-device"})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
 	var execErr error
 	output := captureStderr(func() {
-		execErr = rootCmd.Execute()
+		execErr = root.Execute()
 	})
 
 	if execErr != nil {

--- a/cmd/doctor_test.go
+++ b/cmd/doctor_test.go
@@ -12,18 +12,18 @@ import (
 )
 
 func TestCmdDoctor_TextOutput(t *testing.T) {
-	rootCmd = newPackageRootCmd()
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	setPassEnv(t, string(passphrase))
 	defer setupVaultFlag(t, vaultDir)()
 
 	var buf bytes.Buffer
-	rootCmd.SetOut(&buf)
-	t.Cleanup(func() { rootCmd.SetOut(nil) })
+	root.SetOut(&buf)
+	t.Cleanup(func() { root.SetOut(nil) })
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "doctor", "--no-network"})
-	defer rootCmd.SetArgs(nil)
-	_ = rootCmd.Execute()
+	root.SetArgs([]string{"--vault", vaultDir, "doctor", "--no-network"})
+	defer root.SetArgs(nil)
+	_ = root.Execute()
 
 	out := buf.String()
 	if !strings.Contains(out, "Symaira Vault Doctor") {
@@ -35,18 +35,18 @@ func TestCmdDoctor_TextOutput(t *testing.T) {
 }
 
 func TestCmdDoctor_JSONOutput(t *testing.T) {
-	rootCmd = newPackageRootCmd()
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	setPassEnv(t, string(passphrase))
 	defer setupVaultFlag(t, vaultDir)()
 
 	var buf bytes.Buffer
-	rootCmd.SetOut(&buf)
-	t.Cleanup(func() { rootCmd.SetOut(nil) })
+	root.SetOut(&buf)
+	t.Cleanup(func() { root.SetOut(nil) })
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "doctor", "--no-network", "--json"})
-	defer rootCmd.SetArgs(nil)
-	_ = rootCmd.Execute()
+	root.SetArgs([]string{"--vault", vaultDir, "doctor", "--no-network", "--json"})
+	defer root.SetArgs(nil)
+	_ = root.Execute()
 
 	var result struct {
 		VaultDir string `json:"vault_dir"`
@@ -73,18 +73,18 @@ func TestCmdDoctor_JSONOutput(t *testing.T) {
 }
 
 func TestCmdDoctor_NoNetworkFlag(t *testing.T) {
-	rootCmd = newPackageRootCmd()
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	setPassEnv(t, string(passphrase))
 	defer setupVaultFlag(t, vaultDir)()
 
 	var buf bytes.Buffer
-	rootCmd.SetOut(&buf)
-	t.Cleanup(func() { rootCmd.SetOut(nil) })
+	root.SetOut(&buf)
+	t.Cleanup(func() { root.SetOut(nil) })
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "doctor", "--no-network"})
-	defer rootCmd.SetArgs(nil)
-	_ = rootCmd.Execute()
+	root.SetArgs([]string{"--vault", vaultDir, "doctor", "--no-network"})
+	defer root.SetArgs(nil)
+	_ = root.Execute()
 
 	if buf.Len() == 0 {
 		t.Error("expected non-empty output with --no-network flag")
@@ -102,19 +102,19 @@ func TestCmdDoctor_FixFlag_Registered(t *testing.T) {
 }
 
 func TestCmdDoctor_FixFlag_TextOutput(t *testing.T) {
-	rootCmd = newPackageRootCmd()
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	setPassEnv(t, string(passphrase))
 	defer setupVaultFlag(t, vaultDir)()
 
 	var buf bytes.Buffer
-	rootCmd.SetOut(&buf)
-	t.Cleanup(func() { rootCmd.SetOut(nil) })
+	root.SetOut(&buf)
+	t.Cleanup(func() { root.SetOut(nil) })
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "doctor", "--fix", "--no-network"})
-	defer rootCmd.SetArgs(nil)
+	root.SetArgs([]string{"--vault", vaultDir, "doctor", "--fix", "--no-network"})
+	defer root.SetArgs(nil)
 
-	err := rootCmd.Execute()
+	err := root.Execute()
 	if err != nil {
 		t.Errorf("doctor --fix --no-network failed: %v", err)
 	}

--- a/cmd/dynamic.go
+++ b/cmd/dynamic.go
@@ -18,10 +18,6 @@ var (
 	dynamicTTL    time.Duration
 )
 
-// dynamicCmd is retained for API compatibility; NewCommands() uses
-// newDynamicCmd() so every call gets a fresh command.
-var dynamicCmd = newDynamicCmd()
-
 func newDynamicCmd() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "dynamic",

--- a/cmd/edit_test.go
+++ b/cmd/edit_test.go
@@ -34,13 +34,14 @@ func TestCmdEdit_Success(t *testing.T) {
 }
 
 func TestCmdEdit_NotFound(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	setPassEnv(t, string(passphrase))
 	defer setupVaultFlag(t, vaultDir)()
 	stderr := captureStderr(func() {
-		rootCmd.SetArgs([]string{"--vault", vaultDir, "edit", "ghost"})
-		_ = rootCmd.Execute()
-		rootCmd.SetArgs(nil)
+		root.SetArgs([]string{"--vault", vaultDir, "edit", "ghost"})
+		_ = root.Execute()
+		root.SetArgs(nil)
 	})
 	if !strings.Contains(stderr, "not found") && !strings.Contains(stderr, "Error") {
 		t.Errorf("expected not found, got: %s", stderr)
@@ -48,6 +49,7 @@ func TestCmdEdit_NotFound(t *testing.T) {
 }
 
 func TestCmdEdit_EditorNotFound(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	identity, _ := vaultpkg.OpenWithPassphrase(vaultDir, passphrase)
 	entry := &vaultpkg.Entry{Data: map[string]any{"password": "x"}}
@@ -58,9 +60,9 @@ func TestCmdEdit_EditorNotFound(t *testing.T) {
 	_ = os.Setenv("EDITOR", "nonexistent_editor_xyz_abc")
 	defer func() { _ = os.Setenv("EDITOR", origEditor) }()
 	stderr := captureStderr(func() {
-		rootCmd.SetArgs([]string{"--vault", vaultDir, "edit", "ed-nf"})
-		_ = rootCmd.Execute()
-		rootCmd.SetArgs(nil)
+		root.SetArgs([]string{"--vault", vaultDir, "edit", "ed-nf"})
+		_ = root.Execute()
+		root.SetArgs(nil)
 	})
 	if !strings.Contains(stderr, "not found") && !strings.Contains(stderr, "Error") {
 		t.Errorf("expected editor not found error, got: %s", stderr)
@@ -69,6 +71,7 @@ func TestCmdEdit_EditorNotFound(t *testing.T) {
 
 //nolint:dupl // test coverage helper with similar structure to invalid JSON test
 func TestCmdEdit_EmptyFile(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	identity, _ := vaultpkg.OpenWithPassphrase(vaultDir, passphrase)
 	entry := &vaultpkg.Entry{Data: map[string]any{"password": "x"}}
@@ -79,9 +82,9 @@ func TestCmdEdit_EmptyFile(t *testing.T) {
 	_ = os.Setenv("EDITOR", fakeEditorEmpty(t))
 	defer func() { _ = os.Setenv("EDITOR", origEditor) }()
 	stderr := captureStderr(func() {
-		rootCmd.SetArgs([]string{"--vault", vaultDir, "edit", "empty-edit"})
-		_ = rootCmd.Execute()
-		rootCmd.SetArgs(nil)
+		root.SetArgs([]string{"--vault", vaultDir, "edit", "empty-edit"})
+		_ = root.Execute()
+		root.SetArgs(nil)
 	})
 	if !strings.Contains(stderr, "empty") && !strings.Contains(stderr, "Error") {
 		t.Errorf("expected empty file error, got: %s", stderr)
@@ -90,6 +93,7 @@ func TestCmdEdit_EmptyFile(t *testing.T) {
 
 //nolint:dupl // test coverage helper with similar structure to empty file test
 func TestCmdEdit_InvalidJSON(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	identity, _ := vaultpkg.OpenWithPassphrase(vaultDir, passphrase)
 	entry := &vaultpkg.Entry{Data: map[string]any{"password": "x"}}
@@ -100,9 +104,9 @@ func TestCmdEdit_InvalidJSON(t *testing.T) {
 	_ = os.Setenv("EDITOR", fakeEditorInvalid(t))
 	defer func() { _ = os.Setenv("EDITOR", origEditor) }()
 	stderr := captureStderr(func() {
-		rootCmd.SetArgs([]string{"--vault", vaultDir, "edit", "bad-json"})
-		_ = rootCmd.Execute()
-		rootCmd.SetArgs(nil)
+		root.SetArgs([]string{"--vault", vaultDir, "edit", "bad-json"})
+		_ = root.Execute()
+		root.SetArgs(nil)
 	})
 	if !strings.Contains(stderr, "invalid JSON") && !strings.Contains(stderr, "Error") {
 		t.Errorf("expected invalid JSON error, got: %s", stderr)
@@ -110,6 +114,7 @@ func TestCmdEdit_InvalidJSON(t *testing.T) {
 }
 
 func TestCmdEdit_EditorRunError(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	identity, _ := vaultpkg.OpenWithPassphrase(vaultDir, passphrase)
 	entry := &vaultpkg.Entry{Data: map[string]any{"password": "x"}}
@@ -123,9 +128,9 @@ func TestCmdEdit_EditorRunError(t *testing.T) {
 	defer func() { _ = os.Setenv("EDITOR", origEditor) }()
 
 	stderr := captureStderr(func() {
-		rootCmd.SetArgs([]string{"--vault", vaultDir, "edit", "edit-err"})
-		_ = rootCmd.Execute()
-		rootCmd.SetArgs(nil)
+		root.SetArgs([]string{"--vault", vaultDir, "edit", "edit-err"})
+		_ = root.Execute()
+		root.SetArgs(nil)
 	})
 	if !strings.Contains(stderr, "editor failed") {
 		t.Errorf("expected 'editor failed' in stderr: %s", stderr)
@@ -133,14 +138,15 @@ func TestCmdEdit_EditorRunError(t *testing.T) {
 }
 
 func TestCmdEdit_Uninitialized(t *testing.T) {
+	root := NewRootCmd()
 	resetCmdFlags()
 	t.Cleanup(resetCmdFlags)
 	vaultDir := t.TempDir()
 	defer setupVaultFlag(t, vaultDir)()
 	stderr := captureStderr(func() {
-		rootCmd.SetArgs([]string{"--vault", vaultDir, "edit", "x"})
-		_ = rootCmd.Execute()
-		rootCmd.SetArgs(nil)
+		root.SetArgs([]string{"--vault", vaultDir, "edit", "x"})
+		_ = root.Execute()
+		root.SetArgs(nil)
 	})
 	if !strings.Contains(stderr, "vault not initialized") && !strings.Contains(stderr, "Error") {
 		t.Errorf("expected vault not initialized, got: %s", stderr)
@@ -219,6 +225,7 @@ func TestCmdEdit_AutoCommitError(t *testing.T) {
 }
 
 func TestEdit_ErrorPaths(t *testing.T) {
+	root := NewRootCmd()
 	resetVaultState(t)
 	tests := []struct {
 		name       string
@@ -260,10 +267,10 @@ func TestEdit_ErrorPaths(t *testing.T) {
 
 			vaultDir := tt.setupFunc()
 
-			rootCmd.SetArgs([]string{"--vault", vaultDir, "edit", "nonexistent"})
-			defer rootCmd.SetArgs(nil)
+			root.SetArgs([]string{"--vault", vaultDir, "edit", "nonexistent"})
+			defer root.SetArgs(nil)
 
-			err := rootCmd.Execute()
+			err := root.Execute()
 			if err == nil {
 				t.Errorf("expected error, got nil")
 			} else if !strings.Contains(err.Error(), tt.errContain) {

--- a/cmd/file_test.go
+++ b/cmd/file_test.go
@@ -77,17 +77,18 @@ func TestCmdFile_GetAutoDetectsSoleAttachment(t *testing.T) {
 }
 
 func TestCmdFile_AddSizeLimitRejected(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	setPassEnv(t, string(passphrase))
 	defer setupVaultFlag(t, vaultDir)()
 
 	src := writeTestAttachment(t, make([]byte, 200))
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "file", "add", "toobig/cert",
+	root.SetArgs([]string{"--vault", vaultDir, "file", "add", "toobig/cert",
 		"--field", "cert_p12", "--from", src, "--max-size", "100"})
-	defer rootCmd.SetArgs(nil)
+	defer root.SetArgs(nil)
 
-	err := rootCmd.Execute()
+	err := root.Execute()
 	if err == nil {
 		t.Fatal("expected size-limit error, got nil")
 	}
@@ -96,22 +97,23 @@ func TestCmdFile_AddSizeLimitRejected(t *testing.T) {
 	}
 
 	// Nothing should have been written to the vault.
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "file", "get", "toobig/cert", "--out", filepath.Join(t.TempDir(), "x")})
-	getErr := rootCmd.Execute()
-	rootCmd.SetArgs(nil)
+	root.SetArgs([]string{"--vault", vaultDir, "file", "get", "toobig/cert", "--out", filepath.Join(t.TempDir(), "x")})
+	getErr := root.Execute()
+	root.SetArgs(nil)
 	if getErr == nil {
 		t.Error("expected entry to not exist after rejected add, but get succeeded")
 	}
 }
 
 func TestCmdFile_AddMissingRequiredFlags(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	setPassEnv(t, string(passphrase))
 	defer setupVaultFlag(t, vaultDir)()
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "file", "add", "svc/cert", "--from", "/nonexistent"})
-	defer rootCmd.SetArgs(nil)
-	if err := rootCmd.Execute(); err == nil || !strings.Contains(err.Error(), "--field is required") {
+	root.SetArgs([]string{"--vault", vaultDir, "file", "add", "svc/cert", "--from", "/nonexistent"})
+	defer root.SetArgs(nil)
+	if err := root.Execute(); err == nil || !strings.Contains(err.Error(), "--field is required") {
 		t.Errorf("expected '--field is required' error, got: %v", err)
 	}
 }
@@ -155,18 +157,20 @@ func TestCmdFile_UseCustomAsName(t *testing.T) {
 }
 
 func TestCmdFile_UseMissingCommandArg(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	setPassEnv(t, string(passphrase))
 	defer setupVaultFlag(t, vaultDir)()
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "file", "use", "elster/cert"})
-	defer rootCmd.SetArgs(nil)
-	if err := rootCmd.Execute(); err == nil {
+	root.SetArgs([]string{"--vault", vaultDir, "file", "use", "elster/cert"})
+	defer root.SetArgs(nil)
+	if err := root.Execute(); err == nil {
 		t.Error("expected error when no command is given after path, got nil")
 	}
 }
 
 func TestCmdFile_GetAmbiguousAttachmentsRequiresField(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	setPassEnv(t, string(passphrase))
 	defer setupVaultFlag(t, vaultDir)()
@@ -176,9 +180,9 @@ func TestCmdFile_GetAmbiguousAttachmentsRequiresField(t *testing.T) {
 	execWithStdout("--vault", vaultDir, "file", "add", "multi/certs", "--field", "cert_a", "--from", src1)
 	execWithStdout("--vault", vaultDir, "file", "add", "multi/certs", "--field", "cert_b", "--from", src2)
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "file", "get", "multi/certs", "--out", filepath.Join(t.TempDir(), "x")})
-	defer rootCmd.SetArgs(nil)
-	err := rootCmd.Execute()
+	root.SetArgs([]string{"--vault", vaultDir, "file", "get", "multi/certs", "--out", filepath.Join(t.TempDir(), "x")})
+	defer root.SetArgs(nil)
+	err := root.Execute()
 	if err == nil || !strings.Contains(err.Error(), "multiple attachment fields") {
 		t.Errorf("expected 'multiple attachment fields' error, got: %v", err)
 	}

--- a/cmd/find_test.go
+++ b/cmd/find_test.go
@@ -9,13 +9,14 @@ import (
 )
 
 func TestCmdFind_NoMatches(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	setPassEnv(t, string(passphrase))
 	defer setupVaultFlag(t, vaultDir)()
 	stderr := captureStderr(func() {
-		rootCmd.SetArgs([]string{"--vault", vaultDir, "find", "nomatch_xyz_abc"})
-		_ = rootCmd.Execute()
-		rootCmd.SetArgs(nil)
+		root.SetArgs([]string{"--vault", vaultDir, "find", "nomatch_xyz_abc"})
+		_ = root.Execute()
+		root.SetArgs(nil)
 	})
 	if !strings.Contains(stderr, "No matches") {
 		t.Errorf("expected No matches, got: %s", stderr)
@@ -49,14 +50,15 @@ func TestCmdFind_SearchAlias(t *testing.T) {
 }
 
 func TestCmdFind_Uninitialized(t *testing.T) {
+	root := NewRootCmd()
 	resetCmdFlags()
 	t.Cleanup(resetCmdFlags)
 	vaultDir := t.TempDir()
 	defer setupVaultFlag(t, vaultDir)()
 	stderr := captureStderr(func() {
-		rootCmd.SetArgs([]string{"--vault", vaultDir, "find", "x"})
-		_ = rootCmd.Execute()
-		rootCmd.SetArgs(nil)
+		root.SetArgs([]string{"--vault", vaultDir, "find", "x"})
+		_ = root.Execute()
+		root.SetArgs(nil)
 	})
 	if !strings.Contains(stderr, "vault not initialized") && !strings.Contains(stderr, "Error") {
 		t.Errorf("expected vault not initialized, got: %s", stderr)
@@ -64,16 +66,17 @@ func TestCmdFind_Uninitialized(t *testing.T) {
 }
 
 func TestFind_ErrorPaths(t *testing.T) {
+	root := NewRootCmd()
 	resetVaultState(t)
 	t.Run("uninitialized vault", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		_ = os.Setenv("SYMVAULT_VAULT", tmpDir)
 		defer func() { _ = os.Unsetenv("SYMVAULT_VAULT") }()
 
-		rootCmd.SetArgs([]string{"--vault", tmpDir, "find", "test"})
-		defer rootCmd.SetArgs(nil)
+		root.SetArgs([]string{"--vault", tmpDir, "find", "test"})
+		defer root.SetArgs(nil)
 
-		err := rootCmd.Execute()
+		err := root.Execute()
 		if err == nil || !strings.Contains(err.Error(), "not initialized") {
 			t.Errorf("expected 'not initialized' error, got: %v", err)
 		}

--- a/cmd/flow_test.go
+++ b/cmd/flow_test.go
@@ -49,10 +49,11 @@ func captureStderr(fn func()) string {
 }
 
 func execWithStdout(args ...string) string {
-	rootCmd.SetArgs(args)
-	defer rootCmd.SetArgs(nil)
+	root := NewRootCmd()
+	root.SetArgs(args)
+	defer root.SetArgs(nil)
 	return captureStdout(func() {
-		_ = rootCmd.Execute()
+		_ = root.Execute()
 	})
 }
 
@@ -203,6 +204,7 @@ func TestCmdGenerate(t *testing.T) {
 }
 
 func TestCmdDelete(t *testing.T) {
+	root := NewRootCmd()
 	if testing.Short() {
 		t.Skip("skipping slow CLI flow test in short mode")
 	}
@@ -230,10 +232,10 @@ func TestCmdDelete(t *testing.T) {
 	_, _ = w.WriteString("y\n")
 	_ = w.Close()
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "delete", "delme"})
-	defer rootCmd.SetArgs(nil)
+	root.SetArgs([]string{"--vault", vaultDir, "delete", "delme"})
+	defer root.SetArgs(nil)
 	output := captureStdout(func() {
-		_ = rootCmd.Execute()
+		_ = root.Execute()
 	})
 	os.Stdin = oldStdin
 	_ = r.Close()
@@ -273,6 +275,7 @@ func TestCmdAdd(t *testing.T) {
 }
 
 func TestCmdUnlock(t *testing.T) {
+	root := NewRootCmd()
 	if testing.Short() {
 		t.Skip("skipping slow CLI flow test in short mode")
 	}
@@ -302,10 +305,10 @@ func TestCmdUnlock(t *testing.T) {
 		}
 	}()
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "unlock"})
-	defer rootCmd.SetArgs(nil)
+	root.SetArgs([]string{"--vault", vaultDir, "unlock"})
+	defer root.SetArgs(nil)
 	output := captureStderr(func() {
-		_ = rootCmd.Execute()
+		_ = root.Execute()
 	})
 	if !strings.Contains(output, "unlocked") && !strings.Contains(output, "Unlock") {
 		t.Errorf("unlock output unexpected: %s", output)

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -19,10 +19,6 @@ var (
 	genQuiet   bool
 )
 
-// generateCmd is retained for API compatibility; NewCommands() uses
-// newGenerateCmd() so every call gets a fresh command.
-var generateCmd = newGenerateCmd()
-
 func newGenerateCmd() *cobra.Command {
 	c := &cobra.Command{
 		Use:     "generate",

--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -73,6 +73,7 @@ func TestGeneratePassword_WithSymbols(t *testing.T) {
 }
 
 func TestCmdGenerate_StoreExisting(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir := t.TempDir()
 	passphrase := []byte("correcthorsebatterystaple")
 	vaultFlagReset(t)
@@ -94,11 +95,11 @@ func TestCmdGenerate_StoreExisting(t *testing.T) {
 	_ = os.Setenv("SYMVAULT_PASSPHRASE", string(passphrase))
 	t.Cleanup(func() { _ = os.Unsetenv("SYMVAULT_PASSPHRASE") })
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "generate", "--length", "16", "--store", "existing.password"})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	root.SetArgs([]string{"--vault", vaultDir, "generate", "--length", "16", "--store", "existing.password"})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
 	output := captureStdout(func() {
-		_ = rootCmd.Execute()
+		_ = root.Execute()
 	})
 
 	if !strings.Contains(output, "Password stored at") {
@@ -107,6 +108,7 @@ func TestCmdGenerate_StoreExisting(t *testing.T) {
 }
 
 func TestCmdGenerate_StoreJSONDoesNotRevealByDefault(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir := t.TempDir()
 	passphrase := []byte("correcthorsebatterystaple")
 	vaultFlagReset(t)
@@ -125,11 +127,11 @@ func TestCmdGenerate_StoreJSONDoesNotRevealByDefault(t *testing.T) {
 	_ = os.Setenv("SYMVAULT_PASSPHRASE", string(passphrase))
 	t.Cleanup(func() { _ = os.Unsetenv("SYMVAULT_PASSPHRASE") })
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "generate", "--length", "16", "--store", "json.password", "--output", "json"})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	root.SetArgs([]string{"--vault", vaultDir, "generate", "--length", "16", "--store", "json.password", "--output", "json"})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
 	output := captureStdout(func() {
-		_ = rootCmd.Execute()
+		_ = root.Execute()
 	})
 
 	var result map[string]any
@@ -145,6 +147,7 @@ func TestCmdGenerate_StoreJSONDoesNotRevealByDefault(t *testing.T) {
 }
 
 func TestCmdGenerate_ZeroLength(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir := t.TempDir()
 	passphrase := []byte("correcthorsebatterystaple")
 	vaultFlagReset(t)
@@ -159,12 +162,12 @@ func TestCmdGenerate_ZeroLength(t *testing.T) {
 	_ = os.Setenv("SYMVAULT_PASSPHRASE", string(passphrase))
 	t.Cleanup(func() { _ = os.Unsetenv("SYMVAULT_PASSPHRASE") })
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "generate", "--length", "0"})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	root.SetArgs([]string{"--vault", vaultDir, "generate", "--length", "0"})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
 	var execErr error
 	captureStderr(func() {
-		execErr = rootCmd.Execute()
+		execErr = root.Execute()
 	})
 
 	if execErr == nil {
@@ -173,6 +176,7 @@ func TestCmdGenerate_ZeroLength(t *testing.T) {
 }
 
 func TestCmdGenerate_NoStore(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir := t.TempDir()
 	vaultFlagReset(t)
 
@@ -184,11 +188,11 @@ func TestCmdGenerate_NoStore(t *testing.T) {
 	origGenLength := genLength
 	t.Cleanup(func() { genStore = origGenStore; genLength = origGenLength })
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "generate", "--length", "12"})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	root.SetArgs([]string{"--vault", vaultDir, "generate", "--length", "12"})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
 	output := captureStdout(func() {
-		_ = rootCmd.Execute()
+		_ = root.Execute()
 	})
 
 	if len(strings.TrimSpace(output)) != 12 {
@@ -197,6 +201,7 @@ func TestCmdGenerate_NoStore(t *testing.T) {
 }
 
 func TestGenerate_ErrorPaths(t *testing.T) {
+	root := NewRootCmd()
 	resetVaultState(t)
 	t.Run("invalid length", func(t *testing.T) {
 		tmpDir := t.TempDir()
@@ -210,10 +215,10 @@ func TestGenerate_ErrorPaths(t *testing.T) {
 		cfg := config.Default()
 		_, _ = vaultpkg.InitWithPassphrase(tmpDir, []byte("test"), cfg)
 
-		rootCmd.SetArgs([]string{"--vault", tmpDir, "generate", "--length", "0"})
-		defer rootCmd.SetArgs(nil)
+		root.SetArgs([]string{"--vault", tmpDir, "generate", "--length", "0"})
+		defer root.SetArgs(nil)
 
-		err := rootCmd.Execute()
+		err := root.Execute()
 		if err == nil {
 			t.Error("expected error for zero length")
 		}

--- a/cmd/get_test.go
+++ b/cmd/get_test.go
@@ -209,6 +209,7 @@ func TestCmdGet_WholeEntry(t *testing.T) {
 }
 
 func TestCmdGet_FieldNotFound(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	identity, _ := vaultpkg.OpenWithPassphrase(vaultDir, passphrase)
 	entry := &vaultpkg.Entry{Data: map[string]any{"password": "mypass"}}
@@ -216,9 +217,9 @@ func TestCmdGet_FieldNotFound(t *testing.T) {
 	setPassEnv(t, string(passphrase))
 	defer setupVaultFlag(t, vaultDir)()
 	stderr := captureStderr(func() {
-		rootCmd.SetArgs([]string{"--vault", vaultDir, "get", "getfield.nofield"})
-		_ = rootCmd.Execute()
-		rootCmd.SetArgs(nil)
+		root.SetArgs([]string{"--vault", vaultDir, "get", "getfield.nofield"})
+		_ = root.Execute()
+		root.SetArgs(nil)
 	})
 	if !strings.Contains(stderr, "field not found") && !strings.Contains(stderr, "Error") {
 		t.Errorf("expected field not found, got: %s", stderr)
@@ -226,13 +227,14 @@ func TestCmdGet_FieldNotFound(t *testing.T) {
 }
 
 func TestCmdGet_NotFound(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	setPassEnv(t, string(passphrase))
 	defer setupVaultFlag(t, vaultDir)()
 	stderr := captureStderr(func() {
-		rootCmd.SetArgs([]string{"--vault", vaultDir, "get", "ghost-entry"})
-		_ = rootCmd.Execute()
-		rootCmd.SetArgs(nil)
+		root.SetArgs([]string{"--vault", vaultDir, "get", "ghost-entry"})
+		_ = root.Execute()
+		root.SetArgs(nil)
 	})
 	if !strings.Contains(stderr, "not found") && !strings.Contains(stderr, "Error") {
 		t.Errorf("expected entry not found, got: %s", stderr)
@@ -240,6 +242,7 @@ func TestCmdGet_NotFound(t *testing.T) {
 }
 
 func TestCmdGet_FuzzyMultipleMatches(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	identity, _ := vaultpkg.OpenWithPassphrase(vaultDir, passphrase)
 	e := &vaultpkg.Entry{Data: map[string]any{"password": "p"}}
@@ -249,9 +252,9 @@ func TestCmdGet_FuzzyMultipleMatches(t *testing.T) {
 	defer setupVaultFlag(t, vaultDir)()
 	allOutput := captureStdout(func() {
 		captureStderr(func() {
-			rootCmd.SetArgs([]string{"--vault", vaultDir, "get", "work"})
-			_ = rootCmd.Execute()
-			rootCmd.SetArgs(nil)
+			root.SetArgs([]string{"--vault", vaultDir, "get", "work"})
+			_ = root.Execute()
+			root.SetArgs(nil)
 		})
 	})
 	_ = allOutput
@@ -278,14 +281,15 @@ func TestCmdGet_TOTP(t *testing.T) {
 }
 
 func TestCmdGet_Uninitialized(t *testing.T) {
+	root := NewRootCmd()
 	resetCmdFlags()
 	t.Cleanup(resetCmdFlags)
 	vaultDir := t.TempDir()
 	defer setupVaultFlag(t, vaultDir)()
 	stderr := captureStderr(func() {
-		rootCmd.SetArgs([]string{"--vault", vaultDir, "get", "x"})
-		_ = rootCmd.Execute()
-		rootCmd.SetArgs(nil)
+		root.SetArgs([]string{"--vault", vaultDir, "get", "x"})
+		_ = root.Execute()
+		root.SetArgs(nil)
 	})
 	if !strings.Contains(stderr, "vault not initialized") && !strings.Contains(stderr, "Error") {
 		t.Errorf("expected vault not initialized, got: %s", stderr)
@@ -306,6 +310,7 @@ func TestCmdGet_FuzzySingleMatch(t *testing.T) {
 }
 
 func TestCmdGet_TOTPDisplay(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	identity, _ := vaultpkg.OpenWithPassphrase(vaultDir, passphrase)
 	entry := &vaultpkg.Entry{
@@ -319,10 +324,10 @@ func TestCmdGet_TOTPDisplay(t *testing.T) {
 	_ = vaultpkg.WriteEntry(vaultDir, "totp-display", entry, identity.Identity)
 	setPassEnv(t, string(passphrase))
 	defer setupVaultFlag(t, vaultDir)()
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "get", "totp-display"})
-	defer rootCmd.SetArgs(nil)
+	root.SetArgs([]string{"--vault", vaultDir, "get", "totp-display"})
+	defer root.SetArgs(nil)
 	out := captureStderr(func() {
-		_ = rootCmd.Execute()
+		_ = root.Execute()
 	})
 	if !strings.Contains(out, "TOTP Code") {
 		t.Errorf("expected TOTP Code in output, got: %s", out)
@@ -333,6 +338,7 @@ func TestCmdGet_TOTPDisplay(t *testing.T) {
 }
 
 func TestCmdGet_FieldTTY_DefaultClipboard(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	if err := os.WriteFile(filepath.Join(vaultDir, "config.yaml"), []byte("clipboard:\n  auto_clear_duration: 0\n"), 0o600); err != nil {
 		t.Fatalf("disable clipboard auto-clear: %v", err)
@@ -355,9 +361,9 @@ func TestCmdGet_FieldTTY_DefaultClipboard(t *testing.T) {
 	var execErr error
 	stderr := captureStderr(func() {
 		stdout = captureStdout(func() {
-			rootCmd.SetArgs([]string{"--vault", vaultDir, "get", "clip-entry.password"})
-			execErr = rootCmd.Execute()
-			rootCmd.SetArgs(nil)
+			root.SetArgs([]string{"--vault", vaultDir, "get", "clip-entry.password"})
+			execErr = root.Execute()
+			root.SetArgs(nil)
 		})
 	})
 	if execErr != nil {
@@ -376,6 +382,7 @@ func TestCmdGet_FieldTTY_DefaultClipboard(t *testing.T) {
 }
 
 func TestCmdGet_FieldTTY_AutoClearRunsBeforeReturn(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	if err := os.WriteFile(filepath.Join(vaultDir, "config.yaml"), []byte("clipboard:\n  auto_clear_duration: 1\n"), 0o600); err != nil {
 		t.Fatalf("enable clipboard auto-clear: %v", err)
@@ -407,9 +414,9 @@ func TestCmdGet_FieldTTY_AutoClearRunsBeforeReturn(t *testing.T) {
 	var execErr error
 	captureStderr(func() {
 		captureStdout(func() {
-			rootCmd.SetArgs([]string{"--vault", vaultDir, "get", "clear-entry.password"})
-			execErr = rootCmd.Execute()
-			rootCmd.SetArgs(nil)
+			root.SetArgs([]string{"--vault", vaultDir, "get", "clear-entry.password"})
+			execErr = root.Execute()
+			root.SetArgs(nil)
 		})
 	})
 	if execErr != nil {
@@ -537,6 +544,7 @@ func TestCmdGet_TOTPGenerationError(t *testing.T) {
 }
 
 func TestGet_ErrorPaths(t *testing.T) {
+	root := NewRootCmd()
 	resetVaultState(t)
 	tests := []struct {
 		setupFunc  func() string
@@ -581,10 +589,10 @@ func TestGet_ErrorPaths(t *testing.T) {
 
 			vaultDir := tt.setupFunc()
 
-			rootCmd.SetArgs(append([]string{"--vault", vaultDir}, tt.args...))
-			defer rootCmd.SetArgs(nil)
+			root.SetArgs(append([]string{"--vault", vaultDir}, tt.args...))
+			defer root.SetArgs(nil)
 
-			err := rootCmd.Execute()
+			err := root.Execute()
 			if err == nil {
 				t.Errorf("expected error, got nil")
 			} else if !strings.Contains(err.Error(), tt.errContain) {

--- a/cmd/git.go
+++ b/cmd/git.go
@@ -11,10 +11,6 @@ import (
 	vaultpkg "github.com/danieljustus/symaira-vault/internal/vault"
 )
 
-// gitCmd is retained for API compatibility; NewRootCmd() uses
-// newGitCmd() so every call gets a fresh command.
-var gitCmd = newGitCmd()
-
 func newGitCmd() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "git <push|pull|log> [path]",

--- a/cmd/import_test.go
+++ b/cmd/import_test.go
@@ -127,12 +127,13 @@ func runImportCommand(t *testing.T, passphrase string, args ...string) string {
 	if err := os.Setenv("SYMVAULT_PASSPHRASE", passphrase); err != nil {
 		t.Fatalf("set passphrase env: %v", err)
 	}
-	rootCmd.SetArgs(args)
-	defer rootCmd.SetArgs(nil)
+	root := NewRootCmd()
+	root.SetArgs(args)
+	defer root.SetArgs(nil)
 
 	var execErr error
 	output := captureStdout(func() {
-		execErr = rootCmd.Execute()
+		execErr = root.Execute()
 	})
 	if execErr != nil {
 		t.Fatalf("import command failed: %v", execErr)
@@ -195,6 +196,7 @@ func assertCSVImportedEntries(t *testing.T, v *vaultpkg.Vault, prefix string) {
 }
 
 func TestImportQuarantineMutualExclusion(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	setPassEnv(t, string(passphrase))
 	defer setupVaultFlag(t, vaultDir)()
@@ -202,12 +204,12 @@ func TestImportQuarantineMutualExclusion(t *testing.T) {
 	if err := os.Setenv("SYMVAULT_PASSPHRASE", string(passphrase)); err != nil {
 		t.Fatalf("set passphrase env: %v", err)
 	}
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "import", "--format", "csv", csvImportFixture(t), "--quarantine", "--prefix", "myprefix/"})
-	defer rootCmd.SetArgs(nil)
+	root.SetArgs([]string{"--vault", vaultDir, "import", "--format", "csv", csvImportFixture(t), "--quarantine", "--prefix", "myprefix/"})
+	defer root.SetArgs(nil)
 
 	var execErr error
 	captureStdout(func() {
-		execErr = rootCmd.Execute()
+		execErr = root.Execute()
 	})
 	if execErr == nil {
 		t.Fatal("expected error combining --quarantine and --prefix, got nil")
@@ -218,6 +220,7 @@ func TestImportQuarantineMutualExclusion(t *testing.T) {
 }
 
 func TestImportQuarantinePath(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	setPassEnv(t, string(passphrase))
 	defer setupVaultFlag(t, vaultDir)()
@@ -225,12 +228,12 @@ func TestImportQuarantinePath(t *testing.T) {
 	if err := os.Setenv("SYMVAULT_PASSPHRASE", string(passphrase)); err != nil {
 		t.Fatalf("set passphrase env: %v", err)
 	}
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "import", "--format", "csv", csvImportFixture(t), "--quarantine"})
-	defer rootCmd.SetArgs(nil)
+	root.SetArgs([]string{"--vault", vaultDir, "import", "--format", "csv", csvImportFixture(t), "--quarantine"})
+	defer root.SetArgs(nil)
 
 	var execErr error
 	output := captureStdout(func() {
-		execErr = rootCmd.Execute()
+		execErr = root.Execute()
 	})
 	if execErr != nil {
 		t.Fatalf("import --quarantine failed: %v", execErr)
@@ -263,6 +266,7 @@ func TestImportQuarantinePath(t *testing.T) {
 }
 
 func TestImportReviewListEmpty(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	setPassEnv(t, string(passphrase))
 	defer setupVaultFlag(t, vaultDir)()
@@ -270,12 +274,12 @@ func TestImportReviewListEmpty(t *testing.T) {
 	if err := os.Setenv("SYMVAULT_PASSPHRASE", string(passphrase)); err != nil {
 		t.Fatalf("set passphrase env: %v", err)
 	}
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "import", "review", "list"})
-	defer rootCmd.SetArgs(nil)
+	root.SetArgs([]string{"--vault", vaultDir, "import", "review", "list"})
+	defer root.SetArgs(nil)
 
 	var execErr error
 	output := captureStdout(func() {
-		execErr = rootCmd.Execute()
+		execErr = root.Execute()
 	})
 	if execErr != nil {
 		t.Fatalf("import review list failed: %v", execErr)
@@ -286,6 +290,7 @@ func TestImportReviewListEmpty(t *testing.T) {
 }
 
 func TestImportReviewList(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	setPassEnv(t, string(passphrase))
 	defer setupVaultFlag(t, vaultDir)()
@@ -294,13 +299,13 @@ func TestImportReviewList(t *testing.T) {
 	if err := os.Setenv("SYMVAULT_PASSPHRASE", string(passphrase)); err != nil {
 		t.Fatalf("set passphrase env: %v", err)
 	}
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "import", "--format", "csv", csvImportFixture(t), "--quarantine"})
+	root.SetArgs([]string{"--vault", vaultDir, "import", "--format", "csv", csvImportFixture(t), "--quarantine"})
 	var importOutput string
 	var importErr error
 	importOutput = captureStdout(func() {
-		importErr = rootCmd.Execute()
+		importErr = root.Execute()
 	})
-	rootCmd.SetArgs(nil)
+	root.SetArgs(nil)
 	if importErr != nil {
 		t.Fatalf("quarantine import failed: %v", importErr)
 	}
@@ -322,12 +327,12 @@ func TestImportReviewList(t *testing.T) {
 	}
 
 	// Now run review list
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "import", "review", "list"})
+	root.SetArgs([]string{"--vault", vaultDir, "import", "review", "list"})
 	var listErr error
 	listOutput := captureStdout(func() {
-		listErr = rootCmd.Execute()
+		listErr = root.Execute()
 	})
-	rootCmd.SetArgs(nil)
+	root.SetArgs(nil)
 	if listErr != nil {
 		t.Fatalf("import review list failed: %v", listErr)
 	}
@@ -340,6 +345,7 @@ func TestImportReviewList(t *testing.T) {
 }
 
 func TestImportReviewPromote(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	setPassEnv(t, string(passphrase))
 	defer setupVaultFlag(t, vaultDir)()
@@ -348,13 +354,13 @@ func TestImportReviewPromote(t *testing.T) {
 	if err := os.Setenv("SYMVAULT_PASSPHRASE", string(passphrase)); err != nil {
 		t.Fatalf("set passphrase env: %v", err)
 	}
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "import", "--format", "csv", csvImportFixture(t), "--quarantine"})
+	root.SetArgs([]string{"--vault", vaultDir, "import", "--format", "csv", csvImportFixture(t), "--quarantine"})
 	var importOutput string
 	var importErr error
 	importOutput = captureStdout(func() {
-		importErr = rootCmd.Execute()
+		importErr = root.Execute()
 	})
-	rootCmd.SetArgs(nil)
+	root.SetArgs(nil)
 	if importErr != nil {
 		t.Fatalf("quarantine import failed: %v", importErr)
 	}
@@ -376,12 +382,12 @@ func TestImportReviewPromote(t *testing.T) {
 	}
 
 	// Promote
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "import", "review", "promote", importID})
+	root.SetArgs([]string{"--vault", vaultDir, "import", "review", "promote", importID})
 	var promoteErr error
 	promoteOutput := captureStdout(func() {
-		promoteErr = rootCmd.Execute()
+		promoteErr = root.Execute()
 	})
-	rootCmd.SetArgs(nil)
+	root.SetArgs(nil)
 	if promoteErr != nil {
 		t.Fatalf("import review promote failed: %v", promoteErr)
 	}
@@ -408,6 +414,7 @@ func TestImportReviewPromote(t *testing.T) {
 }
 
 func TestImportReviewPromoteSkipsExisting(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	setPassEnv(t, string(passphrase))
 	defer setupVaultFlag(t, vaultDir)()
@@ -416,13 +423,13 @@ func TestImportReviewPromoteSkipsExisting(t *testing.T) {
 	if err := os.Setenv("SYMVAULT_PASSPHRASE", string(passphrase)); err != nil {
 		t.Fatalf("set passphrase env: %v", err)
 	}
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "import", "--format", "csv", csvImportFixture(t), "--quarantine"})
+	root.SetArgs([]string{"--vault", vaultDir, "import", "--format", "csv", csvImportFixture(t), "--quarantine"})
 	var importOutput string
 	var importErr error
 	importOutput = captureStdout(func() {
-		importErr = rootCmd.Execute()
+		importErr = root.Execute()
 	})
-	rootCmd.SetArgs(nil)
+	root.SetArgs(nil)
 	if importErr != nil {
 		t.Fatalf("quarantine import failed: %v", importErr)
 	}
@@ -453,12 +460,12 @@ func TestImportReviewPromoteSkipsExisting(t *testing.T) {
 	}
 
 	// Promote WITHOUT --overwrite — should fail
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "import", "review", "promote", importID})
+	root.SetArgs([]string{"--vault", vaultDir, "import", "review", "promote", importID})
 	var promoteErr error
 	promoteOutput := captureStdout(func() {
-		promoteErr = rootCmd.Execute()
+		promoteErr = root.Execute()
 	})
-	rootCmd.SetArgs(nil)
+	root.SetArgs(nil)
 	if promoteErr == nil {
 		t.Fatal("expected error when destination already exists without --overwrite, got nil")
 	}
@@ -479,6 +486,7 @@ func TestImportReviewPromoteSkipsExisting(t *testing.T) {
 }
 
 func TestImportReviewPromoteOverwrite(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	setPassEnv(t, string(passphrase))
 	defer setupVaultFlag(t, vaultDir)()
@@ -487,13 +495,13 @@ func TestImportReviewPromoteOverwrite(t *testing.T) {
 	if err := os.Setenv("SYMVAULT_PASSPHRASE", string(passphrase)); err != nil {
 		t.Fatalf("set passphrase env: %v", err)
 	}
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "import", "--format", "csv", csvImportFixture(t), "--quarantine"})
+	root.SetArgs([]string{"--vault", vaultDir, "import", "--format", "csv", csvImportFixture(t), "--quarantine"})
 	var importOutput string
 	var importErr error
 	importOutput = captureStdout(func() {
-		importErr = rootCmd.Execute()
+		importErr = root.Execute()
 	})
-	rootCmd.SetArgs(nil)
+	root.SetArgs(nil)
 	if importErr != nil {
 		t.Fatalf("quarantine import failed: %v", importErr)
 	}
@@ -525,12 +533,12 @@ func TestImportReviewPromoteOverwrite(t *testing.T) {
 	}
 
 	// Promote WITH --overwrite — should succeed
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "import", "review", "promote", importID, "--overwrite"})
+	root.SetArgs([]string{"--vault", vaultDir, "import", "review", "promote", importID, "--overwrite"})
 	var promoteErr error
 	captureStdout(func() {
-		promoteErr = rootCmd.Execute()
+		promoteErr = root.Execute()
 	})
-	rootCmd.SetArgs(nil)
+	root.SetArgs(nil)
 	if promoteErr != nil {
 		t.Fatalf("import review promote --overwrite failed: %v", promoteErr)
 	}
@@ -555,6 +563,7 @@ func TestImportReviewPromoteOverwrite(t *testing.T) {
 }
 
 func TestImportReviewPromoteNotFound(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	setPassEnv(t, string(passphrase))
 	defer setupVaultFlag(t, vaultDir)()
@@ -563,12 +572,12 @@ func TestImportReviewPromoteNotFound(t *testing.T) {
 		t.Fatalf("set passphrase env: %v", err)
 	}
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "import", "review", "promote", "import-00000000-deadbeef"})
-	defer rootCmd.SetArgs(nil)
+	root.SetArgs([]string{"--vault", vaultDir, "import", "review", "promote", "import-00000000-deadbeef"})
+	defer root.SetArgs(nil)
 
 	var execErr error
 	captureStdout(func() {
-		execErr = rootCmd.Execute()
+		execErr = root.Execute()
 	})
 	if execErr == nil {
 		t.Fatal("expected error for unknown import-id, got nil")

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -14,17 +14,18 @@ import (
 )
 
 func TestInitCommand_HiddenPassphrase(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir := t.TempDir()
 	passphrase := []byte("test-hidden-passphrase")
 
 	cli.SetCachedEnvPassphrase(passphrase)
 	defer cli.SetCachedEnvPassphrase(nil)
 
-	rootCmd.SetArgs([]string{"init", vaultDir})
-	defer rootCmd.SetArgs(nil)
+	root.SetArgs([]string{"init", vaultDir})
+	defer root.SetArgs(nil)
 
 	output := captureStdout(func() {
-		if err := rootCmd.Execute(); err != nil {
+		if err := root.Execute(); err != nil {
 			t.Fatalf("init command failed: %v", err)
 		}
 	})
@@ -55,17 +56,18 @@ func TestInitCommand_HiddenPassphrase(t *testing.T) {
 }
 
 func TestCmdInit_Success(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir := t.TempDir()
 	vaultFlagReset(t)
 
 	cli.SetCachedEnvPassphrase([]byte("supersecretpassphrase123"))
 	defer cli.SetCachedEnvPassphrase(nil)
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "init"})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	root.SetArgs([]string{"--vault", vaultDir, "init"})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
 	output := captureStdout(func() {
-		_ = rootCmd.Execute()
+		_ = root.Execute()
 	})
 
 	if !strings.Contains(output, "Vault initialized") {
@@ -74,6 +76,7 @@ func TestCmdInit_Success(t *testing.T) {
 }
 
 func TestCmdInit_AlreadyInitialized(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir := t.TempDir()
 	vaultFlagReset(t)
 
@@ -84,12 +87,12 @@ func TestCmdInit_AlreadyInitialized(t *testing.T) {
 	cli.SetCachedEnvPassphrase([]byte("supersecretpassphrase123"))
 	defer cli.SetCachedEnvPassphrase(nil)
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "init"})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	root.SetArgs([]string{"--vault", vaultDir, "init"})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
 	var execErr error
 	captureStderr(func() {
-		execErr = rootCmd.Execute()
+		execErr = root.Execute()
 	})
 
 	if execErr == nil {
@@ -101,18 +104,19 @@ func TestCmdInit_AlreadyInitialized(t *testing.T) {
 }
 
 func TestCmdInit_ShortPassphrase(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir := t.TempDir()
 	vaultFlagReset(t)
 
 	cli.SetCachedEnvPassphrase([]byte("short"))
 	defer cli.SetCachedEnvPassphrase(nil)
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "init"})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	root.SetArgs([]string{"--vault", vaultDir, "init"})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
 	var execErr error
 	captureStderr(func() {
-		execErr = rootCmd.Execute()
+		execErr = root.Execute()
 	})
 
 	if execErr == nil {
@@ -121,6 +125,7 @@ func TestCmdInit_ShortPassphrase(t *testing.T) {
 }
 
 func TestInit_ErrorPaths(t *testing.T) {
+	root := NewRootCmd()
 	resetVaultState(t)
 	t.Run("already initialized", func(t *testing.T) {
 		tmpDir := t.TempDir()
@@ -133,10 +138,10 @@ func TestInit_ErrorPaths(t *testing.T) {
 		cli.SetCachedEnvPassphrase([]byte("test"))
 		defer cli.SetCachedEnvPassphrase(nil)
 
-		rootCmd.SetArgs([]string{"--vault", tmpDir, "init"})
-		defer rootCmd.SetArgs(nil)
+		root.SetArgs([]string{"--vault", tmpDir, "init"})
+		defer root.SetArgs(nil)
 
-		err := rootCmd.Execute()
+		err := root.Execute()
 		if err == nil || !strings.Contains(err.Error(), "already initialized") {
 			t.Errorf("expected 'already initialized' error, got: %v", err)
 		}

--- a/cmd/integration_test.go
+++ b/cmd/integration_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestCmdGitPush_NoRemote(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir := t.TempDir()
 	vaultFlagReset(t)
 	_ = os.Setenv("SYMVAULT_VAULT", vaultDir)
@@ -24,11 +25,11 @@ func TestCmdGitPush_NoRemote(t *testing.T) {
 		t.Fatalf("git init: %v", err)
 	}
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "git", "push"})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	root.SetArgs([]string{"--vault", vaultDir, "git", "push"})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
 	output := captureStdout(func() {
-		_ = rootCmd.Execute()
+		_ = root.Execute()
 	})
 
 	if !strings.Contains(output, "Pushed") {
@@ -37,6 +38,7 @@ func TestCmdGitPush_NoRemote(t *testing.T) {
 }
 
 func TestCmdGitPull_NoRemote(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir := t.TempDir()
 	vaultFlagReset(t)
 	_ = os.Setenv("SYMVAULT_VAULT", vaultDir)
@@ -46,11 +48,11 @@ func TestCmdGitPull_NoRemote(t *testing.T) {
 		t.Fatalf("git init: %v", err)
 	}
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "git", "pull"})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	root.SetArgs([]string{"--vault", vaultDir, "git", "pull"})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
 	output := captureStdout(func() {
-		_ = rootCmd.Execute()
+		_ = root.Execute()
 	})
 
 	if !strings.Contains(output, "Pulled") {
@@ -59,6 +61,7 @@ func TestCmdGitPull_NoRemote(t *testing.T) {
 }
 
 func TestCmdGitLog_Success(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir := t.TempDir()
 	passphrase := []byte("correcthorsebatterystaple")
 	vaultFlagReset(t)
@@ -82,11 +85,11 @@ func TestCmdGitLog_Success(t *testing.T) {
 	_ = os.Setenv("SYMVAULT_PASSPHRASE", passphrase)
 	t.Cleanup(func() { _ = os.Unsetenv("SYMVAULT_PASSPHRASE") })
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "git", "log"})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	root.SetArgs([]string{"--vault", vaultDir, "git", "log"})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
 	output := captureStdout(func() {
-		_ = rootCmd.Execute()
+		_ = root.Execute()
 	})
 
 	if len(strings.TrimSpace(output)) == 0 {
@@ -95,6 +98,7 @@ func TestCmdGitLog_Success(t *testing.T) {
 }
 
 func TestCmdGitUnknownAction(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir := t.TempDir()
 	passphrase := []byte("correcthorsebatterystaple")
 	vaultFlagReset(t)
@@ -105,12 +109,12 @@ func TestCmdGitUnknownAction(t *testing.T) {
 	_ = os.Setenv("SYMVAULT_VAULT", vaultDir)
 	t.Cleanup(func() { _ = os.Unsetenv("SYMVAULT_VAULT") })
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "git", "unknown"})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	root.SetArgs([]string{"--vault", vaultDir, "git", "unknown"})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
 	var execErr error
 	captureStderr(func() {
-		execErr = rootCmd.Execute()
+		execErr = root.Execute()
 	})
 
 	if execErr == nil {
@@ -122,6 +126,7 @@ func TestCmdGitUnknownAction(t *testing.T) {
 }
 
 func TestCmdLock_Success(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir := t.TempDir()
 	passphrase := []byte("correcthorsebatterystaple")
 	vaultFlagReset(t)
@@ -134,11 +139,11 @@ func TestCmdLock_Success(t *testing.T) {
 		t.Skipf("keyring unavailable: %v", err)
 	}
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "lock"})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	root.SetArgs([]string{"--vault", vaultDir, "lock"})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
 	output := captureStderr(func() {
-		_ = rootCmd.Execute()
+		_ = root.Execute()
 	})
 
 	if !strings.Contains(output, "Vault locked") {
@@ -147,6 +152,7 @@ func TestCmdLock_Success(t *testing.T) {
 }
 
 func TestCmdUnlock_CheckExpired(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir := t.TempDir()
 	passphrase := []byte("correcthorsebatterystaple")
 	vaultFlagReset(t)
@@ -158,12 +164,12 @@ func TestCmdUnlock_CheckExpired(t *testing.T) {
 	_ = os.Unsetenv("SYMVAULT_PASSPHRASE")
 	t.Cleanup(func() { _ = unlockCmd.Flags().Set("check", "false") })
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "unlock", "--check"})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	root.SetArgs([]string{"--vault", vaultDir, "unlock", "--check"})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
 	var execErr error
 	captureStderr(func() {
-		execErr = rootCmd.Execute()
+		execErr = root.Execute()
 	})
 
 	if execErr == nil {
@@ -175,6 +181,7 @@ func TestCmdUnlock_CheckExpired(t *testing.T) {
 }
 
 func TestCmdUnlock_CheckActive(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir := t.TempDir()
 	passphrase := []byte("correcthorsebatterystaple")
 	vaultFlagReset(t)
@@ -192,11 +199,11 @@ func TestCmdUnlock_CheckActive(t *testing.T) {
 		_ = session.ClearSession(vaultDir)
 	})
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "unlock", "--check"})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	root.SetArgs([]string{"--vault", vaultDir, "unlock", "--check"})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
 	output := captureStderr(func() {
-		_ = rootCmd.Execute()
+		_ = root.Execute()
 	})
 
 	if !strings.Contains(output, "Session active") {
@@ -205,16 +212,17 @@ func TestCmdUnlock_CheckActive(t *testing.T) {
 }
 
 func TestLock_ErrorPaths(t *testing.T) {
+	root := NewRootCmd()
 	resetVaultState(t)
 	t.Run("uninitialized vault", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		_ = os.Setenv("SYMVAULT_VAULT", tmpDir)
 		defer func() { _ = os.Unsetenv("SYMVAULT_VAULT") }()
 
-		rootCmd.SetArgs([]string{"--vault", tmpDir, "lock"})
-		defer rootCmd.SetArgs(nil)
+		root.SetArgs([]string{"--vault", tmpDir, "lock"})
+		defer root.SetArgs(nil)
 
-		err := rootCmd.Execute()
+		err := root.Execute()
 		if err == nil || !strings.Contains(err.Error(), "not initialized") {
 			t.Errorf("expected 'not initialized' error, got: %v", err)
 		}
@@ -222,16 +230,17 @@ func TestLock_ErrorPaths(t *testing.T) {
 }
 
 func TestUnlock_ErrorPaths(t *testing.T) {
+	root := NewRootCmd()
 	resetVaultState(t)
 	t.Run("uninitialized vault", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		_ = os.Setenv("SYMVAULT_VAULT", tmpDir)
 		defer func() { _ = os.Unsetenv("SYMVAULT_VAULT") }()
 
-		rootCmd.SetArgs([]string{"--vault", tmpDir, "unlock"})
-		defer rootCmd.SetArgs(nil)
+		root.SetArgs([]string{"--vault", tmpDir, "unlock"})
+		defer root.SetArgs(nil)
 
-		err := rootCmd.Execute()
+		err := root.Execute()
 		if err == nil || !strings.Contains(err.Error(), "not initialized") {
 			t.Errorf("expected 'not initialized' error, got: %v", err)
 		}
@@ -249,10 +258,10 @@ func TestUnlock_ErrorPaths(t *testing.T) {
 			_ = os.Unsetenv("SYMVAULT_PASSPHRASE")
 		}()
 
-		rootCmd.SetArgs([]string{"--vault", tmpDir, "unlock"})
-		defer rootCmd.SetArgs(nil)
+		root.SetArgs([]string{"--vault", tmpDir, "unlock"})
+		defer root.SetArgs(nil)
 
-		err := rootCmd.Execute()
+		err := root.Execute()
 		if err == nil {
 			t.Error("expected error for wrong passphrase")
 		}

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -47,14 +47,15 @@ func TestCmdList_Alias(t *testing.T) {
 }
 
 func TestCmdList_Uninitialized(t *testing.T) {
+	root := NewRootCmd()
 	resetCmdFlags()
 	t.Cleanup(resetCmdFlags)
 	vaultDir := t.TempDir()
 	defer setupVaultFlag(t, vaultDir)()
 	stderr := captureStderr(func() {
-		rootCmd.SetArgs([]string{"--vault", vaultDir, "list"})
-		_ = rootCmd.Execute()
-		rootCmd.SetArgs(nil)
+		root.SetArgs([]string{"--vault", vaultDir, "list"})
+		_ = root.Execute()
+		root.SetArgs(nil)
 	})
 	if !strings.Contains(stderr, "vault not initialized") && !strings.Contains(stderr, "Error") {
 		t.Errorf("expected vault not initialized, got: %s", stderr)
@@ -62,16 +63,17 @@ func TestCmdList_Uninitialized(t *testing.T) {
 }
 
 func TestList_ErrorPaths(t *testing.T) {
+	root := NewRootCmd()
 	resetVaultState(t)
 	t.Run("uninitialized vault", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		_ = os.Setenv("SYMVAULT_VAULT", tmpDir)
 		defer func() { _ = os.Unsetenv("SYMVAULT_VAULT") }()
 
-		rootCmd.SetArgs([]string{"--vault", tmpDir, "list"})
-		defer rootCmd.SetArgs(nil)
+		root.SetArgs([]string{"--vault", tmpDir, "list"})
+		defer root.SetArgs(nil)
 
-		err := rootCmd.Execute()
+		err := root.Execute()
 		if err == nil || !strings.Contains(err.Error(), "not initialized") {
 			t.Errorf("expected 'not initialized' error, got: %v", err)
 		}

--- a/cmd/mcp/serve.go
+++ b/cmd/mcp/serve.go
@@ -46,10 +46,6 @@ The server can run in HTTP mode or stdio mode.`,
 		config.LegacyVaultSubdir)
 }
 
-// McpCmd is retained for API compatibility; NewCommands() uses
-// newMcpCmd() so every call gets a fresh command.
-var McpCmd = newMcpCmd()
-
 func newMcpCmd() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "mcp",
@@ -80,10 +76,6 @@ func newMcpCmd() *cobra.Command {
 	c.AddCommand(newMcpTokenCmd())
 	return c
 }
-
-// ServeCmd is retained for API compatibility; NewCommands() uses
-// newServeCmd() so every call gets a fresh command.
-var ServeCmd = newServeCmd()
 
 func newServeCmd() *cobra.Command {
 	c := &cobra.Command{

--- a/cmd/mcp_config_test.go
+++ b/cmd/mcp_config_test.go
@@ -244,12 +244,13 @@ func TestCmdMCPConfig_HTTPMode(t *testing.T) {
 }
 
 func TestCmdMCPConfig_Stdio(t *testing.T) {
+	root := NewRootCmd()
 	vaultFlagReset(t)
 
-	rootCmd.SetArgs([]string{"mcp-config", "myagent"})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	root.SetArgs([]string{"mcp-config", "myagent"})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
-	err := rootCmd.Execute()
+	err := root.Execute()
 
 	if err == nil {
 		t.Fatal("expected deprecation error")
@@ -260,16 +261,17 @@ func TestCmdMCPConfig_Stdio(t *testing.T) {
 }
 
 func TestCmdMCPConfig_StdioCustomVaultIncludesVaultArg(t *testing.T) {
+	root := NewRootCmd()
 	if runtime.GOOS == "windows" {
 		t.Skip("skipping on windows: path format differs")
 	}
 	vaultDir := t.TempDir()
 	vaultFlagReset(t)
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "mcp-config", "myagent"})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	root.SetArgs([]string{"--vault", vaultDir, "mcp-config", "myagent"})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
-	err := rootCmd.Execute()
+	err := root.Execute()
 
 	if err == nil {
 		t.Fatal("expected deprecation error")
@@ -280,6 +282,7 @@ func TestCmdMCPConfig_StdioCustomVaultIncludesVaultArg(t *testing.T) {
 }
 
 func TestCmdMCPConfig_HTTP(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir := t.TempDir()
 	passphrase := []byte("correcthorsebatterystaple")
 	vaultFlagReset(t)
@@ -290,10 +293,10 @@ func TestCmdMCPConfig_HTTP(t *testing.T) {
 		t.Fatalf("init vault: %v", err)
 	}
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "mcp-config", "myagent"})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	root.SetArgs([]string{"--vault", vaultDir, "mcp-config", "myagent"})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
-	err := rootCmd.Execute()
+	err := root.Execute()
 
 	if err == nil {
 		t.Fatal("expected deprecation error")
@@ -304,6 +307,7 @@ func TestCmdMCPConfig_HTTP(t *testing.T) {
 }
 
 func TestCmdMCPConfig_HermesHTTP(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, _ := initVault(t)
 	vaultFlagReset(t)
 	t.Cleanup(func() {
@@ -314,10 +318,10 @@ func TestCmdMCPConfig_HermesHTTP(t *testing.T) {
 		t.Fatalf("write config: %v", err)
 	}
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "mcp-config", "hermes"})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	root.SetArgs([]string{"--vault", vaultDir, "mcp-config", "hermes"})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
-	err := rootCmd.Execute()
+	err := root.Execute()
 
 	if err == nil {
 		t.Fatal("expected deprecation error")
@@ -356,6 +360,7 @@ func TestOutputHTTPConfig_VaultPathError(t *testing.T) {
 }
 
 func TestOutputHTTPConfig_CustomTokenFile(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, _ := initVault(t)
 	vaultFlagReset(t)
 
@@ -370,10 +375,10 @@ func TestOutputHTTPConfig_CustomTokenFile(t *testing.T) {
 		t.Fatalf("write config: %v", err)
 	}
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "mcp-config", "myagent"})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	root.SetArgs([]string{"--vault", vaultDir, "mcp-config", "myagent"})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
-	err := rootCmd.Execute()
+	err := root.Execute()
 
 	if err == nil {
 		t.Fatal("expected deprecation error")
@@ -382,8 +387,8 @@ func TestOutputHTTPConfig_CustomTokenFile(t *testing.T) {
 		t.Errorf("expected deprecation message, got: %v", err)
 	}
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "mcp-config", "myagent"})
-	err = rootCmd.Execute()
+	root.SetArgs([]string{"--vault", vaultDir, "mcp-config", "myagent"})
+	err = root.Execute()
 
 	if err == nil {
 		t.Fatal("expected deprecation error")
@@ -394,6 +399,7 @@ func TestOutputHTTPConfig_CustomTokenFile(t *testing.T) {
 }
 
 func TestOutputHTTPConfig_TokenLoadError(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, _ := initVault(t)
 	vaultFlagReset(t)
 
@@ -402,10 +408,10 @@ func TestOutputHTTPConfig_TokenLoadError(t *testing.T) {
 		t.Fatalf("write config: %v", err)
 	}
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "mcp-config", "myagent"})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	root.SetArgs([]string{"--vault", vaultDir, "mcp-config", "myagent"})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
-	err := rootCmd.Execute()
+	err := root.Execute()
 
 	if err == nil {
 		t.Fatal("expected deprecation error")
@@ -416,6 +422,7 @@ func TestOutputHTTPConfig_TokenLoadError(t *testing.T) {
 }
 
 func TestOutputHTTPConfig_StaleRuntimePort(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, _ := initVault(t)
 	vaultFlagReset(t)
 
@@ -423,10 +430,10 @@ func TestOutputHTTPConfig_StaleRuntimePort(t *testing.T) {
 		t.Fatalf("save runtime port: %v", err)
 	}
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "mcp-config", "myagent"})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	root.SetArgs([]string{"--vault", vaultDir, "mcp-config", "myagent"})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
-	err := rootCmd.Execute()
+	err := root.Execute()
 
 	if err == nil {
 		t.Fatal("expected deprecation error")

--- a/cmd/mcp_token_test.go
+++ b/cmd/mcp_token_test.go
@@ -33,6 +33,7 @@ func TestMCPTokenCommandRegistration(t *testing.T) {
 }
 
 func TestMCPTokenCreate_Defaults(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir := t.TempDir()
 	_ = os.Setenv("SYMVAULT_VAULT", vaultDir)
 	defer func() { _ = os.Unsetenv("SYMVAULT_VAULT") }()
@@ -47,10 +48,10 @@ func TestMCPTokenCreate_Defaults(t *testing.T) {
 	vaultFlagReset(t)
 	t.Cleanup(func() { resetCobraCommand(rootCmd) })
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "mcp", "token", "create"})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	root.SetArgs([]string{"--vault", vaultDir, "mcp", "token", "create"})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
-	err := rootCmd.Execute()
+	err := root.Execute()
 
 	if err == nil {
 		t.Fatal("expected deprecation error")
@@ -62,6 +63,7 @@ func TestMCPTokenCreate_Defaults(t *testing.T) {
 
 //nolint:dupl
 func TestMCPTokenCreate_WithToolsAndAgent(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir := t.TempDir()
 	_ = os.Setenv("SYMVAULT_VAULT", vaultDir)
 	defer func() { _ = os.Unsetenv("SYMVAULT_VAULT") }()
@@ -76,13 +78,13 @@ func TestMCPTokenCreate_WithToolsAndAgent(t *testing.T) {
 	vaultFlagReset(t)
 	t.Cleanup(func() { resetCobraCommand(rootCmd) })
 
-	rootCmd.SetArgs([]string{
+	root.SetArgs([]string{
 		"--vault", vaultDir,
 		"mcp", "token", "create",
 	})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	t.Cleanup(func() { root.SetArgs(nil) })
 
-	err := rootCmd.Execute()
+	err := root.Execute()
 
 	if err == nil {
 		t.Fatal("expected deprecation error")
@@ -94,6 +96,7 @@ func TestMCPTokenCreate_WithToolsAndAgent(t *testing.T) {
 
 //nolint:dupl
 func TestMCPTokenCreate_MultipleToolFlags(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir := t.TempDir()
 	_ = os.Setenv("SYMVAULT_VAULT", vaultDir)
 	defer func() { _ = os.Unsetenv("SYMVAULT_VAULT") }()
@@ -108,13 +111,13 @@ func TestMCPTokenCreate_MultipleToolFlags(t *testing.T) {
 	vaultFlagReset(t)
 	t.Cleanup(func() { resetCobraCommand(rootCmd) })
 
-	rootCmd.SetArgs([]string{
+	root.SetArgs([]string{
 		"--vault", vaultDir,
 		"mcp", "token", "create",
 	})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	t.Cleanup(func() { root.SetArgs(nil) })
 
-	err := rootCmd.Execute()
+	err := root.Execute()
 
 	if err == nil {
 		t.Fatal("expected deprecation error")
@@ -126,6 +129,7 @@ func TestMCPTokenCreate_MultipleToolFlags(t *testing.T) {
 
 //nolint:dupl
 func TestMCPTokenCreate_WithTTL(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir := t.TempDir()
 	_ = os.Setenv("SYMVAULT_VAULT", vaultDir)
 	defer func() { _ = os.Unsetenv("SYMVAULT_VAULT") }()
@@ -140,13 +144,13 @@ func TestMCPTokenCreate_WithTTL(t *testing.T) {
 	vaultFlagReset(t)
 	t.Cleanup(func() { resetCobraCommand(rootCmd) })
 
-	rootCmd.SetArgs([]string{
+	root.SetArgs([]string{
 		"--vault", vaultDir,
 		"mcp", "token", "create",
 	})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	t.Cleanup(func() { root.SetArgs(nil) })
 
-	err := rootCmd.Execute()
+	err := root.Execute()
 
 	if err == nil {
 		t.Fatal("expected deprecation error")
@@ -157,6 +161,7 @@ func TestMCPTokenCreate_WithTTL(t *testing.T) {
 }
 
 func TestMCPTokenCreate_DefaultTTLFromConfig(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir := t.TempDir()
 	_ = os.Setenv("SYMVAULT_VAULT", vaultDir)
 	defer func() { _ = os.Unsetenv("SYMVAULT_VAULT") }()
@@ -175,13 +180,13 @@ func TestMCPTokenCreate_DefaultTTLFromConfig(t *testing.T) {
 	vaultFlagReset(t)
 	t.Cleanup(func() { resetCobraCommand(rootCmd) })
 
-	rootCmd.SetArgs([]string{
+	root.SetArgs([]string{
 		"--vault", vaultDir,
 		"mcp", "token", "create",
 	})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	t.Cleanup(func() { root.SetArgs(nil) })
 
-	err := rootCmd.Execute()
+	err := root.Execute()
 
 	if err == nil {
 		t.Fatal("expected deprecation error")
@@ -193,6 +198,7 @@ func TestMCPTokenCreate_DefaultTTLFromConfig(t *testing.T) {
 
 //nolint:dupl
 func TestMCPTokenCreate_InvalidTTL(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir := t.TempDir()
 	_ = os.Setenv("SYMVAULT_VAULT", vaultDir)
 	defer func() { _ = os.Unsetenv("SYMVAULT_VAULT") }()
@@ -207,13 +213,13 @@ func TestMCPTokenCreate_InvalidTTL(t *testing.T) {
 	vaultFlagReset(t)
 	t.Cleanup(func() { resetCobraCommand(rootCmd) })
 
-	rootCmd.SetArgs([]string{
+	root.SetArgs([]string{
 		"--vault", vaultDir,
 		"mcp", "token", "create",
 	})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	t.Cleanup(func() { root.SetArgs(nil) })
 
-	err := rootCmd.Execute()
+	err := root.Execute()
 
 	if err == nil {
 		t.Fatal("expected deprecation error")
@@ -224,6 +230,7 @@ func TestMCPTokenCreate_InvalidTTL(t *testing.T) {
 }
 
 func TestMCPTokenCreate_VaultPathError(t *testing.T) {
+	root := NewRootCmd()
 	if runtime.GOOS == "windows" {
 		t.Skip("skipping on windows: HOME env behavior differs")
 	}
@@ -239,12 +246,12 @@ func TestMCPTokenCreate_VaultPathError(t *testing.T) {
 	vaultFlagReset(t)
 	t.Cleanup(func() { resetCobraCommand(rootCmd) })
 
-	rootCmd.SetArgs([]string{"mcp", "token", "create"})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	root.SetArgs([]string{"mcp", "token", "create"})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
 	var execErr error
 	captureStderr(func() {
-		execErr = rootCmd.Execute()
+		execErr = root.Execute()
 	})
 
 	if execErr == nil {
@@ -254,6 +261,7 @@ func TestMCPTokenCreate_VaultPathError(t *testing.T) {
 
 //nolint:dupl
 func TestMCPTokenList_Empty(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir := t.TempDir()
 	_ = os.Setenv("SYMVAULT_VAULT", vaultDir)
 	defer func() { _ = os.Unsetenv("SYMVAULT_VAULT") }()
@@ -268,10 +276,10 @@ func TestMCPTokenList_Empty(t *testing.T) {
 	vaultFlagReset(t)
 	t.Cleanup(func() { resetCobraCommand(rootCmd) })
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "mcp", "token", "list"})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	root.SetArgs([]string{"--vault", vaultDir, "mcp", "token", "list"})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
-	err := rootCmd.Execute()
+	err := root.Execute()
 
 	if err == nil {
 		t.Fatal("expected deprecation error")
@@ -282,6 +290,7 @@ func TestMCPTokenList_Empty(t *testing.T) {
 }
 
 func TestMCPTokenList_WithTokens(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir := t.TempDir()
 	_ = os.Setenv("SYMVAULT_VAULT", vaultDir)
 	defer func() { _ = os.Unsetenv("SYMVAULT_VAULT") }()
@@ -309,10 +318,10 @@ func TestMCPTokenList_WithTokens(t *testing.T) {
 	vaultFlagReset(t)
 	t.Cleanup(func() { resetCobraCommand(rootCmd) })
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "mcp", "token", "list"})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	root.SetArgs([]string{"--vault", vaultDir, "mcp", "token", "list"})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
-	err = rootCmd.Execute()
+	err = root.Execute()
 
 	if err == nil {
 		t.Fatal("expected deprecation error")
@@ -323,6 +332,7 @@ func TestMCPTokenList_WithTokens(t *testing.T) {
 }
 
 func TestMCPTokenRevoke_Success(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir := t.TempDir()
 	_ = os.Setenv("SYMVAULT_VAULT", vaultDir)
 	defer func() { _ = os.Unsetenv("SYMVAULT_VAULT") }()
@@ -350,10 +360,10 @@ func TestMCPTokenRevoke_Success(t *testing.T) {
 	vaultFlagReset(t)
 	t.Cleanup(func() { resetCobraCommand(rootCmd) })
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "mcp", "token", "revoke", token.ID})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	root.SetArgs([]string{"--vault", vaultDir, "mcp", "token", "revoke", token.ID})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
-	err = rootCmd.Execute()
+	err = root.Execute()
 
 	if err == nil {
 		t.Fatal("expected deprecation error")
@@ -364,6 +374,7 @@ func TestMCPTokenRevoke_Success(t *testing.T) {
 }
 
 func TestMCPTokenRevoke_NotFound(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir := t.TempDir()
 	_ = os.Setenv("SYMVAULT_VAULT", vaultDir)
 	defer func() { _ = os.Unsetenv("SYMVAULT_VAULT") }()
@@ -378,10 +389,10 @@ func TestMCPTokenRevoke_NotFound(t *testing.T) {
 	vaultFlagReset(t)
 	t.Cleanup(func() { resetCobraCommand(rootCmd) })
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "mcp", "token", "revoke", "nonexistent-id"})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	root.SetArgs([]string{"--vault", vaultDir, "mcp", "token", "revoke", "nonexistent-id"})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
-	err := rootCmd.Execute()
+	err := root.Execute()
 
 	if err == nil {
 		t.Fatal("expected deprecation error")
@@ -392,6 +403,7 @@ func TestMCPTokenRevoke_NotFound(t *testing.T) {
 }
 
 func TestMCPTokenRevoke_DoubleRevoke(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir := t.TempDir()
 	_ = os.Setenv("SYMVAULT_VAULT", vaultDir)
 	defer func() { _ = os.Unsetenv("SYMVAULT_VAULT") }()
@@ -419,10 +431,10 @@ func TestMCPTokenRevoke_DoubleRevoke(t *testing.T) {
 	vaultFlagReset(t)
 	t.Cleanup(func() { resetCobraCommand(rootCmd) })
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "mcp", "token", "revoke", token.ID})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	root.SetArgs([]string{"--vault", vaultDir, "mcp", "token", "revoke", token.ID})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
-	err = rootCmd.Execute()
+	err = root.Execute()
 	if err == nil {
 		t.Fatal("expected deprecation error on first revoke")
 	}
@@ -430,8 +442,8 @@ func TestMCPTokenRevoke_DoubleRevoke(t *testing.T) {
 		t.Errorf("expected deprecation message on first revoke, got: %v", err)
 	}
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "mcp", "token", "revoke", token.ID})
-	err = rootCmd.Execute()
+	root.SetArgs([]string{"--vault", vaultDir, "mcp", "token", "revoke", token.ID})
+	err = root.Execute()
 	if err == nil {
 		t.Fatal("expected deprecation error on second revoke")
 	}
@@ -441,6 +453,7 @@ func TestMCPTokenRevoke_DoubleRevoke(t *testing.T) {
 }
 
 func TestMCPTokenList_RevokedToken(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir := t.TempDir()
 	_ = os.Setenv("SYMVAULT_VAULT", vaultDir)
 	defer func() { _ = os.Unsetenv("SYMVAULT_VAULT") }()
@@ -469,10 +482,10 @@ func TestMCPTokenList_RevokedToken(t *testing.T) {
 	vaultFlagReset(t)
 	t.Cleanup(func() { resetCobraCommand(rootCmd) })
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "mcp", "token", "list"})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	root.SetArgs([]string{"--vault", vaultDir, "mcp", "token", "list"})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
-	err = rootCmd.Execute()
+	err = root.Execute()
 
 	if err == nil {
 		t.Fatal("expected deprecation error")
@@ -546,6 +559,7 @@ func TestResolveTokenTTL_DefaultFallback(t *testing.T) {
 
 //nolint:dupl
 func TestMCPTokenCreate_ZeroTTL(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir := t.TempDir()
 	_ = os.Setenv("SYMVAULT_VAULT", vaultDir)
 	defer func() { _ = os.Unsetenv("SYMVAULT_VAULT") }()
@@ -560,13 +574,13 @@ func TestMCPTokenCreate_ZeroTTL(t *testing.T) {
 	vaultFlagReset(t)
 	t.Cleanup(func() { resetCobraCommand(rootCmd) })
 
-	rootCmd.SetArgs([]string{
+	root.SetArgs([]string{
 		"--vault", vaultDir,
 		"mcp", "token", "create",
 	})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	t.Cleanup(func() { root.SetArgs(nil) })
 
-	err := rootCmd.Execute()
+	err := root.Execute()
 
 	if err == nil {
 		t.Fatal("expected deprecation error")
@@ -577,6 +591,7 @@ func TestMCPTokenCreate_ZeroTTL(t *testing.T) {
 }
 
 func TestMCPTokenList_ExpiredTokenExcluded(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir := t.TempDir()
 	_ = os.Setenv("SYMVAULT_VAULT", vaultDir)
 	defer func() { _ = os.Unsetenv("SYMVAULT_VAULT") }()
@@ -610,10 +625,10 @@ func TestMCPTokenList_ExpiredTokenExcluded(t *testing.T) {
 	vaultFlagReset(t)
 	t.Cleanup(func() { resetCobraCommand(rootCmd) })
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "mcp", "token", "list"})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	root.SetArgs([]string{"--vault", vaultDir, "mcp", "token", "list"})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
-	err = rootCmd.Execute()
+	err = root.Execute()
 
 	if err == nil {
 		t.Fatal("expected deprecation error")
@@ -625,6 +640,7 @@ func TestMCPTokenList_ExpiredTokenExcluded(t *testing.T) {
 
 //nolint:dupl
 func TestMCPTokenCreate_PreservesInRegistry(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir := t.TempDir()
 	_ = os.Setenv("SYMVAULT_VAULT", vaultDir)
 	defer func() { _ = os.Unsetenv("SYMVAULT_VAULT") }()
@@ -639,13 +655,13 @@ func TestMCPTokenCreate_PreservesInRegistry(t *testing.T) {
 	vaultFlagReset(t)
 	t.Cleanup(func() { resetCobraCommand(rootCmd) })
 
-	rootCmd.SetArgs([]string{
+	root.SetArgs([]string{
 		"--vault", vaultDir,
 		"mcp", "token", "create",
 	})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	t.Cleanup(func() { root.SetArgs(nil) })
 
-	err := rootCmd.Execute()
+	err := root.Execute()
 
 	if err == nil {
 		t.Fatal("expected deprecation error")
@@ -656,6 +672,7 @@ func TestMCPTokenCreate_PreservesInRegistry(t *testing.T) {
 }
 
 func TestMCPTokenRevoke_MissingArg(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir := t.TempDir()
 	_ = os.Setenv("SYMVAULT_VAULT", vaultDir)
 	defer func() { _ = os.Unsetenv("SYMVAULT_VAULT") }()
@@ -670,12 +687,12 @@ func TestMCPTokenRevoke_MissingArg(t *testing.T) {
 	vaultFlagReset(t)
 	t.Cleanup(func() { resetCobraCommand(rootCmd) })
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "mcp", "token", "revoke"})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	root.SetArgs([]string{"--vault", vaultDir, "mcp", "token", "revoke"})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
 	var execErr error
 	captureStderr(func() {
-		execErr = rootCmd.Execute()
+		execErr = root.Execute()
 	})
 
 	if execErr == nil {
@@ -684,6 +701,7 @@ func TestMCPTokenRevoke_MissingArg(t *testing.T) {
 }
 
 func TestMCPTokenCreate_ToolsLongOutput(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir := t.TempDir()
 	_ = os.Setenv("SYMVAULT_VAULT", vaultDir)
 	defer func() { _ = os.Unsetenv("SYMVAULT_VAULT") }()
@@ -716,10 +734,10 @@ func TestMCPTokenCreate_ToolsLongOutput(t *testing.T) {
 	vaultFlagReset(t)
 	t.Cleanup(func() { resetCobraCommand(rootCmd) })
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "mcp", "token", "list"})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	root.SetArgs([]string{"--vault", vaultDir, "mcp", "token", "list"})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
-	err = rootCmd.Execute()
+	err = root.Execute()
 
 	if err == nil {
 		t.Fatal("expected deprecation error")
@@ -731,6 +749,7 @@ func TestMCPTokenCreate_ToolsLongOutput(t *testing.T) {
 
 //nolint:dupl
 func TestMCPTokenList_HeaderFormat(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir := t.TempDir()
 	_ = os.Setenv("SYMVAULT_VAULT", vaultDir)
 	defer func() { _ = os.Unsetenv("SYMVAULT_VAULT") }()
@@ -758,10 +777,10 @@ func TestMCPTokenList_HeaderFormat(t *testing.T) {
 	vaultFlagReset(t)
 	t.Cleanup(func() { resetCobraCommand(rootCmd) })
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "mcp", "token", "list"})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	root.SetArgs([]string{"--vault", vaultDir, "mcp", "token", "list"})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
-	err = rootCmd.Execute()
+	err = root.Execute()
 
 	if err == nil {
 		t.Fatal("expected deprecation error")
@@ -772,8 +791,9 @@ func TestMCPTokenList_HeaderFormat(t *testing.T) {
 }
 
 func TestMCPCmdRegistration(t *testing.T) {
+	root := NewRootCmd()
 	found := false
-	for _, c := range rootCmd.Commands() {
+	for _, c := range root.Commands() {
 		if c.Name() == "mcp" {
 			found = true
 			break
@@ -787,6 +807,7 @@ func TestMCPCmdRegistration(t *testing.T) {
 //nolint:dupl
 //nolint:dupl
 func TestMCPTokenCreate_NegativeDayTTL(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir := t.TempDir()
 	_ = os.Setenv("SYMVAULT_VAULT", vaultDir)
 	defer func() { _ = os.Unsetenv("SYMVAULT_VAULT") }()
@@ -801,13 +822,13 @@ func TestMCPTokenCreate_NegativeDayTTL(t *testing.T) {
 	vaultFlagReset(t)
 	t.Cleanup(func() { resetCobraCommand(rootCmd) })
 
-	rootCmd.SetArgs([]string{
+	root.SetArgs([]string{
 		"--vault", vaultDir,
 		"mcp", "token", "create",
 	})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	t.Cleanup(func() { root.SetArgs(nil) })
 
-	err := rootCmd.Execute()
+	err := root.Execute()
 
 	if err == nil {
 		t.Fatal("expected deprecation error")
@@ -818,6 +839,7 @@ func TestMCPTokenCreate_NegativeDayTTL(t *testing.T) {
 }
 
 func TestMCPTokenCreate_RegistryFilePermissions(t *testing.T) {
+	root := NewRootCmd()
 	if runtime.GOOS == "windows" {
 		t.Skip("skipping on windows: file permissions differ")
 	}
@@ -835,13 +857,13 @@ func TestMCPTokenCreate_RegistryFilePermissions(t *testing.T) {
 	vaultFlagReset(t)
 	t.Cleanup(func() { resetCobraCommand(rootCmd) })
 
-	rootCmd.SetArgs([]string{
+	root.SetArgs([]string{
 		"--vault", vaultDir,
 		"mcp", "token", "create",
 	})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	t.Cleanup(func() { root.SetArgs(nil) })
 
-	err := rootCmd.Execute()
+	err := root.Execute()
 
 	if err == nil {
 		t.Fatal("expected deprecation error")
@@ -853,6 +875,7 @@ func TestMCPTokenCreate_RegistryFilePermissions(t *testing.T) {
 
 //nolint:dupl
 func TestMCPTokenCreate_EmptyLabelOK(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir := t.TempDir()
 	_ = os.Setenv("SYMVAULT_VAULT", vaultDir)
 	defer func() { _ = os.Unsetenv("SYMVAULT_VAULT") }()
@@ -867,13 +890,13 @@ func TestMCPTokenCreate_EmptyLabelOK(t *testing.T) {
 	vaultFlagReset(t)
 	t.Cleanup(func() { resetCobraCommand(rootCmd) })
 
-	rootCmd.SetArgs([]string{
+	root.SetArgs([]string{
 		"--vault", vaultDir,
 		"mcp", "token", "create",
 	})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	t.Cleanup(func() { root.SetArgs(nil) })
 
-	err := rootCmd.Execute()
+	err := root.Execute()
 
 	if err == nil {
 		t.Fatal("expected deprecation error")
@@ -884,6 +907,7 @@ func TestMCPTokenCreate_EmptyLabelOK(t *testing.T) {
 }
 
 func TestMCPTokenRevoke_VaultPathError(t *testing.T) {
+	root := NewRootCmd()
 	if runtime.GOOS == "windows" {
 		t.Skip("skipping on windows: HOME env behavior differs")
 	}
@@ -899,12 +923,12 @@ func TestMCPTokenRevoke_VaultPathError(t *testing.T) {
 	vaultFlagReset(t)
 	t.Cleanup(func() { resetCobraCommand(rootCmd) })
 
-	rootCmd.SetArgs([]string{"mcp", "token", "revoke", "some-id"})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	root.SetArgs([]string{"mcp", "token", "revoke", "some-id"})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
 	var execErr error
 	captureStderr(func() {
-		execErr = rootCmd.Execute()
+		execErr = root.Execute()
 	})
 
 	if execErr == nil {
@@ -913,6 +937,7 @@ func TestMCPTokenRevoke_VaultPathError(t *testing.T) {
 }
 
 func TestMCPTokenList_VaultPathError(t *testing.T) {
+	root := NewRootCmd()
 	if runtime.GOOS == "windows" {
 		t.Skip("skipping on windows: HOME env behavior differs")
 	}
@@ -928,12 +953,12 @@ func TestMCPTokenList_VaultPathError(t *testing.T) {
 	vaultFlagReset(t)
 	t.Cleanup(func() { resetCobraCommand(rootCmd) })
 
-	rootCmd.SetArgs([]string{"mcp", "token", "list"})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	root.SetArgs([]string{"mcp", "token", "list"})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
 	var execErr error
 	captureStderr(func() {
-		execErr = rootCmd.Execute()
+		execErr = root.Execute()
 	})
 
 	if execErr == nil {
@@ -943,6 +968,7 @@ func TestMCPTokenList_VaultPathError(t *testing.T) {
 
 //nolint:dupl
 func TestMCPTokenCreate_WithDaySuffixTTL(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir := t.TempDir()
 	_ = os.Setenv("SYMVAULT_VAULT", vaultDir)
 	defer func() { _ = os.Unsetenv("SYMVAULT_VAULT") }()
@@ -957,13 +983,13 @@ func TestMCPTokenCreate_WithDaySuffixTTL(t *testing.T) {
 	vaultFlagReset(t)
 	t.Cleanup(func() { resetCobraCommand(rootCmd) })
 
-	rootCmd.SetArgs([]string{
+	root.SetArgs([]string{
 		"--vault", vaultDir,
 		"mcp", "token", "create",
 	})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	t.Cleanup(func() { root.SetArgs(nil) })
 
-	err := rootCmd.Execute()
+	err := root.Execute()
 
 	if err == nil {
 		t.Fatal("expected deprecation error")
@@ -975,6 +1001,7 @@ func TestMCPTokenCreate_WithDaySuffixTTL(t *testing.T) {
 
 //nolint:dupl
 func TestMCPTokenList_EmptyAgentAndLabel(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir := t.TempDir()
 	_ = os.Setenv("SYMVAULT_VAULT", vaultDir)
 	defer func() { _ = os.Unsetenv("SYMVAULT_VAULT") }()
@@ -1002,10 +1029,10 @@ func TestMCPTokenList_EmptyAgentAndLabel(t *testing.T) {
 	vaultFlagReset(t)
 	t.Cleanup(func() { resetCobraCommand(rootCmd) })
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "mcp", "token", "list"})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	root.SetArgs([]string{"--vault", vaultDir, "mcp", "token", "list"})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
-	err = rootCmd.Execute()
+	err = root.Execute()
 
 	if err == nil {
 		t.Fatal("expected deprecation error")
@@ -1016,6 +1043,7 @@ func TestMCPTokenList_EmptyAgentAndLabel(t *testing.T) {
 }
 
 func TestMCPTokenCreate_RawTokenUnique(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir := t.TempDir()
 	_ = os.Setenv("SYMVAULT_VAULT", vaultDir)
 	defer func() { _ = os.Unsetenv("SYMVAULT_VAULT") }()
@@ -1031,13 +1059,13 @@ func TestMCPTokenCreate_RawTokenUnique(t *testing.T) {
 		vaultFlagReset(t)
 		t.Cleanup(func() { resetCobraCommand(rootCmd) })
 
-		rootCmd.SetArgs([]string{
+		root.SetArgs([]string{
 			"--vault", vaultDir,
 			"mcp", "token", "create",
 		})
-		t.Cleanup(func() { rootCmd.SetArgs(nil) })
+		t.Cleanup(func() { root.SetArgs(nil) })
 
-		err := rootCmd.Execute()
+		err := root.Execute()
 		if err == nil {
 			t.Fatal("expected deprecation error")
 		}

--- a/cmd/migrate_kdf_test.go
+++ b/cmd/migrate_kdf_test.go
@@ -81,10 +81,11 @@ func writeStdinPipe(t *testing.T, lines ...string) {
 
 func runMigrateKDF(t *testing.T, vaultDir string) (stdout string, execErr error) {
 	t.Helper()
+	root := NewRootCmd()
 	stdout = captureStdout(func() {
-		rootCmd.SetArgs([]string{"--vault", vaultDir, "migrate", "kdf"})
-		execErr = rootCmd.Execute()
-		rootCmd.SetArgs(nil)
+		root.SetArgs([]string{"--vault", vaultDir, "migrate", "kdf"})
+		execErr = root.Execute()
+		root.SetArgs(nil)
 	})
 	return stdout, execErr
 }

--- a/cmd/policy.go
+++ b/cmd/policy.go
@@ -86,10 +86,6 @@ Example:
 	return policyValidateCmd
 }
 
-// policyCmd is retained for API compatibility; NewCommands() uses
-// newPolicyCmd() so every call gets a fresh command.
-var policyCmd = newPolicyCmd()
-
 func newPolicyCmd() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "policy",

--- a/cmd/policy_test.go
+++ b/cmd/policy_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestPolicyValidateCmd_Success(t *testing.T) {
-	rootCmd = newPackageRootCmd()
+	root := NewRootCmd()
 	resetVaultState(t)
 	tmpDir := t.TempDir()
 	policyFile := filepath.Join(tmpDir, "test-policy.yaml")
@@ -28,13 +28,13 @@ rules:
 	}
 
 	var out strings.Builder
-	rootCmd.SetOut(&out)
-	rootCmd.SetErr(&out)
-	rootCmd.SetArgs([]string{"policy", "validate", policyFile})
-	defer rootCmd.SetArgs(nil)
+	root.SetOut(&out)
+	root.SetErr(&out)
+	root.SetArgs([]string{"policy", "validate", policyFile})
+	defer root.SetArgs(nil)
 
-	if err := rootCmd.Execute(); err != nil {
-		t.Fatalf("Execute() error = %v", err)
+	if err := root.Execute(); err != nil {
+		t.Fatalf("ExecuteRoot(root) error = %v", err)
 	}
 
 	output := out.String()
@@ -44,6 +44,7 @@ rules:
 }
 
 func TestPolicyValidateCmd_Invalid(t *testing.T) {
+	root := NewRootCmd()
 	resetVaultState(t)
 	tmpDir := t.TempDir()
 	policyFile := filepath.Join(tmpDir, "invalid-policy.yaml")
@@ -59,14 +60,14 @@ rules:
 	}
 
 	var out strings.Builder
-	rootCmd.SetOut(&out)
-	rootCmd.SetErr(&out)
-	rootCmd.SetArgs([]string{"policy", "validate", policyFile})
-	defer rootCmd.SetArgs(nil)
+	root.SetOut(&out)
+	root.SetErr(&out)
+	root.SetArgs([]string{"policy", "validate", policyFile})
+	defer root.SetArgs(nil)
 
-	err := rootCmd.Execute()
+	err := root.Execute()
 	if err == nil {
-		t.Fatal("Execute() expected error, got nil")
+		t.Fatal("ExecuteRoot(root) expected error, got nil")
 	}
 }
 
@@ -122,6 +123,7 @@ rules:
 `
 
 func TestPolicyRemoveCmd_RejectsTraversal(t *testing.T) {
+	root := NewRootCmd()
 	resetVaultState(t)
 	vaultDir := t.TempDir()
 	restore := setupVaultFlag(t, vaultDir)
@@ -134,12 +136,12 @@ func TestPolicyRemoveCmd_RejectsTraversal(t *testing.T) {
 	}
 
 	var out strings.Builder
-	rootCmd.SetOut(&out)
-	rootCmd.SetErr(&out)
-	rootCmd.SetArgs([]string{"policy", "remove", "../identity.age"})
-	defer rootCmd.SetArgs(nil)
+	root.SetOut(&out)
+	root.SetErr(&out)
+	root.SetArgs([]string{"policy", "remove", "../identity.age"})
+	defer root.SetArgs(nil)
 
-	if err := rootCmd.Execute(); err == nil {
+	if err := root.Execute(); err == nil {
 		t.Fatal("policy remove with traversal name: expected error, got nil")
 	}
 	if _, err := os.Stat(sentinel); err != nil {
@@ -148,6 +150,7 @@ func TestPolicyRemoveCmd_RejectsTraversal(t *testing.T) {
 }
 
 func TestPolicyApplyCmd_RejectsSymlinkDest(t *testing.T) {
+	root := NewRootCmd()
 	resetVaultState(t)
 	vaultDir := t.TempDir()
 	restore := setupVaultFlag(t, vaultDir)
@@ -175,12 +178,12 @@ func TestPolicyApplyCmd_RejectsSymlinkDest(t *testing.T) {
 	}
 
 	var out strings.Builder
-	rootCmd.SetOut(&out)
-	rootCmd.SetErr(&out)
-	rootCmd.SetArgs([]string{"policy", "apply", src})
-	defer rootCmd.SetArgs(nil)
+	root.SetOut(&out)
+	root.SetErr(&out)
+	root.SetArgs([]string{"policy", "apply", src})
+	defer root.SetArgs(nil)
 
-	if err := rootCmd.Execute(); err == nil {
+	if err := root.Execute(); err == nil {
 		t.Fatal("policy apply over a symlink: expected error, got nil")
 	}
 	data, err := os.ReadFile(outside)
@@ -193,6 +196,7 @@ func TestPolicyApplyCmd_RejectsSymlinkDest(t *testing.T) {
 }
 
 func TestPolicyApplyRemoveCmd_RoundTrip(t *testing.T) {
+	root := NewRootCmd()
 	resetVaultState(t)
 	vaultDir := t.TempDir()
 	restore := setupVaultFlag(t, vaultDir)
@@ -204,11 +208,11 @@ func TestPolicyApplyRemoveCmd_RoundTrip(t *testing.T) {
 	}
 
 	var out strings.Builder
-	rootCmd.SetOut(&out)
-	rootCmd.SetErr(&out)
-	rootCmd.SetArgs([]string{"policy", "apply", src})
-	defer rootCmd.SetArgs(nil)
-	if err := rootCmd.Execute(); err != nil {
+	root.SetOut(&out)
+	root.SetErr(&out)
+	root.SetArgs([]string{"policy", "apply", src})
+	defer root.SetArgs(nil)
+	if err := root.Execute(); err != nil {
 		t.Fatalf("policy apply: %v", err)
 	}
 
@@ -217,8 +221,8 @@ func TestPolicyApplyRemoveCmd_RoundTrip(t *testing.T) {
 		t.Fatalf("applied policy missing: %v", err)
 	}
 
-	rootCmd.SetArgs([]string{"policy", "remove", "dev.yaml"})
-	if err := rootCmd.Execute(); err != nil {
+	root.SetArgs([]string{"policy", "remove", "dev.yaml"})
+	if err := root.Execute(); err != nil {
 		t.Fatalf("policy remove: %v", err)
 	}
 	if _, err := os.Stat(applied); !os.IsNotExist(err) {

--- a/cmd/profile.go
+++ b/cmd/profile.go
@@ -16,10 +16,6 @@ import (
 
 var profileVaultPath string
 
-// profileCmd is retained for API compatibility; NewRootCmd() uses
-// newProfileCmd() so every call gets a fresh command.
-var profileCmd = newProfileCmd()
-
 func newProfileCmd() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "profile",

--- a/cmd/recipients.go
+++ b/cmd/recipients.go
@@ -18,10 +18,6 @@ var (
 	reencryptAfterAdd bool
 )
 
-// recipientsCmd is retained for API compatibility; NewCommands() uses
-// newRecipientsCmd() so every call gets a fresh command.
-var recipientsCmd = newRecipientsCmd()
-
 func newRecipientsCmd() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "recipients",
@@ -44,10 +40,6 @@ Lines starting with # are treated as comments.`,
 	c.AddCommand(newRecipientsRemoveCmd())
 	return c
 }
-
-// recipientsListCmd is retained for API compatibility; NewCommands() uses
-// newRecipientsListCmd() so every call gets a fresh command.
-var recipientsListCmd = newRecipientsListCmd()
 
 func newRecipientsListCmd() *cobra.Command {
 	c := &cobra.Command{
@@ -114,10 +106,6 @@ func newRecipientsListCmd() *cobra.Command {
 	return c
 }
 
-// recipientsAddCmd is retained for API compatibility; NewCommands() uses
-// newRecipientsAddCmd() so every call gets a fresh command.
-var recipientsAddCmd = newRecipientsAddCmd()
-
 func newRecipientsAddCmd() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "add <public-key>",
@@ -165,25 +153,6 @@ Once added, all new entries will be encrypted for this recipient.`,
 	c.Flags().BoolVar(&reencryptAfterAdd, "reencrypt", false, "Re-encrypt existing entries for the new recipient")
 	return c
 }
-
-// recipientsRemoveCmd is retained for API compatibility; NewCommands() uses
-// newRecipientsRemoveCmd() so every call gets a fresh command.
-var recipientsRemoveCmd = newRecipientsRemoveCmd()
-
-// The compat instances mirror the pre-migration singleton topology for
-// tests that execute or mutate the package-level command vars directly:
-// the compat parent carries the compat children (replacing the fresh
-// instances the constructor added), and root.go attaches the parent to
-// the package rootCmd.
-var _ = func() int {
-	for _, c := range recipientsCmd.Commands() {
-		recipientsCmd.RemoveCommand(c)
-	}
-	recipientsCmd.AddCommand(recipientsListCmd)
-	recipientsCmd.AddCommand(recipientsAddCmd)
-	recipientsCmd.AddCommand(recipientsRemoveCmd)
-	return 0
-}()
 
 func newRecipientsRemoveCmd() *cobra.Command {
 	c := &cobra.Command{

--- a/cmd/recipients_test.go
+++ b/cmd/recipients_test.go
@@ -19,14 +19,15 @@ const (
 )
 
 func TestRecipientsListCmd_VaultNotInitialized(t *testing.T) {
+	root := NewRootCmd()
 	resetVaultState(t)
 	vaultDir := t.TempDir()
 	buf := &bytes.Buffer{}
-	rootCmd.SetOut(buf)
-	rootCmd.SetErr(buf)
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "recipients", "list"})
+	root.SetOut(buf)
+	root.SetErr(buf)
+	root.SetArgs([]string{"--vault", vaultDir, "recipients", "list"})
 
-	err := rootCmd.Execute()
+	err := root.Execute()
 	if err == nil {
 		t.Error("expected error for vault not initialized")
 	}
@@ -36,28 +37,30 @@ func TestRecipientsListCmd_VaultNotInitialized(t *testing.T) {
 }
 
 func TestRecipientsAddCmd_VaultNotInitialized(t *testing.T) {
+	root := NewRootCmd()
 	resetVaultState(t)
 	vaultDir := t.TempDir()
 	buf := &bytes.Buffer{}
-	rootCmd.SetOut(buf)
-	rootCmd.SetErr(buf)
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "recipients", "add", testRecipient1})
+	root.SetOut(buf)
+	root.SetErr(buf)
+	root.SetArgs([]string{"--vault", vaultDir, "recipients", "add", testRecipient1})
 
-	err := rootCmd.Execute()
+	err := root.Execute()
 	if err == nil {
 		t.Error("expected error for vault not initialized")
 	}
 }
 
 func TestRecipientsRemoveCmd_VaultNotInitialized(t *testing.T) {
+	root := NewRootCmd()
 	resetVaultState(t)
 	vaultDir := t.TempDir()
 	buf := &bytes.Buffer{}
-	rootCmd.SetOut(buf)
-	rootCmd.SetErr(buf)
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "recipients", "remove", testRecipient1})
+	root.SetOut(buf)
+	root.SetErr(buf)
+	root.SetArgs([]string{"--vault", vaultDir, "recipients", "remove", testRecipient1})
 
-	err := rootCmd.Execute()
+	err := root.Execute()
 	if err == nil {
 		t.Error("expected error for vault not initialized")
 	}
@@ -376,6 +379,7 @@ func TestRecipientsRemove_CorrectOne_Integration(t *testing.T) {
 }
 
 func TestCmdRecipientsList_WithRecipients(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir := t.TempDir()
 	passphrase := []byte("correcthorsebatterystaple")
 	vaultFlagReset(t)
@@ -391,11 +395,11 @@ func TestCmdRecipientsList_WithRecipients(t *testing.T) {
 		t.Fatalf("add recipient: %v", err)
 	}
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "recipients", "list"})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	root.SetArgs([]string{"--vault", vaultDir, "recipients", "list"})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
 	output := captureStdout(func() {
-		_ = rootCmd.Execute()
+		_ = root.Execute()
 	})
 
 	if !strings.Contains(output, "Recipients") {
@@ -407,6 +411,7 @@ func TestCmdRecipientsList_WithRecipients(t *testing.T) {
 }
 
 func TestCmdRecipientsAdd_Invalid(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir := t.TempDir()
 	passphrase := []byte("correcthorsebatterystaple")
 	vaultFlagReset(t)
@@ -418,12 +423,12 @@ func TestCmdRecipientsAdd_Invalid(t *testing.T) {
 	_ = os.Setenv("SYMVAULT_PASSPHRASE", string(passphrase))
 	t.Cleanup(func() { _ = os.Unsetenv("SYMVAULT_PASSPHRASE") })
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "recipients", "add", "not-a-valid-key"})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	root.SetArgs([]string{"--vault", vaultDir, "recipients", "add", "not-a-valid-key"})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
 	var execErr error
 	captureStderr(func() {
-		execErr = rootCmd.Execute()
+		execErr = root.Execute()
 	})
 
 	if execErr == nil {
@@ -435,6 +440,7 @@ func TestCmdRecipientsAdd_Invalid(t *testing.T) {
 }
 
 func TestCmdRecipientsAdd_Duplicate(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir := t.TempDir()
 	passphrase := []byte("correcthorsebatterystaple")
 	vaultFlagReset(t)
@@ -451,12 +457,12 @@ func TestCmdRecipientsAdd_Duplicate(t *testing.T) {
 	_ = os.Setenv("SYMVAULT_PASSPHRASE", string(passphrase))
 	t.Cleanup(func() { _ = os.Unsetenv("SYMVAULT_PASSPHRASE") })
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "recipients", "add", testRecipient1})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	root.SetArgs([]string{"--vault", vaultDir, "recipients", "add", testRecipient1})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
 	var execErr error
 	captureStderr(func() {
-		execErr = rootCmd.Execute()
+		execErr = root.Execute()
 	})
 
 	if execErr == nil {
@@ -468,6 +474,7 @@ func TestCmdRecipientsAdd_Duplicate(t *testing.T) {
 }
 
 func TestCmdRecipientsRemove_NotFound(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir := t.TempDir()
 	passphrase := []byte("correcthorsebatterystaple")
 	vaultFlagReset(t)
@@ -479,12 +486,12 @@ func TestCmdRecipientsRemove_NotFound(t *testing.T) {
 	_ = os.Setenv("SYMVAULT_PASSPHRASE", string(passphrase))
 	t.Cleanup(func() { _ = os.Unsetenv("SYMVAULT_PASSPHRASE") })
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "recipients", "remove", testRecipient2, "--yes"})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	root.SetArgs([]string{"--vault", vaultDir, "recipients", "remove", testRecipient2, "--yes"})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
 	var execErr error
 	captureStderr(func() {
-		execErr = rootCmd.Execute()
+		execErr = root.Execute()
 	})
 
 	if execErr == nil {
@@ -496,6 +503,7 @@ func TestCmdRecipientsRemove_NotFound(t *testing.T) {
 }
 
 func TestCmdRecipientsRemove_Cancel(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir := t.TempDir()
 	passphrase := []byte("correcthorsebatterystaple")
 	vaultFlagReset(t)
@@ -521,12 +529,12 @@ func TestCmdRecipientsRemove_Cancel(t *testing.T) {
 		_ = r.Close()
 	})
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "recipients", "remove", testRecipient1})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	root.SetArgs([]string{"--vault", vaultDir, "recipients", "remove", testRecipient1})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
 	var execErr error
 	output := captureStderr(func() {
-		execErr = rootCmd.Execute()
+		execErr = root.Execute()
 	})
 
 	if execErr != nil {
@@ -538,6 +546,7 @@ func TestCmdRecipientsRemove_Cancel(t *testing.T) {
 }
 
 func TestCmdRecipientsRemove_WithYesFlag(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir := t.TempDir()
 	passphrase := []byte("correcthorsebatterystaple")
 	vaultFlagReset(t)
@@ -554,11 +563,11 @@ func TestCmdRecipientsRemove_WithYesFlag(t *testing.T) {
 	_ = os.Setenv("SYMVAULT_PASSPHRASE", string(passphrase))
 	t.Cleanup(func() { _ = os.Unsetenv("SYMVAULT_PASSPHRASE") })
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "recipients", "remove", testRecipient1, "--yes"})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	root.SetArgs([]string{"--vault", vaultDir, "recipients", "remove", testRecipient1, "--yes"})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
 	output := captureStdout(func() {
-		_ = rootCmd.Execute()
+		_ = root.Execute()
 	})
 
 	if !strings.Contains(output, "Recipient removed") {
@@ -570,6 +579,7 @@ func TestCmdRecipientsRemove_WithYesFlag(t *testing.T) {
 }
 
 func TestCmdRecipientsRemove_InvalidKey(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir := t.TempDir()
 	passphrase := []byte("correcthorsebatterystaple")
 	vaultFlagReset(t)
@@ -581,12 +591,12 @@ func TestCmdRecipientsRemove_InvalidKey(t *testing.T) {
 	_ = os.Setenv("SYMVAULT_PASSPHRASE", string(passphrase))
 	t.Cleanup(func() { _ = os.Unsetenv("SYMVAULT_PASSPHRASE") })
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "recipients", "remove", "not-a-valid-key", "--yes"})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	root.SetArgs([]string{"--vault", vaultDir, "recipients", "remove", "not-a-valid-key", "--yes"})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
 	var execErr error
 	captureStderr(func() {
-		execErr = rootCmd.Execute()
+		execErr = root.Execute()
 	})
 
 	if execErr == nil {
@@ -598,6 +608,7 @@ func TestCmdRecipientsRemove_InvalidKey(t *testing.T) {
 }
 
 func TestCmdRecipientsAdd_UnlockError(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir := t.TempDir()
 	passphrase := []byte("correcthorsebatterystaple")
 	vaultFlagReset(t)
@@ -609,12 +620,12 @@ func TestCmdRecipientsAdd_UnlockError(t *testing.T) {
 	_ = os.Setenv("SYMVAULT_PASSPHRASE", "wrong-passphrase")
 	t.Cleanup(func() { _ = os.Unsetenv("SYMVAULT_PASSPHRASE") })
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "recipients", "add", testRecipient1})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	root.SetArgs([]string{"--vault", vaultDir, "recipients", "add", testRecipient1})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
 	var execErr error
 	captureStderr(func() {
-		execErr = rootCmd.Execute()
+		execErr = root.Execute()
 	})
 
 	if execErr == nil {
@@ -626,6 +637,7 @@ func TestCmdRecipientsAdd_UnlockError(t *testing.T) {
 }
 
 func TestCmdRecipientsRemove_UnlockError(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir := t.TempDir()
 	passphrase := []byte("correcthorsebatterystaple")
 	vaultFlagReset(t)
@@ -637,12 +649,12 @@ func TestCmdRecipientsRemove_UnlockError(t *testing.T) {
 	_ = os.Setenv("SYMVAULT_PASSPHRASE", "wrong-passphrase")
 	t.Cleanup(func() { _ = os.Unsetenv("SYMVAULT_PASSPHRASE") })
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "recipients", "remove", testRecipient1, "--yes"})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	root.SetArgs([]string{"--vault", vaultDir, "recipients", "remove", testRecipient1, "--yes"})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
 	var execErr error
 	captureStderr(func() {
-		execErr = rootCmd.Execute()
+		execErr = root.Execute()
 	})
 
 	if execErr == nil {
@@ -654,16 +666,17 @@ func TestCmdRecipientsRemove_UnlockError(t *testing.T) {
 }
 
 func TestRecipients_ErrorPaths(t *testing.T) {
+	root := NewRootCmd()
 	resetVaultState(t)
 	t.Run("list - uninitialized vault", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		_ = os.Setenv("SYMVAULT_VAULT", tmpDir)
 		defer func() { _ = os.Unsetenv("SYMVAULT_VAULT") }()
 
-		rootCmd.SetArgs([]string{"--vault", tmpDir, "recipients", "list"})
-		defer rootCmd.SetArgs(nil)
+		root.SetArgs([]string{"--vault", tmpDir, "recipients", "list"})
+		defer root.SetArgs(nil)
 
-		err := rootCmd.Execute()
+		err := root.Execute()
 		if err == nil || !strings.Contains(err.Error(), "not initialized") {
 			t.Errorf("expected 'not initialized' error, got: %v", err)
 		}
@@ -681,10 +694,10 @@ func TestRecipients_ErrorPaths(t *testing.T) {
 		cfg := config.Default()
 		_, _ = vaultpkg.InitWithPassphrase(tmpDir, []byte("test"), cfg)
 
-		rootCmd.SetArgs([]string{"--vault", tmpDir, "recipients", "add", "invalid-key"})
-		defer rootCmd.SetArgs(nil)
+		root.SetArgs([]string{"--vault", tmpDir, "recipients", "add", "invalid-key"})
+		defer root.SetArgs(nil)
 
-		err := rootCmd.Execute()
+		err := root.Execute()
 		if err == nil || !strings.Contains(err.Error(), "invalid") {
 			t.Errorf("expected 'invalid' error, got: %v", err)
 		}
@@ -702,10 +715,10 @@ func TestRecipients_ErrorPaths(t *testing.T) {
 		cfg := config.Default()
 		_, _ = vaultpkg.InitWithPassphrase(tmpDir, []byte("test"), cfg)
 
-		rootCmd.SetArgs([]string{"--vault", tmpDir, "recipients", "remove", "not-age1-key", "-y"})
-		defer rootCmd.SetArgs(nil)
+		root.SetArgs([]string{"--vault", tmpDir, "recipients", "remove", "not-age1-key", "-y"})
+		defer root.SetArgs(nil)
 
-		err := rootCmd.Execute()
+		err := root.Execute()
 		if err == nil || !strings.Contains(err.Error(), "invalid") {
 			t.Errorf("expected 'invalid' error, got: %v", err)
 		}
@@ -726,10 +739,10 @@ func TestRecipients_ErrorPaths(t *testing.T) {
 		_ = os.Setenv("SYMVAULT_PASSPHRASE", "test")
 		identity2, _ := vaultpkg.InitWithPassphrase(tmpDir+"_second", []byte("test2"), cfg)
 
-		rootCmd.SetArgs([]string{"--vault", tmpDir, "recipients", "remove", identity2.Recipient().String(), "-y"})
-		defer rootCmd.SetArgs(nil)
+		root.SetArgs([]string{"--vault", tmpDir, "recipients", "remove", identity2.Recipient().String(), "-y"})
+		defer root.SetArgs(nil)
 
-		err := rootCmd.Execute()
+		err := root.Execute()
 		if err == nil || !strings.Contains(err.Error(), "not found") {
 			t.Errorf("expected 'not found' error, got: %v", err)
 		}
@@ -737,6 +750,7 @@ func TestRecipients_ErrorPaths(t *testing.T) {
 }
 
 func TestRecipients_ListEmpty(t *testing.T) {
+	root := NewRootCmd()
 	resetVaultState(t)
 
 	tmpDir := t.TempDir()
@@ -750,11 +764,11 @@ func TestRecipients_ListEmpty(t *testing.T) {
 	cfg := config.Default()
 	_, _ = vaultpkg.InitWithPassphrase(tmpDir, []byte("test"), cfg)
 
-	rootCmd.SetArgs([]string{"--vault", tmpDir, "recipients", "list"})
-	defer rootCmd.SetArgs(nil)
+	root.SetArgs([]string{"--vault", tmpDir, "recipients", "list"})
+	defer root.SetArgs(nil)
 
 	output := captureStdout(func() {
-		_ = rootCmd.Execute()
+		_ = root.Execute()
 	})
 
 	if !strings.Contains(output, "No recipients configured") {
@@ -763,6 +777,7 @@ func TestRecipients_ListEmpty(t *testing.T) {
 }
 
 func TestRecipients_ListInvalidRecipient(t *testing.T) {
+	root := NewRootCmd()
 	resetVaultState(t)
 
 	tmpDir := t.TempDir()
@@ -779,11 +794,11 @@ func TestRecipients_ListInvalidRecipient(t *testing.T) {
 	// Write an invalid recipient directly to recipients.txt
 	_ = os.WriteFile(tmpDir+"/recipients.txt", []byte("invalid-key\n"), 0o600)
 
-	rootCmd.SetArgs([]string{"--vault", tmpDir, "recipients", "list"})
-	defer rootCmd.SetArgs(nil)
+	root.SetArgs([]string{"--vault", tmpDir, "recipients", "list"})
+	defer root.SetArgs(nil)
 
 	output := captureStdout(func() {
-		_ = rootCmd.Execute()
+		_ = root.Execute()
 	})
 
 	if !strings.Contains(output, "invalid key format") {
@@ -792,6 +807,7 @@ func TestRecipients_ListInvalidRecipient(t *testing.T) {
 }
 
 func TestRecipients_AddAlreadyExists(t *testing.T) {
+	root := NewRootCmd()
 	resetVaultState(t)
 
 	tmpDir := t.TempDir()
@@ -810,16 +826,17 @@ func TestRecipients_AddAlreadyExists(t *testing.T) {
 	_ = vaultpkg.NewRecipientsManager(tmpDir).AddRecipient(recipient)
 
 	// Try to add again via CLI
-	rootCmd.SetArgs([]string{"--vault", tmpDir, "recipients", "add", recipient})
-	defer rootCmd.SetArgs(nil)
+	root.SetArgs([]string{"--vault", tmpDir, "recipients", "add", recipient})
+	defer root.SetArgs(nil)
 
-	err := rootCmd.Execute()
+	err := root.Execute()
 	if err == nil || !strings.Contains(err.Error(), "already exists") {
 		t.Errorf("expected 'already exists' error, got: %v", err)
 	}
 }
 
 func TestRecipients_RemoveCancelled(t *testing.T) {
+	root := NewRootCmd()
 	resetVaultState(t)
 
 	tmpDir := t.TempDir()
@@ -841,10 +858,10 @@ func TestRecipients_RemoveCancelled(t *testing.T) {
 	_, _ = w.WriteString("n\n")
 	_ = w.Close()
 
-	rootCmd.SetArgs([]string{"--vault", tmpDir, "recipients", "remove", recipient})
-	defer rootCmd.SetArgs(nil)
+	root.SetArgs([]string{"--vault", tmpDir, "recipients", "remove", recipient})
+	defer root.SetArgs(nil)
 
-	_ = rootCmd.Execute()
+	_ = root.Execute()
 	os.Stdin = oldStdin
 	_ = r.Close()
 }

--- a/cmd/remote.go
+++ b/cmd/remote.go
@@ -23,10 +23,6 @@ var (
 	remotePushFlag bool
 )
 
-// remoteCmd is retained for API compatibility; NewCommands() uses
-// newRemoteCmd() so every call gets a fresh command.
-var remoteCmd = newRemoteCmd()
-
 func newRemoteCmd() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "remote",

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -24,37 +24,8 @@ var (
 )
 
 // rootCmd is the package-level root used by production code.
-// Tests that modify command state should use a fresh NewRootCmd() for
-// isolation.
-var rootCmd = newPackageRootCmd()
-
-// newPackageRootCmd builds the package-level root tree: a fresh
-// NewRootCmd() tree whose top-level commands are replaced by the
-// package-level compat instances (deviceCmd, generateCmd, mcp.ServeCmd,
-// ...). This mirrors the pre-migration singleton topology for tests that
-// execute or mutate package-level command vars directly (for example
-// recipientsAddCmd.Execute() or resets of mcpcmd.ServeCmd flags): the
-// executed commands are the same objects the tests mutate. Fresh
-// NewRootCmd() calls are unaffected and remain fully independent trees.
-func newPackageRootCmd() *cobra.Command {
-	root := NewRootCmd()
-	compat := []*cobra.Command{
-		brokerCmd, deviceCmd, dynamicCmd, generateCmd, gitCmd, policyCmd, profileCmd,
-		recipientsCmd, remoteCmd, runCmd, shareCmd, syncCmd, templateCmd, uiCmd,
-		mcp.ServeCmd, mcp.McpCmd,
-	}
-	compatByName := make(map[string]struct{}, len(compat))
-	for _, compatCmd := range compat {
-		compatByName[compatCmd.Name()] = struct{}{}
-	}
-	for _, c := range root.Commands() {
-		if _, ok := compatByName[c.Name()]; ok {
-			root.RemoveCommand(c)
-		}
-	}
-	root.AddCommand(compat...)
-	return root
-}
+// Tests should use fresh NewRootCmd() instances for isolation.
+var rootCmd = NewRootCmd()
 
 // NewRootCmd returns a fully assembled root command tree containing all
 // subpackages and top-level commands without relying on init() side effects.

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -226,7 +226,7 @@ func TestVaultPathPrefersExplicitFlagOverEnv(t *testing.T) {
 
 // TestExecute_Error verifies that Execute() calls cli.OsExit(1) when rootCmd.Execute() returns an error.
 func TestExecute_Error(t *testing.T) {
-	rootCmd = newPackageRootCmd()
+	root := NewRootCmd()
 	var exitCode int
 
 	// Save and restore original cli.OsExit
@@ -247,23 +247,23 @@ func TestExecute_Error(t *testing.T) {
 	}()
 
 	// Save and restore rootCmd args and settings
-	origArgs := rootCmd.Args
-	origSilenceUsage := rootCmd.SilenceUsage
-	origSilenceErrors := rootCmd.SilenceErrors
-	rootCmd.SilenceUsage = true
-	rootCmd.SilenceErrors = true
-	rootCmd.SetArgs([]string{"__nonexistent_subcommand__"})
+	origArgs := root.Args
+	origSilenceUsage := root.SilenceUsage
+	origSilenceErrors := root.SilenceErrors
+	root.SilenceUsage = true
+	root.SilenceErrors = true
+	root.SetArgs([]string{"__nonexistent_subcommand__"})
 	defer func() {
-		rootCmd.Args = origArgs
-		rootCmd.SilenceUsage = origSilenceUsage
-		rootCmd.SilenceErrors = origSilenceErrors
-		rootCmd.SetArgs(nil)
+		root.Args = origArgs
+		root.SilenceUsage = origSilenceUsage
+		root.SilenceErrors = origSilenceErrors
+		root.SetArgs(nil)
 	}()
 
-	Execute()
+	ExecuteRoot(root)
 
 	if exitCode != 1 {
-		t.Errorf("Execute() called cli.OsExit(%d), want cli.OsExit(1)", exitCode)
+		t.Errorf("ExecuteRoot(root) called cli.OsExit(%d), want cli.OsExit(1)", exitCode)
 	}
 }
 
@@ -380,6 +380,7 @@ func TestUnlockVault_UsesConfiguredSessionTimeout(t *testing.T) {
 }
 
 func TestUnlockCommand_UsesConfiguredSessionTimeoutByDefault(t *testing.T) {
+	root := NewRootCmd()
 	resetVaultFlag(t)
 
 	vaultDir := t.TempDir()
@@ -422,12 +423,12 @@ func TestUnlockCommand_UsesConfiguredSessionTimeoutByDefault(t *testing.T) {
 		checkFlag.Changed = origCheckChanged
 	})
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "unlock"})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	root.SetArgs([]string{"--vault", vaultDir, "unlock"})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
 	var execErr error
 	output := captureStderr(func() {
-		execErr = rootCmd.Execute()
+		execErr = root.Execute()
 	})
 	if execErr != nil {
 		t.Fatalf("unlock command: %v", execErr)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -26,10 +26,6 @@ var (
 	runBrokerPassthrough []string
 )
 
-// runCmd is retained for API compatibility; NewRootCmd() uses
-// newRunCmd() so every call gets a fresh command.
-var runCmd = newRunCmd()
-
 func newRunCmd() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "run [flags] -- <command> [args...]",

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -36,14 +36,15 @@ func TestCmdRun_SecretInjection(t *testing.T) {
 }
 
 func TestCmdRun_MissingSecretRef(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	setPassEnv(t, string(passphrase))
 	defer setupVaultFlag(t, vaultDir)()
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "run", "--env", "FOO=missing.value", "--", "echo", "hello"})
-	defer rootCmd.SetArgs(nil)
+	root.SetArgs([]string{"--vault", vaultDir, "run", "--env", "FOO=missing.value", "--", "echo", "hello"})
+	defer root.SetArgs(nil)
 
-	err := rootCmd.Execute()
+	err := root.Execute()
 	if err == nil {
 		t.Error("expected error for missing secret ref, got nil")
 	} else {
@@ -55,14 +56,15 @@ func TestCmdRun_MissingSecretRef(t *testing.T) {
 }
 
 func TestCmdRun_Timeout(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	setPassEnv(t, string(passphrase))
 	defer setupVaultFlag(t, vaultDir)()
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "run", "--timeout", "100ms", "--", "sleep", "10"})
-	defer rootCmd.SetArgs(nil)
+	root.SetArgs([]string{"--vault", vaultDir, "run", "--timeout", "100ms", "--", "sleep", "10"})
+	defer root.SetArgs(nil)
 
-	err := rootCmd.Execute()
+	err := root.Execute()
 	if err == nil {
 		t.Error("expected timeout error, got nil")
 	} else {
@@ -120,14 +122,15 @@ func TestCmdRun_MultipleEnvFlags(t *testing.T) {
 }
 
 func TestCmdRun_NonZeroExit(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	setPassEnv(t, string(passphrase))
 	defer setupVaultFlag(t, vaultDir)()
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "run", "--", "sh", "-c", "exit 42"})
-	defer rootCmd.SetArgs(nil)
+	root.SetArgs([]string{"--vault", vaultDir, "run", "--", "sh", "-c", "exit 42"})
+	defer root.SetArgs(nil)
 
-	err := rootCmd.Execute()
+	err := root.Execute()
 	if err == nil {
 		t.Error("expected non-zero exit error, got nil")
 	} else {
@@ -139,15 +142,16 @@ func TestCmdRun_NonZeroExit(t *testing.T) {
 }
 
 func TestCmdRun_UninitializedVault(t *testing.T) {
+	root := NewRootCmd()
 	resetCmdFlags()
 	t.Cleanup(resetCmdFlags)
 	vaultDir := t.TempDir()
 	defer setupVaultFlag(t, vaultDir)()
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "run", "--", "echo", "hello"})
-	defer rootCmd.SetArgs(nil)
+	root.SetArgs([]string{"--vault", vaultDir, "run", "--", "echo", "hello"})
+	defer root.SetArgs(nil)
 
-	err := rootCmd.Execute()
+	err := root.Execute()
 	if err == nil {
 		t.Error("expected error for uninitialized vault, got nil")
 	} else {
@@ -159,6 +163,7 @@ func TestCmdRun_UninitializedVault(t *testing.T) {
 }
 
 func TestCmdRun_TooManyEnvironmentVariables(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	identity, _ := vaultpkg.OpenWithPassphrase(vaultDir, passphrase)
 
@@ -170,15 +175,15 @@ func TestCmdRun_TooManyEnvironmentVariables(t *testing.T) {
 	setPassEnv(t, string(passphrase))
 	defer setupVaultFlag(t, vaultDir)()
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "run",
+	root.SetArgs([]string{"--vault", vaultDir, "run",
 		"--env", "A=a.key", "--env", "B=b.key", "--env", "C=c.key",
 		"--env", "D=d.key", "--env", "E=e.key", "--env", "F=f.key",
 		"--env", "G=g.key", "--env", "H=h.key", "--env", "I=i.key",
 		"--env", "J=j.key",
 		"--", "sh", "-c", "echo ALL_SET"})
-	defer rootCmd.SetArgs(nil)
+	defer root.SetArgs(nil)
 
-	err := rootCmd.Execute()
+	err := root.Execute()
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -199,6 +204,7 @@ func TestCmdRun_EnvWithBareRef(t *testing.T) {
 }
 
 func TestCmdRun_StdoutStderrPassthrough(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	setPassEnv(t, string(passphrase))
 	defer setupVaultFlag(t, vaultDir)()
@@ -207,9 +213,9 @@ func TestCmdRun_StdoutStderrPassthrough(t *testing.T) {
 
 	stdout = captureStdout(func() {
 		stderr = captureStderr(func() {
-			rootCmd.SetArgs([]string{"--vault", vaultDir, "run", "--", "sh", "-c", "echo stdout; echo stderr >&2"})
-			_ = rootCmd.Execute()
-			rootCmd.SetArgs(nil)
+			root.SetArgs([]string{"--vault", vaultDir, "run", "--", "sh", "-c", "echo stdout; echo stderr >&2"})
+			_ = root.Execute()
+			root.SetArgs(nil)
 		})
 	})
 
@@ -222,28 +228,30 @@ func TestCmdRun_StdoutStderrPassthrough(t *testing.T) {
 }
 
 func TestCmdRun_NoArgsError(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	setPassEnv(t, string(passphrase))
 	defer setupVaultFlag(t, vaultDir)()
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "run"})
-	defer rootCmd.SetArgs(nil)
+	root.SetArgs([]string{"--vault", vaultDir, "run"})
+	defer root.SetArgs(nil)
 
-	err := rootCmd.Execute()
+	err := root.Execute()
 	if err == nil {
 		t.Error("expected error when no command provided, got nil")
 	}
 }
 
 func TestCmdRun_InvalidEnvFormat(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	setPassEnv(t, string(passphrase))
 	defer setupVaultFlag(t, vaultDir)()
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "run", "--env", "NOEQUALSIGN", "--", "echo", "hello"})
-	defer rootCmd.SetArgs(nil)
+	root.SetArgs([]string{"--vault", vaultDir, "run", "--env", "NOEQUALSIGN", "--", "echo", "hello"})
+	defer root.SetArgs(nil)
 
-	err := rootCmd.Execute()
+	err := root.Execute()
 	if err == nil {
 		t.Error("expected error for invalid --env format, got nil")
 	} else {
@@ -320,14 +328,15 @@ func TestCmdRun_EnvFileWithComments(t *testing.T) {
 }
 
 func TestCmdRun_EnvFileNotFound(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	setPassEnv(t, string(passphrase))
 	defer setupVaultFlag(t, vaultDir)()
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "run", "--env-file", "/nonexistent/.env.symvault", "--", "echo", "hello"})
-	defer rootCmd.SetArgs(nil)
+	root.SetArgs([]string{"--vault", vaultDir, "run", "--env-file", "/nonexistent/.env.symvault", "--", "echo", "hello"})
+	defer root.SetArgs(nil)
 
-	err := rootCmd.Execute()
+	err := root.Execute()
 	if err == nil {
 		t.Error("expected error for missing env file, got nil")
 	} else {
@@ -339,6 +348,7 @@ func TestCmdRun_EnvFileNotFound(t *testing.T) {
 }
 
 func TestCmdRun_EnvFileInvalidFormat(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	setPassEnv(t, string(passphrase))
 	defer setupVaultFlag(t, vaultDir)()
@@ -348,10 +358,10 @@ func TestCmdRun_EnvFileInvalidFormat(t *testing.T) {
 		t.Fatalf("write env file: %v", err)
 	}
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "run", "--env-file", envFile, "--", "echo", "hello"})
-	defer rootCmd.SetArgs(nil)
+	root.SetArgs([]string{"--vault", vaultDir, "run", "--env-file", envFile, "--", "echo", "hello"})
+	defer root.SetArgs(nil)
 
-	err := rootCmd.Execute()
+	err := root.Execute()
 	if err == nil {
 		t.Error("expected error for invalid env file format, got nil")
 	} else {
@@ -363,6 +373,7 @@ func TestCmdRun_EnvFileInvalidFormat(t *testing.T) {
 }
 
 func TestCmdRun_EnvFileDuplicateVar(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	identity, _ := vaultpkg.OpenWithPassphrase(vaultDir, passphrase)
 	entry := &vaultpkg.Entry{Data: map[string]any{"password": "dup_test"}}
@@ -375,13 +386,13 @@ func TestCmdRun_EnvFileDuplicateVar(t *testing.T) {
 		t.Fatalf("write env file: %v", err)
 	}
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "run",
+	root.SetArgs([]string{"--vault", vaultDir, "run",
 		"--env", "DB_PASS=db.password",
 		"--env-file", envFile,
 		"--", "echo", "hello"})
-	defer rootCmd.SetArgs(nil)
+	defer root.SetArgs(nil)
 
-	err := rootCmd.Execute()
+	err := root.Execute()
 	if err == nil {
 		t.Error("expected error for duplicate env var, got nil")
 	} else {
@@ -482,6 +493,7 @@ func TestParseEnvFile_VeryLongLine(t *testing.T) {
 }
 
 func TestCmdRun_EnvFileMissingSecret(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	setPassEnv(t, string(passphrase))
 	defer setupVaultFlag(t, vaultDir)()
@@ -491,10 +503,10 @@ func TestCmdRun_EnvFileMissingSecret(t *testing.T) {
 		t.Fatalf("write env file: %v", err)
 	}
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "run", "--env-file", envFile, "--", "echo", "hello"})
-	defer rootCmd.SetArgs(nil)
+	root.SetArgs([]string{"--vault", vaultDir, "run", "--env-file", envFile, "--", "echo", "hello"})
+	defer root.SetArgs(nil)
 
-	err := rootCmd.Execute()
+	err := root.Execute()
 	if err == nil {
 		t.Error("expected error for missing secret in env file, got nil")
 	} else {

--- a/cmd/scripting_tty_test.go
+++ b/cmd/scripting_tty_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestScriptingGet_TTYDetection_InProcess(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	identity, _ := vaultpkg.OpenWithPassphrase(vaultDir, passphrase)
 	entry := &vaultpkg.Entry{Data: map[string]any{"password": "tty-test-pass"}}
@@ -49,9 +50,9 @@ func TestScriptingGet_TTYDetection_InProcess(t *testing.T) {
 		var stdout string
 		captureStderr(func() {
 			stdout = captureStdout(func() {
-				rootCmd.SetArgs([]string{"--vault", vaultDir, "get", "tty-entry.password"})
-				_ = rootCmd.Execute()
-				rootCmd.SetArgs(nil)
+				root.SetArgs([]string{"--vault", vaultDir, "get", "tty-entry.password"})
+				_ = root.Execute()
+				root.SetArgs(nil)
 			})
 		})
 		if stdout != "" {

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -1571,6 +1571,8 @@ func TestRunHTTPServerFunc_ApprovalDeviceSession(t *testing.T) {
 	resetVaultState(t)
 
 	tmpDir := t.TempDir()
+	restoreVaultFlag := setupVaultFlag(t, tmpDir)
+	defer restoreVaultFlag()
 	_ = os.Setenv("SYMVAULT_VAULT", tmpDir)
 	_ = os.Setenv("SYMVAULT_PASSPHRASE", "test")
 	defer func() {

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -753,6 +753,7 @@ func TestRunHTTPServer_HandleMessageError(t *testing.T) {
 }
 
 func TestServeCommand_StdioOnlyDoesNotStartHTTP(t *testing.T) {
+	root := NewRootCmd()
 	resetCommandTestState()
 	t.Cleanup(resetCommandTestState)
 
@@ -775,10 +776,10 @@ func TestServeCommand_StdioOnlyDoesNotStartHTTP(t *testing.T) {
 	}
 	mcpcmd.ServeSignalNotify = func(_ chan<- os.Signal, _ ...os.Signal) {}
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "serve", "--stdio", "--agent", "default"})
-	defer rootCmd.SetArgs(nil)
+	root.SetArgs([]string{"--vault", vaultDir, "serve", "--stdio", "--agent", "default"})
+	defer root.SetArgs(nil)
 
-	if err := rootCmd.Execute(); err != nil {
+	if err := root.Execute(); err != nil {
 		t.Fatalf("serve command failed: %v", err)
 	}
 	if !stdioStarted {
@@ -807,6 +808,7 @@ func setupServeCommandTest(t *testing.T) (vaultDir string, cleanup func()) {
 }
 
 func TestServeCommand_ActiveSessionUsesNonInteractiveUnlock(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, cleanup := setupServeCommandTest(t)
 	defer cleanup()
 
@@ -819,10 +821,10 @@ func TestServeCommand_ActiveSessionUsesNonInteractiveUnlock(t *testing.T) {
 		return &vaultpkg.Vault{}, nil
 	}
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "serve", "--port", "18080"})
-	defer rootCmd.SetArgs(nil)
+	root.SetArgs([]string{"--vault", vaultDir, "serve", "--port", "18080"})
+	defer root.SetArgs(nil)
 
-	if err := rootCmd.Execute(); err != nil {
+	if err := root.Execute(); err != nil {
 		t.Fatalf("serve command failed: %v", err)
 	}
 
@@ -835,6 +837,7 @@ func TestServeCommand_ActiveSessionUsesNonInteractiveUnlock(t *testing.T) {
 }
 
 func TestServeCommand_ExpiredSessionUsesInteractiveUnlock(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, cleanup := setupServeCommandTest(t)
 	defer cleanup()
 
@@ -847,10 +850,10 @@ func TestServeCommand_ExpiredSessionUsesInteractiveUnlock(t *testing.T) {
 		return nil, nil
 	}
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "serve", "--port", "18081"})
-	defer rootCmd.SetArgs(nil)
+	root.SetArgs([]string{"--vault", vaultDir, "serve", "--port", "18081"})
+	defer root.SetArgs(nil)
 
-	if err := rootCmd.Execute(); err != nil {
+	if err := root.Execute(); err != nil {
 		t.Fatalf("serve command failed: %v", err)
 	}
 
@@ -863,6 +866,7 @@ func TestServeCommand_ExpiredSessionUsesInteractiveUnlock(t *testing.T) {
 }
 
 func TestServeCommand_ActiveSessionFallbackToInteractive(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, cleanup := setupServeCommandTest(t)
 	defer cleanup()
 
@@ -878,10 +882,10 @@ func TestServeCommand_ActiveSessionFallbackToInteractive(t *testing.T) {
 		return nil, nil
 	}
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "serve", "--port", "18082"})
-	defer rootCmd.SetArgs(nil)
+	root.SetArgs([]string{"--vault", vaultDir, "serve", "--port", "18082"})
+	defer root.SetArgs(nil)
 
-	if err := rootCmd.Execute(); err != nil {
+	if err := root.Execute(); err != nil {
 		t.Fatalf("serve command failed: %v", err)
 	}
 
@@ -957,22 +961,24 @@ func TestRunHTTPServer_HealthEndpoint_NonLoopback(t *testing.T) {
 }
 
 func TestCmdServe_EmptyBind(t *testing.T) {
+	root := NewRootCmd()
+	serveCmd, _, _ := root.Find([]string{"serve"})
 	vaultDir := t.TempDir()
 	vaultFlagReset(t)
 	_ = os.Setenv("SYMVAULT_VAULT", vaultDir)
 	t.Cleanup(func() { _ = os.Unsetenv("SYMVAULT_VAULT") })
 
 	t.Cleanup(func() {
-		_ = mcpcmd.ServeCmd.Flags().Set("bind", "127.0.0.1")
-		_ = mcpcmd.ServeCmd.Flags().Set("stdio", "false")
+		_ = serveCmd.Flags().Set("bind", "127.0.0.1")
+		_ = serveCmd.Flags().Set("stdio", "false")
 	})
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "serve", "--bind", ""})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	root.SetArgs([]string{"--vault", vaultDir, "serve", "--bind", ""})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
 	var execErr error
 	captureStderr(func() {
-		execErr = rootCmd.Execute()
+		execErr = root.Execute()
 	})
 
 	if execErr == nil {
@@ -984,24 +990,26 @@ func TestCmdServe_EmptyBind(t *testing.T) {
 }
 
 func TestCmdServe_MissingAgentInStdioMode(t *testing.T) {
+	root := NewRootCmd()
+	serveCmd, _, _ := root.Find([]string{"serve"})
 	vaultDir := t.TempDir()
 	vaultFlagReset(t)
 	_ = os.Setenv("SYMVAULT_VAULT", vaultDir)
 	t.Cleanup(func() { _ = os.Unsetenv("SYMVAULT_VAULT") })
 
 	t.Cleanup(func() {
-		_ = mcpcmd.ServeCmd.Flags().Set("bind", "127.0.0.1")
-		_ = mcpcmd.ServeCmd.Flags().Set("stdio", "false")
-		_ = mcpcmd.ServeCmd.Flags().Set("agent", "")
+		_ = serveCmd.Flags().Set("bind", "127.0.0.1")
+		_ = serveCmd.Flags().Set("stdio", "false")
+		_ = serveCmd.Flags().Set("agent", "")
 	})
-	_ = mcpcmd.ServeCmd.Flags().Set("agent", "")
+	_ = serveCmd.Flags().Set("agent", "")
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "serve", "--bind", "127.0.0.1", "--stdio"})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	root.SetArgs([]string{"--vault", vaultDir, "serve", "--bind", "127.0.0.1", "--stdio"})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
 	var execErr error
 	captureStderr(func() {
-		execErr = rootCmd.Execute()
+		execErr = root.Execute()
 	})
 
 	if execErr == nil {
@@ -1013,6 +1021,8 @@ func TestCmdServe_MissingAgentInStdioMode(t *testing.T) {
 }
 
 func TestServe_RunE_HTTPWithAgent(t *testing.T) {
+	root := NewRootCmd()
+	serveCmd, _, _ := root.Find([]string{"serve"})
 	vaultDir := t.TempDir()
 	identity := testutil.TempIdentity(t)
 	cfg := config.Default()
@@ -1075,18 +1085,18 @@ func TestServe_RunE_HTTPWithAgent(t *testing.T) {
 	t.Cleanup(func() { mcpcmd.RunHTTPServerFunc = origHTTP })
 
 	t.Cleanup(func() {
-		_ = mcpcmd.ServeCmd.Flags().Set("bind", "127.0.0.1")
-		_ = mcpcmd.ServeCmd.Flags().Set("stdio", "false")
-		_ = mcpcmd.ServeCmd.Flags().Set("agent", "")
+		_ = serveCmd.Flags().Set("bind", "127.0.0.1")
+		_ = serveCmd.Flags().Set("stdio", "false")
+		_ = serveCmd.Flags().Set("agent", "")
 	})
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "serve", "--agent", "test-agent", "--port", fmt.Sprintf("%d", port)})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	root.SetArgs([]string{"--vault", vaultDir, "serve", "--agent", "test-agent", "--port", fmt.Sprintf("%d", port)})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		_ = rootCmd.Execute()
+		_ = root.Execute()
 	}()
 
 	select {
@@ -1110,18 +1120,20 @@ func TestServe_RunE_HTTPWithAgent(t *testing.T) {
 }
 
 func TestCmdServe_UninitializedVault(t *testing.T) {
+	root := NewRootCmd()
+	serveCmd, _, _ := root.Find([]string{"serve"})
 	vaultDir := t.TempDir()
 	vaultFlagReset(t)
 
-	_ = mcpcmd.ServeCmd.Flags().Set("bind", "127.0.0.1")
-	_ = mcpcmd.ServeCmd.Flags().Set("stdio", "false")
+	_ = serveCmd.Flags().Set("bind", "127.0.0.1")
+	_ = serveCmd.Flags().Set("stdio", "false")
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "serve", "--bind", "127.0.0.1"})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	root.SetArgs([]string{"--vault", vaultDir, "serve", "--bind", "127.0.0.1"})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
 	var execErr error
 	captureStderr(func() {
-		execErr = rootCmd.Execute()
+		execErr = root.Execute()
 	})
 
 	if execErr == nil {
@@ -1133,16 +1145,17 @@ func TestCmdServe_UninitializedVault(t *testing.T) {
 }
 
 func TestServe_ErrorPaths(t *testing.T) {
+	root := NewRootCmd()
 	resetVaultState(t)
 	t.Run("uninitialized vault", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		_ = os.Setenv("SYMVAULT_VAULT", tmpDir)
 		defer func() { _ = os.Unsetenv("SYMVAULT_VAULT") }()
 
-		rootCmd.SetArgs([]string{"--vault", tmpDir, "serve", "--port", "0"})
-		defer rootCmd.SetArgs(nil)
+		root.SetArgs([]string{"--vault", tmpDir, "serve", "--port", "0"})
+		defer root.SetArgs(nil)
 
-		err := rootCmd.Execute()
+		err := root.Execute()
 		if err == nil || !strings.Contains(err.Error(), "not initialized") {
 			t.Errorf("expected 'not initialized' error, got: %v", err)
 		}
@@ -1160,10 +1173,10 @@ func TestServe_ErrorPaths(t *testing.T) {
 			_ = os.Unsetenv("SYMVAULT_PASSPHRASE")
 		}()
 
-		rootCmd.SetArgs([]string{"--vault", tmpDir, "serve", "--stdio"})
-		defer rootCmd.SetArgs(nil)
+		root.SetArgs([]string{"--vault", tmpDir, "serve", "--stdio"})
+		defer root.SetArgs(nil)
 
-		err := rootCmd.Execute()
+		err := root.Execute()
 		if err == nil || !strings.Contains(err.Error(), "--agent is required") {
 			t.Errorf("expected '--agent is required' error, got: %v", err)
 		}
@@ -1181,10 +1194,10 @@ func TestServe_ErrorPaths(t *testing.T) {
 			_ = os.Unsetenv("SYMVAULT_PASSPHRASE")
 		}()
 
-		rootCmd.SetArgs([]string{"--vault", tmpDir, "serve", "--bind", ""})
-		defer rootCmd.SetArgs(nil)
+		root.SetArgs([]string{"--vault", tmpDir, "serve", "--bind", ""})
+		defer root.SetArgs(nil)
 
-		err := rootCmd.Execute()
+		err := root.Execute()
 		if err == nil || !strings.Contains(err.Error(), "bind") {
 			t.Errorf("expected bind error, got: %v", err)
 		}
@@ -1192,6 +1205,8 @@ func TestServe_ErrorPaths(t *testing.T) {
 }
 
 func TestServe_HTTPSignalShutdown(t *testing.T) {
+	root := NewRootCmd()
+	serveCmd, _, _ := root.Find([]string{"serve"})
 	if testing.Short() {
 		t.Skip("skipping slow integration server test in short mode")
 	}
@@ -1208,8 +1223,8 @@ func TestServe_HTTPSignalShutdown(t *testing.T) {
 	cfg := config.Default()
 	_, _ = vaultpkg.InitWithPassphrase(tmpDir, []byte("test"), cfg)
 
-	_ = mcpcmd.ServeCmd.Flags().Set("bind", "127.0.0.1")
-	_ = mcpcmd.ServeCmd.Flags().Set("stdio", "false")
+	_ = serveCmd.Flags().Set("bind", "127.0.0.1")
+	_ = serveCmd.Flags().Set("stdio", "false")
 
 	port := findFreePort(t)
 
@@ -1222,12 +1237,12 @@ func TestServe_HTTPSignalShutdown(t *testing.T) {
 		}()
 	}
 
-	rootCmd.SetArgs([]string{"--vault", tmpDir, "serve", "--port", fmt.Sprintf("%d", port)})
-	defer rootCmd.SetArgs(nil)
+	root.SetArgs([]string{"--vault", tmpDir, "serve", "--port", fmt.Sprintf("%d", port)})
+	defer root.SetArgs(nil)
 
 	done := make(chan struct{})
 	go func() {
-		_ = rootCmd.Execute()
+		_ = root.Execute()
 		close(done)
 	}()
 
@@ -1264,6 +1279,8 @@ func TestIsLocalhostBind(t *testing.T) {
 }
 
 func TestCmdServe_NonLoopbackWarning(t *testing.T) {
+	root := NewRootCmd()
+	serveCmd, _, _ := root.Find([]string{"serve"})
 	vaultDir := t.TempDir()
 	identity := testutil.TempIdentity(t)
 	cfg := config.Default()
@@ -1303,21 +1320,21 @@ func TestCmdServe_NonLoopbackWarning(t *testing.T) {
 	}
 	defer func() { mcpcmd.RunHTTPServerFunc = origHTTP }()
 
-	_ = mcpcmd.ServeCmd.Flags().Set("stdio", "false")
-	_ = mcpcmd.ServeCmd.Flags().Set("agent", "")
-	_ = mcpcmd.ServeCmd.Flags().Set("port", fmt.Sprintf("%d", port))
-	_ = mcpcmd.ServeCmd.Flags().Set("bind", "0.0.0.0")
+	_ = serveCmd.Flags().Set("stdio", "false")
+	_ = serveCmd.Flags().Set("agent", "")
+	_ = serveCmd.Flags().Set("port", fmt.Sprintf("%d", port))
+	_ = serveCmd.Flags().Set("bind", "0.0.0.0")
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "serve", "--bind", "0.0.0.0", "--port", fmt.Sprintf("%d", port)})
+	root.SetArgs([]string{"--vault", vaultDir, "serve", "--bind", "0.0.0.0", "--port", fmt.Sprintf("%d", port)})
 	t.Cleanup(func() {
-		rootCmd.SetArgs(nil)
-		_ = mcpcmd.ServeCmd.Flags().Set("bind", "127.0.0.1")
+		root.SetArgs(nil)
+		_ = serveCmd.Flags().Set("bind", "127.0.0.1")
 	})
 
 	done := make(chan struct{})
 	stderr := captureStderr(func() {
 		go func() {
-			_ = rootCmd.Execute()
+			_ = root.Execute()
 			close(done)
 		}()
 		sigCh := <-serveSignals
@@ -1337,6 +1354,8 @@ func TestCmdServe_NonLoopbackWarning(t *testing.T) {
 }
 
 func TestCmdServe_TLSFlagsOverride(t *testing.T) {
+	root := NewRootCmd()
+	serveCmd, _, _ := root.Find([]string{"serve"})
 	vaultDir := t.TempDir()
 	identity := testutil.TempIdentity(t)
 	cfg := config.Default()
@@ -1377,11 +1396,11 @@ func TestCmdServe_TLSFlagsOverride(t *testing.T) {
 	defer func() { mcpcmd.RunHTTPServerFunc = origHTTP }()
 
 	const port = 18182
-	_ = mcpcmd.ServeCmd.Flags().Set("stdio", "false")
-	_ = mcpcmd.ServeCmd.Flags().Set("agent", "")
-	_ = mcpcmd.ServeCmd.Flags().Set("port", fmt.Sprintf("%d", port))
+	_ = serveCmd.Flags().Set("stdio", "false")
+	_ = serveCmd.Flags().Set("agent", "")
+	_ = serveCmd.Flags().Set("port", fmt.Sprintf("%d", port))
 
-	rootCmd.SetArgs([]string{
+	root.SetArgs([]string{
 		"--vault", vaultDir,
 		"serve",
 		"--bind", "127.0.0.1",
@@ -1390,15 +1409,15 @@ func TestCmdServe_TLSFlagsOverride(t *testing.T) {
 		"--tls-key", "/path/to/key.pem",
 	})
 	t.Cleanup(func() {
-		rootCmd.SetArgs(nil)
-		_ = mcpcmd.ServeCmd.Flags().Set("bind", "127.0.0.1")
-		_ = mcpcmd.ServeCmd.Flags().Set("tls-cert", "")
-		_ = mcpcmd.ServeCmd.Flags().Set("tls-key", "")
+		root.SetArgs(nil)
+		_ = serveCmd.Flags().Set("bind", "127.0.0.1")
+		_ = serveCmd.Flags().Set("tls-cert", "")
+		_ = serveCmd.Flags().Set("tls-key", "")
 	})
 
 	done := make(chan struct{})
 	go func() {
-		_ = rootCmd.Execute()
+		_ = root.Execute()
 		close(done)
 	}()
 
@@ -1422,6 +1441,8 @@ func TestCmdServe_TLSFlagsOverride(t *testing.T) {
 }
 
 func TestCmdServe_TLSFlagsOnlyCert(t *testing.T) {
+	root := NewRootCmd()
+	serveCmd, _, _ := root.Find([]string{"serve"})
 	vaultDir := t.TempDir()
 	identity := testutil.TempIdentity(t)
 	cfg := config.Default()
@@ -1462,12 +1483,12 @@ func TestCmdServe_TLSFlagsOnlyCert(t *testing.T) {
 	defer func() { mcpcmd.RunHTTPServerFunc = origHTTP }()
 
 	const port = 18183
-	_ = mcpcmd.ServeCmd.Flags().Set("stdio", "false")
-	_ = mcpcmd.ServeCmd.Flags().Set("agent", "")
-	_ = mcpcmd.ServeCmd.Flags().Set("port", fmt.Sprintf("%d", port))
+	_ = serveCmd.Flags().Set("stdio", "false")
+	_ = serveCmd.Flags().Set("agent", "")
+	_ = serveCmd.Flags().Set("port", fmt.Sprintf("%d", port))
 
 	// Only set --tls-cert, leave --tls-key as default
-	rootCmd.SetArgs([]string{
+	root.SetArgs([]string{
 		"--vault", vaultDir,
 		"serve",
 		"--bind", "127.0.0.1",
@@ -1475,15 +1496,15 @@ func TestCmdServe_TLSFlagsOnlyCert(t *testing.T) {
 		"--tls-cert", "/path/to/cert.pem",
 	})
 	t.Cleanup(func() {
-		rootCmd.SetArgs(nil)
-		_ = mcpcmd.ServeCmd.Flags().Set("bind", "127.0.0.1")
-		_ = mcpcmd.ServeCmd.Flags().Set("tls-cert", "")
-		_ = mcpcmd.ServeCmd.Flags().Set("tls-key", "")
+		root.SetArgs(nil)
+		_ = serveCmd.Flags().Set("bind", "127.0.0.1")
+		_ = serveCmd.Flags().Set("tls-cert", "")
+		_ = serveCmd.Flags().Set("tls-key", "")
 	})
 
 	done := make(chan struct{})
 	go func() {
-		_ = rootCmd.Execute()
+		_ = root.Execute()
 		close(done)
 	}()
 
@@ -1507,6 +1528,8 @@ func TestCmdServe_TLSFlagsOnlyCert(t *testing.T) {
 }
 
 func TestServe_StdioError(t *testing.T) {
+	root := NewRootCmd()
+	serveCmd, _, _ := root.Find([]string{"serve"})
 	resetVaultState(t)
 
 	tmpDir := t.TempDir()
@@ -1520,9 +1543,9 @@ func TestServe_StdioError(t *testing.T) {
 	cfg := config.Default()
 	_, _ = vaultpkg.InitWithPassphrase(tmpDir, []byte("test"), cfg)
 
-	_ = mcpcmd.ServeCmd.Flags().Set("bind", "127.0.0.1")
-	_ = mcpcmd.ServeCmd.Flags().Set("stdio", "false")
-	_ = mcpcmd.ServeCmd.Flags().Set("agent", "")
+	_ = serveCmd.Flags().Set("bind", "127.0.0.1")
+	_ = serveCmd.Flags().Set("stdio", "false")
+	_ = serveCmd.Flags().Set("agent", "")
 
 	port := findFreePort(t)
 
@@ -1532,10 +1555,10 @@ func TestServe_StdioError(t *testing.T) {
 	}
 	defer func() { mcpcmd.RunStdioServerFunc = origRunStdio }()
 
-	rootCmd.SetArgs([]string{"--vault", tmpDir, "serve", "--stdio", "--agent", "test-agent", "--port", fmt.Sprintf("%d", port)})
-	defer rootCmd.SetArgs(nil)
+	root.SetArgs([]string{"--vault", tmpDir, "serve", "--stdio", "--agent", "test-agent", "--port", fmt.Sprintf("%d", port)})
+	defer root.SetArgs(nil)
 
-	err := rootCmd.Execute()
+	err := root.Execute()
 	if err == nil || !strings.Contains(err.Error(), "mock stdio error") {
 		t.Errorf("expected mock stdio error, got: %v", err)
 	}

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -1622,6 +1622,7 @@ func TestRunHTTPServerFunc_ApprovalDeviceSession(t *testing.T) {
 			v.Config.MCP = &config.MCPConfig{}
 		}
 		v.Config.MCP.AllowInsecureBind = true
+		v.Config.MCP.HTTPTokenFile = filepath.Join(tmpDir, "mcp-token")
 		if err := mcpcmd.RunHTTPServerFunc(ctx, "127.0.0.1", port, v); err != nil {
 			t.Logf("RunHTTPServerFunc: %v", err)
 		}

--- a/cmd/set_test.go
+++ b/cmd/set_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestSetCommand_HiddenPassword(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	setPassEnv(t, string(passphrase))
 	defer setupVaultFlag(t, vaultDir)()
@@ -19,11 +20,11 @@ func TestSetCommand_HiddenPassword(t *testing.T) {
 	restore := pipeStdin(t, "myuser\nnew-secret-password\n\n\n")
 	defer restore()
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "set", "test-entry"})
-	defer rootCmd.SetArgs(nil)
+	root.SetArgs([]string{"--vault", vaultDir, "set", "test-entry"})
+	defer root.SetArgs(nil)
 
 	output := captureStdout(func() {
-		if err := rootCmd.Execute(); err != nil {
+		if err := root.Execute(); err != nil {
 			t.Fatalf("set command failed: %v", err)
 		}
 	})
@@ -34,15 +35,16 @@ func TestSetCommand_HiddenPassword(t *testing.T) {
 }
 
 func TestSetCommand_InvalidTOTPSecretRejected(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	setPassEnv(t, string(passphrase))
 	defer setupVaultFlag(t, vaultDir)()
 
 	stderr := captureStderr(func() {
-		rootCmd.SetArgs([]string{"--vault", vaultDir, "set", "bad-totp-set",
+		root.SetArgs([]string{"--vault", vaultDir, "set", "bad-totp-set",
 			"--value", "StrongP@ssw0rd123", "--totp-secret", "not-valid-base32!!!"})
-		_ = rootCmd.Execute()
-		rootCmd.SetArgs(nil)
+		_ = root.Execute()
+		root.SetArgs(nil)
 	})
 
 	if !strings.Contains(stderr, "TOTP secret must be Base32-encoded") {
@@ -112,15 +114,16 @@ func TestCmdSet_TOTP(t *testing.T) {
 }
 
 func TestCmdSet_InteractiveField(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	setPassEnv(t, string(passphrase))
 	defer setupVaultFlag(t, vaultDir)()
 	restore := pipeStdin(t, "newvalue\n")
 	defer restore()
 	out := captureStdout(func() {
-		rootCmd.SetArgs([]string{"--vault", vaultDir, "set", "ifield.custom"})
-		_ = rootCmd.Execute()
-		rootCmd.SetArgs(nil)
+		root.SetArgs([]string{"--vault", vaultDir, "set", "ifield.custom"})
+		_ = root.Execute()
+		root.SetArgs(nil)
 	})
 	if !strings.Contains(out, "Entry saved") {
 		t.Errorf("expected Entry saved, got: %s", out)
@@ -128,15 +131,16 @@ func TestCmdSet_InteractiveField(t *testing.T) {
 }
 
 func TestCmdSet_InteractiveFieldStdinError(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	setPassEnv(t, string(passphrase))
 	defer setupVaultFlag(t, vaultDir)()
 	restore := pipeStdin(t, "")
 	defer restore()
 	stderr := captureStderr(func() {
-		rootCmd.SetArgs([]string{"--vault", vaultDir, "set", "ifield.custom"})
-		_ = rootCmd.Execute()
-		rootCmd.SetArgs(nil)
+		root.SetArgs([]string{"--vault", vaultDir, "set", "ifield.custom"})
+		_ = root.Execute()
+		root.SetArgs(nil)
 	})
 	if !strings.Contains(stderr, "read value") {
 		t.Errorf("expected read value error, got: %s", stderr)
@@ -144,15 +148,16 @@ func TestCmdSet_InteractiveFieldStdinError(t *testing.T) {
 }
 
 func TestCmdSet_Interactive(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	setPassEnv(t, string(passphrase))
 	defer setupVaultFlag(t, vaultDir)()
 	restore := pipeStdin(t, "alice\nStrongP@ssw0rd123\nhttps://example.com\n\n")
 	defer restore()
 	out := captureStdout(func() {
-		rootCmd.SetArgs([]string{"--vault", vaultDir, "set", "interactive-set"})
-		_ = rootCmd.Execute()
-		rootCmd.SetArgs(nil)
+		root.SetArgs([]string{"--vault", vaultDir, "set", "interactive-set"})
+		_ = root.Execute()
+		root.SetArgs(nil)
 	})
 	if !strings.Contains(out, "Entry saved") {
 		t.Errorf("expected Entry saved, got: %s", out)
@@ -160,15 +165,16 @@ func TestCmdSet_Interactive(t *testing.T) {
 }
 
 func TestCmdSet_InteractiveStdinError(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	setPassEnv(t, string(passphrase))
 	defer setupVaultFlag(t, vaultDir)()
 	restore := pipeStdin(t, "")
 	defer restore()
 	stderr := captureStderr(func() {
-		rootCmd.SetArgs([]string{"--vault", vaultDir, "set", "stdin-err"})
-		_ = rootCmd.Execute()
-		rootCmd.SetArgs(nil)
+		root.SetArgs([]string{"--vault", vaultDir, "set", "stdin-err"})
+		_ = root.Execute()
+		root.SetArgs(nil)
 	})
 	if !strings.Contains(stderr, "read username") {
 		t.Errorf("expected read username error, got: %s", stderr)
@@ -176,14 +182,15 @@ func TestCmdSet_InteractiveStdinError(t *testing.T) {
 }
 
 func TestCmdSet_Uninitialized(t *testing.T) {
+	root := NewRootCmd()
 	resetCmdFlags()
 	t.Cleanup(resetCmdFlags)
 	vaultDir := t.TempDir()
 	defer setupVaultFlag(t, vaultDir)()
 	stderr := captureStderr(func() {
-		rootCmd.SetArgs([]string{"--vault", vaultDir, "set", "x", "--value", "v"})
-		_ = rootCmd.Execute()
-		rootCmd.SetArgs(nil)
+		root.SetArgs([]string{"--vault", vaultDir, "set", "x", "--value", "v"})
+		_ = root.Execute()
+		root.SetArgs(nil)
 	})
 	if !strings.Contains(stderr, "vault not initialized") && !strings.Contains(stderr, "Error") {
 		t.Errorf("expected vault not initialized, got: %s", stderr)
@@ -191,15 +198,16 @@ func TestCmdSet_Uninitialized(t *testing.T) {
 }
 
 func TestCmdSet_InteractiveFull(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	setPassEnv(t, string(passphrase))
 	defer setupVaultFlag(t, vaultDir)()
 	restore := pipeStdin(t, "alice\nStrongP@ssw0rd123\nhttps://example.com\n\n")
 	defer restore()
 	out := captureStdout(func() {
-		rootCmd.SetArgs([]string{"--vault", vaultDir, "set", "interactive-full"})
-		_ = rootCmd.Execute()
-		rootCmd.SetArgs(nil)
+		root.SetArgs([]string{"--vault", vaultDir, "set", "interactive-full"})
+		_ = root.Execute()
+		root.SetArgs(nil)
 	})
 	if !strings.Contains(out, "Entry saved") {
 		t.Errorf("expected Entry saved, got: %s", out)
@@ -221,16 +229,17 @@ func TestCmdSet_InteractiveFull(t *testing.T) {
 }
 
 func TestCmdSet_InteractiveFieldWithTOTP(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	setPassEnv(t, string(passphrase))
 	defer setupVaultFlag(t, vaultDir)()
 	restore := pipeStdin(t, "fieldvalue\n")
 	defer restore()
 	out := captureStdout(func() {
-		rootCmd.SetArgs([]string{"--vault", vaultDir, "set", "totpfield.custom",
+		root.SetArgs([]string{"--vault", vaultDir, "set", "totpfield.custom",
 			"--totp-secret", "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ", "--totp-issuer", "MyService"})
-		_ = rootCmd.Execute()
-		rootCmd.SetArgs(nil)
+		_ = root.Execute()
+		root.SetArgs(nil)
 	})
 	if !strings.Contains(out, "Entry saved") {
 		t.Errorf("expected Entry saved, got: %s", out)
@@ -253,6 +262,7 @@ func TestCmdSet_InteractiveFieldWithTOTP(t *testing.T) {
 }
 
 func TestCmdSet_AutoCommitError(t *testing.T) {
+	root := NewRootCmd()
 	if runtime.GOOS == "windows" {
 		t.Skip("skipping on windows: stderr capture not reliable")
 	}
@@ -265,9 +275,9 @@ func TestCmdSet_AutoCommitError(t *testing.T) {
 	defer setupVaultFlag(t, vaultDir)()
 
 	stderr := captureStderr(func() {
-		rootCmd.SetArgs([]string{"--vault", vaultDir, "set", "autocommit-set", "--value", "StrongP@ssw0rd123"})
-		_ = rootCmd.Execute()
-		rootCmd.SetArgs(nil)
+		root.SetArgs([]string{"--vault", vaultDir, "set", "autocommit-set", "--value", "StrongP@ssw0rd123"})
+		_ = root.Execute()
+		root.SetArgs(nil)
 	})
 	if !strings.Contains(stderr, "auto-commit failed") {
 		t.Errorf("expected auto-commit warning in stderr: %s", stderr)
@@ -275,16 +285,17 @@ func TestCmdSet_AutoCommitError(t *testing.T) {
 }
 
 func TestSet_ErrorPaths(t *testing.T) {
+	root := NewRootCmd()
 	resetVaultState(t)
 	t.Run("uninitialized vault", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		_ = os.Setenv("SYMVAULT_VAULT", tmpDir)
 		defer func() { _ = os.Unsetenv("SYMVAULT_VAULT") }()
 
-		rootCmd.SetArgs([]string{"--vault", tmpDir, "set", "test.key", "--value", "val"})
-		defer rootCmd.SetArgs(nil)
+		root.SetArgs([]string{"--vault", tmpDir, "set", "test.key", "--value", "val"})
+		defer root.SetArgs(nil)
 
-		err := rootCmd.Execute()
+		err := root.Execute()
 		if err == nil || !strings.Contains(err.Error(), "not initialized") {
 			t.Errorf("expected 'not initialized' error, got: %v", err)
 		}
@@ -292,6 +303,7 @@ func TestSet_ErrorPaths(t *testing.T) {
 }
 
 func TestSet_InteractiveMode(t *testing.T) {
+	root := NewRootCmd()
 	resetVaultState(t)
 
 	tmpDir := t.TempDir()
@@ -322,11 +334,11 @@ func TestSet_InteractiveMode(t *testing.T) {
 		_ = w.Close()
 	}()
 
-	rootCmd.SetArgs([]string{"--vault", tmpDir, "set", "interactive-set"})
-	defer rootCmd.SetArgs(nil)
+	root.SetArgs([]string{"--vault", tmpDir, "set", "interactive-set"})
+	defer root.SetArgs(nil)
 
 	output := captureStdout(func() {
-		_ = rootCmd.Execute()
+		_ = root.Execute()
 	})
 
 	os.Stdin = oldStdin
@@ -338,6 +350,7 @@ func TestSet_InteractiveMode(t *testing.T) {
 }
 
 func TestSet_InteractiveMode_Field(t *testing.T) {
+	root := NewRootCmd()
 	resetVaultState(t)
 
 	tmpDir := t.TempDir()
@@ -363,11 +376,11 @@ func TestSet_InteractiveMode_Field(t *testing.T) {
 		_ = w.Close()
 	}()
 
-	rootCmd.SetArgs([]string{"--vault", tmpDir, "set", "test.customfield"})
-	defer rootCmd.SetArgs(nil)
+	root.SetArgs([]string{"--vault", tmpDir, "set", "test.customfield"})
+	defer root.SetArgs(nil)
 
 	output := captureStdout(func() {
-		_ = rootCmd.Execute()
+		_ = root.Execute()
 	})
 
 	os.Stdin = oldStdin
@@ -379,6 +392,7 @@ func TestSet_InteractiveMode_Field(t *testing.T) {
 }
 
 func TestSet_InteractiveReadErrors(t *testing.T) {
+	root := NewRootCmd()
 	resetVaultState(t)
 
 	tests := []struct {
@@ -411,10 +425,10 @@ func TestSet_InteractiveReadErrors(t *testing.T) {
 			os.Stdin = r
 			_ = w.Close()
 
-			rootCmd.SetArgs([]string{"--vault", tmpDir, "set", tt.path})
-			defer rootCmd.SetArgs(nil)
+			root.SetArgs([]string{"--vault", tmpDir, "set", tt.path})
+			defer root.SetArgs(nil)
 
-			err := rootCmd.Execute()
+			err := root.Execute()
 			os.Stdin = oldStdin
 			_ = r.Close()
 

--- a/cmd/share.go
+++ b/cmd/share.go
@@ -12,10 +12,6 @@ import (
 	"github.com/danieljustus/symaira-vault/internal/vault/taint"
 )
 
-// shareCmd is retained for API compatibility; NewRootCmd() uses
-// newShareCmd() so every call gets a fresh command.
-var shareCmd = newShareCmd()
-
 func newShareCmd() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "share",

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -17,10 +17,6 @@ import (
 var syncPush bool
 var syncForce bool
 
-// syncCmd is retained for API compatibility; NewRootCmd() uses
-// newSyncCmd() so every call gets a fresh command.
-var syncCmd = newSyncCmd()
-
 func newSyncCmd() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "sync",

--- a/cmd/template.go
+++ b/cmd/template.go
@@ -22,10 +22,6 @@ var (
 	templatePrefix string
 )
 
-// templateCmd is retained for API compatibility; NewCommands() uses
-// newTemplateCmd() so every call gets a fresh command.
-var templateCmd = newTemplateCmd()
-
 func newTemplateCmd() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "template",

--- a/cmd/template_test.go
+++ b/cmd/template_test.go
@@ -89,14 +89,15 @@ func TestCmdTemplateGenerate_PrefixWithPositionalOverride(t *testing.T) {
 }
 
 func TestCmdTemplateGenerate_NoRefsError(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	setPassEnv(t, string(passphrase))
 	defer setupVaultFlag(t, vaultDir)()
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "template", "generate", "--type", "env"})
-	defer rootCmd.SetArgs(nil)
+	root.SetArgs([]string{"--vault", vaultDir, "template", "generate", "--type", "env"})
+	defer root.SetArgs(nil)
 
-	err := rootCmd.Execute()
+	err := root.Execute()
 	if err == nil {
 		t.Error("expected error for no refs, got nil")
 	} else {
@@ -108,15 +109,16 @@ func TestCmdTemplateGenerate_NoRefsError(t *testing.T) {
 }
 
 func TestCmdTemplateGenerate_InvalidRefFormat(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	setPassEnv(t, string(passphrase))
 	defer setupVaultFlag(t, vaultDir)()
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "template", "generate", "--type", "env",
+	root.SetArgs([]string{"--vault", vaultDir, "template", "generate", "--type", "env",
 		"NOEQUALSIGN"})
-	defer rootCmd.SetArgs(nil)
+	defer root.SetArgs(nil)
 
-	err := rootCmd.Execute()
+	err := root.Execute()
 	if err == nil {
 		t.Error("expected error for invalid ref format, got nil")
 	} else {
@@ -146,6 +148,7 @@ func TestCmdTemplateGenerate_DryRun(t *testing.T) {
 }
 
 func TestCmdTemplateGenerate_OutputFile(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	identity, _ := vaultpkg.OpenWithPassphrase(vaultDir, passphrase)
 	entry := &vaultpkg.Entry{Data: map[string]any{"password": "filetest"}}
@@ -154,11 +157,11 @@ func TestCmdTemplateGenerate_OutputFile(t *testing.T) {
 	defer setupVaultFlag(t, vaultDir)()
 
 	outFile := filepath.Join(t.TempDir(), "output.env")
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "template", "generate", "--type", "env",
+	root.SetArgs([]string{"--vault", vaultDir, "template", "generate", "--type", "env",
 		"--output", outFile, "DB_PASS=db.password"})
-	defer rootCmd.SetArgs(nil)
+	defer root.SetArgs(nil)
 
-	err := rootCmd.Execute()
+	err := root.Execute()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -173,15 +176,16 @@ func TestCmdTemplateGenerate_OutputFile(t *testing.T) {
 }
 
 func TestCmdTemplateGenerate_EmptyKeyInRef(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	setPassEnv(t, string(passphrase))
 	defer setupVaultFlag(t, vaultDir)()
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "template", "generate", "--type", "env",
+	root.SetArgs([]string{"--vault", vaultDir, "template", "generate", "--type", "env",
 		"=db.password"})
-	defer rootCmd.SetArgs(nil)
+	defer root.SetArgs(nil)
 
-	err := rootCmd.Execute()
+	err := root.Execute()
 	if err == nil {
 		t.Error("expected error for empty key in ref, got nil")
 	} else {
@@ -192,15 +196,16 @@ func TestCmdTemplateGenerate_EmptyKeyInRef(t *testing.T) {
 }
 
 func TestCmdTemplateGenerate_EmptyRefInRef(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	setPassEnv(t, string(passphrase))
 	defer setupVaultFlag(t, vaultDir)()
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "template", "generate", "--type", "env",
+	root.SetArgs([]string{"--vault", vaultDir, "template", "generate", "--type", "env",
 		"DB_PASS="})
-	defer rootCmd.SetArgs(nil)
+	defer root.SetArgs(nil)
 
-	err := rootCmd.Execute()
+	err := root.Execute()
 	if err == nil {
 		t.Error("expected error for empty ref in positional arg, got nil")
 	} else {
@@ -211,6 +216,7 @@ func TestCmdTemplateGenerate_EmptyRefInRef(t *testing.T) {
 }
 
 func TestCmdTemplateGenerate_InvalidTemplateType(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	identity, _ := vaultpkg.OpenWithPassphrase(vaultDir, passphrase)
 	entry := &vaultpkg.Entry{Data: map[string]any{"password": "s3cret"}}
@@ -218,11 +224,11 @@ func TestCmdTemplateGenerate_InvalidTemplateType(t *testing.T) {
 	setPassEnv(t, string(passphrase))
 	defer setupVaultFlag(t, vaultDir)()
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "template", "generate", "--type", "nonexistent",
+	root.SetArgs([]string{"--vault", vaultDir, "template", "generate", "--type", "nonexistent",
 		"DB_PASS=db.password"})
-	defer rootCmd.SetArgs(nil)
+	defer root.SetArgs(nil)
 
-	err := rootCmd.Execute()
+	err := root.Execute()
 	if err == nil {
 		t.Error("expected error for invalid template type, got nil")
 	} else {
@@ -233,6 +239,7 @@ func TestCmdTemplateGenerate_InvalidTemplateType(t *testing.T) {
 }
 
 func TestCmdTemplateGenerate_OutputFilePermissionError(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	identity, _ := vaultpkg.OpenWithPassphrase(vaultDir, passphrase)
 	entry := &vaultpkg.Entry{Data: map[string]any{"password": "permtest"}}
@@ -240,11 +247,11 @@ func TestCmdTemplateGenerate_OutputFilePermissionError(t *testing.T) {
 	setPassEnv(t, string(passphrase))
 	defer setupVaultFlag(t, vaultDir)()
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "template", "generate", "--type", "env",
+	root.SetArgs([]string{"--vault", vaultDir, "template", "generate", "--type", "env",
 		"--output", "/nonexistent/dir/output.env", "DB_PASS=db.password"})
-	defer rootCmd.SetArgs(nil)
+	defer root.SetArgs(nil)
 
-	err := rootCmd.Execute()
+	err := root.Execute()
 	if err == nil {
 		t.Error("expected error for unwritable output path, got nil")
 	} else {
@@ -255,6 +262,7 @@ func TestCmdTemplateGenerate_OutputFilePermissionError(t *testing.T) {
 }
 
 func TestCmdTemplateGenerate_JSONOutputWithFile(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	identity, _ := vaultpkg.OpenWithPassphrase(vaultDir, passphrase)
 	entry := &vaultpkg.Entry{Data: map[string]any{"password": "json_out_test"}}
@@ -267,10 +275,10 @@ func TestCmdTemplateGenerate_JSONOutputWithFile(t *testing.T) {
 
 	outFile := filepath.Join(t.TempDir(), "output.env")
 	stdout := captureStdout(func() {
-		rootCmd.SetArgs([]string{"--vault", vaultDir, "template", "generate", "--type", "env",
+		root.SetArgs([]string{"--vault", vaultDir, "template", "generate", "--type", "env",
 			"--output", outFile, "DB_PASS=db.password"})
-		_ = rootCmd.Execute()
-		rootCmd.SetArgs(nil)
+		_ = root.Execute()
+		root.SetArgs(nil)
 	})
 
 	fileContent, readErr := os.ReadFile(outFile)
@@ -286,6 +294,7 @@ func TestCmdTemplateGenerate_JSONOutputWithFile(t *testing.T) {
 }
 
 func TestCmdTemplateGenerate_PrefixReadError(t *testing.T) {
+	root := NewRootCmd()
 	vaultDir, passphrase := initVault(t)
 	identity, _ := vaultpkg.OpenWithPassphrase(vaultDir, passphrase)
 	entry := &vaultpkg.Entry{Data: map[string]any{"token": "good_token"}}
@@ -299,11 +308,11 @@ func TestCmdTemplateGenerate_PrefixReadError(t *testing.T) {
 		t.Fatalf("write bad entry file: %v", err)
 	}
 
-	rootCmd.SetArgs([]string{"--vault", vaultDir, "template", "generate", "--type", "env",
+	root.SetArgs([]string{"--vault", vaultDir, "template", "generate", "--type", "env",
 		"--prefix", "work/"})
-	defer rootCmd.SetArgs(nil)
+	defer root.SetArgs(nil)
 
-	err := rootCmd.Execute()
+	err := root.Execute()
 	if err == nil {
 		t.Error("expected error for unreadable entry in prefix, got nil")
 	} else {

--- a/cmd/ui.go
+++ b/cmd/ui.go
@@ -14,10 +14,6 @@ import (
 var uiPrintKeybindings bool
 var uiExperimental bool
 
-// uiCmd is retained for API compatibility; NewCommands() uses
-// newUICmd() so every call gets a fresh command.
-var uiCmd = newUICmd()
-
 func newUICmd() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "ui",

--- a/cmd/ui_test.go
+++ b/cmd/ui_test.go
@@ -5,6 +5,7 @@ import (
 )
 
 func TestUICommandExperimentalFlagRegisteredAsNoOp(t *testing.T) {
+	uiCmd, _, _ := NewRootCmd().Find([]string{"ui"})
 	flag := uiCmd.Flags().Lookup("experimental")
 	if flag == nil {
 		t.Fatal("expected --experimental flag to be registered on uiCmd")
@@ -17,6 +18,7 @@ func TestUICommandExperimentalFlagRegisteredAsNoOp(t *testing.T) {
 func TestUICommandLaunchWithoutExperimental(t *testing.T) {
 	// The ui command no longer requires --experimental. With no vault set up,
 	// it will fail during vault loading rather than at the experimental gate.
+	uiCmd, _, _ := NewRootCmd().Find([]string{"ui"})
 	flag := uiCmd.Flags().Lookup("experimental")
 	if flag == nil {
 		t.Fatal("expected --experimental flag to be registered on uiCmd")

--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -18,6 +18,8 @@ import (
 	"gopkg.in/yaml.v3"
 
 	updatepkg "github.com/danieljustus/symaira-vault/internal/update"
+
+	"github.com/spf13/cobra"
 )
 
 type stubUpdateChecker struct {
@@ -38,15 +40,15 @@ func (s *stubUpdateChecker) CheckWithForce(_ context.Context, currentVersion str
 	return s.result, s.err
 }
 
-func prepareRootCommandOutput(t *testing.T) *bytes.Buffer {
+func prepareRootCommandOutput(t *testing.T, root *cobra.Command) *bytes.Buffer {
 	t.Helper()
 
 	resetCommandTestState()
 	t.Cleanup(resetCommandTestState)
 
 	buf := new(bytes.Buffer)
-	rootCmd.SetOut(buf)
-	rootCmd.SetErr(buf)
+	root.SetOut(buf)
+	root.SetErr(buf)
 	return buf
 }
 
@@ -71,8 +73,8 @@ func setVersionInfoForTest(t *testing.T, version string) {
 }
 
 func TestUpdateCheckCommandReportsAvailableUpdate(t *testing.T) {
-	rootCmd = newPackageRootCmd()
-	buf := prepareRootCommandOutput(t)
+	root := NewRootCmd()
+	buf := prepareRootCommandOutput(t, root)
 	setVersionInfoForTest(t, "1.0.0")
 
 	checker := &stubUpdateChecker{
@@ -86,12 +88,12 @@ func TestUpdateCheckCommandReportsAvailableUpdate(t *testing.T) {
 	}
 	setUpdateCheckerForTest(t, checker)
 
-	rootCmd.SetArgs([]string{"update", "check"})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	root.SetArgs([]string{"update", "check"})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
-	err := rootCmd.Execute()
+	err := root.Execute()
 	if err == nil {
-		t.Fatal("expected Execute() to return an error for update available")
+		t.Fatal("expected ExecuteRoot(root) to return an error for update available")
 	}
 
 	got := buf.String()
@@ -109,8 +111,8 @@ func TestUpdateCheckCommandReportsAvailableUpdate(t *testing.T) {
 }
 
 func TestUpdateCheckCommandReportsUpToDate(t *testing.T) {
-	rootCmd = newPackageRootCmd()
-	buf := prepareRootCommandOutput(t)
+	root := NewRootCmd()
+	buf := prepareRootCommandOutput(t, root)
 	setVersionInfoForTest(t, "1.0.0")
 
 	setUpdateCheckerForTest(t, &stubUpdateChecker{
@@ -121,11 +123,11 @@ func TestUpdateCheckCommandReportsUpToDate(t *testing.T) {
 		},
 	})
 
-	rootCmd.SetArgs([]string{"update", "check"})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	root.SetArgs([]string{"update", "check"})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
-	if err := rootCmd.Execute(); err != nil {
-		t.Fatalf("Execute() error = %v", err)
+	if err := root.Execute(); err != nil {
+		t.Fatalf("ExecuteRoot(root) error = %v", err)
 	}
 
 	got := buf.String()
@@ -135,8 +137,8 @@ func TestUpdateCheckCommandReportsUpToDate(t *testing.T) {
 }
 
 func TestUpdateCheckCommandHandlesNonReleaseBuild(t *testing.T) {
-	rootCmd = newPackageRootCmd()
-	buf := prepareRootCommandOutput(t)
+	root := NewRootCmd()
+	buf := prepareRootCommandOutput(t, root)
 	setVersionInfoForTest(t, "dev")
 
 	checker := &stubUpdateChecker{
@@ -147,11 +149,11 @@ func TestUpdateCheckCommandHandlesNonReleaseBuild(t *testing.T) {
 	}
 	setUpdateCheckerForTest(t, checker)
 
-	rootCmd.SetArgs([]string{"update", "check"})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	root.SetArgs([]string{"update", "check"})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
-	if err := rootCmd.Execute(); err != nil {
-		t.Fatalf("Execute() error = %v", err)
+	if err := root.Execute(); err != nil {
+		t.Fatalf("ExecuteRoot(root) error = %v", err)
 	}
 
 	got := buf.String()
@@ -164,16 +166,17 @@ func TestUpdateCheckCommandHandlesNonReleaseBuild(t *testing.T) {
 }
 
 func TestUpdateCheckCommandReturnsCheckerError(t *testing.T) {
-	prepareRootCommandOutput(t)
+	root := NewRootCmd()
+	prepareRootCommandOutput(t, root)
 	setVersionInfoForTest(t, "1.0.0")
 	setUpdateCheckerForTest(t, &stubUpdateChecker{err: errors.New("boom")})
 
-	rootCmd.SetArgs([]string{"update", "check"})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	root.SetArgs([]string{"update", "check"})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
-	err := rootCmd.Execute()
+	err := root.Execute()
 	if err == nil {
-		t.Fatal("expected Execute() to return an error")
+		t.Fatal("expected ExecuteRoot(root) to return an error")
 	}
 	if !strings.Contains(err.Error(), "check for updates: boom") {
 		t.Fatalf("unexpected error: %v", err)
@@ -181,8 +184,8 @@ func TestUpdateCheckCommandReturnsCheckerError(t *testing.T) {
 }
 
 func TestUpdateCheckCommandDoesNotRequireVault(t *testing.T) {
-	rootCmd = newPackageRootCmd()
-	buf := prepareRootCommandOutput(t)
+	root := NewRootCmd()
+	buf := prepareRootCommandOutput(t, root)
 	setVersionInfoForTest(t, "dev")
 	setUpdateCheckerForTest(t, &stubUpdateChecker{
 		result: &updatepkg.Result{
@@ -212,11 +215,11 @@ func TestUpdateCheckCommandDoesNotRequireVault(t *testing.T) {
 		}
 	})
 
-	rootCmd.SetArgs([]string{"update", "check"})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	root.SetArgs([]string{"update", "check"})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
-	if err := rootCmd.Execute(); err != nil {
-		t.Fatalf("Execute() error = %v", err)
+	if err := root.Execute(); err != nil {
+		t.Fatalf("ExecuteRoot(root) error = %v", err)
 	}
 
 	if !strings.Contains(buf.String(), "stable release builds") {
@@ -225,8 +228,8 @@ func TestUpdateCheckCommandDoesNotRequireVault(t *testing.T) {
 }
 
 func TestUpdateCheckCommandJSONOutput(t *testing.T) {
-	rootCmd = newPackageRootCmd()
-	buf := prepareRootCommandOutput(t)
+	root := NewRootCmd()
+	buf := prepareRootCommandOutput(t, root)
 	setVersionInfoForTest(t, "1.0.0")
 
 	checker := &stubUpdateChecker{
@@ -240,12 +243,12 @@ func TestUpdateCheckCommandJSONOutput(t *testing.T) {
 	}
 	setUpdateCheckerForTest(t, checker)
 
-	rootCmd.SetArgs([]string{"update", "check", "--json"})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	root.SetArgs([]string{"update", "check", "--json"})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
-	err := rootCmd.Execute()
+	err := root.Execute()
 	if err == nil {
-		t.Fatal("expected Execute() to return an error for update available with --json")
+		t.Fatal("expected ExecuteRoot(root) to return an error for update available with --json")
 	}
 
 	got := buf.String()
@@ -263,8 +266,8 @@ func TestUpdateCheckCommandJSONOutput(t *testing.T) {
 }
 
 func TestUpdateCheckCommandJSONOutputNoUpdate(t *testing.T) {
-	rootCmd = newPackageRootCmd()
-	buf := prepareRootCommandOutput(t)
+	root := NewRootCmd()
+	buf := prepareRootCommandOutput(t, root)
 	setVersionInfoForTest(t, "1.0.0")
 
 	checker := &stubUpdateChecker{
@@ -276,11 +279,11 @@ func TestUpdateCheckCommandJSONOutputNoUpdate(t *testing.T) {
 	}
 	setUpdateCheckerForTest(t, checker)
 
-	rootCmd.SetArgs([]string{"update", "check", "--json"})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	root.SetArgs([]string{"update", "check", "--json"})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
-	if err := rootCmd.Execute(); err != nil {
-		t.Fatalf("Execute() error = %v", err)
+	if err := root.Execute(); err != nil {
+		t.Fatalf("ExecuteRoot(root) error = %v", err)
 	}
 
 	got := buf.String()
@@ -297,7 +300,8 @@ func TestUpdateCheckCommandJSONOutputNoUpdate(t *testing.T) {
 }
 
 func TestUpdateCheckCommandQuietModeUpdateAvailable(t *testing.T) {
-	buf := prepareRootCommandOutput(t)
+	root := NewRootCmd()
+	buf := prepareRootCommandOutput(t, root)
 	setVersionInfoForTest(t, "1.0.0")
 
 	checker := &stubUpdateChecker{
@@ -314,12 +318,12 @@ func TestUpdateCheckCommandQuietModeUpdateAvailable(t *testing.T) {
 	admin.UpdateCheckCmd.SilenceUsage = true
 	admin.UpdateCheckCmd.SilenceErrors = true
 
-	rootCmd.SetArgs([]string{"update", "check", "--quiet"})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	root.SetArgs([]string{"update", "check", "--quiet"})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
-	err := rootCmd.Execute()
+	err := root.Execute()
 	if err == nil {
-		t.Fatal("expected Execute() to return an error for update available with --quiet")
+		t.Fatal("expected ExecuteRoot(root) to return an error for update available with --quiet")
 	}
 
 	got := buf.String()
@@ -329,7 +333,8 @@ func TestUpdateCheckCommandQuietModeUpdateAvailable(t *testing.T) {
 }
 
 func TestUpdateCheckCommandQuietModeNoUpdate(t *testing.T) {
-	buf := prepareRootCommandOutput(t)
+	root := NewRootCmd()
+	buf := prepareRootCommandOutput(t, root)
 	setVersionInfoForTest(t, "1.0.0")
 
 	checker := &stubUpdateChecker{
@@ -341,11 +346,11 @@ func TestUpdateCheckCommandQuietModeNoUpdate(t *testing.T) {
 	}
 	setUpdateCheckerForTest(t, checker)
 
-	rootCmd.SetArgs([]string{"update", "check", "--quiet"})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	root.SetArgs([]string{"update", "check", "--quiet"})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
-	if err := rootCmd.Execute(); err != nil {
-		t.Fatalf("Execute() error = %v", err)
+	if err := root.Execute(); err != nil {
+		t.Fatalf("ExecuteRoot(root) error = %v", err)
 	}
 
 	got := buf.String()
@@ -355,7 +360,8 @@ func TestUpdateCheckCommandQuietModeNoUpdate(t *testing.T) {
 }
 
 func TestUpdateCheckCommandForceFlag(t *testing.T) {
-	prepareRootCommandOutput(t)
+	root := NewRootCmd()
+	prepareRootCommandOutput(t, root)
 	setVersionInfoForTest(t, "1.0.0")
 
 	checker := &stubUpdateChecker{
@@ -367,11 +373,11 @@ func TestUpdateCheckCommandForceFlag(t *testing.T) {
 	}
 	setUpdateCheckerForTest(t, checker)
 
-	rootCmd.SetArgs([]string{"update", "check", "--force"})
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	root.SetArgs([]string{"update", "check", "--force"})
+	t.Cleanup(func() { root.SetArgs(nil) })
 
-	if err := rootCmd.Execute(); err != nil {
-		t.Fatalf("Execute() error = %v", err)
+	if err := root.Execute(); err != nil {
+		t.Fatalf("ExecuteRoot(root) error = %v", err)
 	}
 
 	if !checker.forceUsed {


### PR DESCRIPTION
## Summary
- remove the package-level command compatibility shim and mutable command singletons
- have tests resolve command instances from fresh `NewRootCmd()` trees, eliminating shared mutable command state
- preserve the existing command hierarchy and user-facing help categories

## Verification
- `go build ./...`
- `go test ./cmd -count=1 -timeout=300s`
- real CLI help smoke test with `Usage:`, `Essentials:`, and `Agents & MCP:` markers

Closes #916
