### PR TITLE
test(ios): assert ACL error propagation

### DIFF
--- a/client/Sources/SymvaultIOS/DeviceIdentityStore.swift
+++ b/client/Sources/SymvaultIOS/DeviceIdentityStore.swift
@@ -57,19 +57,16 @@ enum DeviceIdentityStore {
     }
 
     static func accessControl() throws -> SecAccessControl {
-        // Test hook: allows tests to simulate ACL creation failures without
-        // relying on host biometric configuration.
-        if let override = accessControlOverride {
-            return try override()
-        }
-
         // ThisDeviceOnly + biometric-required: the identity never leaves the
         // device and can only be read after a local biometric prompt.
         var error: Unmanaged<CFError>?
         let flags: SecAccessControlCreateFlags = [.biometryCurrentSet]
-        guard let ac = SecAccessControlCreateWithFlags(kCFAllocatorDefault,
-                                                      kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly,
-                                                      flags, &error) else {
+        let create = accessControlFactory ?? { flags, error in
+            SecAccessControlCreateWithFlags(kCFAllocatorDefault,
+                                            kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly,
+                                            flags, error)
+        }
+        guard let ac = create(flags, &error) else {
             let underlying = error?.takeRetainedValue() as Error? ?? NSError(domain: "DeviceIdentityStore", code: Int(errSecParam), userInfo: nil)
             throw NSError(domain: "DeviceIdentityStore",
                           code: Int(errSecParam),
@@ -79,6 +76,6 @@ enum DeviceIdentityStore {
         return ac
     }
 
-    // Test-only override for ACL creation. Nil in production.
-    static var accessControlOverride: (() throws -> SecAccessControl)?
+    // Test hook for deterministic ACL-creation failures. Nil in production.
+    static var accessControlFactory: ((SecAccessControlCreateFlags, UnsafeMutablePointer<Unmanaged<CFError>?>?) -> SecAccessControl?)?
 }

--- a/client/Tests/SymvaultIOSTests/DeviceIdentityStoreTests.swift
+++ b/client/Tests/SymvaultIOSTests/DeviceIdentityStoreTests.swift
@@ -9,7 +9,7 @@ import Testing
     let underlying = NSError(domain: "TestACL", code: 42,
                              userInfo: [NSLocalizedDescriptionKey: "simulated ACL failure"])
     DeviceIdentityStore.accessControlFactory = { _, error in
-        error?.pointee = Unmanaged.passRetained(underlying as CFError)
+        error?.pointee = Unmanaged.passRetained(underlying as! CFError)
         return nil
     }
     defer { DeviceIdentityStore.accessControlFactory = nil }
@@ -29,7 +29,7 @@ import Testing
     DeviceIdentityStore.accessControlFactory = { _, error in
         let failure = NSError(domain: "Test", code: Int(errSecParam),
                               userInfo: [NSLocalizedDescriptionKey: "Simulated ACL failure"])
-        error?.pointee = Unmanaged.passRetained(failure as CFError)
+        error?.pointee = Unmanaged.passRetained(failure as! CFError)
         return nil
     }
     defer { DeviceIdentityStore.accessControlFactory = nil }

--- a/client/Tests/SymvaultIOSTests/DeviceIdentityStoreTests.swift
+++ b/client/Tests/SymvaultIOSTests/DeviceIdentityStoreTests.swift
@@ -6,33 +6,40 @@ import Testing
 
 @MainActor
 @Test func accessControlThrowsWhenBiometryUnavailable() throws {
-    // On systems without enrolled biometrics, SecAccessControlCreateWithFlags
-    // returns nil and populates an error. The wrapper must throw rather than
-    // force-unwrap (the previous behaviour).
+    let underlying = NSError(domain: "TestACL", code: 42,
+                             userInfo: [NSLocalizedDescriptionKey: "simulated ACL failure"])
+    DeviceIdentityStore.accessControlFactory = { _, error in
+        error?.pointee = Unmanaged.passRetained(underlying as CFError)
+        return nil
+    }
+    defer { DeviceIdentityStore.accessControlFactory = nil }
+
     do {
         _ = try DeviceIdentityStore.accessControl()
-        // Biometrics are available on this host; the function returns valid.
-        // The important guarantee is that it is `throws` and does not crash.
+        Issue.record("expected accessControl() to throw")
     } catch {
-        // Expected on hosts without biometrics; test passes because the
-        // error is thrown cleanly.
+        let nsError = error as NSError
+        #expect(nsError.userInfo[NSUnderlyingErrorKey] as? NSError === underlying)
+        #expect(nsError.localizedDescription.contains("simulated ACL failure"))
     }
 }
 
 @MainActor
 @Test func savePropagatesAccessControlError() throws {
-    DeviceIdentityStore.accessControlOverride = {
-        throw NSError(domain: "Test", code: Int(errSecParam),
-                      userInfo: [NSLocalizedDescriptionKey: "Simulated ACL failure"])
+    DeviceIdentityStore.accessControlFactory = { _, error in
+        let failure = NSError(domain: "Test", code: Int(errSecParam),
+                              userInfo: [NSLocalizedDescriptionKey: "Simulated ACL failure"])
+        error?.pointee = Unmanaged.passRetained(failure as CFError)
+        return nil
     }
-    defer { DeviceIdentityStore.accessControlOverride = nil }
+    defer { DeviceIdentityStore.accessControlFactory = nil }
 
     do {
         try DeviceIdentityStore.save("test-identity")
         Issue.record("expected DeviceIdentityStore.save to throw")
     } catch let error as NSError {
-        #expect(error.domain == "Test")
-        #expect(error.code == Int(errSecParam))
+        #expect(error.userInfo[NSUnderlyingErrorKey] != nil)
+        #expect(error.localizedDescription.contains("Simulated ACL failure"))
     } catch {
         Issue.record("expected NSError, got \(error)")
     }


### PR DESCRIPTION
## Summary

Strengthens the iOS enrollment error-path tests for #915.

- Inject a deterministic `SecAccessControlCreateWithFlags` failure through a factory hook.
- Assert that the production wrapper throws and preserves the underlying `CFError`.
- Verify `DeviceIdentityStore.save` surfaces the actionable ACL failure instead of silently succeeding or crashing.

## Verification

- Local `swift test` is blocked by the host's CommandLineTools-only environment because the private `SwiftUIMacros` plugin from `symaira-appkit` is unavailable.
- GitHub macOS CI is required for the Swift build and test verification.

Closes #915
