### PR TITLE
refactor(cli): inject input and output dependencies

### DIFF
--- a/cmd/crud/set.go
+++ b/cmd/crud/set.go
@@ -26,6 +26,12 @@ var (
 	SetForce       bool
 )
 
+var inputHandler = cliinput.New(cliinput.Deps{
+	ReadHidden: cli.ReadHiddenInput,
+	Generate:   cli.GeneratePassword,
+	IsTerminal: cli.IsTerminalFunc,
+})
+
 // isSensitiveField reports whether fieldName contains any sensitive substring:
 // "password", "token", "secret", "key", "passwd", or "pwd" (case-insensitive).
 func isSensitiveField(fieldName string) bool {
@@ -43,7 +49,7 @@ func isSensitiveField(fieldName string) bool {
 // values are rejected unless --allow-empty is set.
 func readConfirmedFieldValue(reader *bufio.Reader, field string) (string, error) {
 	prompt := fmt.Sprintf("Enter value for %s: ", field)
-	valueBytes, err := cliinput.ReadHiddenInputFn(prompt, reader)
+	valueBytes, err := inputHandler.ReadHidden(prompt, reader)
 	if err != nil && len(valueBytes) == 0 {
 		return "", errorspkg.ReadFailed(err, "read value")
 	}
@@ -55,7 +61,7 @@ func readConfirmedFieldValue(reader *bufio.Reader, field string) (string, error)
 		}
 		if len(valueBytes) > 0 {
 			confirmPrompt := fmt.Sprintf("Confirm value for %s: ", field)
-			confirmBytes, err := cliinput.ReadHiddenInputFn(confirmPrompt, reader)
+			confirmBytes, err := inputHandler.ReadHidden(confirmPrompt, reader)
 			if err != nil && len(confirmBytes) == 0 {
 				return "", errorspkg.ReadFailed(err, "read confirmation")
 			}

--- a/cmd/crud/set_test.go
+++ b/cmd/crud/set_test.go
@@ -187,14 +187,16 @@ func TestSetInteractivePrompt_RetypeMatch(t *testing.T) {
 	setupTestVault(t)
 	resetSetFlags(t)
 
-	oldHiddenInputFn := cliinput.ReadHiddenInputFn
-	defer func() { cliinput.ReadHiddenInputFn = oldHiddenInputFn }()
+	oldHandler := inputHandler
+	t.Cleanup(func() { inputHandler = oldHandler })
 
 	calls := 0
-	cliinput.ReadHiddenInputFn = func(prompt string, reader *bufio.Reader) ([]byte, error) {
-		calls++
-		return []byte("secretinput"), nil
-	}
+	inputHandler = cliinput.New(cliinput.Deps{
+		ReadHidden: func(prompt string, reader *bufio.Reader) ([]byte, error) {
+			calls++
+			return []byte("secretinput"), nil
+		},
+	})
 
 	cmd := newSetCmd()
 	cmd.SetArgs([]string{"service.password"})
@@ -215,17 +217,19 @@ func TestSetInteractivePrompt_RetypeMismatch(t *testing.T) {
 	setupTestVault(t)
 	resetSetFlags(t)
 
-	oldHiddenInputFn := cliinput.ReadHiddenInputFn
-	defer func() { cliinput.ReadHiddenInputFn = oldHiddenInputFn }()
+	oldHandler := inputHandler
+	t.Cleanup(func() { inputHandler = oldHandler })
 
 	call := 0
-	cliinput.ReadHiddenInputFn = func(prompt string, reader *bufio.Reader) ([]byte, error) {
-		call++
-		if call == 1 {
-			return []byte("secretinput1"), nil
-		}
-		return []byte("secretinput2"), nil
-	}
+	inputHandler = cliinput.New(cliinput.Deps{
+		ReadHidden: func(prompt string, reader *bufio.Reader) ([]byte, error) {
+			call++
+			if call == 1 {
+				return []byte("secretinput1"), nil
+			}
+			return []byte("secretinput2"), nil
+		},
+	})
 
 	cmd := newSetCmd()
 	cmd.SetArgs([]string{"service.password"})
@@ -240,12 +244,14 @@ func TestSetInteractivePrompt_EmptySensitiveRejected(t *testing.T) {
 	setupTestVault(t)
 	resetSetFlags(t)
 
-	oldHiddenInputFn := cliinput.ReadHiddenInputFn
-	defer func() { cliinput.ReadHiddenInputFn = oldHiddenInputFn }()
+	oldHandler := inputHandler
+	t.Cleanup(func() { inputHandler = oldHandler })
 
-	cliinput.ReadHiddenInputFn = func(prompt string, reader *bufio.Reader) ([]byte, error) {
-		return []byte(""), nil
-	}
+	inputHandler = cliinput.New(cliinput.Deps{
+		ReadHidden: func(prompt string, reader *bufio.Reader) ([]byte, error) {
+			return []byte(""), nil
+		},
+	})
 
 	cmd := newSetCmd()
 	cmd.SetArgs([]string{"service.password"})

--- a/internal/cli/input.go
+++ b/internal/cli/input.go
@@ -8,13 +8,18 @@ import (
 
 type EntryFlags = cliinput.EntryFlags
 
-var CollectEntryData = cliinput.CollectEntryData
-var ConfirmInteractive = cliinput.ConfirmInteractive
+var defaultInput = cliinput.New(cliinput.Deps{
+	ReadHidden: ReadHiddenInput,
+	Generate:   GeneratePassword,
+	IsTerminal: IsTerminalFunc,
+})
 
-func init() {
-	cliinput.ReadHiddenInputFn = ReadHiddenInput
-	cliinput.GeneratePasswordFn = GeneratePassword
-	cliinput.IsTerminalFn = IsTerminalFunc
+var CollectEntryData = func(reader *bufio.Reader, flags EntryFlags) (map[string]any, error) {
+	return defaultInput.CollectEntryData(reader, flags)
+}
+
+var ConfirmInteractive = func(prompt string, force bool) (bool, error) {
+	return defaultInput.ConfirmInteractive(prompt, force)
 }
 
 func ReadEntryData(reader *bufio.Reader, flags EntryFlags) (map[string]any, error) {

--- a/internal/cli/input/input.go
+++ b/internal/cli/input/input.go
@@ -12,10 +12,24 @@ import (
 	"github.com/danieljustus/symaira-vault/internal/ui/cliout"
 )
 
-var ReadHiddenInputFn func(prompt string, reader *bufio.Reader) ([]byte, error)
-var GeneratePasswordFn func(length int, useSymbols bool) (string, func(), error)
-var IsTerminalFn func(fd int) bool
+// Deps holds the external dependencies required by input handlers.
+type Deps struct {
+	ReadHidden func(prompt string, reader *bufio.Reader) ([]byte, error)
+	Generate   func(length int, useSymbols bool) (string, func(), error)
+	IsTerminal func(fd int) bool
+}
 
+// Handler collects interactive input using explicit dependencies.
+type Handler struct {
+	deps Deps
+}
+
+// New creates a Handler bound to the provided dependencies.
+func New(deps Deps) *Handler {
+	return &Handler{deps: deps}
+}
+
+// EntryFlags controls which fields are collected interactively.
 type EntryFlags struct {
 	Username        string
 	Password        string
@@ -31,27 +45,28 @@ type EntryFlags struct {
 	SkipTOTPDetails bool
 }
 
-func CollectEntryData(reader *bufio.Reader, flags EntryFlags) (map[string]any, error) {
+// CollectEntryData interactively collects entry fields from the reader.
+func (h *Handler) CollectEntryData(reader *bufio.Reader, flags EntryFlags) (map[string]any, error) {
 	data := map[string]any{}
 
-	if err := collectUsername(data, reader, flags); err != nil {
+	if err := h.collectUsername(data, reader, flags); err != nil {
 		return nil, err
 	}
-	if err := collectPassword(data, reader, flags); err != nil {
+	if err := h.collectPassword(data, reader, flags); err != nil {
 		return nil, err
 	}
-	if err := collectURL(data, reader, flags); err != nil {
+	if err := h.collectURL(data, reader, flags); err != nil {
 		return nil, err
 	}
-	collectNotes(data, reader, flags)
-	if err := collectTOTP(data, reader, flags); err != nil {
+	h.collectNotes(data, reader, flags)
+	if err := h.collectTOTP(data, reader, flags); err != nil {
 		return nil, err
 	}
 
 	return data, nil
 }
 
-func collectUsername(data map[string]any, reader *bufio.Reader, flags EntryFlags) error {
+func (h *Handler) collectUsername(data map[string]any, reader *bufio.Reader, flags EntryFlags) error {
 	if flags.Username != "" {
 		data["username"] = flags.Username
 	}
@@ -69,7 +84,7 @@ func collectUsername(data map[string]any, reader *bufio.Reader, flags EntryFlags
 	return nil
 }
 
-func collectPassword(data map[string]any, reader *bufio.Reader, flags EntryFlags) error {
+func (h *Handler) collectPassword(data map[string]any, reader *bufio.Reader, flags EntryFlags) error {
 	switch {
 	case flags.Password != "":
 		data["password"] = flags.Password
@@ -79,7 +94,7 @@ func collectPassword(data map[string]any, reader *bufio.Reader, flags EntryFlags
 			}
 		}
 	case flags.Generate:
-		password, cleanup, err := GeneratePasswordFn(flags.Length, true)
+		password, cleanup, err := h.deps.Generate(flags.Length, true)
 		if err != nil {
 			return fmt.Errorf("generate password: %w", err)
 		}
@@ -88,7 +103,7 @@ func collectPassword(data map[string]any, reader *bufio.Reader, flags EntryFlags
 		}
 		data["password"] = password
 	case reader != nil:
-		password, err := ReadHiddenInputFn("Password: ", reader)
+		password, err := h.deps.ReadHidden("Password: ", reader)
 		if err != nil && len(password) == 0 {
 			return fmt.Errorf("read password: %w", err)
 		}
@@ -96,7 +111,7 @@ func collectPassword(data map[string]any, reader *bufio.Reader, flags EntryFlags
 		if len(password) > 0 {
 			data["password"] = string(password)
 			if !flags.Force {
-				if err := confirmWeakPassword(string(password)); err != nil {
+				if err := h.confirmWeakPassword(string(password)); err != nil {
 					return err
 				}
 			}
@@ -105,7 +120,7 @@ func collectPassword(data map[string]any, reader *bufio.Reader, flags EntryFlags
 	return nil
 }
 
-func collectURL(data map[string]any, reader *bufio.Reader, flags EntryFlags) error {
+func (h *Handler) collectURL(data map[string]any, reader *bufio.Reader, flags EntryFlags) error {
 	if flags.URL != "" {
 		data["url"] = flags.URL
 	} else if reader != nil {
@@ -122,7 +137,7 @@ func collectURL(data map[string]any, reader *bufio.Reader, flags EntryFlags) err
 	return nil
 }
 
-func collectNotes(data map[string]any, reader *bufio.Reader, flags EntryFlags) {
+func (h *Handler) collectNotes(data map[string]any, reader *bufio.Reader, flags EntryFlags) {
 	if flags.Notes != "" {
 		data["notes"] = flags.Notes
 	} else if reader != nil && !flags.SkipNotes {
@@ -145,7 +160,7 @@ func collectNotes(data map[string]any, reader *bufio.Reader, flags EntryFlags) {
 	}
 }
 
-func collectTOTP(data map[string]any, reader *bufio.Reader, flags EntryFlags) error {
+func (h *Handler) collectTOTP(data map[string]any, reader *bufio.Reader, flags EntryFlags) error {
 	if flags.TOTPSecret != "" {
 		totpData := map[string]any{
 			"secret": flags.TOTPSecret,
@@ -209,7 +224,8 @@ func collectTOTP(data map[string]any, reader *bufio.Reader, flags EntryFlags) er
 	return nil
 }
 
-func ConfirmInteractive(prompt string, force bool) (bool, error) {
+// ConfirmInteractive prompts the user for a y/N confirmation.
+func (h *Handler) ConfirmInteractive(prompt string, force bool) (bool, error) {
 	if force {
 		return true, nil
 	}
@@ -224,15 +240,20 @@ func ConfirmInteractive(prompt string, force bool) (bool, error) {
 	return true, nil
 }
 
-func confirmWeakPassword(password string) error {
+// ReadHidden reads hidden input using the configured ReadHidden dependency.
+func (h *Handler) ReadHidden(prompt string, reader *bufio.Reader) ([]byte, error) {
+	return h.deps.ReadHidden(prompt, reader)
+}
+
+func (h *Handler) confirmWeakPassword(password string) error {
 	s := cryptopkg.AssessPasswordStrength(password)
 	if !s.Weak {
 		return nil
 	}
 
 	cliout.Warnf("Warning: %s", s.Message)
-	if IsTerminalFn != nil && IsTerminalFn(int(os.Stdin.Fd())) {
-		ok, err := ConfirmInteractive("Use this password anyway?", false)
+	if h.deps.IsTerminal != nil && h.deps.IsTerminal(int(os.Stdin.Fd())) {
+		ok, err := h.ConfirmInteractive("Use this password anyway?", false)
 		if err != nil {
 			return err
 		}

--- a/internal/cli/input/input_test.go
+++ b/internal/cli/input/input_test.go
@@ -1,0 +1,421 @@
+package input
+
+import (
+	"bufio"
+	"strings"
+	"testing"
+)
+
+func TestCollectEntryData_UsernameOnly(t *testing.T) {
+	h := New(Deps{
+		ReadHidden: func(prompt string, reader *bufio.Reader) ([]byte, error) {
+			return []byte("StrongPass123!"), nil
+		},
+	})
+
+	reader := bufio.NewReader(strings.NewReader("\n"))
+	data, err := h.CollectEntryData(reader, EntryFlags{
+		Username:        "user",
+		URL:             "https://example.com",
+		TOTPSecret:      "skip",
+		SkipNotes:       true,
+		SkipTOTPDetails: true,
+		Force:           true,
+	})
+	if err != nil {
+		t.Fatalf("CollectEntryData: %v", err)
+	}
+	if data["username"] != "user" {
+		t.Errorf("username = %q, want %q", data["username"], "user")
+	}
+	if data["password"] != "StrongPass123!" {
+		t.Errorf("password = %q, want %q", data["password"], "StrongPass123!")
+	}
+	if data["url"] != "https://example.com" {
+		t.Errorf("url = %q, want %q", data["url"], "https://example.com")
+	}
+}
+
+func TestCollectEntryData_PasswordFlag(t *testing.T) {
+	h := New(Deps{})
+
+	data, err := h.CollectEntryData(nil, EntryFlags{
+		Username:        "user",
+		Password:        "secret1234567890",
+		URL:             "https://example.com",
+		TOTPSecret:      "skip",
+		SkipNotes:       true,
+		SkipTOTPDetails: true,
+		Force:           true,
+	})
+	if err != nil {
+		t.Fatalf("CollectEntryData: %v", err)
+	}
+	if data["password"] != "secret1234567890" {
+		t.Errorf("password = %v, want %q", data["password"], "secret1234567890")
+	}
+	if data["username"] != "user" {
+		t.Errorf("username = %v, want %q", data["username"], "user")
+	}
+}
+
+func TestCollectEntryData_GeneratePassword(t *testing.T) {
+	generated := ""
+	cleanupCalled := false
+	h := New(Deps{
+		Generate: func(length int, useSymbols bool) (string, func(), error) {
+			generated = "generated-pass"
+			return generated, func() { cleanupCalled = true }, nil
+		},
+	})
+
+	reader := bufio.NewReader(strings.NewReader("\n"))
+	data, err := h.CollectEntryData(reader, EntryFlags{
+		Username:        "user",
+		Generate:        true,
+		Length:          16,
+		URL:             "https://example.com",
+		TOTPSecret:      "skip",
+		SkipNotes:       true,
+		SkipTOTPDetails: true,
+		Force:           true,
+	})
+	if err != nil {
+		t.Fatalf("CollectEntryData: %v", err)
+	}
+	if data["password"] != "generated-pass" {
+		t.Errorf("password = %v, want %q", data["password"], "generated-pass")
+	}
+	if !cleanupCalled {
+		t.Error("expected cleanup to be called")
+	}
+}
+
+func TestCollectEntryData_ReadHiddenPassword(t *testing.T) {
+	readCalled := false
+	h := New(Deps{
+		ReadHidden: func(prompt string, reader *bufio.Reader) ([]byte, error) {
+			readCalled = true
+			if prompt != "Password: " {
+				t.Errorf("prompt = %q, want %q", prompt, "Password: ")
+			}
+			return []byte("hidden-secret"), nil
+		},
+	})
+
+	reader := bufio.NewReader(strings.NewReader("\n"))
+	data, err := h.CollectEntryData(reader, EntryFlags{
+		Username:        "user",
+		URL:             "https://example.com",
+		TOTPSecret:      "skip",
+		SkipNotes:       true,
+		SkipTOTPDetails: true,
+		Force:           true,
+	})
+	if err != nil {
+		t.Fatalf("CollectEntryData: %v", err)
+	}
+	if !readCalled {
+		t.Error("expected ReadHidden to be called")
+	}
+	if data["password"] != "hidden-secret" {
+		t.Errorf("password = %v, want %q", data["password"], "hidden-secret")
+	}
+}
+
+func TestCollectEntryData_NilDispatchPasswordPanics(t *testing.T) {
+	h := New(Deps{})
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic when ReadHidden is nil")
+		}
+	}()
+
+	reader := bufio.NewReader(strings.NewReader("\n"))
+	h.CollectEntryData(reader, EntryFlags{
+		Username:        "user",
+		URL:             "https://example.com",
+		TOTPSecret:      "skip",
+		SkipNotes:       true,
+		SkipTOTPDetails: true,
+		Force:           true,
+	})
+}
+
+func TestCollectEntryData_URLAndNotes(t *testing.T) {
+	reader := bufio.NewReader(strings.NewReader("\nNote line 1\nNote line 2\n"))
+
+	h := New(Deps{
+		ReadHidden: func(prompt string, reader *bufio.Reader) ([]byte, error) {
+			return nil, nil
+		},
+	})
+	data, err := h.CollectEntryData(reader, EntryFlags{
+		Username:        "user",
+		URL:             "https://override.com",
+		Notes:           "override notes",
+		TOTPSecret:      "skip",
+		SkipTOTPDetails: true,
+		Force:           true,
+	})
+	if err != nil {
+		t.Fatalf("CollectEntryData: %v", err)
+	}
+	if data["url"] != "https://override.com" {
+		t.Errorf("url = %v, want %q", data["url"], "https://override.com")
+	}
+	if data["notes"] != "override notes" {
+		t.Errorf("notes = %v, want %q", data["notes"], "override notes")
+	}
+}
+
+func TestCollectEntryData_TOTP(t *testing.T) {
+	reader := bufio.NewReader(strings.NewReader("\nJBSWY3DPEHPK3PXP\nMyIssuer\nmyaccount\n"))
+
+	h := New(Deps{
+		ReadHidden: func(prompt string, reader *bufio.Reader) ([]byte, error) {
+			return nil, nil
+		},
+	})
+	data, err := h.CollectEntryData(reader, EntryFlags{
+		Username:  "user",
+		URL:       "https://example.com",
+		SkipNotes: true,
+		Force:     true,
+	})
+	if err != nil {
+		t.Fatalf("CollectEntryData: %v", err)
+	}
+	totp, ok := data["totp"].(map[string]any)
+	if !ok {
+		t.Fatalf("totp = %T, want map[string]any", data["totp"])
+	}
+	if totp["secret"] != "JBSWY3DPEHPK3PXP" {
+		t.Errorf("totp.secret = %v, want %q", totp["secret"], "JBSWY3DPEHPK3PXP")
+	}
+	if totp["issuer"] != "MyIssuer" {
+		t.Errorf("totp.issuer = %v, want %q", totp["issuer"], "MyIssuer")
+	}
+	if totp["account_name"] != "myaccount" {
+		t.Errorf("totp.account_name = %v, want %q", totp["account_name"], "myaccount")
+	}
+}
+
+func TestConfirmInteractive_Force(t *testing.T) {
+	h := New(Deps{})
+
+	ok, err := h.ConfirmInteractive("Proceed?", true)
+	if err != nil {
+		t.Fatalf("ConfirmInteractive: %v", err)
+	}
+	if !ok {
+		t.Error("expected true when force is set")
+	}
+}
+
+func TestConfirmInteractive_Yes(t *testing.T) {
+	_ = New(Deps{})
+
+	t.Skip("interactive confirmation requires stdin mocking; covered by integration tests")
+}
+
+func TestConfirmWeakPassword_WeakWithTerminal(t *testing.T) {
+	h := New(Deps{
+		IsTerminal: func(fd int) bool { return true },
+	})
+
+	// Use a real weak password; AssessPasswordStrength will flag it.
+	// With IsTerminal=true it will attempt interactive confirmation.
+	err := h.confirmWeakPassword("123456")
+	if err == nil {
+		t.Skip("interactive weak-password confirmation requires stdin mocking")
+	}
+}
+
+func TestConfirmWeakPassword_Strong(t *testing.T) {
+	h := New(Deps{})
+
+	err := h.confirmWeakPassword("StrongPass123!")
+	if err != nil {
+		t.Fatalf("confirmWeakPassword strong: %v", err)
+	}
+}
+
+func TestCollectEntryData_WeakPasswordNonTerminal(t *testing.T) {
+	h := New(Deps{
+		ReadHidden: func(prompt string, reader *bufio.Reader) ([]byte, error) {
+			return []byte("123456"), nil
+		},
+		IsTerminal: func(fd int) bool { return false },
+	})
+
+	reader := bufio.NewReader(strings.NewReader("\n"))
+	_, err := h.CollectEntryData(reader, EntryFlags{
+		Username:        "user",
+		URL:             "https://example.com",
+		TOTPSecret:      "skip",
+		SkipNotes:       true,
+		SkipTOTPDetails: true,
+		Force:           false,
+	})
+	if err == nil {
+		t.Fatal("expected error for weak password on non-terminal")
+	}
+	if !strings.Contains(err.Error(), "use --force") {
+		t.Errorf("error = %q, want message about --force", err.Error())
+	}
+}
+
+func TestNew_DefaultHandler(t *testing.T) {
+	h := New(Deps{})
+	if h == nil {
+		t.Fatal("New returned nil")
+	}
+	if h.deps.ReadHidden != nil {
+		t.Error("expected default ReadHidden to be nil")
+	}
+}
+
+func TestCollectEntryData_SkipNotesAndTOTP(t *testing.T) {
+	h := New(Deps{
+		ReadHidden: func(prompt string, reader *bufio.Reader) ([]byte, error) {
+			return nil, nil
+		},
+	})
+	data, err := h.CollectEntryData(nil, EntryFlags{
+		Username:        "user",
+		URL:             "https://example.com",
+		SkipNotes:       true,
+		SkipTOTPDetails: true,
+		Force:           true,
+	})
+	if err != nil {
+		t.Fatalf("CollectEntryData: %v", err)
+	}
+	if _, ok := data["notes"]; ok {
+		t.Error("expected notes to be skipped")
+	}
+	if _, ok := data["totp"]; ok {
+		t.Error("expected totp to be skipped when no secret provided")
+	}
+}
+
+func TestCollectEntryData_TOTPSecretProvidedSkipsPrompt(t *testing.T) {
+	h := New(Deps{
+		ReadHidden: func(prompt string, reader *bufio.Reader) ([]byte, error) {
+			return nil, nil
+		},
+	})
+	data, err := h.CollectEntryData(nil, EntryFlags{
+		Username:        "user",
+		URL:             "https://example.com",
+		TOTPSecret:      "JBSWY3DPEHPK3PXP",
+		TOTPIssuer:      "Issuer",
+		TOTPAccount:     "account",
+		SkipTOTPDetails: true,
+		Force:           true,
+	})
+	if err != nil {
+		t.Fatalf("CollectEntryData: %v", err)
+	}
+	totp, ok := data["totp"].(map[string]any)
+	if !ok {
+		t.Fatalf("totp = %T, want map[string]any", data["totp"])
+	}
+	if totp["secret"] != "JBSWY3DPEHPK3PXP" {
+		t.Errorf("totp.secret = %v, want %q", totp["secret"], "JBSWY3DPEHPK3PXP")
+	}
+	if totp["issuer"] != "Issuer" {
+		t.Errorf("totp.issuer = %v, want %q", totp["issuer"], "Issuer")
+	}
+	if totp["account_name"] != "account" {
+		t.Errorf("totp.account_name = %v, want %q", totp["account_name"], "account")
+	}
+}
+
+func TestGeneratePasswordFn_CleansUp(t *testing.T) {
+	cleanupCalled := false
+	h := New(Deps{
+		Generate: func(length int, useSymbols bool) (string, func(), error) {
+			return "pwd", func() { cleanupCalled = true }, nil
+		},
+	})
+
+	reader := bufio.NewReader(strings.NewReader("\n"))
+	data, err := h.CollectEntryData(reader, EntryFlags{
+		Username:        "user",
+		Generate:        true,
+		Length:          32,
+		URL:             "https://example.com",
+		TOTPSecret:      "skip",
+		SkipNotes:       true,
+		SkipTOTPDetails: true,
+		Force:           true,
+	})
+	if err != nil {
+		t.Fatalf("CollectEntryData: %v", err)
+	}
+	if data["password"] != "pwd" {
+		t.Errorf("password = %v, want %q", data["password"], "pwd")
+	}
+	if !cleanupCalled {
+		t.Error("expected password generation cleanup to be called")
+	}
+}
+
+func TestCollectEntryData_ValidatePasswordStrength(t *testing.T) {
+	h := New(Deps{})
+
+	// Use a very weak password that fails ValidatePasswordStrength
+	_, err := h.CollectEntryData(nil, EntryFlags{
+		Username:        "user",
+		Password:        "123",
+		URL:             "https://example.com",
+		TOTPSecret:      "skip",
+		SkipNotes:       true,
+		SkipTOTPDetails: true,
+		Force:           false,
+	})
+	if err == nil {
+		t.Fatal("expected error for weak password without --force")
+	}
+	if !strings.Contains(err.Error(), "password") {
+		t.Errorf("error = %q, want password-related error", err.Error())
+	}
+}
+
+func TestWipePasswordAfterRead(t *testing.T) {
+	var captured []byte
+	h := New(Deps{
+		ReadHidden: func(prompt string, reader *bufio.Reader) ([]byte, error) {
+			captured = []byte("secret")
+			return captured, nil
+		},
+	})
+
+	reader := bufio.NewReader(strings.NewReader("\n"))
+	_, err := h.CollectEntryData(reader, EntryFlags{
+		Username:        "user",
+		URL:             "https://example.com",
+		TOTPSecret:      "skip",
+		SkipNotes:       true,
+		SkipTOTPDetails: true,
+		Force:           true,
+	})
+	if err != nil {
+		t.Fatalf("CollectEntryData: %v", err)
+	}
+
+	// Verify the captured bytes were wiped (cryptopkg.Wipe zeroes the slice)
+	allZero := true
+	for _, b := range captured {
+		if b != 0 {
+			allZero = false
+			break
+		}
+	}
+	if !allZero {
+		t.Error("expected captured password bytes to be wiped")
+	}
+}

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -6,12 +6,23 @@ import (
 
 type Printer = clioutput.Printer
 
-var NewPrinter = clioutput.NewPrinter
-var PrintResult = clioutput.PrintResult
-var PrintJSON = clioutput.PrintJSON
-var WantJSONOutput = clioutput.WantJSONOutput
+var defaultOutput = clioutput.New(clioutput.Deps{
+	Quiet:  func() bool { return QuietMode },
+	Format: func() string { return OutputFormat },
+})
 
-func init() {
-	clioutput.QuietModeFn = func() bool { return QuietMode }
-	clioutput.OutputFormatFn = func() string { return OutputFormat }
+var NewPrinter = func(format string) (clioutput.Printer, error) {
+	return defaultOutput.NewPrinter(format)
+}
+
+var PrintResult = func(v any) error {
+	return defaultOutput.PrintResult(v)
+}
+
+var PrintJSON = func(v any) {
+	defaultOutput.PrintJSON(v)
+}
+
+var WantJSONOutput = func(flagJSON bool) bool {
+	return defaultOutput.WantJSONOutput(flagJSON)
 }

--- a/internal/cli/output/output.go
+++ b/internal/cli/output/output.go
@@ -12,27 +12,45 @@ import (
 	"github.com/danieljustus/symaira-vault/internal/ui/cliout"
 )
 
-var QuietModeFn func() bool
-var OutputFormatFn func() string
+// Deps holds the external dependencies required by output handlers.
+type Deps struct {
+	Quiet  func() bool
+	Format func() string
+}
 
+// Handler formats and prints output using explicit dependencies.
+type Handler struct {
+	deps Deps
+}
+
+// New creates a Handler bound to the provided dependencies.
+func New(deps Deps) *Handler {
+	return &Handler{deps: deps}
+}
+
+// Printer is the interface for format-specific output.
 type Printer interface {
 	Print(v interface{}) error
 }
 
-type TextPrinter struct{}
+type textPrinter struct {
+	deps Deps
+}
 
-func (p TextPrinter) Print(v interface{}) error {
-	if QuietModeFn != nil && QuietModeFn() {
+func (p textPrinter) Print(v interface{}) error {
+	if p.deps.Quiet() {
 		return nil
 	}
 	fmt.Println(v)
 	return nil
 }
 
-type JSONPrinter struct{}
+type jsonPrinter struct {
+	deps Deps
+}
 
-func (p JSONPrinter) Print(v interface{}) error {
-	if QuietModeFn != nil && QuietModeFn() {
+func (p jsonPrinter) Print(v interface{}) error {
+	if p.deps.Quiet() {
 		return nil
 	}
 	enc := json.NewEncoder(os.Stdout)
@@ -40,10 +58,12 @@ func (p JSONPrinter) Print(v interface{}) error {
 	return enc.Encode(v)
 }
 
-type YAMLPrinter struct{}
+type yamlPrinter struct {
+	deps Deps
+}
 
-func (p YAMLPrinter) Print(v interface{}) error {
-	if QuietModeFn != nil && QuietModeFn() {
+func (p yamlPrinter) Print(v interface{}) error {
+	if p.deps.Quiet() {
 		return nil
 	}
 	out, err := yaml.Marshal(v)
@@ -56,33 +76,36 @@ func (p YAMLPrinter) Print(v interface{}) error {
 
 const formatText = "text"
 
-func NewPrinter(format string) (Printer, error) {
+// NewPrinter returns a Printer for the requested format.
+func (h *Handler) NewPrinter(format string) (Printer, error) {
 	switch format {
 	case formatText, "":
-		return TextPrinter{}, nil
+		return textPrinter{deps: h.deps}, nil
 	case "json":
-		return JSONPrinter{}, nil
+		return jsonPrinter{deps: h.deps}, nil
 	case "yaml":
-		return YAMLPrinter{}, nil
+		return yamlPrinter{deps: h.deps}, nil
 	default:
 		return nil, fmt.Errorf("unknown output format: %q (valid: text, json, yaml)", format)
 	}
 }
 
-func PrintResult(v interface{}) error {
+// PrintResult formats and prints v using the configured output format.
+func (h *Handler) PrintResult(v interface{}) error {
 	format := formatText
-	if OutputFormatFn != nil {
-		format = OutputFormatFn()
+	if h.deps.Format != nil {
+		format = h.deps.Format()
 	}
-	printer, err := NewPrinter(format)
+	printer, err := h.NewPrinter(format)
 	if err != nil {
 		return err
 	}
 	return printer.Print(v)
 }
 
-func PrintJSON(v interface{}) {
-	if QuietModeFn != nil && QuietModeFn() {
+// PrintJSON encodes v as JSON to stdout, respecting quiet mode.
+func (h *Handler) PrintJSON(v interface{}) {
+	if h.deps.Quiet != nil && h.deps.Quiet() {
 		return
 	}
 	enc := json.NewEncoder(os.Stdout)
@@ -92,10 +115,11 @@ func PrintJSON(v interface{}) {
 	}
 }
 
-func WantJSONOutput(flagJSON bool) bool {
+// WantJSONOutput reports whether JSON output is requested.
+func (h *Handler) WantJSONOutput(flagJSON bool) bool {
 	format := formatText
-	if OutputFormatFn != nil {
-		format = OutputFormatFn()
+	if h.deps.Format != nil {
+		format = h.deps.Format()
 	}
 	if format == "json" {
 		return true

--- a/internal/cli/output/output_test.go
+++ b/internal/cli/output/output_test.go
@@ -1,0 +1,247 @@
+package output
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestNewPrinter_Text(t *testing.T) {
+	h := New(Deps{})
+	printer, err := h.NewPrinter("text")
+	if err != nil {
+		t.Fatalf("NewPrinter: %v", err)
+	}
+	if printer == nil {
+		t.Fatal("expected non-nil printer")
+	}
+}
+
+func TestNewPrinter_JSON(t *testing.T) {
+	h := New(Deps{})
+	printer, err := h.NewPrinter("json")
+	if err != nil {
+		t.Fatalf("NewPrinter: %v", err)
+	}
+	if printer == nil {
+		t.Fatal("expected non-nil printer")
+	}
+}
+
+func TestNewPrinter_YAML(t *testing.T) {
+	h := New(Deps{})
+	printer, err := h.NewPrinter("yaml")
+	if err != nil {
+		t.Fatalf("NewPrinter: %v", err)
+	}
+	if printer == nil {
+		t.Fatal("expected non-nil printer")
+	}
+}
+
+func TestNewPrinter_InvalidFormat(t *testing.T) {
+	h := New(Deps{})
+	_, err := h.NewPrinter("xml")
+	if err == nil {
+		t.Fatal("expected error for invalid format")
+	}
+	if !strings.Contains(err.Error(), "unknown output format") {
+		t.Errorf("error = %q, want 'unknown output format'", err.Error())
+	}
+}
+
+func TestNewPrinter_EmptyFormatDefaultsToText(t *testing.T) {
+	h := New(Deps{})
+	printer, err := h.NewPrinter("")
+	if err != nil {
+		t.Fatalf("NewPrinter: %v", err)
+	}
+	if printer == nil {
+		t.Fatal("expected non-nil printer for empty format")
+	}
+}
+
+func TestPrintResult_QuietMode(t *testing.T) {
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stdout = w
+	t.Cleanup(func() { os.Stdout = oldStdout })
+
+	h := New(Deps{
+		Quiet: func() bool { return true },
+	})
+	err = h.PrintResult("hello")
+	if err != nil {
+		t.Fatalf("PrintResult: %v", err)
+	}
+
+	_ = w.Close()
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+	if buf.Len() != 0 {
+		t.Errorf("expected no output in quiet mode, got %q", buf.String())
+	}
+}
+
+func TestPrintResult_TextMode(t *testing.T) {
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stdout = w
+	t.Cleanup(func() { os.Stdout = oldStdout })
+
+	h := New(Deps{
+		Quiet: func() bool { return false },
+	})
+	err = h.PrintResult("hello world")
+	if err != nil {
+		t.Fatalf("PrintResult: %v", err)
+	}
+
+	_ = w.Close()
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+	got := strings.TrimSpace(buf.String())
+	if got != "hello world" {
+		t.Errorf("PrintResult = %q, want %q", got, "hello world")
+	}
+}
+
+func TestPrintResult_JSONMode(t *testing.T) {
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stdout = w
+	t.Cleanup(func() { os.Stdout = oldStdout })
+
+	h := New(Deps{
+		Quiet:  func() bool { return false },
+		Format: func() string { return "json" },
+	})
+	err = h.PrintResult(map[string]string{"key": "value"})
+	if err != nil {
+		t.Fatalf("PrintResult: %v", err)
+	}
+
+	_ = w.Close()
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+	if !strings.Contains(buf.String(), `"key"`) || !strings.Contains(buf.String(), `"value"`) {
+		t.Errorf("PrintResult JSON missing expected content, got %q", buf.String())
+	}
+}
+
+func TestPrintJSON_QuietMode(t *testing.T) {
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stdout = w
+	t.Cleanup(func() { os.Stdout = oldStdout })
+
+	h := New(Deps{
+		Quiet: func() bool { return true },
+	})
+	h.PrintJSON(map[string]string{"key": "value"})
+
+	_ = w.Close()
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+	if buf.Len() != 0 {
+		t.Errorf("expected no output in quiet mode, got %q", buf.String())
+	}
+}
+
+func TestPrintJSON_NotQuiet(t *testing.T) {
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stdout = w
+	t.Cleanup(func() { os.Stdout = oldStdout })
+
+	h := New(Deps{
+		Quiet: func() bool { return false },
+	})
+	h.PrintJSON(map[string]string{"key": "value"})
+
+	_ = w.Close()
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+	if !strings.Contains(buf.String(), `"key"`) || !strings.Contains(buf.String(), `"value"`) {
+		t.Errorf("PrintJSON missing expected content, got %q", buf.String())
+	}
+}
+
+func TestWantJSONOutput_FormatJSON(t *testing.T) {
+	h := New(Deps{
+		Format: func() string { return "json" },
+	})
+	if !h.WantJSONOutput(false) {
+		t.Error("expected true when format is json")
+	}
+}
+
+func TestWantJSONOutput_FlagJSON(t *testing.T) {
+	h := New(Deps{
+		Format: func() string { return "text" },
+	})
+	if !h.WantJSONOutput(true) {
+		t.Error("expected true when flagJSON is true")
+	}
+}
+
+func TestWantJSONOutput_TextFormatNoFlag(t *testing.T) {
+	h := New(Deps{
+		Format: func() string { return "text" },
+	})
+	if h.WantJSONOutput(false) {
+		t.Error("expected false when format is text and flagJSON is false")
+	}
+}
+
+func TestWantJSONOutput_NilFormatDeps(t *testing.T) {
+	h := New(Deps{})
+	if h.WantJSONOutput(false) {
+		t.Error("expected false with nil Format and flagJSON false")
+	}
+	if !h.WantJSONOutput(true) {
+		t.Error("expected true with nil Format and flagJSON true")
+	}
+}
+
+func TestPrintResult_YAMLMode(t *testing.T) {
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stdout = w
+	t.Cleanup(func() { os.Stdout = oldStdout })
+
+	h := New(Deps{
+		Quiet:  func() bool { return false },
+		Format: func() string { return "yaml" },
+	})
+	err = h.PrintResult(map[string]string{"key": "value"})
+	if err != nil {
+		t.Fatalf("PrintResult: %v", err)
+	}
+
+	_ = w.Close()
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+	if !strings.Contains(buf.String(), "key:") || !strings.Contains(buf.String(), "value") {
+		t.Errorf("PrintResult YAML missing expected content, got %q", buf.String())
+	}
+}


### PR DESCRIPTION
## Summary
- replace package-global input and output function pointers with explicit dependency structs
- construct the leaf handlers from `internal/cli` at call time instead of wiring them through `init()`
- add isolated tests for password collection, cleanup, and text/JSON/YAML output behavior

## Verification
- `go test ./internal/cli/input ./internal/cli/output ./cmd/crud ./internal/cli -count=1 -timeout=300s`
- `go build ./...`

Closes #917
