### PR TITLE
fix(auth): re-establish the session on an explicit unlock

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -155,11 +155,16 @@ sequenceDiagram
         CLI->>User: Enter passphrase
         User->>CLI: passphrase
         CLI->>Session: SavePassphrase(vaultDir, passphrase, TTL)
-        Session->>Keyring: Set(vaultDir, passphrase, TTL)
+        Session->>Keyring: Set(vaultDir, passphrase, idle TTL, max lifetime)
     end
 ```
 
-**Default TTL:** 15 minutes
+**Default idle TTL:** 15 minutes
+
+**Default maximum lifetime:** 8 hours. Identity and passphrase cache entries
+share the session entry's `SavedAt`, `LastAccess`, idle TTL, and maximum lifetime
+so repeated activity cannot extend a cached session indefinitely. Read-only
+probes such as health checks do not refresh either entry.
 
 ### `internal/config/` — Configuration
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- The macOS app could no longer unlock the vault: entering the passphrase and
+  pressing "Entsperren" appeared to do nothing while the CLI kept working.
+  `symvault unlock` short-circuited on the cached age identity and returned
+  "Vault unlocked" without ever rewriting the session entry. Since the identity
+  entry is renewed by every vault command and the session entry only when the
+  passphrase is actually loaded, the session aged out permanently — and the
+  app's `unlock --check` probe reported a locked vault forever, sending it
+  straight back to the unlock screen.
+  - `symvault unlock` now re-verifies the passphrase (or Touch ID) and always
+    rewrites the session instead of taking the cached-identity shortcut. As a
+    side effect it no longer reports success for a wrong passphrase, and a
+    non-interactive `unlock` with no credential available now fails with
+    `ExitLocked` instead of exiting 0.
+  - `symvault unlock --check` now treats a valid cached identity as an active
+    session, matching the vault every other command can already read.
+  - The macOS app no longer returns to the unlock screen without a message when
+    a reported-successful unlock leaves no active session.
+
 ### Dependencies
 - Bumped `corekit` from `v0.9.1` to `v0.11.0` (pulls in latest audit/security improvements from the corekit module).
 - Bumped `appkit` from `0.4.0` to `0.10.0` in `client/Package.swift` (latest Swift Package release, includes `CLIRunnerError` plaintext-redaction security fix).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -425,6 +425,8 @@ OS-managed buffers.
 - **Minimize session TTL**: Set `sessionTimeout: 0` in `config.yaml` to disable
   session caching entirely. This forces passphrase entry on every operation,
   eliminating the keyring as a persistence vector.
+- **Bound active sessions**: `sessionMaxLifetime` defaults to 8 hours. It limits
+  the total lifetime of a cached session even when the idle timeout is refreshed.
 - **Use stdio MCP mode**: The `symvault mcp --stdio` mode avoids D-Bus entirely
   for MCP transport, reducing the keyring's attack surface to the unlock path.
 - **Prefer passphrase-only unlock**: Set `authMethod: passphrase` to avoid

--- a/client/Sources/SymvaultFeature/VaultStore.swift
+++ b/client/Sources/SymvaultFeature/VaultStore.swift
@@ -130,6 +130,15 @@
         try await client.unlock(passphrase: passphrase, ttl: ttl, profile: activeProfile)
         isBusy = false
         await refresh()
+        if availability != .ready, errorMessage == nil {
+          // The runtime reported a successful unlock but the follow-up
+          // session check still says locked. Never fall back to the unlock
+          // screen without a reason — that reads as "the button does
+          // nothing".
+          errorMessage =
+            "symvault meldet ein erfolgreiches Entsperren, aber es besteht danach keine aktive Sitzung. "
+            + "Aktualisiere die Runtime (brew upgrade symvault) und prüfe 'symvault unlock' im Terminal."
+        }
         return availability == .ready
       } catch {
         isBusy = false

--- a/cmd/auth/unlock.go
+++ b/cmd/auth/unlock.go
@@ -60,7 +60,12 @@ alone is ignored (default-deny). It should NOT be used on shared machines
 			}
 
 			if check {
-				if cli.SessionIsExpired(vaultDir) {
+				// A cached age identity opens the vault without prompting
+				// just as a cached passphrase does, so it counts as an
+				// active session. Looking only at the passphrase entry
+				// reported "locked" for a vault every other command could
+				// read.
+				if cli.SessionIsExpired(vaultDir) && cli.SessionIdentityIsExpired(vaultDir) {
 					cmd.SilenceUsage = true
 					return errorspkg.NewCLIError(errorspkg.ExitLocked, "no active session", errorspkg.ErrVaultLocked)
 				}
@@ -68,7 +73,7 @@ alone is ignored (default-deny). It should NOT be used on shared machines
 				return nil
 			}
 
-			v, effectiveTTL, err := cli.UnlockVaultWithTTL(vaultDir, true, ttlOverride, true)
+			v, effectiveTTL, err := cli.UnlockVaultForSession(vaultDir, true, ttlOverride)
 			if err != nil {
 				return err
 			}

--- a/cmd/auth/unlock_test.go
+++ b/cmd/auth/unlock_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	cli "github.com/danieljustus/symaira-vault/internal/cli"
 	errorspkg "github.com/danieljustus/symaira-vault/internal/errors"
@@ -147,6 +148,58 @@ func TestUnlock_CheckNoSession(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "no active session") {
 		t.Errorf("error = %v, want no-active-session message", err)
+	}
+	var cliErr *errorspkg.CLIError
+	if !errors.As(err, &cliErr) {
+		t.Fatalf("error = %T, want *errorspkg.CLIError", err)
+	}
+	if cliErr.Code != errorspkg.ExitLocked {
+		t.Errorf("exit code = %d, want %d", cliErr.Code, errorspkg.ExitLocked)
+	}
+}
+
+// A cached age identity opens the vault without prompting exactly as a
+// cached passphrase does. Reporting "no active session" for it sent the
+// macOS app back to its unlock screen after every successful unlock.
+func TestUnlock_CheckAcceptsCachedIdentity(t *testing.T) {
+	vaultDir, _ := setupTestVault(t)
+	swapSessionManager(t, &testKeyring{store: map[string]string{}}, true)
+	if err := session.SaveIdentity(vaultDir, "AGE-SECRET-KEY-TEST", 30*time.Minute); err != nil {
+		t.Fatalf("save identity: %v", err)
+	}
+
+	cmd := newAuthUnlockCmd()
+	if err := cmd.Flags().Set("check", "true"); err != nil {
+		t.Fatalf("set check flag: %v", err)
+	}
+
+	stderr := captureStderr(t, func() {
+		if err := cmd.RunE(cmd, nil); err != nil {
+			t.Fatalf("unlock --check error = %v", err)
+		}
+	})
+	if !strings.Contains(stderr, "Session active") {
+		t.Errorf("stderr = %q, want session-active message", stderr)
+	}
+}
+
+// An expired identity must not keep the vault looking unlocked.
+func TestUnlock_CheckRejectsExpiredIdentity(t *testing.T) {
+	vaultDir, _ := setupTestVault(t)
+	swapSessionManager(t, &testKeyring{store: map[string]string{}}, true)
+	if err := session.SaveIdentity(vaultDir, "AGE-SECRET-KEY-TEST", time.Millisecond); err != nil {
+		t.Fatalf("save identity: %v", err)
+	}
+	time.Sleep(10 * time.Millisecond)
+
+	cmd := newAuthUnlockCmd()
+	if err := cmd.Flags().Set("check", "true"); err != nil {
+		t.Fatalf("set check flag: %v", err)
+	}
+
+	err := cmd.RunE(cmd, nil)
+	if err == nil {
+		t.Fatal("unlock --check error = nil, want locked error")
 	}
 	var cliErr *errorspkg.CLIError
 	if !errors.As(err, &cliErr) {

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -17,6 +17,9 @@ defaultAgent: default
 # OS keyring cache TTL for unlocked vault passphrases.
 sessionTimeout: 15m
 
+# Absolute maximum lifetime of a cached session, even while it is active.
+sessionMaxLifetime: 8h
+
 # Unlock method for this vault. Use "touchid" on macOS to allow Touch ID
 # unlock after the passphrase has been stored in the biometric Keychain item.
 # Change with: symvault auth set passphrase|touchid

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -26,6 +26,9 @@ defaultAgent: default
 # Session timeout for OS keyring cache (default: 15m)
 sessionTimeout: 15m
 
+# Absolute maximum lifetime for a cached session (default: 8h)
+sessionMaxLifetime: 8h
+
 # Unlock method: passphrase or touchid
 authMethod: passphrase
 
@@ -67,6 +70,7 @@ mcp:
 | `vaultDir` | `~/.symvault` | Default vault directory |
 | `defaultAgent` | `default` | Default MCP agent profile |
 | `sessionTimeout` | `15m` | OS keyring cache TTL |
+| `sessionMaxLifetime` | `8h` | Absolute maximum lifetime of an OS keyring session |
 | `authMethod` | `passphrase` | Unlock method: `passphrase` or macOS `touchid` |
 
 ## Agent Profile Options
@@ -257,6 +261,7 @@ The following rules are checked:
 |------|-------------|
 | `vaultDir` | Must not be empty |
 | `sessionTimeout` | Must be greater than 0 |
+| `sessionMaxLifetime` | Must be greater than 0 |
 | `defaultAgent` | Must reference an agent that exists in `agents` |
 | `agents.*.approvalMode` | Must be one of: `none`, `deny`, `prompt`, `auto` |
 | `agents.*.allowedPaths` | Each path must be a valid glob pattern |

--- a/docs/symvault-config.schema.json
+++ b/docs/symvault-config.schema.json
@@ -230,6 +230,9 @@
     "SessionTimeout": {
       "type": "integer"
     },
+    "SessionMaxLifetime": {
+      "type": "integer"
+    },
     "AuthMethod": {
       "type": "string"
     },
@@ -269,6 +272,7 @@
     "VaultDir",
     "DefaultAgent",
     "SessionTimeout",
+    "SessionMaxLifetime",
     "AuthMethod",
     "UseTouchID",
     "Profiles",

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -218,7 +218,9 @@ MCP server could in principle alter them. See backlog item O-10.
 - **Go GC Copies:** Because Go's garbage collector manages allocations, it may copy or move slices in memory during compaction. Go does not currently guarantee single-copy semantics.
 - **Practical Impact:** Temporary copies of the passphrase created by the Go runtime may persist in process memory until overwritten or until the process exits. This is not remotely exploitable under normal circumstances (requiring root-level memory dump capabilities).
 - **Mitigations:**
-  - Active sessions are capped by a 15-minute TTL.
+  - **Active sessions use a 15-minute idle TTL and an 8-hour absolute maximum
+    lifetime by default.** Activity refreshes both cache entries together but
+    cannot extend the absolute limit.
   - OS-keyring caching is used where available to avoid repeated passphrase entry and decryption.
   - The `SYMVAULT_PASSPHRASE` environment variable is cleared in memory immediately on startup.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -72,7 +72,8 @@ symvault mcp --stdio --agent default  # Restart MCP server
 
 **Session caching issues:**
 - If `symvault unlock` works but MCP server still reports locked, the session cache may have expired
-- Default TTL is 15 minutes; extend with: `symvault unlock --ttl 30m`
+- Default idle TTL is 15 minutes; extend with: `symvault unlock --ttl 30m`
+- The absolute session lifetime defaults to 8 hours and is configured with `sessionMaxLifetime`
 - Clear cache and retry: `symvault lock && symvault unlock`
 
 ---

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -94,15 +94,16 @@ var DefaultSessionManager SessionManager = defaultSessionManager{}
 // They delegate to the session package directly. Prefer injecting
 // a SessionManager via CLIContext in new code.
 var (
-	SessionLoadPassphrase func(vaultDir string) ([]byte, error)                               = session.LoadPassphrase
-	SessionSavePassphrase func(vaultDir string, passphrase []byte, ttl time.Duration) error   = session.SavePassphrase
-	SessionIsExpired      func(vaultDir string) bool                                          = session.IsSessionExpired
-	SessionLoadBiometric  func(ctx context.Context, vaultDir string) ([]byte, error)          = session.LoadBiometricPassphrase
-	SessionSaveBiometric  func(ctx context.Context, vaultDir string, passphrase []byte) error = session.SaveBiometricPassphrase
-	SessionGetCacheStatus func() session.CacheStatus                                          = session.GetCacheStatus
-	SessionLoadIdentity   func(vaultDir string) (string, error)                               = session.LoadIdentity
-	SessionSaveIdentity   func(vaultDir string, identity string, ttl time.Duration) error     = session.SaveIdentity
-	SessionHasGUISession  func() bool                                                         = session.HasGUISession
+	SessionLoadPassphrase    func(vaultDir string) ([]byte, error)                               = session.LoadPassphrase
+	SessionSavePassphrase    func(vaultDir string, passphrase []byte, ttl time.Duration) error   = session.SavePassphrase
+	SessionIsExpired         func(vaultDir string) bool                                          = session.IsSessionExpired
+	SessionLoadBiometric     func(ctx context.Context, vaultDir string) ([]byte, error)          = session.LoadBiometricPassphrase
+	SessionSaveBiometric     func(ctx context.Context, vaultDir string, passphrase []byte) error = session.SaveBiometricPassphrase
+	SessionGetCacheStatus    func() session.CacheStatus                                          = session.GetCacheStatus
+	SessionLoadIdentity      func(vaultDir string) (string, error)                               = session.LoadIdentity
+	SessionSaveIdentity      func(vaultDir string, identity string, ttl time.Duration) error     = session.SaveIdentity
+	SessionIdentityIsExpired func(vaultDir string) bool                                          = session.IsIdentityExpired
+	SessionHasGUISession     func() bool                                                         = session.HasGUISession
 )
 
 // currentCommandPath is the cobra command path of the command currently

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -94,16 +94,18 @@ var DefaultSessionManager SessionManager = defaultSessionManager{}
 // They delegate to the session package directly. Prefer injecting
 // a SessionManager via CLIContext in new code.
 var (
-	SessionLoadPassphrase    func(vaultDir string) ([]byte, error)                               = session.LoadPassphrase
-	SessionSavePassphrase    func(vaultDir string, passphrase []byte, ttl time.Duration) error   = session.SavePassphrase
-	SessionIsExpired         func(vaultDir string) bool                                          = session.IsSessionExpired
-	SessionLoadBiometric     func(ctx context.Context, vaultDir string) ([]byte, error)          = session.LoadBiometricPassphrase
-	SessionSaveBiometric     func(ctx context.Context, vaultDir string, passphrase []byte) error = session.SaveBiometricPassphrase
-	SessionGetCacheStatus    func() session.CacheStatus                                          = session.GetCacheStatus
-	SessionLoadIdentity      func(vaultDir string) (string, error)                               = session.LoadIdentity
-	SessionSaveIdentity      func(vaultDir string, identity string, ttl time.Duration) error     = session.SaveIdentity
-	SessionIdentityIsExpired func(vaultDir string) bool                                          = session.IsIdentityExpired
-	SessionHasGUISession     func() bool                                                         = session.HasGUISession
+	SessionLoadPassphrase                func(vaultDir string) ([]byte, error)                                          = session.LoadPassphrase
+	SessionSavePassphrase                func(vaultDir string, passphrase []byte, ttl time.Duration) error              = session.SavePassphrase
+	SessionSavePassphraseWithMaxLifetime func(vaultDir string, passphrase []byte, ttl, maxLifetime time.Duration) error = session.SavePassphraseWithMaxLifetime
+	SessionIsExpired                     func(vaultDir string) bool                                                     = session.IsSessionExpired
+	SessionLoadBiometric                 func(ctx context.Context, vaultDir string) ([]byte, error)                     = session.LoadBiometricPassphrase
+	SessionSaveBiometric                 func(ctx context.Context, vaultDir string, passphrase []byte) error            = session.SaveBiometricPassphrase
+	SessionGetCacheStatus                func() session.CacheStatus                                                     = session.GetCacheStatus
+	SessionLoadIdentity                  func(vaultDir string) (string, error)                                          = session.LoadIdentity
+	SessionSaveIdentity                  func(vaultDir string, identity string, ttl time.Duration) error                = session.SaveIdentity
+	SessionSaveIdentityWithMaxLifetime   func(vaultDir string, identity string, ttl, maxLifetime time.Duration) error   = session.SaveIdentityWithMaxLifetime
+	SessionIdentityIsExpired             func(vaultDir string) bool                                                     = session.IsIdentityExpired
+	SessionHasGUISession                 func() bool                                                                    = session.HasGUISession
 )
 
 // currentCommandPath is the cobra command path of the command currently

--- a/internal/cli/unlock.go
+++ b/internal/cli/unlock.go
@@ -23,23 +23,45 @@ func UnlockVault(vaultDir string, interactive bool) (*vaultpkg.Vault, error) {
 }
 
 func UnlockVaultWithTTL(vaultDir string, interactive bool, ttlOverride time.Duration, cacheEnvPassphrase bool) (*vaultpkg.Vault, time.Duration, error) {
+	return unlockVault(vaultDir, interactive, ttlOverride, cacheEnvPassphrase, true)
+}
+
+// UnlockVaultForSession backs the explicit `symvault unlock` command. It
+// deliberately skips the cached-identity shortcut: the passphrase (or Touch
+// ID) is verified again and the session entry is rewritten, so a successful
+// `unlock` always leaves behind the session that `unlock --check` and other
+// processes look for.
+//
+// Taking the shortcut here is what made the GUI unusable: the identity entry
+// is renewed by every vault command, while the session entry is only renewed
+// when the passphrase is actually loaded. Once the session aged out, `unlock`
+// still reported success from the cached identity without recreating it, so
+// `unlock --check` reported a locked vault forever and the app bounced
+// straight back to its unlock screen.
+func UnlockVaultForSession(vaultDir string, interactive bool, ttlOverride time.Duration) (*vaultpkg.Vault, time.Duration, error) {
+	return unlockVault(vaultDir, interactive, ttlOverride, true, false)
+}
+
+func unlockVault(vaultDir string, interactive bool, ttlOverride time.Duration, cacheEnvPassphrase, useIdentityCache bool) (*vaultpkg.Vault, time.Duration, error) {
 	cfg, err := resolveConfig(vaultDir, interactive)
 	if err != nil {
 		return nil, 0, errorspkg.NewCLIError(errorspkg.ExitConfigError, "configuration is invalid", err)
 	}
 
-	if cachedIdentity, cacheErr := SessionLoadIdentity(vaultDir); cacheErr == nil && cachedIdentity != "" {
-		if identity, parseErr := age.ParseX25519Identity(cachedIdentity); parseErr == nil {
-			v, openErr := vaultpkg.OpenWithCachedIdentity(vaultDir, identity)
-			if openErr == nil {
-				metrics.RecordIdentityCacheEvent("hit")
-				ttl := ConfiguredSessionTTL(v, ttlOverride)
-				return v, ttl, nil
+	if useIdentityCache {
+		if cachedIdentity, cacheErr := SessionLoadIdentity(vaultDir); cacheErr == nil && cachedIdentity != "" {
+			if identity, parseErr := age.ParseX25519Identity(cachedIdentity); parseErr == nil {
+				v, openErr := vaultpkg.OpenWithCachedIdentity(vaultDir, identity)
+				if openErr == nil {
+					metrics.RecordIdentityCacheEvent("hit")
+					ttl := ConfiguredSessionTTL(v, ttlOverride)
+					return v, ttl, nil
+				}
 			}
+			metrics.RecordIdentityCacheEvent("miss")
+		} else {
+			metrics.RecordIdentityCacheEvent("miss")
 		}
-		metrics.RecordIdentityCacheEvent("miss")
-	} else {
-		metrics.RecordIdentityCacheEvent("miss")
 	}
 
 	passphrase, passphraseFromEnv, _, err := resolveUnlockPassphrase(vaultDir, interactive, cfg)

--- a/internal/cli/unlock.go
+++ b/internal/cli/unlock.go
@@ -78,13 +78,14 @@ func unlockVault(vaultDir string, interactive bool, ttlOverride time.Duration, c
 	}
 
 	ttl := ConfiguredSessionTTL(v, ttlOverride)
+	maxLifetime := ConfiguredSessionMaxLifetime(v)
 
 	if !passphraseFromEnv || cacheEnvPassphrase {
-		if err := SessionSavePassphrase(vaultDir, passphrase, ttl); err != nil {
+		if err := saveSessionPassphrase(vaultDir, passphrase, ttl, maxLifetime); err != nil {
 			return nil, 0, errorspkg.NewCLIError(errorspkg.ExitGeneralError, "save session", err)
 		}
 		if v != nil && v.Identity != nil {
-			_ = SessionSaveIdentity(vaultDir, v.Identity.String(), ttl)
+			_ = saveSessionIdentity(vaultDir, v.Identity.String(), ttl, maxLifetime)
 		}
 	}
 	if cfg.EffectiveAuthMethod() == configpkg.AuthMethodTouchID && (!passphraseFromEnv || cacheEnvPassphrase) {
@@ -280,4 +281,25 @@ func ConfiguredSessionTTL(v *vaultpkg.Vault, override time.Duration) time.Durati
 		return v.Config.SessionTimeout
 	}
 	return DefaultSessionTTL()
+}
+
+func ConfiguredSessionMaxLifetime(v *vaultpkg.Vault) time.Duration {
+	if v != nil && v.Config != nil && v.Config.SessionMaxLifetime > 0 {
+		return v.Config.SessionMaxLifetime
+	}
+	return configpkg.Default().SessionMaxLifetime
+}
+
+func saveSessionPassphrase(vaultDir string, passphrase []byte, ttl, maxLifetime time.Duration) error {
+	if maxLifetime == configpkg.Default().SessionMaxLifetime {
+		return SessionSavePassphrase(vaultDir, passphrase, ttl)
+	}
+	return SessionSavePassphraseWithMaxLifetime(vaultDir, passphrase, ttl, maxLifetime)
+}
+
+func saveSessionIdentity(vaultDir, identity string, ttl, maxLifetime time.Duration) error {
+	if maxLifetime == configpkg.Default().SessionMaxLifetime {
+		return SessionSaveIdentity(vaultDir, identity, ttl)
+	}
+	return SessionSaveIdentityWithMaxLifetime(vaultDir, identity, ttl, maxLifetime)
 }

--- a/internal/cli/unlock_session_test.go
+++ b/internal/cli/unlock_session_test.go
@@ -1,0 +1,166 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"filippo.io/age"
+
+	configpkg "github.com/danieljustus/symaira-vault/internal/config"
+	vaultpkg "github.com/danieljustus/symaira-vault/internal/vault"
+)
+
+// initPassphraseVault creates a vault whose auth method is a plain
+// passphrase, so unlock paths under test never reach for Touch ID.
+func initPassphraseVault(t *testing.T, passphrase []byte) string {
+	t.Helper()
+	vaultDir := t.TempDir()
+	cfg := configpkg.Default()
+	if err := cfg.SetAuthMethod(configpkg.AuthMethodPassphrase); err != nil {
+		t.Fatalf("SetAuthMethod() error = %v", err)
+	}
+	if _, err := vaultpkg.InitWithPassphrase(vaultDir, passphrase, cfg); err != nil {
+		t.Fatalf("InitWithPassphrase() error = %v", err)
+	}
+	if err := cfg.SaveTo(filepath.Join(vaultDir, "config.yaml")); err != nil {
+		t.Fatalf("SaveTo() error = %v", err)
+	}
+	return vaultDir
+}
+
+// The identity entry is renewed by every vault command while the session
+// entry is only renewed when the passphrase is actually loaded. If the
+// explicit unlock command took the cached-identity shortcut it would report
+// success without rewriting the session, so `unlock --check` — and the GUI
+// that calls it — would keep seeing a locked vault.
+func TestUnlockVaultForSessionIgnoresCachedIdentityAndRewritesSession(t *testing.T) {
+	passphrase := []byte("test-passphrase")
+	vaultDir := initPassphraseVault(t, passphrase)
+
+	identity, err := age.GenerateX25519Identity()
+	if err != nil {
+		t.Fatalf("GenerateX25519Identity() error = %v", err)
+	}
+
+	oldLoadIdentity := SessionLoadIdentity
+	oldSaveIdentity := SessionSaveIdentity
+	oldLoadPassphrase := SessionLoadPassphrase
+	oldSavePassphrase := SessionSavePassphrase
+	oldLoadBiometric := SessionLoadBiometric
+	oldHasGUISession := SessionHasGUISession
+	t.Cleanup(func() {
+		SessionLoadIdentity = oldLoadIdentity
+		SessionSaveIdentity = oldSaveIdentity
+		SessionLoadPassphrase = oldLoadPassphrase
+		SessionSavePassphrase = oldSavePassphrase
+		SessionLoadBiometric = oldLoadBiometric
+		SessionHasGUISession = oldHasGUISession
+	})
+
+	identityLoaded := false
+	SessionLoadIdentity = func(string) (string, error) {
+		identityLoaded = true
+		return identity.String(), nil
+	}
+	SessionSaveIdentity = func(string, string, time.Duration) error { return nil }
+	SessionHasGUISession = func() bool { return false }
+	SessionLoadBiometric = func(context.Context, string) ([]byte, error) {
+		return nil, errors.New("biometric unavailable")
+	}
+	// A still-valid session entry supplies the passphrase, mirroring the
+	// real unlock path after a fresh session was cached.
+	SessionLoadPassphrase = func(string) ([]byte, error) {
+		return append([]byte(nil), passphrase...), nil
+	}
+	savedSessions := 0
+	SessionSavePassphrase = func(string, []byte, time.Duration) error {
+		savedSessions++
+		return nil
+	}
+
+	v, ttl, err := UnlockVaultForSession(vaultDir, false, 0)
+	if err != nil {
+		t.Fatalf("UnlockVaultForSession() error = %v", err)
+	}
+	if v == nil {
+		t.Fatal("UnlockVaultForSession() returned nil vault")
+	}
+	if ttl <= 0 {
+		t.Fatalf("UnlockVaultForSession() ttl = %v, want > 0", ttl)
+	}
+	if identityLoaded {
+		t.Error("UnlockVaultForSession() consulted the identity cache; it must re-verify the passphrase")
+	}
+	if savedSessions != 1 {
+		t.Errorf("SessionSavePassphrase called %d times, want 1", savedSessions)
+	}
+}
+
+// Without a passphrase to verify, the explicit unlock must fail loudly
+// rather than report success off the cached identity.
+func TestUnlockVaultForSessionFailsWithoutPassphrase(t *testing.T) {
+	passphrase := []byte("test-passphrase")
+	vaultDir := initPassphraseVault(t, passphrase)
+
+	identity, err := age.GenerateX25519Identity()
+	if err != nil {
+		t.Fatalf("GenerateX25519Identity() error = %v", err)
+	}
+
+	oldLoadIdentity := SessionLoadIdentity
+	oldLoadPassphrase := SessionLoadPassphrase
+	oldHasGUISession := SessionHasGUISession
+	t.Cleanup(func() {
+		SessionLoadIdentity = oldLoadIdentity
+		SessionLoadPassphrase = oldLoadPassphrase
+		SessionHasGUISession = oldHasGUISession
+	})
+
+	SessionLoadIdentity = func(string) (string, error) { return identity.String(), nil }
+	SessionLoadPassphrase = func(string) ([]byte, error) { return nil, errors.New("expired") }
+	SessionHasGUISession = func() bool { return false }
+
+	if _, _, err := UnlockVaultForSession(vaultDir, false, 0); err == nil {
+		t.Fatal("UnlockVaultForSession() error = nil, want locked error")
+	}
+}
+
+// The implicit path (every other command) keeps the shortcut: it is what
+// lets a cached identity serve reads without re-deriving the key.
+func TestUnlockVaultWithTTLStillUsesCachedIdentity(t *testing.T) {
+	passphrase := []byte("test-passphrase")
+	vaultDir := initPassphraseVault(t, passphrase)
+
+	oldLoadIdentity := SessionLoadIdentity
+	oldLoadPassphrase := SessionLoadPassphrase
+	t.Cleanup(func() {
+		SessionLoadIdentity = oldLoadIdentity
+		SessionLoadPassphrase = oldLoadPassphrase
+	})
+
+	cachedIdentity := readVaultIdentity(t, vaultDir, passphrase)
+	SessionLoadIdentity = func(string) (string, error) { return cachedIdentity, nil }
+	SessionLoadPassphrase = func(string) ([]byte, error) {
+		t.Error("SessionLoadPassphrase called; the cached identity should have served this unlock")
+		return nil, errors.New("miss")
+	}
+
+	if _, _, err := UnlockVaultWithTTL(vaultDir, false, 0, false); err != nil {
+		t.Fatalf("UnlockVaultWithTTL() error = %v", err)
+	}
+}
+
+func readVaultIdentity(t *testing.T, vaultDir string, passphrase []byte) string {
+	t.Helper()
+	v, err := vaultpkg.OpenWithPassphrase(vaultDir, append([]byte(nil), passphrase...))
+	if err != nil {
+		t.Fatalf("OpenWithPassphrase() error = %v", err)
+	}
+	if v.Identity == nil {
+		t.Fatal("OpenWithPassphrase() returned a vault without an identity")
+	}
+	return v.Identity.String()
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,13 +21,14 @@ const (
 
 	// Prefer DefaultConfigDir(), DefaultDataDir(), or DefaultCacheDir() for
 	// new code. Kept for backward compatibility and migration detection.
-	DefaultVaultSubdir    = ".symvault"
-	defaultConfigDir      = DefaultVaultSubdir
-	defaultConfigFile     = "config.yaml"
-	defaultAgentName      = "default"
-	defaultSessionTimeout = 15 * time.Minute
-	AuthMethodPassphrase  = "passphrase"
-	AuthMethodTouchID     = "touchid"
+	DefaultVaultSubdir        = ".symvault"
+	defaultConfigDir          = DefaultVaultSubdir
+	defaultConfigFile         = "config.yaml"
+	defaultAgentName          = "default"
+	defaultSessionTimeout     = 15 * time.Minute
+	defaultSessionMaxLifetime = 8 * time.Hour
+	AuthMethodPassphrase      = "passphrase"
+	AuthMethodTouchID         = "touchid"
 )
 
 // XDGConfigHome returns the XDG config directory ($XDG_CONFIG_HOME or
@@ -92,26 +93,27 @@ type CustomPattern struct {
 }
 
 type Config struct {
-	Agents          map[string]AgentProfile  `yaml:"agents,omitempty"`
-	Vault           *VaultConfig             `yaml:"vault,omitempty"`
-	Git             *GitConfig               `yaml:"git,omitempty"`
-	MCP             *MCPConfig               `yaml:"mcp,omitempty"`
-	Update          *UpdateConfig            `yaml:"update,omitempty"`
-	Clipboard       *ClipboardConfig         `yaml:"clipboard,omitempty"`
-	Audit           *AuditConfig             `yaml:"audit,omitempty"`
-	Logging         *LoggingConfig           `yaml:"logging,omitempty"`
-	Security        *SecurityConfig          `yaml:"security,omitempty"`
-	VaultDir        string                   `yaml:"vaultDir,omitempty"`
-	DefaultAgent    string                   `yaml:"defaultAgent,omitempty"`
-	SessionTimeout  time.Duration            `yaml:"sessionTimeout,omitempty"`
-	AuthMethod      string                   `yaml:"authMethod,omitempty"`
-	UseTouchID      *bool                    `yaml:"useTouchID,omitempty"`
-	Profiles        map[string]*Profile      `yaml:"profiles,omitempty"`
-	DefaultProfile  string                   `yaml:"defaultProfile,omitempty"`
-	EnvAllowlist    []string                 `yaml:"envAllowlist,omitempty"`
-	EnvWhitelist    []string                 `yaml:"envWhitelist,omitempty"`
-	ScanPatterns    []CustomPattern          `yaml:"scan_patterns,omitempty"`
-	PaymentPolicies map[string]PaymentPolicy `yaml:"paymentPolicies,omitempty"`
+	Agents             map[string]AgentProfile  `yaml:"agents,omitempty"`
+	Vault              *VaultConfig             `yaml:"vault,omitempty"`
+	Git                *GitConfig               `yaml:"git,omitempty"`
+	MCP                *MCPConfig               `yaml:"mcp,omitempty"`
+	Update             *UpdateConfig            `yaml:"update,omitempty"`
+	Clipboard          *ClipboardConfig         `yaml:"clipboard,omitempty"`
+	Audit              *AuditConfig             `yaml:"audit,omitempty"`
+	Logging            *LoggingConfig           `yaml:"logging,omitempty"`
+	Security           *SecurityConfig          `yaml:"security,omitempty"`
+	VaultDir           string                   `yaml:"vaultDir,omitempty"`
+	DefaultAgent       string                   `yaml:"defaultAgent,omitempty"`
+	SessionTimeout     time.Duration            `yaml:"sessionTimeout,omitempty"`
+	SessionMaxLifetime time.Duration            `yaml:"sessionMaxLifetime,omitempty"`
+	AuthMethod         string                   `yaml:"authMethod,omitempty"`
+	UseTouchID         *bool                    `yaml:"useTouchID,omitempty"`
+	Profiles           map[string]*Profile      `yaml:"profiles,omitempty"`
+	DefaultProfile     string                   `yaml:"defaultProfile,omitempty"`
+	EnvAllowlist       []string                 `yaml:"envAllowlist,omitempty"`
+	EnvWhitelist       []string                 `yaml:"envWhitelist,omitempty"`
+	ScanPatterns       []CustomPattern          `yaml:"scan_patterns,omitempty"`
+	PaymentPolicies    map[string]PaymentPolicy `yaml:"paymentPolicies,omitempty"`
 }
 
 // PaymentMaxAmount defines per-transaction and per-day spending limits.

--- a/internal/config/config_load.go
+++ b/internal/config/config_load.go
@@ -25,11 +25,12 @@ func validateConfigPath(path string) error {
 func Default() *Config {
 	r := NewPathResolver()
 	return &Config{
-		VaultDir:       r.DataDir,
-		DefaultAgent:   defaultAgentName,
-		SessionTimeout: defaultSessionTimeout,
-		AuthMethod:     AuthMethodPassphrase,
-		Agents:         builtinAgentProfiles(),
+		VaultDir:           r.DataDir,
+		DefaultAgent:       defaultAgentName,
+		SessionTimeout:     defaultSessionTimeout,
+		SessionMaxLifetime: defaultSessionMaxLifetime,
+		AuthMethod:         AuthMethodPassphrase,
+		Agents:             builtinAgentProfiles(),
 	}
 }
 

--- a/internal/config/config_merge.go
+++ b/internal/config/config_merge.go
@@ -64,6 +64,9 @@ func mergeTopLevel(cfg *Config, raw Config) {
 	if raw.SessionTimeout > 0 {
 		cfg.SessionTimeout = raw.SessionTimeout
 	}
+	if raw.SessionMaxLifetime > 0 {
+		cfg.SessionMaxLifetime = raw.SessionMaxLifetime
+	}
 	if raw.AuthMethod != "" {
 		authMethod, err := NormalizeAuthMethod(raw.AuthMethod)
 		if err == nil {

--- a/internal/config/config_save.go
+++ b/internal/config/config_save.go
@@ -36,12 +36,13 @@ func (c *Config) SaveTo(path string) error {
 	authMethod := c.EffectiveAuthMethod()
 
 	raw := Config{
-		VaultDir:       c.VaultDir,
-		DefaultAgent:   c.DefaultAgent,
-		SessionTimeout: c.SessionTimeout,
-		AuthMethod:     authMethod,
-		DefaultProfile: c.DefaultProfile,
-		Agents:         make(map[string]AgentProfile, len(c.Agents)),
+		VaultDir:           c.VaultDir,
+		DefaultAgent:       c.DefaultAgent,
+		SessionTimeout:     c.SessionTimeout,
+		SessionMaxLifetime: c.SessionMaxLifetime,
+		AuthMethod:         authMethod,
+		DefaultProfile:     c.DefaultProfile,
+		Agents:             make(map[string]AgentProfile, len(c.Agents)),
 	}
 
 	if c.UseTouchID != nil && *c.UseTouchID {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -169,9 +169,10 @@ func TestSaveWritesToDefaultConfigPath(t *testing.T) {
 	home := setTestHome(t)
 
 	cfg := &Config{
-		VaultDir:       filepath.Join(home, DefaultVaultSubdir),
-		DefaultAgent:   "default",
-		SessionTimeout: defaultSessionTimeout,
+		VaultDir:           filepath.Join(home, DefaultVaultSubdir),
+		DefaultAgent:       "default",
+		SessionTimeout:     defaultSessionTimeout,
+		SessionMaxLifetime: defaultSessionMaxLifetime,
 		Agents: map[string]AgentProfile{
 			"default": {
 				Name:         "default",
@@ -313,9 +314,10 @@ func TestSaveWritesRedactFields(t *testing.T) {
 	home := setTestHome(t)
 
 	cfg := &Config{
-		VaultDir:       filepath.Join(home, DefaultVaultSubdir),
-		DefaultAgent:   "default",
-		SessionTimeout: defaultSessionTimeout,
+		VaultDir:           filepath.Join(home, DefaultVaultSubdir),
+		DefaultAgent:       "default",
+		SessionTimeout:     defaultSessionTimeout,
+		SessionMaxLifetime: defaultSessionMaxLifetime,
 		Agents: map[string]AgentProfile{
 			"restricted": {
 				Name:         "restricted",
@@ -456,9 +458,10 @@ func TestSaveWithAllConfigSections(t *testing.T) {
 	home := setTestHome(t)
 
 	cfg := &Config{
-		VaultDir:       filepath.Join(home, DefaultVaultSubdir),
-		DefaultAgent:   "default",
-		SessionTimeout: defaultSessionTimeout,
+		VaultDir:           filepath.Join(home, DefaultVaultSubdir),
+		DefaultAgent:       "default",
+		SessionTimeout:     defaultSessionTimeout,
+		SessionMaxLifetime: defaultSessionMaxLifetime,
 		Agents: map[string]AgentProfile{
 			"default": {
 				Name:         "default",
@@ -546,9 +549,10 @@ func TestSaveLoadRoundTrip_PreservesAllFields(t *testing.T) {
 	home := setTestHome(t)
 
 	cfg := &Config{
-		VaultDir:       filepath.Join(home, DefaultVaultSubdir),
-		DefaultAgent:   "test-agent",
-		SessionTimeout: defaultSessionTimeout,
+		VaultDir:           filepath.Join(home, DefaultVaultSubdir),
+		DefaultAgent:       "test-agent",
+		SessionTimeout:     defaultSessionTimeout,
+		SessionMaxLifetime: defaultSessionMaxLifetime,
 		Agents: map[string]AgentProfile{
 			"test-agent": {
 				Name:            "test-agent",
@@ -1082,10 +1086,11 @@ func TestSave_PermissionDeniedOnReadOnlyDir(t *testing.T) {
 	t.Setenv("HOME", home)
 
 	cfg := &Config{
-		VaultDir:       filepath.Join(readonlyDir, DefaultVaultSubdir),
-		DefaultAgent:   "default",
-		SessionTimeout: defaultSessionTimeout,
-		Agents:         builtinAgentProfiles(),
+		VaultDir:           filepath.Join(readonlyDir, DefaultVaultSubdir),
+		DefaultAgent:       "default",
+		SessionTimeout:     defaultSessionTimeout,
+		SessionMaxLifetime: defaultSessionMaxLifetime,
+		Agents:             builtinAgentProfiles(),
 	}
 
 	err := cfg.Save()
@@ -1111,10 +1116,11 @@ func TestSave_FilePermissionDenied(t *testing.T) {
 	}
 
 	cfg := &Config{
-		VaultDir:       readonlyDir,
-		DefaultAgent:   "default",
-		SessionTimeout: defaultSessionTimeout,
-		Agents:         builtinAgentProfiles(),
+		VaultDir:           readonlyDir,
+		DefaultAgent:       "default",
+		SessionTimeout:     defaultSessionTimeout,
+		SessionMaxLifetime: defaultSessionMaxLifetime,
+		Agents:             builtinAgentProfiles(),
 	}
 
 	err := cfg.Save()
@@ -2729,13 +2735,14 @@ func TestRoundTrip_AllFieldsSet(t *testing.T) {
 	home := setTestHome(t)
 
 	cfg := &Config{
-		VaultDir:       filepath.Join(home, DefaultVaultSubdir),
-		DefaultAgent:   "test-agent",
-		SessionTimeout: 10 * time.Minute,
-		AuthMethod:     "touchid",
-		UseTouchID:     bptr(true),
-		EnvAllowlist:   []string{"HOME", "PATH"},
-		DefaultProfile: "work",
+		VaultDir:           filepath.Join(home, DefaultVaultSubdir),
+		DefaultAgent:       "test-agent",
+		SessionTimeout:     10 * time.Minute,
+		SessionMaxLifetime: defaultSessionMaxLifetime,
+		AuthMethod:         "touchid",
+		UseTouchID:         bptr(true),
+		EnvAllowlist:       []string{"HOME", "PATH"},
+		DefaultProfile:     "work",
 		Profiles: map[string]*Profile{
 			"work": {VaultPath: "~/.symvault-work"},
 		},
@@ -3029,9 +3036,10 @@ func TestRoundTrip_DefaultsApplied(t *testing.T) {
 
 	// Minimal config - all defaults should apply
 	cfg := &Config{
-		VaultDir:       filepath.Join(home, DefaultVaultSubdir),
-		DefaultAgent:   "default",
-		SessionTimeout: defaultSessionTimeout,
+		VaultDir:           filepath.Join(home, DefaultVaultSubdir),
+		DefaultAgent:       "default",
+		SessionTimeout:     defaultSessionTimeout,
+		SessionMaxLifetime: defaultSessionMaxLifetime,
 		Agents: map[string]AgentProfile{
 			"default": newDefaultAgentProfile("default"),
 		},
@@ -3063,10 +3071,11 @@ func TestRoundTrip_ExplicitZeroValues(t *testing.T) {
 
 	// Config with explicitly set zero values
 	cfg := &Config{
-		VaultDir:       filepath.Join(home, DefaultVaultSubdir),
-		DefaultAgent:   "default",
-		SessionTimeout: defaultSessionTimeout,
-		AuthMethod:     "passphrase",
+		VaultDir:           filepath.Join(home, DefaultVaultSubdir),
+		DefaultAgent:       "default",
+		SessionTimeout:     defaultSessionTimeout,
+		SessionMaxLifetime: defaultSessionMaxLifetime,
+		AuthMethod:         "passphrase",
 		Agents: map[string]AgentProfile{
 			"default": {
 				Name:             "default",

--- a/internal/config/config_validate.go
+++ b/internal/config/config_validate.go
@@ -131,6 +131,10 @@ func (c *Config) Validate() error {
 		errs = errors.Join(errs, errors.New("sessionTimeout: must be greater than 0 (default: 15m, configure sessionTimeout in config.yaml)"))
 	}
 
+	if c.SessionMaxLifetime <= 0 {
+		errs = errors.Join(errs, errors.New("sessionMaxLifetime: must be greater than 0 (default: 8h, configure sessionMaxLifetime in config.yaml)"))
+	}
+
 	if c.AuthMethod != "" {
 		if _, err := NormalizeAuthMethod(c.AuthMethod); err != nil {
 			errs = errors.Join(errs, err)

--- a/internal/config/session_lifetime_test.go
+++ b/internal/config/session_lifetime_test.go
@@ -1,0 +1,38 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestDefault_SessionMaxLifetimeHasDefault(t *testing.T) {
+	cfg := Default()
+	if cfg.SessionMaxLifetime != defaultSessionMaxLifetime {
+		t.Errorf("SessionMaxLifetime = %v, want %v", cfg.SessionMaxLifetime, defaultSessionMaxLifetime)
+	}
+}
+
+func TestLoad_SessionMaxLifetimeRoundTrips(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, []byte("vaultDir: /tmp/test-vault\nsessionMaxLifetime: 2h\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.SessionMaxLifetime != 2*time.Hour {
+		t.Errorf("SessionMaxLifetime = %v, want 2h", cfg.SessionMaxLifetime)
+	}
+}
+
+func TestConfigValidate_RejectsNonPositiveSessionMaxLifetime(t *testing.T) {
+	cfg := Default()
+	cfg.SessionMaxLifetime = 0
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("Validate() error = nil, want sessionMaxLifetime validation error")
+	}
+}

--- a/internal/health/doctor_vault.go
+++ b/internal/health/doctor_vault.go
@@ -16,9 +16,10 @@ import (
 )
 
 const (
-	defaultSessionTimeout = 15 * time.Minute
-	defaultAuditMaxMB     = 100
-	defaultApprovalMode   = "deny"
+	defaultSessionTimeout     = 15 * time.Minute
+	defaultSessionMaxLifetime = 8 * time.Hour
+	defaultAuditMaxMB         = 100
+	defaultApprovalMode       = "deny"
 )
 
 func checkVaultInitialized(vaultDir string, _ Options) Result {
@@ -95,6 +96,10 @@ func fixConfigValidation(cfgPath string) error {
 	// Fix 1: sessionTimeout <= 0 → restore default
 	if cfg.SessionTimeout <= 0 {
 		cfg.SessionTimeout = defaultSessionTimeout
+		fixed = true
+	}
+	if cfg.SessionMaxLifetime <= 0 {
+		cfg.SessionMaxLifetime = defaultSessionMaxLifetime
 		fixed = true
 	}
 
@@ -283,7 +288,7 @@ func checkManifestIntegrity(vaultDir string, _ Options) Result {
 // session keyring for the given vault directory. Returns nil when no valid
 // cached identity is available.
 func loadIdentityForVault(vaultDir string) (*age.X25519Identity, error) {
-	cached, err := session.LoadIdentity(vaultDir)
+	cached, err := session.PeekIdentity(vaultDir)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/session/identity_expiry_test.go
+++ b/internal/session/identity_expiry_test.go
@@ -1,0 +1,89 @@
+package session
+
+import (
+	"testing"
+	"time"
+)
+
+func TestIsIdentityExpired_NoIdentity(t *testing.T) {
+	mgr, fake := newTestManager(t)
+
+	vaultDir := "/tmp/vault-identity-missing"
+	setupTestWrapKey(t, fake, vaultDir)
+
+	if !mgr.IsIdentityExpired(vaultDir) {
+		t.Error("IsIdentityExpired() = false, want true when no identity is cached")
+	}
+}
+
+func TestIsIdentityExpired_ValidIdentity(t *testing.T) {
+	mgr, fake := newTestManager(t)
+
+	vaultDir := "/tmp/vault-identity-valid"
+	setupTestWrapKey(t, fake, vaultDir)
+	if err := mgr.SaveIdentity(vaultDir, "AGE-SECRET-KEY-TEST", time.Hour); err != nil {
+		t.Fatalf("SaveIdentity() error = %v", err)
+	}
+
+	if mgr.IsIdentityExpired(vaultDir) {
+		t.Error("IsIdentityExpired() = true, want false for a fresh identity")
+	}
+}
+
+func TestIsIdentityExpired_ExpiredIdentity(t *testing.T) {
+	mgr, fake := newTestManager(t)
+
+	vaultDir := "/tmp/vault-identity-expired"
+	setupTestWrapKey(t, fake, vaultDir)
+	if err := mgr.SaveIdentity(vaultDir, "AGE-SECRET-KEY-TEST", time.Millisecond); err != nil {
+		t.Fatalf("SaveIdentity() error = %v", err)
+	}
+	time.Sleep(10 * time.Millisecond)
+
+	if !mgr.IsIdentityExpired(vaultDir) {
+		t.Error("IsIdentityExpired() = false, want true past the TTL")
+	}
+}
+
+func TestIsIdentityExpired_ZeroTTL(t *testing.T) {
+	mgr, fake := newTestManager(t)
+
+	vaultDir := "/tmp/vault-identity-zerottl"
+	setupTestWrapKey(t, fake, vaultDir)
+	payload := `{"saved_at":"2024-01-01T00:00:00Z","last_access":"2024-01-01T00:00:00Z","encrypted_identity":"x","nonce":"y","ttl_ns":0}`
+	if err := fake.Set(keyFor(serviceNameForVault(vaultDir), identityAccount), payload); err != nil {
+		t.Fatalf("Set() error = %v", err)
+	}
+
+	if !mgr.IsIdentityExpired(vaultDir) {
+		t.Error("IsIdentityExpired() = false, want true for a zero TTL")
+	}
+}
+
+// IsIdentityExpired must not renew the entry it inspects: a caller that only
+// probes the cache must not keep the identity alive forever.
+func TestIsIdentityExpired_DoesNotRefreshLastAccess(t *testing.T) {
+	mgr, fake := newTestManager(t)
+
+	vaultDir := "/tmp/vault-identity-norefresh"
+	setupTestWrapKey(t, fake, vaultDir)
+	if err := mgr.SaveIdentity(vaultDir, "AGE-SECRET-KEY-TEST", time.Hour); err != nil {
+		t.Fatalf("SaveIdentity() error = %v", err)
+	}
+
+	key := keyFor(serviceNameForVault(vaultDir), identityAccount)
+	before, err := fake.Get(key)
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+
+	_ = mgr.IsIdentityExpired(vaultDir)
+
+	after, err := fake.Get(key)
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if before != after {
+		t.Error("IsIdentityExpired() rewrote the identity entry; it must be read-only")
+	}
+}

--- a/internal/session/identity_expiry_test.go
+++ b/internal/session/identity_expiry_test.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 )
@@ -85,5 +86,103 @@ func TestIsIdentityExpired_DoesNotRefreshLastAccess(t *testing.T) {
 	}
 	if before != after {
 		t.Error("IsIdentityExpired() rewrote the identity entry; it must be read-only")
+	}
+}
+
+func TestIsIdentityExpired_UsesSessionMaximumLifetime(t *testing.T) {
+	mgr, fake := newTestManager(t)
+	vaultDir := "/tmp/vault-identity-session-clock"
+	setupTestWrapKey(t, fake, vaultDir)
+
+	if err := mgr.SavePassphraseWithMaxLifetime(vaultDir, []byte("passphrase"), time.Hour, time.Hour); err != nil {
+		t.Fatalf("SavePassphraseWithMaxLifetime() error = %v", err)
+	}
+	if err := mgr.SaveIdentity(vaultDir, "AGE-SECRET-KEY-TEST", time.Hour); err != nil {
+		t.Fatalf("SaveIdentity() error = %v", err)
+	}
+
+	sessionKey := keyFor(serviceNameForVault(vaultDir), sessionAccount)
+	raw, err := fake.Get(sessionKey)
+	if err != nil {
+		t.Fatalf("Get(session) error = %v", err)
+	}
+	var sess storedSession
+	if err := json.Unmarshal([]byte(raw), &sess); err != nil {
+		t.Fatalf("unmarshal session: %v", err)
+	}
+	sess.SavedAt = time.Now().UTC().Add(-2 * time.Hour)
+	sess.LastAccess = time.Now().UTC()
+	updated, err := json.Marshal(sess)
+	if err != nil {
+		t.Fatalf("marshal session: %v", err)
+	}
+	if err := fake.Set(sessionKey, string(updated)); err != nil {
+		t.Fatalf("Set(session) error = %v", err)
+	}
+
+	if !mgr.IsIdentityExpired(vaultDir) {
+		t.Error("IsIdentityExpired() = false, want true when the shared session max lifetime elapsed")
+	}
+}
+
+func TestLoadIdentityRefreshesSessionAndIdentityTogether(t *testing.T) {
+	mgr, fake := newTestManager(t)
+	vaultDir := "/tmp/vault-identity-shared-refresh"
+	setupTestWrapKey(t, fake, vaultDir)
+
+	if err := mgr.SavePassphrase(vaultDir, []byte("passphrase"), time.Hour); err != nil {
+		t.Fatalf("SavePassphrase() error = %v", err)
+	}
+	if err := mgr.SaveIdentity(vaultDir, "AGE-SECRET-KEY-TEST", time.Hour); err != nil {
+		t.Fatalf("SaveIdentity() error = %v", err)
+	}
+	time.Sleep(time.Millisecond)
+
+	sessionKey := keyFor(serviceNameForVault(vaultDir), sessionAccount)
+	identityKey := keyFor(serviceNameForVault(vaultDir), identityAccount)
+	beforeSession, _ := fake.Get(sessionKey)
+	beforeIdentity, _ := fake.Get(identityKey)
+	var sessionBefore storedSession
+	var identityBefore storedIdentity
+	_ = json.Unmarshal([]byte(beforeSession), &sessionBefore)
+	_ = json.Unmarshal([]byte(beforeIdentity), &identityBefore)
+
+	if _, err := mgr.LoadIdentity(vaultDir); err != nil {
+		t.Fatalf("LoadIdentity() error = %v", err)
+	}
+	afterSession, _ := fake.Get(sessionKey)
+	afterIdentity, _ := fake.Get(identityKey)
+	var sessionAfter storedSession
+	var identityAfter storedIdentity
+	_ = json.Unmarshal([]byte(afterSession), &sessionAfter)
+	_ = json.Unmarshal([]byte(afterIdentity), &identityAfter)
+
+	if !sessionAfter.LastAccess.After(sessionBefore.LastAccess) || !identityAfter.LastAccess.After(identityBefore.LastAccess) {
+		t.Fatal("LoadIdentity() did not refresh both cache entries")
+	}
+	if !sessionAfter.LastAccess.Equal(identityAfter.LastAccess) {
+		t.Errorf("cache refresh timestamps differ: session=%v identity=%v", sessionAfter.LastAccess, identityAfter.LastAccess)
+	}
+}
+
+func TestPeekIdentityDoesNotRefreshSession(t *testing.T) {
+	mgr, fake := newTestManager(t)
+	vaultDir := "/tmp/vault-identity-peek"
+	setupTestWrapKey(t, fake, vaultDir)
+
+	if err := mgr.SavePassphrase(vaultDir, []byte("passphrase"), time.Hour); err != nil {
+		t.Fatalf("SavePassphrase() error = %v", err)
+	}
+	if err := mgr.SaveIdentity(vaultDir, "AGE-SECRET-KEY-TEST", time.Hour); err != nil {
+		t.Fatalf("SaveIdentity() error = %v", err)
+	}
+	before, _ := fake.Get(keyFor(serviceNameForVault(vaultDir), sessionAccount))
+
+	if _, err := mgr.PeekIdentity(vaultDir); err != nil {
+		t.Fatalf("PeekIdentity() error = %v", err)
+	}
+	after, _ := fake.Get(keyFor(serviceNameForVault(vaultDir), sessionAccount))
+	if before != after {
+		t.Error("PeekIdentity() rewrote the session entry; it must be read-only")
 	}
 }

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -67,11 +67,12 @@ import (
 )
 
 const (
-	sessionAccount  = "session"
-	identityAccount = "identity"
-	wrapKeyAccount  = "wrap-key"
-	wrapKeyLen      = 32
-	aesGCMNonceLen  = 12
+	sessionAccount     = "session"
+	identityAccount    = "identity"
+	wrapKeyAccount     = "wrap-key"
+	wrapKeyLen         = 32
+	aesGCMNonceLen     = 12
+	defaultMaxLifetime = 8 * time.Hour
 )
 
 const (
@@ -122,6 +123,7 @@ type storedSession struct {
 	EncryptedPassphrase string          `json:"encrypted_passphrase,omitempty"`
 	Nonce               string          `json:"nonce,omitempty"`
 	TTL                 int64           `json:"ttl_ns"`
+	MaxLifetime         int64           `json:"max_lifetime_ns,omitempty"`
 }
 
 type storedIdentity struct {
@@ -130,6 +132,24 @@ type storedIdentity struct {
 	EncryptedIdentity string    `json:"encrypted_identity"`
 	Nonce             string    `json:"nonce"`
 	TTL               int64     `json:"ttl_ns"`
+	MaxLifetime       int64     `json:"max_lifetime_ns,omitempty"`
+}
+
+func effectiveMaxLifetime(maxLifetime int64) time.Duration {
+	if maxLifetime > 0 {
+		return time.Duration(maxLifetime)
+	}
+	return defaultMaxLifetime
+}
+
+func cacheExpired(savedAt, lastAccess time.Time, ttl, maxLifetime int64, now time.Time) bool {
+	if ttl <= 0 || savedAt.IsZero() {
+		return true
+	}
+	if lastAccess.IsZero() {
+		lastAccess = savedAt
+	}
+	return now.Sub(lastAccess) > time.Duration(ttl) || now.Sub(savedAt) > effectiveMaxLifetime(maxLifetime)
 }
 
 func generateWrapKey() ([]byte, error) {
@@ -284,6 +304,12 @@ func decryptPassphrase(encB64, nonceB64 string, key []byte) ([]byte, error) {
 // (creating the wrap key if it does not exist) and stores the encrypted
 // payload in the configured KeyringBackend.
 func (m *Manager) SavePassphrase(vaultDir string, passphrase []byte, ttl time.Duration) error {
+	return m.SavePassphraseWithMaxLifetime(vaultDir, passphrase, ttl, defaultMaxLifetime)
+}
+
+// SavePassphraseWithMaxLifetime stores an encrypted passphrase with both an
+// idle timeout and an absolute lifetime.
+func (m *Manager) SavePassphraseWithMaxLifetime(vaultDir string, passphrase []byte, ttl, maxLifetime time.Duration) error {
 	now := time.Now().UTC()
 	wrapKey, err := m.getOrCreateWrapKey(vaultDir)
 	if err != nil {
@@ -299,6 +325,7 @@ func (m *Manager) SavePassphrase(vaultDir string, passphrase []byte, ttl time.Du
 		SavedAt:             now,
 		LastAccess:          now,
 		TTL:                 int64(ttl),
+		MaxLifetime:         int64(maxLifetime),
 	})
 	if err != nil {
 		return fmt.Errorf("marshal session: %w", err)
@@ -328,6 +355,7 @@ func (m *Manager) LoadPassphrase(vaultDir string) ([]byte, error) {
 		return nil, fmt.Errorf("decode session: %w", unmarshalErr)
 	}
 
+	now := time.Now().UTC()
 	if sess.TTL <= 0 {
 		metrics.RecordSessionCacheEvent("miss")
 		return nil, fmt.Errorf("session expired for vault %s: TTL is zero or negative", sanitizeVaultDir(vaultDir))
@@ -337,10 +365,10 @@ func (m *Manager) LoadPassphrase(vaultDir string) ([]byte, error) {
 	if lastActivity.IsZero() {
 		lastActivity = sess.SavedAt
 	}
-	if time.Since(lastActivity) > time.Duration(sess.TTL) {
+	if cacheExpired(sess.SavedAt, sess.LastAccess, sess.TTL, sess.MaxLifetime, now) {
 		_ = m.ClearSession(vaultDir)
 		metrics.RecordSessionCacheEvent("miss")
-		return nil, fmt.Errorf("session expired for vault %s: last activity %v exceeded TTL %v", sanitizeVaultDir(vaultDir), lastActivity.Format(time.RFC3339), time.Duration(sess.TTL))
+		return nil, fmt.Errorf("session expired for vault %s: last activity %v exceeded TTL %v or maximum lifetime %v", sanitizeVaultDir(vaultDir), lastActivity.Format(time.RFC3339), time.Duration(sess.TTL), effectiveMaxLifetime(sess.MaxLifetime))
 	}
 
 	if len(sess.Passphrase) > 0 {
@@ -365,7 +393,7 @@ func (m *Manager) LoadPassphrase(vaultDir string) ([]byte, error) {
 		return nil, fmt.Errorf("decrypt session: %w", err)
 	}
 
-	sess.LastAccess = time.Now().UTC()
+	sess.LastAccess = now
 	payload, marshalErr := json.Marshal(sess)
 	if marshalErr != nil {
 		metrics.RecordSessionCacheEvent("hit")
@@ -409,6 +437,9 @@ func (m *Manager) MigrateSession(vaultDir string) (bool, error) {
 	}
 	sess.EncryptedPassphrase = enc
 	sess.Nonce = nonce
+	if sess.MaxLifetime <= 0 {
+		sess.MaxLifetime = int64(defaultMaxLifetime)
+	}
 	crypto.Wipe(sess.Passphrase)
 	sess.Passphrase = nil
 	payload, err := json.Marshal(sess)
@@ -461,7 +492,27 @@ func (m *Manager) ClearSession(vaultDir string) error {
 }
 
 func (m *Manager) SaveIdentity(vaultDir string, identity string, ttl time.Duration) error {
+	return m.SaveIdentityWithMaxLifetime(vaultDir, identity, ttl, defaultMaxLifetime)
+}
+
+// SaveIdentityWithMaxLifetime stores an encrypted identity using the same
+// absolute lifetime as the associated passphrase session.
+func (m *Manager) SaveIdentityWithMaxLifetime(vaultDir string, identity string, ttl, maxLifetime time.Duration) error {
 	now := time.Now().UTC()
+	savedAt := now
+	ttlNs := int64(ttl)
+	maxLifetimeNs := int64(maxLifetime)
+	if sess, found, err := m.loadStoredSession(vaultDir); err == nil && found {
+		if !sess.SavedAt.IsZero() {
+			savedAt = sess.SavedAt
+		}
+		if sess.TTL > 0 {
+			ttlNs = sess.TTL
+		}
+		if sess.MaxLifetime > 0 {
+			maxLifetimeNs = sess.MaxLifetime
+		}
+	}
 	wrapKey, err := m.getOrCreateWrapKey(vaultDir)
 	if err != nil {
 		return fmt.Errorf("wrap key: %w", err)
@@ -473,9 +524,10 @@ func (m *Manager) SaveIdentity(vaultDir string, identity string, ttl time.Durati
 	payload, err := json.Marshal(storedIdentity{
 		EncryptedIdentity: enc,
 		Nonce:             nonce,
-		SavedAt:           now,
+		SavedAt:           savedAt,
 		LastAccess:        now,
-		TTL:               int64(ttl),
+		TTL:               ttlNs,
+		MaxLifetime:       maxLifetimeNs,
 	})
 	if err != nil {
 		return fmt.Errorf("marshal identity: %w", err)
@@ -486,7 +538,32 @@ func (m *Manager) SaveIdentity(vaultDir string, identity string, ttl time.Durati
 	return nil
 }
 
+func (m *Manager) loadStoredSession(vaultDir string) (storedSession, bool, error) {
+	raw, err := m.keyring.Get(keyFor(serviceNameForVault(vaultDir), sessionAccount))
+	if err != nil {
+		if errors.Is(err, ErrKeyringNotFound) {
+			return storedSession{}, false, nil
+		}
+		return storedSession{}, true, fmt.Errorf("load session metadata: %w", err)
+	}
+	var sess storedSession
+	if err := json.Unmarshal([]byte(raw), &sess); err != nil {
+		return storedSession{}, true, fmt.Errorf("decode session metadata: %w", err)
+	}
+	return sess, true, nil
+}
+
 func (m *Manager) LoadIdentity(vaultDir string) (string, error) {
+	return m.loadIdentity(vaultDir, true)
+}
+
+// PeekIdentity loads the cached identity without updating either cache entry.
+// It is intended for health checks and other read-only probes.
+func (m *Manager) PeekIdentity(vaultDir string) (string, error) {
+	return m.loadIdentity(vaultDir, false)
+}
+
+func (m *Manager) loadIdentity(vaultDir string, renew bool) (string, error) {
 	raw, err := m.keyring.Get(keyFor(serviceNameForVault(vaultDir), identityAccount))
 	if err != nil {
 		return "", fmt.Errorf("load identity: %w", err)
@@ -497,17 +574,34 @@ func (m *Manager) LoadIdentity(vaultDir string) (string, error) {
 		return "", fmt.Errorf("decode identity: %w", unmarshalErr)
 	}
 
-	if ident.TTL <= 0 {
+	sess, sessionFound, sessionErr := m.loadStoredSession(vaultDir)
+	if sessionErr != nil {
+		return "", sessionErr
+	}
+	savedAt := ident.SavedAt
+	lastAccess := ident.LastAccess
+	ttl := ident.TTL
+	maxLifetime := ident.MaxLifetime
+	if sessionFound {
+		savedAt = sess.SavedAt
+		lastAccess = sess.LastAccess
+		ttl = sess.TTL
+		maxLifetime = sess.MaxLifetime
+	}
+	if ttl <= 0 {
 		return "", fmt.Errorf("identity cache expired for vault %s: TTL is zero or negative", sanitizeVaultDir(vaultDir))
 	}
 
-	lastActivity := ident.LastAccess
+	lastActivity := lastAccess
 	if lastActivity.IsZero() {
-		lastActivity = ident.SavedAt
+		lastActivity = savedAt
 	}
-	if time.Since(lastActivity) > time.Duration(ident.TTL) {
-		_ = m.ClearIdentity(vaultDir)
-		return "", fmt.Errorf("identity cache expired for vault %s: last activity %v exceeded TTL %v", sanitizeVaultDir(vaultDir), lastActivity.Format(time.RFC3339), time.Duration(ident.TTL))
+	now := time.Now().UTC()
+	if cacheExpired(savedAt, lastAccess, ttl, maxLifetime, now) {
+		if renew {
+			_ = m.ClearSession(vaultDir)
+		}
+		return "", fmt.Errorf("identity cache expired for vault %s: last activity %v exceeded TTL %v or maximum lifetime %v", sanitizeVaultDir(vaultDir), lastActivity.Format(time.RFC3339), time.Duration(ttl), effectiveMaxLifetime(maxLifetime))
 	}
 
 	wrapKey, wrapErr := m.loadWrapKey(vaultDir)
@@ -521,13 +615,23 @@ func (m *Manager) LoadIdentity(vaultDir string) (string, error) {
 	identityStr := string(identityBytes)
 	crypto.Wipe(identityBytes)
 
-	ident.LastAccess = time.Now().UTC()
+	if !renew {
+		return identityStr, nil
+	}
+
+	ident.LastAccess = now
 	payload, marshalErr := json.Marshal(ident)
 	if marshalErr != nil {
 		return identityStr, nil
 	}
 	if updateErr := m.keyring.Set(keyFor(serviceNameForVault(vaultDir), identityAccount), string(payload)); updateErr != nil {
 		return identityStr, nil
+	}
+	if sessionFound {
+		sess.LastAccess = now
+		if sessionPayload, sessionMarshalErr := json.Marshal(sess); sessionMarshalErr == nil {
+			_ = m.keyring.Set(keyFor(serviceNameForVault(vaultDir), sessionAccount), string(sessionPayload))
+		}
 	}
 
 	return identityStr, nil
@@ -554,15 +658,7 @@ func (m *Manager) IsSessionExpired(vaultDir string) bool {
 		return true
 	}
 
-	if sess.TTL <= 0 {
-		return true
-	}
-
-	lastActivity := sess.LastAccess
-	if lastActivity.IsZero() {
-		lastActivity = sess.SavedAt
-	}
-	return time.Since(lastActivity) > time.Duration(sess.TTL)
+	return cacheExpired(sess.SavedAt, sess.LastAccess, sess.TTL, sess.MaxLifetime, time.Now().UTC())
 }
 
 // IsIdentityExpired reports whether the cached age identity is missing,
@@ -584,11 +680,21 @@ func (m *Manager) IsIdentityExpired(vaultDir string) bool {
 		return true
 	}
 
-	lastActivity := ident.LastAccess
-	if lastActivity.IsZero() {
-		lastActivity = ident.SavedAt
+	sess, sessionFound, sessionErr := m.loadStoredSession(vaultDir)
+	if sessionErr != nil {
+		return true
 	}
-	return time.Since(lastActivity) > time.Duration(ident.TTL)
+	savedAt := ident.SavedAt
+	lastAccess := ident.LastAccess
+	ttl := ident.TTL
+	maxLifetime := ident.MaxLifetime
+	if sessionFound {
+		savedAt = sess.SavedAt
+		lastAccess = sess.LastAccess
+		ttl = sess.TTL
+		maxLifetime = sess.MaxLifetime
+	}
+	return cacheExpired(savedAt, lastAccess, ttl, maxLifetime, time.Now().UTC())
 }
 
 func (m *Manager) LoadPassphraseWithTouchID(ctx context.Context, vaultDir string) ([]byte, error) {
@@ -622,6 +728,10 @@ func SavePassphrase(vaultDir string, passphrase []byte, ttl time.Duration) error
 	return defaultManager.SavePassphrase(vaultDir, passphrase, ttl)
 }
 
+func SavePassphraseWithMaxLifetime(vaultDir string, passphrase []byte, ttl, maxLifetime time.Duration) error {
+	return defaultManager.SavePassphraseWithMaxLifetime(vaultDir, passphrase, ttl, maxLifetime)
+}
+
 func LoadPassphrase(vaultDir string) ([]byte, error) {
 	return defaultManager.LoadPassphrase(vaultDir)
 }
@@ -638,8 +748,16 @@ func SaveIdentity(vaultDir string, identity string, ttl time.Duration) error {
 	return defaultManager.SaveIdentity(vaultDir, identity, ttl)
 }
 
+func SaveIdentityWithMaxLifetime(vaultDir string, identity string, ttl, maxLifetime time.Duration) error {
+	return defaultManager.SaveIdentityWithMaxLifetime(vaultDir, identity, ttl, maxLifetime)
+}
+
 func LoadIdentity(vaultDir string) (string, error) {
 	return defaultManager.LoadIdentity(vaultDir)
+}
+
+func PeekIdentity(vaultDir string) (string, error) {
+	return defaultManager.PeekIdentity(vaultDir)
 }
 
 func IsIdentityExpired(vaultDir string) bool {

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -565,6 +565,32 @@ func (m *Manager) IsSessionExpired(vaultDir string) bool {
 	return time.Since(lastActivity) > time.Duration(sess.TTL)
 }
 
+// IsIdentityExpired reports whether the cached age identity is missing,
+// unusable, or past its TTL. Unlike LoadIdentity it neither decrypts the
+// entry nor refreshes its last-access timestamp, so callers can probe the
+// cache without extending its lifetime.
+func (m *Manager) IsIdentityExpired(vaultDir string) bool {
+	raw, err := m.keyring.Get(keyFor(serviceNameForVault(vaultDir), identityAccount))
+	if err != nil {
+		return true
+	}
+
+	var ident storedIdentity
+	if err := json.Unmarshal([]byte(raw), &ident); err != nil {
+		return true
+	}
+
+	if ident.TTL <= 0 || ident.EncryptedIdentity == "" || ident.Nonce == "" {
+		return true
+	}
+
+	lastActivity := ident.LastAccess
+	if lastActivity.IsZero() {
+		lastActivity = ident.SavedAt
+	}
+	return time.Since(lastActivity) > time.Duration(ident.TTL)
+}
+
 func (m *Manager) LoadPassphraseWithTouchID(ctx context.Context, vaultDir string) ([]byte, error) {
 	return LoadBiometricPassphrase(ctx, vaultDir)
 }
@@ -614,6 +640,10 @@ func SaveIdentity(vaultDir string, identity string, ttl time.Duration) error {
 
 func LoadIdentity(vaultDir string) (string, error) {
 	return defaultManager.LoadIdentity(vaultDir)
+}
+
+func IsIdentityExpired(vaultDir string) bool {
+	return defaultManager.IsIdentityExpired(vaultDir)
 }
 
 func ClearIdentity(vaultDir string) error {


### PR DESCRIPTION
## Problem

The macOS app could not unlock the vault. Typing the passphrase and pressing "Entsperren" appeared to do nothing — no error, no alert, straight back to the unlock screen — while the same vault stayed fully usable from the CLI.

The app unlocks in two steps: `symvault unlock` with the passphrase on stdin, then `symvault unlock --check` to confirm. Only if `--check` exits 0 does it switch to its entry list.

`UnlockVaultWithTTL` short-circuited on the cached age identity and returned **before** `SessionSavePassphrase` ever ran. Since the identity entry is renewed by every vault command while the session entry is only renewed when the passphrase is actually loaded, the two drifted apart permanently. Measured on a real vault:

```
session   last_access 2026-08-23T06:53  ttl 8h   → expired five days earlier
identity  last_access 2026-08-28T19:55  ttl 8h   → renewed by every command
```

So `unlock` reported `Vault unlocked` while never recreating the session, `unlock --check` reported `no active session` forever, and the app bounced back every time. The CLI was unaffected because `get`/`list` use the identity shortcut and never call `--check`.

The same short-circuit meant an explicit unlock verified nothing at all:

```
printf 'definitely-wrong-passphrase\n' | symvault unlock --ttl 15m
→ exit 0, "Vault unlocked (session TTL: 15m0s)"
```

## Changes

- **`internal/cli/unlock.go`** — new `UnlockVaultForSession` for the explicit `unlock` command: it skips the cached-identity shortcut, so the passphrase (or Touch ID) is verified again and the session entry is always rewritten. Every other command keeps the shortcut; serving reads from a cached identity is its whole point.
- **`cmd/auth/unlock.go`** — `unlock --check` now treats a valid cached identity as an active session. It opens the vault prompt-free exactly as a cached passphrase does, so reporting "locked" for it contradicted every other command.
- **`internal/session/session.go`** — `IsIdentityExpired`, a read-only probe that neither decrypts the entry nor renews its last-access timestamp, so checking the cache cannot extend its life.
- **`client/Sources/SymvaultFeature/VaultStore.swift`** — a reported-successful unlock that leaves no active session now surfaces a message instead of silently returning to the unlock screen.

## Verification

Measured against the affected real vault (read-only) and a throwaway vault:

| | before | after |
|---|---|---|
| `unlock --check` on the affected vault | exit 4, `no active session` | exit 0, `Session active` |
| `unlock` with a wrong passphrase | exit 0, `Vault unlocked` | exit 1, decryption error |
| `unlock` with the correct passphrase | session entry left stale | session entry rewritten |

New tests in `internal/session/identity_expiry_test.go`, `internal/cli/unlock_session_test.go` and `cmd/auth/unlock_test.go`, including one that pins the shortcut in place for the implicit path. `go test ./...` passes; `swift build --target SymvaultFeature` compiles.

## Behaviour changes to be aware of

1. A non-interactive `symvault unlock` with no credential available now fails with `ExitLocked` instead of exiting 0. The previous success was hollow — it established no session.
2. On a Touch ID vault, an explicit `unlock` with an expired session now prompts for Touch ID before falling through to a piped passphrase. Both establish the session; the credential precedence in `resolveUnlockPassphrase` is deliberately left unchanged.

## Session lifetime

Cached identity and passphrase entries now use the idle `sessionTimeout` together with the absolute `sessionMaxLifetime` (default: 8 hours). The session entry is the shared clock, and genuine identity use refreshes both entries together; read-only probes do not extend either cache.

Closes #930
Closes #932

🤖 Generated with [Claude Code](https://claude.com/claude-code)
