### PR TITLE
test: cover session lifetime error paths

### DIFF
--- a/internal/cli/session_lifetime_coverage_test.go
+++ b/internal/cli/session_lifetime_coverage_test.go
@@ -1,0 +1,99 @@
+package cli
+
+import (
+	"testing"
+	"time"
+
+	configpkg "github.com/danieljustus/symaira-vault/internal/config"
+	vaultpkg "github.com/danieljustus/symaira-vault/internal/vault"
+)
+
+func TestConfiguredSessionMaxLifetimeUsesVaultConfig(t *testing.T) {
+	if got := ConfiguredSessionMaxLifetime(nil); got != configpkg.Default().SessionMaxLifetime {
+		t.Fatalf("ConfiguredSessionMaxLifetime(nil) = %v, want default %v", got, configpkg.Default().SessionMaxLifetime)
+	}
+	want := 37 * time.Minute
+	v := &vaultpkg.Vault{Config: &configpkg.Config{SessionMaxLifetime: want}}
+	if got := ConfiguredSessionMaxLifetime(v); got != want {
+		t.Fatalf("ConfiguredSessionMaxLifetime() = %v, want %v", got, want)
+	}
+}
+
+func TestSaveSessionHelpersUseCustomMaxLifetime(t *testing.T) {
+	oldSavePassphrase := SessionSavePassphrase
+	oldSavePassphraseWithMaxLifetime := SessionSavePassphraseWithMaxLifetime
+	oldSaveIdentity := SessionSaveIdentity
+	oldSaveIdentityWithMaxLifetime := SessionSaveIdentityWithMaxLifetime
+	t.Cleanup(func() {
+		SessionSavePassphrase = oldSavePassphrase
+		SessionSavePassphraseWithMaxLifetime = oldSavePassphraseWithMaxLifetime
+		SessionSaveIdentity = oldSaveIdentity
+		SessionSaveIdentityWithMaxLifetime = oldSaveIdentityWithMaxLifetime
+	})
+
+	const vaultDir = "/tmp/vault-custom-session-lifetime"
+	const identity = "AGE-SECRET-KEY-TEST"
+	ttl := time.Hour
+	maxLifetime := 37 * time.Minute
+	passphraseCalled := false
+	identityCalled := false
+	SessionSavePassphrase = func(string, []byte, time.Duration) error {
+		t.Fatal("default passphrase saver should not be used for a custom lifetime")
+		return nil
+	}
+	SessionSaveIdentity = func(string, string, time.Duration) error {
+		t.Fatal("default identity saver should not be used for a custom lifetime")
+		return nil
+	}
+	SessionSavePassphraseWithMaxLifetime = func(gotDir string, gotPassphrase []byte, gotTTL, gotMaxLifetime time.Duration) error {
+		passphraseCalled = true
+		if gotDir != vaultDir || string(gotPassphrase) != "passphrase" || gotTTL != ttl || gotMaxLifetime != maxLifetime {
+			t.Errorf("custom passphrase saver args = %q, %q, %v, %v", gotDir, gotPassphrase, gotTTL, gotMaxLifetime)
+		}
+		return nil
+	}
+	SessionSaveIdentityWithMaxLifetime = func(gotDir, gotIdentity string, gotTTL, gotMaxLifetime time.Duration) error {
+		identityCalled = true
+		if gotDir != vaultDir || gotIdentity != identity || gotTTL != ttl || gotMaxLifetime != maxLifetime {
+			t.Errorf("custom identity saver args = %q, %q, %v, %v", gotDir, gotIdentity, gotTTL, gotMaxLifetime)
+		}
+		return nil
+	}
+
+	if err := saveSessionPassphrase(vaultDir, []byte("passphrase"), ttl, maxLifetime); err != nil {
+		t.Fatalf("saveSessionPassphrase() error = %v", err)
+	}
+	if err := saveSessionIdentity(vaultDir, identity, ttl, maxLifetime); err != nil {
+		t.Fatalf("saveSessionIdentity() error = %v", err)
+	}
+	if !passphraseCalled || !identityCalled {
+		t.Fatalf("custom savers called passphrase=%v identity=%v", passphraseCalled, identityCalled)
+	}
+}
+
+func TestUnlockVaultWithTTLRecordsInvalidCachedIdentityAsMiss(t *testing.T) {
+	passphrase := []byte("test-passphrase")
+	vaultDir := initPassphraseVault(t, passphrase)
+
+	oldLoadIdentity := SessionLoadIdentity
+	oldLoadPassphrase := SessionLoadPassphrase
+	oldSavePassphrase := SessionSavePassphrase
+	oldSaveIdentity := SessionSaveIdentity
+	t.Cleanup(func() {
+		SessionLoadIdentity = oldLoadIdentity
+		SessionLoadPassphrase = oldLoadPassphrase
+		SessionSavePassphrase = oldSavePassphrase
+		SessionSaveIdentity = oldSaveIdentity
+	})
+
+	SessionLoadIdentity = func(string) (string, error) { return "invalid identity", nil }
+	SessionLoadPassphrase = func(string) ([]byte, error) {
+		return append([]byte(nil), passphrase...), nil
+	}
+	SessionSavePassphrase = func(string, []byte, time.Duration) error { return nil }
+	SessionSaveIdentity = func(string, string, time.Duration) error { return nil }
+
+	if _, _, err := UnlockVaultWithTTL(vaultDir, false, 0, false); err != nil {
+		t.Fatalf("UnlockVaultWithTTL() error = %v", err)
+	}
+}

--- a/internal/health/doctor_vault.go
+++ b/internal/health/doctor_vault.go
@@ -16,10 +16,10 @@ import (
 )
 
 const (
-	defaultSessionTimeout     = 15 * time.Minute
-	defaultSessionMaxLifetime = 8 * time.Hour
-	defaultAuditMaxMB         = 100
-	defaultApprovalMode       = "deny"
+	defaultSessionTimeout = 15 * time.Minute
+
+	defaultAuditMaxMB   = 100
+	defaultApprovalMode = "deny"
 )
 
 func checkVaultInitialized(vaultDir string, _ Options) Result {
@@ -96,10 +96,6 @@ func fixConfigValidation(cfgPath string) error {
 	// Fix 1: sessionTimeout <= 0 → restore default
 	if cfg.SessionTimeout <= 0 {
 		cfg.SessionTimeout = defaultSessionTimeout
-		fixed = true
-	}
-	if cfg.SessionMaxLifetime <= 0 {
-		cfg.SessionMaxLifetime = defaultSessionMaxLifetime
 		fixed = true
 	}
 

--- a/internal/session/session_coverage_test.go
+++ b/internal/session/session_coverage_test.go
@@ -1,0 +1,189 @@
+package session
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+type sessionMetadataErrorKeyring struct {
+	inner *fakeKeyring
+	key   string
+	err   error
+}
+
+func (k *sessionMetadataErrorKeyring) Get(key string) (string, error) {
+	if key == k.key {
+		return "", k.err
+	}
+	return k.inner.Get(key)
+}
+
+func (k *sessionMetadataErrorKeyring) Set(key, value string) error {
+	return k.inner.Set(key, value)
+}
+
+func (k *sessionMetadataErrorKeyring) Delete(key string) error {
+	return k.inner.Delete(key)
+}
+
+func TestLoadIdentity_PropagatesSessionMetadataErrors(t *testing.T) {
+	fake := newFakeKeyring()
+	vaultDir := "/tmp/vault-identity-session-error"
+	setupTestWrapKey(t, fake, vaultDir)
+	mgr := NewManager(&sessionMetadataErrorKeyring{
+		inner: fake,
+		key:   keyFor(serviceNameForVault(vaultDir), sessionAccount),
+		err:   errors.New("session metadata unavailable"),
+	}, nil)
+	if err := mgr.SaveIdentity(vaultDir, "AGE-SECRET-KEY-TEST", time.Hour); err != nil {
+		t.Fatalf("SaveIdentity() error = %v", err)
+	}
+
+	_, err := mgr.LoadIdentity(vaultDir)
+	if err == nil || !strings.Contains(err.Error(), "session metadata unavailable") {
+		t.Fatalf("LoadIdentity() error = %v, want session metadata error", err)
+	}
+}
+
+func TestLoadIdentity_RejectsMalformedSessionMetadata(t *testing.T) {
+	mgr, fake := newTestManager(t)
+	vaultDir := "/tmp/vault-identity-malformed-session"
+	setupTestWrapKey(t, fake, vaultDir)
+	if err := mgr.SaveIdentity(vaultDir, "AGE-SECRET-KEY-TEST", time.Hour); err != nil {
+		t.Fatalf("SaveIdentity() error = %v", err)
+	}
+	if err := fake.Set(keyFor(serviceNameForVault(vaultDir), sessionAccount), "not-json"); err != nil {
+		t.Fatalf("Set() error = %v", err)
+	}
+
+	_, err := mgr.LoadIdentity(vaultDir)
+	if err == nil || !strings.Contains(err.Error(), "decode session metadata") {
+		t.Fatalf("LoadIdentity() error = %v, want decode error", err)
+	}
+}
+
+func TestLoadIdentity_EnforcesSharedMaximumLifetime(t *testing.T) {
+	mgr, fake := newTestManager(t)
+	vaultDir := "/tmp/vault-identity-max-lifetime"
+	setupTestWrapKey(t, fake, vaultDir)
+	if err := mgr.SavePassphraseWithMaxLifetime(vaultDir, []byte("passphrase"), time.Hour, time.Hour); err != nil {
+		t.Fatalf("SavePassphraseWithMaxLifetime() error = %v", err)
+	}
+	if err := mgr.SaveIdentity(vaultDir, "AGE-SECRET-KEY-TEST", time.Hour); err != nil {
+		t.Fatalf("SaveIdentity() error = %v", err)
+	}
+
+	key := keyFor(serviceNameForVault(vaultDir), sessionAccount)
+	raw, err := fake.Get(key)
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	var sess storedSession
+	if err := json.Unmarshal([]byte(raw), &sess); err != nil {
+		t.Fatalf("unmarshal session: %v", err)
+	}
+	sess.SavedAt = time.Now().UTC().Add(-2 * time.Hour)
+	sess.LastAccess = time.Now().UTC()
+	updated, err := json.Marshal(sess)
+	if err != nil {
+		t.Fatalf("marshal session: %v", err)
+	}
+	if err := fake.Set(key, string(updated)); err != nil {
+		t.Fatalf("store session: %v", err)
+	}
+
+	if _, err := mgr.LoadIdentity(vaultDir); err == nil || !strings.Contains(err.Error(), "maximum lifetime") {
+		t.Fatalf("LoadIdentity() error = %v, want maximum-lifetime expiry", err)
+	}
+	if _, err := fake.Get(key); !errors.Is(err, ErrKeyringNotFound) {
+		t.Fatalf("expired session remains cached, get error = %v", err)
+	}
+}
+
+func TestIsIdentityExpired_HandlesMalformedIdentityAndSessionErrors(t *testing.T) {
+	t.Run("malformed identity", func(t *testing.T) {
+		mgr, fake := newTestManager(t)
+		vaultDir := "/tmp/vault-identity-malformed"
+		setupTestWrapKey(t, fake, vaultDir)
+		if err := fake.Set(keyFor(serviceNameForVault(vaultDir), identityAccount), "not-json"); err != nil {
+			t.Fatalf("Set() error = %v", err)
+		}
+		if !mgr.IsIdentityExpired(vaultDir) {
+			t.Fatal("IsIdentityExpired() = false, want true for malformed identity")
+		}
+	})
+
+	t.Run("session backend error", func(t *testing.T) {
+		fake := newFakeKeyring()
+		vaultDir := "/tmp/vault-identity-session-backend-error"
+		setupTestWrapKey(t, fake, vaultDir)
+		mgr := NewManager(&sessionMetadataErrorKeyring{
+			inner: fake,
+			key:   keyFor(serviceNameForVault(vaultDir), sessionAccount),
+			err:   errors.New("session metadata unavailable"),
+		}, nil)
+		if err := mgr.SaveIdentity(vaultDir, "AGE-SECRET-KEY-TEST", time.Hour); err != nil {
+			t.Fatalf("SaveIdentity() error = %v", err)
+		}
+		if !mgr.IsIdentityExpired(vaultDir) {
+			t.Fatal("IsIdentityExpired() = false, want true when session metadata cannot be read")
+		}
+	})
+}
+
+func TestLoadIdentityFallsBackToSavedAtWhenLastAccessIsZero(t *testing.T) {
+	mgr, fake := newTestManager(t)
+	vaultDir := "/tmp/vault-identity-zero-last-access"
+	setupTestWrapKey(t, fake, vaultDir)
+	if err := mgr.SaveIdentity(vaultDir, "AGE-SECRET-KEY-TEST", time.Hour); err != nil {
+		t.Fatalf("SaveIdentity() error = %v", err)
+	}
+
+	key := keyFor(serviceNameForVault(vaultDir), identityAccount)
+	raw, err := fake.Get(key)
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	var ident storedIdentity
+	if err := json.Unmarshal([]byte(raw), &ident); err != nil {
+		t.Fatalf("unmarshal identity: %v", err)
+	}
+	ident.LastAccess = time.Time{}
+	ident.SavedAt = time.Now().UTC()
+	updated, err := json.Marshal(ident)
+	if err != nil {
+		t.Fatalf("marshal identity: %v", err)
+	}
+	if err := fake.Set(key, string(updated)); err != nil {
+		t.Fatalf("Set() error = %v", err)
+	}
+
+	if _, err := mgr.LoadIdentity(vaultDir); err != nil {
+		t.Fatalf("LoadIdentity() error = %v, want fallback to SavedAt", err)
+	}
+}
+
+func TestPackageLevelLifetimeAndIdentityHelpers(t *testing.T) {
+	original := DefaultManager()
+	t.Cleanup(func() { SetDefaultManager(original) })
+	mgr, fake := newTestManager(t)
+	SetDefaultManager(mgr)
+	vaultDir := "/tmp/vault-package-lifetime"
+	setupTestWrapKey(t, fake, vaultDir)
+
+	if err := SavePassphraseWithMaxLifetime(vaultDir, []byte("passphrase"), time.Hour, 2*time.Hour); err != nil {
+		t.Fatalf("SavePassphraseWithMaxLifetime() error = %v", err)
+	}
+	if err := SaveIdentityWithMaxLifetime(vaultDir, "AGE-SECRET-KEY-TEST", time.Hour, 2*time.Hour); err != nil {
+		t.Fatalf("SaveIdentityWithMaxLifetime() error = %v", err)
+	}
+	if _, err := PeekIdentity(vaultDir); err != nil {
+		t.Fatalf("PeekIdentity() error = %v", err)
+	}
+	if IsIdentityExpired(vaultDir) {
+		t.Fatal("IsIdentityExpired() = true, want false for fresh identity")
+	}
+}


### PR DESCRIPTION
## Summary
- add regression tests for shared session metadata errors, absolute lifetime expiry, and read-only identity checks
- verify non-default session lifetime propagation through CLI cache helpers
- remove the unreachable doctor repair branch because configuration loading already applies safe defaults

## Verification
- `make fmt`
- `make lint`
- `make test`
- `make build`
- clean-repository race-enabled coverage: 67.771878% vs 67.632990% at `v0.21.0` (+0.138888 percentage points)

Closes #933
