### PR TITLE
perf(vault): cache decrypted search index safely

### DIFF
--- a/internal/config/config_merge.go
+++ b/internal/config/config_merge.go
@@ -267,6 +267,9 @@ func mergeVaultConfig(raw *VaultConfig, sf map[string]bool, rawAuthMethod string
 	if sf["search_workers"] {
 		defaults.SearchWorkers = raw.SearchWorkers
 	}
+	if sf["search_index_cache"] {
+		defaults.SearchIndexCache = raw.SearchIndexCache
+	}
 	if sf["config_cache_entries"] {
 		defaults.ConfigCacheEntries = raw.ConfigCacheEntries
 	}

--- a/internal/config/config_save.go
+++ b/internal/config/config_save.go
@@ -66,6 +66,7 @@ func (c *Config) SaveTo(path string) error {
 			LegacyMode:         c.Vault.LegacyMode,
 			SearchIndex:        c.Vault.SearchIndex,
 			SearchWorkers:      c.Vault.SearchWorkers,
+			SearchIndexCache:   c.Vault.SearchIndexCache,
 			ConfigCacheEntries: c.Vault.ConfigCacheEntries,
 			PseudonymizePaths:  c.Vault.PseudonymizePaths,
 			ScryptWorkFactor:   c.Vault.ScryptWorkFactor,

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -14,6 +14,7 @@ type VaultConfig struct {
 	LegacyMode         *bool         `yaml:"legacy_mode,omitempty"`
 	SearchIndex        bool          `yaml:"search_index,omitempty"`
 	SearchWorkers      int           `yaml:"search_workers,omitempty"`
+	SearchIndexCache   bool          `yaml:"search_index_cache,omitempty"`
 	ConfigCacheEntries int           `yaml:"config_cache_entries,omitempty"`
 	PseudonymizePaths  bool          `yaml:"pseudonymize_paths,omitempty"`
 	ScryptWorkFactor   int           `yaml:"scrypt_work_factor,omitempty"`
@@ -305,6 +306,9 @@ func MergeFromVault(dst *VaultConfig, src VaultConfig) {
 	}
 	if src.SearchWorkers > 0 {
 		dst.SearchWorkers = src.SearchWorkers
+	}
+	if src.SearchIndexCache {
+		dst.SearchIndexCache = true
 	}
 	if src.PseudonymizePaths {
 		dst.PseudonymizePaths = true

--- a/internal/vault/search_index.go
+++ b/internal/vault/search_index.go
@@ -1,6 +1,7 @@
 package vault
 
 import (
+	"bytes"
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/json"
@@ -59,12 +60,39 @@ type EncryptedIndex struct {
 	persistErr error             // last on-disk persistence failure, if any
 	suspended  bool              // batch mode: incremental writes defer to Resume
 	dirty      bool              // set when a write was skipped while suspended
+	doc        *indexDoc         // optional in-memory decrypted cache (config-gated)
+	docValid   bool              // true when doc matches the current ciphertext
 }
 
 // indexBuildCounter counts successful index builds (buildIndex commits). It
 // exists so tests and benchmarks can assert that a batch of writes triggers
 // exactly one full index build instead of one rebuild per write.
 var indexBuildCounter atomic.Int64
+
+// isSearchIndexCacheEnabled returns true when the vault config explicitly
+// enables the in-memory decrypted index cache. The default is false so
+// ciphertext-only remains the documented safe default.
+func isSearchIndexCacheEnabled(vaultDir string) bool {
+	cfg, err := loadVaultConfig(vaultDir)
+	if err != nil || cfg == nil || cfg.Vault == nil {
+		return false
+	}
+	return cfg.Vault.SearchIndexCache
+}
+
+// wipeIndexDoc drops all references to plaintext data in doc so the GC can
+// reclaim the memory. The maps themselves are left for the garbage collector;
+// only the indexDoc's references are cleared.
+func wipeIndexDoc(doc *indexDoc) {
+	if doc == nil {
+		return
+	}
+	doc.Values = nil
+	doc.TokenIndex = nil
+	doc.PathTokens = nil
+	doc.HostIndex = nil
+	doc.PathHosts = nil
+}
 
 // Suspend puts the index into batch mode: subsequent UpdateEntry/RemoveEntry
 // calls mark the index dirty instead of decrypting, re-marshaling,
@@ -417,12 +445,21 @@ func (idx *EncryptedIndex) buildIndex(vaultDir string, identity *age.X25519Ident
 	}
 
 	idHash := sha256.Sum256([]byte(identity.Recipient().String()))
+	cacheEnabled := isSearchIndexCacheEnabled(vaultDir)
 
 	idx.mu.Lock()
 	idx.ciphertext = ciphertext
 	idx.salt = salt
 	idx.vaultDir = vaultDir
 	idx.idHash = idHash
+	if cacheEnabled {
+		idx.doc = &doc
+		idx.docValid = true
+	} else {
+		wipeIndexDoc(idx.doc)
+		idx.doc = nil
+		idx.docValid = false
+	}
 	idx.mu.Unlock()
 
 	indexBuildCounter.Add(1)
@@ -450,16 +487,24 @@ func (idx *EncryptedIndex) MatchEntries(vaultDir string, identity *age.X25519Ide
 		return nil, nil
 	}
 
+	cacheEnabled := isSearchIndexCacheEnabled(vaultDir)
 	idx.mu.RLock()
 	ct := idx.ciphertext
 	idHash := idx.idHash
 	storedSalt := idx.salt
 	storedDir := idx.vaultDir
-	idx.mu.RUnlock()
-
+	doc := idx.doc
+	docValid := idx.docValid
 	if ct == nil {
+		idx.mu.RUnlock()
 		return nil, nil
 	}
+	if docValid && cacheEnabled && doc != nil {
+		matching := matchEntriesWithDoc(candidates, needle, doc)
+		idx.mu.RUnlock()
+		return matching, nil
+	}
+	idx.mu.RUnlock()
 
 	currentHash := sha256.Sum256([]byte(identity.Recipient().String()))
 	if currentHash != idHash {
@@ -473,6 +518,9 @@ func (idx *EncryptedIndex) MatchEntries(vaultDir string, identity *age.X25519Ide
 		return nil, errors.New("vault directory changed")
 	}
 
+	// The in-memory cache was checked while holding idx.mu.RLock above.
+	// Reaching this point means the ciphertext must be decrypted.
+
 	key := deriveIndexKey(identity, storedSalt)
 	defer vaultcrypto.Wipe(key)
 
@@ -482,45 +530,22 @@ func (idx *EncryptedIndex) MatchEntries(vaultDir string, identity *age.X25519Ide
 	}
 	defer vaultcrypto.Wipe(plaintext)
 
-	var doc indexDoc
-	if err := json.Unmarshal(plaintext, &doc); err != nil {
+	var docParsed indexDoc
+	if err := json.Unmarshal(plaintext, &docParsed); err != nil {
 		return nil, err
 	}
 
-	needleLower := strings.ToLower(needle)
-	matching := make(map[string]struct{}, len(candidates))
-
-	// Fast path: O(1) token lookup — if the search needle is a whole token
-	// (no whitespace, single word), check the token index directly. This
-	// avoids scanning all values in the common case of exact-term searches.
-	if isSingleToken(needle) && doc.TokenIndex != nil {
-		if paths, ok := doc.TokenIndex[needleLower]; ok {
-			for _, path := range candidates {
-				if _, found := paths[path]; found {
-					matching[path] = struct{}{}
-				}
-			}
-			if len(matching) > 0 {
-				return matching, nil
-			}
+	// Populate cache for subsequent lookups if enabled.
+	if isSearchIndexCacheEnabled(vaultDir) {
+		idx.mu.Lock()
+		if len(idx.ciphertext) == len(ct) && bytes.Equal(idx.ciphertext, ct) {
+			idx.doc = &docParsed
+			idx.docValid = true
 		}
+		idx.mu.Unlock()
 	}
 
-	// Fallback: substring scan for multi-word queries or partial matches.
-	for _, path := range candidates {
-		values, ok := doc.Values[path]
-		if !ok {
-			continue
-		}
-		for _, val := range values {
-			if strings.Contains(val, needleLower) {
-				matching[path] = struct{}{}
-				break
-			}
-		}
-	}
-
-	return matching, nil
+	return matchEntriesWithDoc(candidates, needle, &docParsed), nil
 }
 
 // MatchHost decrypts the index and returns the subset of entry paths whose
@@ -537,16 +562,24 @@ func (idx *EncryptedIndex) MatchHost(vaultDir string, identity *age.X25519Identi
 		return nil, err
 	}
 
+	cacheEnabled := isSearchIndexCacheEnabled(vaultDir)
 	idx.mu.RLock()
 	ct := idx.ciphertext
 	idHash := idx.idHash
 	storedSalt := idx.salt
 	storedDir := idx.vaultDir
-	idx.mu.RUnlock()
-
+	doc := idx.doc
+	docValid := idx.docValid
 	if ct == nil {
+		idx.mu.RUnlock()
 		return nil, nil
 	}
+	if docValid && cacheEnabled && doc != nil {
+		matching := matchHostWithDoc(candidates, targetHost, doc)
+		idx.mu.RUnlock()
+		return matching, nil
+	}
+	idx.mu.RUnlock()
 
 	currentHash := sha256.Sum256([]byte(identity.Recipient().String()))
 	if currentHash != idHash {
@@ -555,6 +588,9 @@ func (idx *EncryptedIndex) MatchHost(vaultDir string, identity *age.X25519Identi
 	if canonicalVaultDir(storedDir) != canonicalVaultDir(vaultDir) {
 		return nil, errors.New("vault directory changed")
 	}
+
+	// The in-memory cache was checked while holding idx.mu.RLock above.
+	// Reaching this point means the ciphertext must be decrypted.
 
 	key := deriveIndexKey(identity, storedSalt)
 	defer vaultcrypto.Wipe(key)
@@ -565,38 +601,22 @@ func (idx *EncryptedIndex) MatchHost(vaultDir string, identity *age.X25519Identi
 	}
 	defer vaultcrypto.Wipe(plaintext)
 
-	var doc indexDoc
-	if err := json.Unmarshal(plaintext, &doc); err != nil {
+	var docParsed indexDoc
+	if err := json.Unmarshal(plaintext, &docParsed); err != nil {
 		return nil, err
 	}
 
-	if doc.HostIndex == nil {
-		return make(map[string]struct{}), nil
+	// Populate cache for subsequent lookups if enabled.
+	if isSearchIndexCacheEnabled(vaultDir) {
+		idx.mu.Lock()
+		if len(idx.ciphertext) == len(ct) && bytes.Equal(idx.ciphertext, ct) {
+			idx.doc = &docParsed
+			idx.docValid = true
+		}
+		idx.mu.Unlock()
 	}
 
-	paths, found := doc.HostIndex[targetHost]
-	if !found || len(paths) == 0 {
-		return make(map[string]struct{}), nil
-	}
-
-	matching := make(map[string]struct{}, len(paths))
-	if len(candidates) > 0 {
-		candSet := make(map[string]struct{}, len(candidates))
-		for _, c := range candidates {
-			candSet[c] = struct{}{}
-		}
-		for path := range paths {
-			if _, ok := candSet[path]; ok {
-				matching[path] = struct{}{}
-			}
-		}
-	} else {
-		for path := range paths {
-			matching[path] = struct{}{}
-		}
-	}
-
-	return matching, nil
+	return matchHostWithDoc(candidates, targetHost, &docParsed), nil
 }
 
 // IsBuilt returns true if the index has been built (ciphertext exists).
@@ -630,10 +650,7 @@ func (idx *EncryptedIndex) Covers(vaultDir string, identity *age.X25519Identity)
 func (idx *EncryptedIndex) Invalidate() {
 	idx.mu.Lock()
 	vaultDir := idx.vaultDir
-	idx.ciphertext = nil
-	idx.salt = nil
-	idx.vaultDir = ""
-	idx.idHash = [sha256.Size]byte{}
+	idx.clearLocked()
 	idx.mu.Unlock()
 
 	if vaultDir != "" {
@@ -642,13 +659,15 @@ func (idx *EncryptedIndex) Invalidate() {
 }
 
 // UpdateEntry incrementally updates a single entry in the encrypted index.
-// It decrypts the existing index, re-indexes the given path, and re-encrypts.
+// It uses the in-memory decrypted cache when available and config-enabled,
+// falling back to decrypting the entire ciphertext. The on-disk persistence
+// is debounced so rapid single-entry writes do not pay a full I/O cost per write.
 // If the index is not built, this is a no-op (the index will be built lazily).
 func (idx *EncryptedIndex) UpdateEntry(vaultDir, path string, identity *age.X25519Identity) error {
 	idx.mu.Lock()
-	defer idx.mu.Unlock()
 
 	if idx.ciphertext == nil {
+		idx.mu.Unlock()
 		return nil
 	}
 
@@ -656,26 +675,35 @@ func (idx *EncryptedIndex) UpdateEntry(vaultDir, path string, identity *age.X255
 	// Resume rebuild the index once.
 	if idx.suspended {
 		idx.dirty = true
+		idx.mu.Unlock()
 		return nil
 	}
-
-	storedSalt := idx.salt
-	key := deriveIndexKey(identity, storedSalt)
-	defer vaultcrypto.Wipe(key)
-
-	plaintext, err := vaultcrypto.DecryptWithKey(idx.ciphertext, key)
-	if err != nil {
-		idx.clearLocked()
-		_ = os.Remove(indexFilePath(vaultDir))
-		return nil
-	}
-	defer vaultcrypto.Wipe(plaintext)
-
-	var doc indexDoc
-	if err = json.Unmarshal(plaintext, &doc); err != nil {
-		idx.clearLocked()
-		_ = os.Remove(indexFilePath(vaultDir))
-		return nil
+	cacheEnabled := isSearchIndexCacheEnabled(vaultDir)
+	useCache := idx.docValid && idx.doc != nil && cacheEnabled
+	var doc *indexDoc
+	if useCache {
+		doc = idx.doc
+	} else {
+		storedSalt := idx.salt
+		key := deriveIndexKey(identity, storedSalt)
+		plaintext, err := vaultcrypto.DecryptWithKey(idx.ciphertext, key)
+		vaultcrypto.Wipe(key)
+		if err != nil {
+			idx.clearLocked()
+			_ = os.Remove(indexFilePath(vaultDir))
+			idx.mu.Unlock()
+			return nil
+		}
+		var parsed indexDoc
+		if err = json.Unmarshal(plaintext, &parsed); err != nil {
+			vaultcrypto.Wipe(plaintext)
+			idx.clearLocked()
+			_ = os.Remove(indexFilePath(vaultDir))
+			idx.mu.Unlock()
+			return nil
+		}
+		vaultcrypto.Wipe(plaintext)
+		doc = &parsed
 	}
 
 	if doc.Values == nil {
@@ -687,8 +715,8 @@ func (idx *EncryptedIndex) UpdateEntry(vaultDir, path string, identity *age.X255
 	if doc.HostIndex == nil {
 		doc.HostIndex = make(map[string]map[string]struct{})
 	}
-	ensurePathTokens(&doc)
-	ensurePathHosts(&doc)
+	ensurePathTokens(doc)
+	ensurePathHosts(doc)
 
 	removeFromTokenIndex(doc.TokenIndex, doc.PathTokens, path)
 	removeFromHostIndex(doc.HostIndex, doc.PathHosts, path)
@@ -710,12 +738,18 @@ func (idx *EncryptedIndex) UpdateEntry(vaultDir, path string, identity *age.X255
 
 	newPlaintext, err := json.Marshal(doc)
 	if err != nil {
+		idx.mu.Unlock()
 		return err
 	}
 	defer vaultcrypto.Wipe(newPlaintext)
 
+	storedSalt := idx.salt
+	key := deriveIndexKey(identity, storedSalt)
+	defer vaultcrypto.Wipe(key)
+
 	newCiphertext, err := vaultcrypto.EncryptWithKey(newPlaintext, key)
 	if err != nil {
+		idx.mu.Unlock()
 		return err
 	}
 
@@ -723,12 +757,20 @@ func (idx *EncryptedIndex) UpdateEntry(vaultDir, path string, identity *age.X255
 	idx.vaultDir = vaultDir
 	idx.idHash = sha256.Sum256([]byte(identity.Recipient().String()))
 
-	// Persist the incrementally-updated index so the on-disk copy tracks the
-	// write. Without this the edited entry's previous value would remain on
-	// disk and, because an in-place edit leaves the entry count unchanged, be
-	// reloaded as a valid index after a restart — returning stale results.
+	if cacheEnabled {
+		idx.doc = doc
+		idx.docValid = true
+	} else {
+		wipeIndexDoc(idx.doc)
+		idx.doc = nil
+		idx.docValid = false
+	}
+
+	// Persist while holding the write lock so another update cannot overwrite
+	// the on-disk file with an older ciphertext after this update returns.
 	persistErr := writeIndexFile(vaultDir, storedSalt, newCiphertext)
 	idx.persistErr = persistErr
+	idx.mu.Unlock()
 	return persistErr
 }
 
@@ -736,9 +778,9 @@ func (idx *EncryptedIndex) UpdateEntry(vaultDir, path string, identity *age.X255
 // If the index is not built, this is a no-op.
 func (idx *EncryptedIndex) RemoveEntry(path string, identity *age.X25519Identity) {
 	idx.mu.Lock()
-	defer idx.mu.Unlock()
 
 	if idx.ciphertext == nil {
+		idx.mu.Unlock()
 		return
 	}
 
@@ -746,6 +788,7 @@ func (idx *EncryptedIndex) RemoveEntry(path string, identity *age.X25519Identity
 	// Resume rebuild the index once.
 	if idx.suspended {
 		idx.dirty = true
+		idx.mu.Unlock()
 		return
 	}
 
@@ -759,33 +802,43 @@ func (idx *EncryptedIndex) RemoveEntry(path string, identity *age.X25519Identity
 
 	if identity == nil {
 		dropDisk()
+		idx.mu.Unlock()
 		return
 	}
 
-	storedSalt := idx.salt
-	key := deriveIndexKey(identity, storedSalt)
-	defer vaultcrypto.Wipe(key)
-
-	plaintext, err := vaultcrypto.DecryptWithKey(idx.ciphertext, key)
-	if err != nil {
-		dropDisk()
-		return
-	}
-	defer vaultcrypto.Wipe(plaintext)
-
-	var doc indexDoc
-	if err = json.Unmarshal(plaintext, &doc); err != nil {
-		dropDisk()
-		return
+	cacheEnabled := isSearchIndexCacheEnabled(vaultDir)
+	useCache := idx.docValid && idx.doc != nil && cacheEnabled
+	var doc *indexDoc
+	if useCache {
+		doc = idx.doc
+	} else {
+		storedSalt := idx.salt
+		key := deriveIndexKey(identity, storedSalt)
+		plaintext, err := vaultcrypto.DecryptWithKey(idx.ciphertext, key)
+		vaultcrypto.Wipe(key)
+		if err != nil {
+			dropDisk()
+			idx.mu.Unlock()
+			return
+		}
+		var parsed indexDoc
+		if err = json.Unmarshal(plaintext, &parsed); err != nil {
+			vaultcrypto.Wipe(plaintext)
+			dropDisk()
+			idx.mu.Unlock()
+			return
+		}
+		vaultcrypto.Wipe(plaintext)
+		doc = &parsed
 	}
 
 	delete(doc.Values, path)
 	if doc.TokenIndex != nil {
-		ensurePathTokens(&doc)
+		ensurePathTokens(doc)
 		removeFromTokenIndex(doc.TokenIndex, doc.PathTokens, path)
 	}
 	if doc.HostIndex != nil {
-		ensurePathHosts(&doc)
+		ensurePathHosts(doc)
 		removeFromHostIndex(doc.HostIndex, doc.PathHosts, path)
 	}
 	// A delete removes exactly one vault entry; keep the persisted entry count
@@ -797,19 +850,35 @@ func (idx *EncryptedIndex) RemoveEntry(path string, identity *age.X25519Identity
 	newPlaintext, err := json.Marshal(doc)
 	if err != nil {
 		dropDisk()
+		idx.mu.Unlock()
 		return
 	}
 	defer vaultcrypto.Wipe(newPlaintext)
 
+	storedSalt := idx.salt
+	key := deriveIndexKey(identity, storedSalt)
 	newCiphertext, err := vaultcrypto.EncryptWithKey(newPlaintext, key)
+	vaultcrypto.Wipe(key)
 	if err != nil {
 		dropDisk()
+		idx.mu.Unlock()
 		return
 	}
 
 	idx.ciphertext = newCiphertext
-	// Persist so the deletion is reflected on disk and survives a restart.
+	if cacheEnabled {
+		idx.doc = doc
+		idx.docValid = true
+	} else {
+		wipeIndexDoc(idx.doc)
+		idx.doc = nil
+		idx.docValid = false
+	}
+
+	// Persist while holding the write lock so another update cannot overwrite
+	// the on-disk file with an older ciphertext after this update returns.
 	idx.persistErr = writeIndexFile(vaultDir, storedSalt, newCiphertext)
+	idx.mu.Unlock()
 }
 
 const indexFormatVersion = byte(0x01)
@@ -860,10 +929,17 @@ func writeIndexFile(vaultDir string, salt, ciphertext []byte) error {
 // clearLocked resets the in-memory index to the unbuilt state. The caller must
 // hold idx.mu.
 func (idx *EncryptedIndex) clearLocked() {
+	if idx.doc != nil {
+		wipeIndexDoc(idx.doc)
+		idx.doc = nil
+	}
+	idx.docValid = false
 	idx.ciphertext = nil
 	idx.salt = nil
 	idx.vaultDir = ""
 	idx.idHash = [sha256.Size]byte{}
+	idx.dirty = false
+	idx.persistErr = nil
 }
 
 func (idx *EncryptedIndex) saveToDisk(vaultDir string) error {
@@ -930,11 +1006,20 @@ func (idx *EncryptedIndex) loadFromDisk(vaultDir string, identity *age.X25519Ide
 
 	idHash := sha256.Sum256([]byte(identity.Recipient().String()))
 
+	cacheEnabled := isSearchIndexCacheEnabled(vaultDir)
 	idx.mu.Lock()
 	idx.ciphertext = ct
 	idx.salt = salt
 	idx.vaultDir = vaultDir
 	idx.idHash = idHash
+	if cacheEnabled {
+		idx.doc = &doc
+		idx.docValid = true
+	} else {
+		wipeIndexDoc(idx.doc)
+		idx.doc = nil
+		idx.docValid = false
+	}
 	idx.mu.Unlock()
 
 	if len(salt) == 0 {
@@ -1152,4 +1237,71 @@ func ensurePathHosts(doc *indexDoc) {
 			doc.PathHosts[path] = append(doc.PathHosts[path], host)
 		}
 	}
+}
+
+// matchEntriesWithDoc returns the subset of candidates whose stored values
+// contain needle as a case-insensitive substring. It operates purely on the
+// provided doc without any I/O.
+func matchEntriesWithDoc(candidates []string, needle string, doc *indexDoc) map[string]struct{} {
+	needleLower := strings.ToLower(needle)
+	matching := make(map[string]struct{}, len(candidates))
+
+	if isSingleToken(needle) && doc.TokenIndex != nil {
+		if paths, ok := doc.TokenIndex[needleLower]; ok {
+			for _, path := range candidates {
+				if _, found := paths[path]; found {
+					matching[path] = struct{}{}
+				}
+			}
+			if len(matching) > 0 {
+				return matching
+			}
+		}
+	}
+
+	for _, path := range candidates {
+		values, ok := doc.Values[path]
+		if !ok {
+			continue
+		}
+		for _, val := range values {
+			if strings.Contains(val, needleLower) {
+				matching[path] = struct{}{}
+				break
+			}
+		}
+	}
+	return matching
+}
+
+// matchHostWithDoc returns the subset of candidates whose url field matches
+// targetHost. If candidates is non-empty, only candidates that match are
+// returned; if candidates is empty, all matching paths in the doc are returned.
+func matchHostWithDoc(candidates []string, targetHost string, doc *indexDoc) map[string]struct{} {
+	if doc.HostIndex == nil {
+		return make(map[string]struct{})
+	}
+
+	paths, found := doc.HostIndex[targetHost]
+	if !found || len(paths) == 0 {
+		return make(map[string]struct{})
+	}
+
+	matching := make(map[string]struct{}, len(paths))
+	if len(candidates) > 0 {
+		candSet := make(map[string]struct{}, len(candidates))
+		for _, c := range candidates {
+			candSet[c] = struct{}{}
+		}
+		for path := range paths {
+			if _, ok := candSet[path]; ok {
+				matching[path] = struct{}{}
+			}
+		}
+	} else {
+		for path := range paths {
+			matching[path] = struct{}{}
+		}
+	}
+	return matching
 }

--- a/internal/vault/search_index.go
+++ b/internal/vault/search_index.go
@@ -660,8 +660,8 @@ func (idx *EncryptedIndex) Invalidate() {
 
 // UpdateEntry incrementally updates a single entry in the encrypted index.
 // It uses the in-memory decrypted cache when available and config-enabled,
-// falling back to decrypting the entire ciphertext. The on-disk persistence
-// is debounced so rapid single-entry writes do not pay a full I/O cost per write.
+// falling back to decrypting the entire ciphertext. On-disk persistence stays
+// synchronous so a successful return guarantees restart visibility.
 // If the index is not built, this is a no-op (the index will be built lazily).
 func (idx *EncryptedIndex) UpdateEntry(vaultDir, path string, identity *age.X25519Identity) error {
 	idx.mu.Lock()

--- a/internal/vault/search_index_batch_bench_test.go
+++ b/internal/vault/search_index_batch_bench_test.go
@@ -2,20 +2,29 @@ package vault
 
 import (
 	"fmt"
+	"path/filepath"
 	"testing"
+
+	vaultconfig "github.com/danieljustus/symaira-vault/internal/config"
 )
 
 // BenchmarkEncryptedIndexUpdateEntry_1kEntries measures the cost of a single
 // incremental UpdateEntry on a 1k-entry vault: each call decrypts, re-marshals,
 // re-encrypts, and re-persists the whole index document.
 func BenchmarkEncryptedIndexUpdateEntry_1kEntries(b *testing.B) {
-	benchmarkIndexUpdateEntry(b, 1000)
+	benchmarkIndexUpdateEntry(b, 1000, false)
+}
+
+// BenchmarkEncryptedIndexUpdateEntryCached_1kEntries measures the same write
+// with the opt-in decrypted index cache enabled.
+func BenchmarkEncryptedIndexUpdateEntryCached_1kEntries(b *testing.B) {
+	benchmarkIndexUpdateEntry(b, 1000, true)
 }
 
 // BenchmarkEncryptedIndexUpdateEntry_2kEntries measures the per-write cost on
 // a 2k-entry vault, showing the O(N) growth that makes bulk imports O(N²).
 func BenchmarkEncryptedIndexUpdateEntry_2kEntries(b *testing.B) {
-	benchmarkIndexUpdateEntry(b, 2000)
+	benchmarkIndexUpdateEntry(b, 2000, false)
 }
 
 // BenchmarkEncryptedIndexBatchUpdate_1kEntries_100Writes measures a batch of
@@ -38,10 +47,18 @@ func BenchmarkEncryptedIndexRemoveEntry_2kEntries(b *testing.B) {
 	benchmarkIndexRemoveEntry(b, 2000)
 }
 
-func benchmarkIndexUpdateEntry(b *testing.B, numEntries int) {
+func benchmarkIndexUpdateEntry(b *testing.B, numEntries int, cacheEnabled bool) {
 	vaultDir := b.TempDir()
 	identity := generateTestIdentity(b)
 	createTestEntries(b, vaultDir, identity, numEntries)
+	if cacheEnabled {
+		cfg := vaultconfig.Default()
+		cfg.VaultDir = vaultDir
+		cfg.Vault = &vaultconfig.VaultConfig{SearchIndexCache: true}
+		if err := cfg.SaveTo(filepath.Join(vaultDir, "config.yaml")); err != nil {
+			b.Fatalf("save cache config: %v", err)
+		}
+	}
 
 	idx := &EncryptedIndex{}
 	if err := idx.Build(vaultDir, identity); err != nil {

--- a/internal/vault/search_index_test.go
+++ b/internal/vault/search_index_test.go
@@ -3,14 +3,17 @@ package vault
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
 
 	"filippo.io/age"
 
+	vaultconfig "github.com/danieljustus/symaira-vault/internal/config"
 	vaultcrypto "github.com/danieljustus/symaira-vault/internal/crypto"
 	"github.com/danieljustus/symaira-vault/internal/testutil"
 )
@@ -1094,5 +1097,296 @@ func TestEncryptedIndex_NoServiceLeakageOnDisk(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("Walk vault dir: %v", err)
+	}
+}
+
+func TestSearchIndexCache_CacheHit(t *testing.T) {
+	searchIndexStore.invalidateAll()
+	t.Cleanup(searchIndexStore.invalidateAll)
+
+	vaultDir := t.TempDir()
+	identity := testutil.TempIdentity(t)
+
+	cfg := vaultconfig.Default()
+	cfg.VaultDir = vaultDir
+	cfg.Vault = &vaultconfig.VaultConfig{SearchIndexCache: true}
+	if err := cfg.SaveTo(filepath.Join(vaultDir, "config.yaml")); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	mustWriteEntry(t, vaultDir, identity, "github.com/user", map[string]interface{}{
+		"username": "alice",
+		"password": "s3cr3t",
+	})
+	mustWriteEntry(t, vaultDir, identity, "personal/email", map[string]interface{}{
+		"email": "bob@example.com",
+	})
+
+	idx := searchIndexForVault(vaultDir)
+	if err := idx.Build(vaultDir, identity); err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+
+	results1, err := idx.MatchEntries(vaultDir, identity, []string{"github.com/user"}, "alice")
+	if err != nil {
+		t.Fatalf("MatchEntries() error = %v", err)
+	}
+	if len(results1) != 1 {
+		t.Fatalf("MatchEntries('alice') = %d results, want 1", len(results1))
+	}
+
+	idx.mu.RLock()
+	cached := idx.docValid && idx.doc != nil
+	idx.mu.RUnlock()
+	if !cached {
+		t.Fatal("expected doc cache to be populated after first MatchEntries")
+	}
+
+	results2, err := idx.MatchEntries(vaultDir, identity, []string{"personal/email"}, "bob")
+	if err != nil {
+		t.Fatalf("MatchEntries() error = %v", err)
+	}
+	if len(results2) != 1 {
+		t.Fatalf("MatchEntries('bob') = %d results, want 1", len(results2))
+	}
+}
+
+func TestSearchIndexCache_ClearMemoryWipesPlaintext(t *testing.T) {
+	searchIndexStore.invalidateAll()
+	t.Cleanup(searchIndexStore.invalidateAll)
+
+	vaultDir := t.TempDir()
+	identity := testutil.TempIdentity(t)
+
+	cfg := vaultconfig.Default()
+	cfg.VaultDir = vaultDir
+	cfg.Vault = &vaultconfig.VaultConfig{SearchIndexCache: true}
+	if err := cfg.SaveTo(filepath.Join(vaultDir, "config.yaml")); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	mustWriteEntry(t, vaultDir, identity, "test/entry", map[string]interface{}{"key": "value"})
+
+	idx := searchIndexForVault(vaultDir)
+	if err := idx.Build(vaultDir, identity); err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+
+	idx.mu.RLock()
+	wasValid := idx.docValid
+	idx.mu.RUnlock()
+	if !wasValid {
+		t.Fatal("expected docValid to be true after Build with cache enabled")
+	}
+
+	idx.ClearMemory()
+
+	idx.mu.RLock()
+	nowValid := idx.docValid
+	hasDoc := idx.doc != nil
+	idx.mu.RUnlock()
+	if nowValid {
+		t.Error("ClearMemory() should set docValid = false")
+	}
+	if hasDoc {
+		t.Error("ClearMemory() should set doc = nil")
+	}
+	if idx.IsBuilt() {
+		t.Error("ClearMemory() should clear IsBuilt() state")
+	}
+}
+
+func TestSearchIndexCache_InvalidateWipesPlaintext(t *testing.T) {
+	searchIndexStore.invalidateAll()
+	t.Cleanup(searchIndexStore.invalidateAll)
+
+	vaultDir := t.TempDir()
+	identity := testutil.TempIdentity(t)
+
+	cfg := vaultconfig.Default()
+	cfg.VaultDir = vaultDir
+	cfg.Vault = &vaultconfig.VaultConfig{SearchIndexCache: true}
+	if err := cfg.SaveTo(filepath.Join(vaultDir, "config.yaml")); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	mustWriteEntry(t, vaultDir, identity, "test/entry", map[string]interface{}{"key": "value"})
+
+	idx := searchIndexForVault(vaultDir)
+	if err := idx.Build(vaultDir, identity); err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+
+	idx.mu.RLock()
+	wasValid := idx.docValid
+	idx.mu.RUnlock()
+	if !wasValid {
+		t.Fatal("expected docValid to be true after Build with cache enabled")
+	}
+
+	idx.Invalidate()
+
+	idx.mu.RLock()
+	nowValid := idx.docValid
+	hasDoc := idx.doc != nil
+	idx.mu.RUnlock()
+	if nowValid {
+		t.Error("Invalidate() should set docValid = false")
+	}
+	if hasDoc {
+		t.Error("Invalidate() should set doc = nil")
+	}
+	if _, err := os.Stat(indexFilePath(vaultDir)); !os.IsNotExist(err) {
+		t.Error("Invalidate() should remove the on-disk index file")
+	}
+}
+
+func TestSearchIndexCache_CiphertextOnlyDefault(t *testing.T) {
+	searchIndexStore.invalidateAll()
+	t.Cleanup(searchIndexStore.invalidateAll)
+
+	vaultDir := t.TempDir()
+	identity := testutil.TempIdentity(t)
+
+	cfg := vaultconfig.Default()
+	cfg.VaultDir = vaultDir
+	if err := cfg.SaveTo(filepath.Join(vaultDir, "config.yaml")); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	mustWriteEntry(t, vaultDir, identity, "test/entry", map[string]interface{}{"key": "value"})
+
+	idx := searchIndexForVault(vaultDir)
+	if err := idx.Build(vaultDir, identity); err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+
+	idx.mu.RLock()
+	cached := idx.docValid && idx.doc != nil
+	idx.mu.RUnlock()
+	if cached {
+		t.Error("doc cache must not be populated when SearchIndexCache is not enabled")
+	}
+
+	results, err := idx.MatchEntries(vaultDir, identity, []string{"test/entry"}, "value")
+	if err != nil {
+		t.Fatalf("MatchEntries() error = %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("MatchEntries('value') = %d results, want 1", len(results))
+	}
+}
+
+func TestSearchIndexCache_ConcurrentAccess(t *testing.T) {
+	searchIndexStore.invalidateAll()
+	t.Cleanup(searchIndexStore.invalidateAll)
+
+	vaultDir := t.TempDir()
+	identity := testutil.TempIdentity(t)
+
+	cfg := vaultconfig.Default()
+	cfg.VaultDir = vaultDir
+	cfg.Vault = &vaultconfig.VaultConfig{SearchIndexCache: true}
+	if err := cfg.SaveTo(filepath.Join(vaultDir, "config.yaml")); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	for i := 0; i < 50; i++ {
+		path := fmt.Sprintf("service-%d/entry-%05d", i/10, i)
+		mustWriteEntry(t, vaultDir, identity, path, map[string]interface{}{
+			"username": fmt.Sprintf("user-%05d", i),
+			"password": fmt.Sprintf("pass-%05d", i),
+		})
+	}
+
+	idx := searchIndexForVault(vaultDir)
+	if err := idx.Build(vaultDir, identity); err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, 20)
+
+	for w := 0; w < 4; w++ {
+		wg.Add(1)
+		go func(workerID int) {
+			defer wg.Done()
+			for i := 0; i < 25; i++ {
+				path := fmt.Sprintf("service-%d/entry-%05d", i/10, i)
+				if err := idx.UpdateEntry(vaultDir, path, identity); err != nil {
+					errCh <- fmt.Errorf("worker %d UpdateEntry(%s): %w", workerID, path, err)
+					return
+				}
+				_, err := idx.MatchEntries(vaultDir, identity, []string{path}, fmt.Sprintf("pass-%05d", i))
+				if err != nil {
+					errCh <- fmt.Errorf("worker %d MatchEntries(%s): %w", workerID, path, err)
+					return
+				}
+			}
+		}(w)
+	}
+
+	wg.Wait()
+	close(errCh)
+
+	for err := range errCh {
+		t.Error(err)
+	}
+
+	results, err := idx.MatchEntries(vaultDir, identity, []string{"service-0/entry-00000"}, "pass-00000")
+	if err != nil {
+		t.Fatalf("MatchEntries() error = %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("MatchEntries('pass-00000') = %d results, want 1", len(results))
+	}
+}
+
+func TestSearchIndexCache_DebouncedPersistence(t *testing.T) {
+	searchIndexStore.invalidateAll()
+	t.Cleanup(searchIndexStore.invalidateAll)
+
+	vaultDir := t.TempDir()
+	identity := testutil.TempIdentity(t)
+
+	cfg := vaultconfig.Default()
+	cfg.VaultDir = vaultDir
+	cfg.Vault = &vaultconfig.VaultConfig{SearchIndexCache: true}
+	if err := cfg.SaveTo(filepath.Join(vaultDir, "config.yaml")); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	mustWriteEntry(t, vaultDir, identity, "a/entry", map[string]interface{}{"key": "a"})
+	mustWriteEntry(t, vaultDir, identity, "b/entry", map[string]interface{}{"key": "b"})
+
+	idx := searchIndexForVault(vaultDir)
+	if err := idx.Build(vaultDir, identity); err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+
+	for _, p := range []string{"a/entry", "b/entry", "a/entry"} {
+		if err := idx.UpdateEntry(vaultDir, p, identity); err != nil {
+			t.Fatalf("UpdateEntry(%s) error = %v", p, err)
+		}
+	}
+
+	results, err := idx.MatchEntries(vaultDir, identity, []string{"a/entry"}, "a")
+	if err != nil {
+		t.Fatalf("MatchEntries() error = %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("MatchEntries('a') = %d results, want 1", len(results))
+	}
+
+	freshIdx := &EncryptedIndex{}
+	if err := freshIdx.loadFromDisk(vaultDir, identity); err != nil {
+		t.Fatalf("loadFromDisk() error = %v", err)
+	}
+	freshResults, err := freshIdx.MatchEntries(vaultDir, identity, []string{"a/entry"}, "a")
+	if err != nil {
+		t.Fatalf("freshIdx.MatchEntries() error = %v", err)
+	}
+	if len(freshResults) != 1 {
+		t.Fatalf("freshIdx.MatchEntries('a') = %d results, want 1", len(freshResults))
 	}
 }


### PR DESCRIPTION
## Summary
- add an opt-in decrypted in-memory search-index cache with explicit plaintext wipe paths
- persist incremental index updates synchronously so restart visibility remains deterministic
- persist and merge the cache configuration and add cache-hit, invalidation, wipe, and restart coverage

## Verification
- `go test -race ./internal/config ./internal/vault -count=1 -timeout=360s`
- `go vet ./internal/config ./internal/vault`
- full repository race suite completed successfully before the final Main merge; affected packages were re-run after the merge

Closes #918

## Benchmark

Apple M4 Pro, Go 1.26.5, 1,000-entry index, three 3-iteration samples:
- ciphertext-only: 9.71–10.00 ms/op, 7.66–7.67 MB/op, ~45,578 allocs/op
- cache enabled: 7.91–9.04 ms/op, 3.53 MB/op, ~7,295 allocs/op

The measured median improves write latency by about 15%, cuts allocated bytes by about 54%, and cuts allocations by about 84%. Persistence remains synchronous to preserve deterministic restart visibility.