### PR TITLE
feat(approval): pair a phone as an approval device via QR code

### DIFF
--- a/client/Package.swift
+++ b/client/Package.swift
@@ -44,10 +44,12 @@ let package = Package(
             dependencies: [],
             path: "Sources/SymvaultIOS",
             exclude: [
+                "ApprovalsListView.swift",
                 "EnrollView.swift",
                 "EntryDetailView.swift",
                 "EntryListView.swift",
                 "MobileVaultCore.swift",
+                "PairingScanView.swift",
                 "SymvaultApp.swift",
                 "UnlockView.swift",
                 "VaultStore.swift",

--- a/client/Sources/SymvaultIOS/ApprovalDeviceClient.swift
+++ b/client/Sources/SymvaultIOS/ApprovalDeviceClient.swift
@@ -1,0 +1,213 @@
+import CryptoKit
+import Foundation
+import Security
+
+/// Errors surfaced by ApprovalDeviceClient. All are user-facing (shown via
+/// VaultStore-style `.error` propagation), so keep messages plain.
+enum ApprovalClientError: LocalizedError {
+    case invalidResponse
+    case server(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidResponse:
+            return "The server returned an unexpected response."
+        case .server(let message):
+            return message
+        }
+    }
+}
+
+/// Computes and compares certificate fingerprints for pinning. Kept
+/// separate from the URLSessionDelegate glue so the actual accept/reject
+/// decision is a pure function, testable without a real TLS handshake.
+enum CertificatePinning {
+    /// Returns the lowercase hex SHA-256 fingerprint of a certificate's DER
+    /// encoding — the same value `internal/mcp/serverbootstrap.CertFingerprint`
+    /// computes on the Go side, so the two must always agree.
+    static func fingerprint(of certificate: SecCertificate) -> String {
+        let data = SecCertificateCopyData(certificate) as Data
+        let digest = SHA256.hash(data: data)
+        return digest.map { String(format: "%02x", $0) }.joined()
+    }
+
+    /// Reports whether `certificate`'s fingerprint matches `expected`
+    /// (case-insensitive). This is the entire trust decision for a pinned
+    /// connection — callers must fail closed (reject) on `false`, never
+    /// fall back to system trust evaluation.
+    static func matches(_ certificate: SecCertificate, expected: String) -> Bool {
+        fingerprint(of: certificate) == expected.lowercased()
+    }
+}
+
+/// A URLSessionDelegate that pins a connection to one exact certificate
+/// fingerprint, ignoring standard hostname/CA validation. This is
+/// deliberate: the server's self-signed certificate only covers loopback
+/// SANs, and the trust anchor here is the fingerprint the user scanned from
+/// a physically-displayed QR code, not a certificate authority. Any
+/// mismatch fails the handshake — there is no fallback to system trust.
+final class PinnedSessionDelegate: NSObject, URLSessionDelegate, @unchecked Sendable {
+    private let expectedFingerprint: String
+
+    init(expectedFingerprint: String) {
+        self.expectedFingerprint = expectedFingerprint
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        didReceive challenge: URLAuthenticationChallenge,
+        completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+    ) {
+        guard challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust,
+              let serverTrust = challenge.protectionSpace.serverTrust,
+              let chain = SecTrustCopyCertificateChain(serverTrust) as? [SecCertificate],
+              let leaf = chain.first,
+              CertificatePinning.matches(leaf, expected: expectedFingerprint)
+        else {
+            completionHandler(.cancelAuthenticationChallenge, nil)
+            return
+        }
+        completionHandler(.useCredential, URLCredential(trust: serverTrust))
+    }
+}
+
+/// The minimal networking seam ApprovalDeviceClient depends on, so tests
+/// can assert on request shape without opening real sockets. The production
+/// implementation wraps a URLSession configured with PinnedSessionDelegate;
+/// tests substitute a closure-based fake.
+protocol ApprovalTransport: Sendable {
+    func send(_ request: URLRequest) async throws -> (Data, HTTPURLResponse)
+}
+
+/// Production transport: a pinned URLSession per call, since each call may
+/// target a different fingerprint (enrollment happens before a session
+/// exists) and URLSessionDelegate is fixed at session-creation time.
+struct URLSessionApprovalTransport: ApprovalTransport {
+    let fingerprint: String
+
+    func send(_ request: URLRequest) async throws -> (Data, HTTPURLResponse) {
+        let delegate = PinnedSessionDelegate(expectedFingerprint: fingerprint)
+        let session = URLSession(configuration: .ephemeral, delegate: delegate, delegateQueue: nil)
+        defer { session.finishTasksAndInvalidate() }
+        let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            throw ApprovalClientError.invalidResponse
+        }
+        return (data, http)
+    }
+}
+
+/// Talks to the approval-device HTTP surface (`internal/approval`): device
+/// enrollment, listing pending requests, and approving/denying them. Every
+/// call is over a connection pinned to the fingerprint supplied at
+/// construction — there is no unpinned code path.
+struct ApprovalDeviceClient: @unchecked Sendable {
+    private let transportFactory: @Sendable (String) -> any ApprovalTransport
+    private let decoder: JSONDecoder
+    private let encoder: JSONEncoder
+
+    init(transportFactory: @escaping @Sendable (String) -> any ApprovalTransport = { URLSessionApprovalTransport(fingerprint: $0) }) {
+        self.transportFactory = transportFactory
+        self.decoder = Self.makeDecoder()
+        self.encoder = JSONEncoder()
+    }
+
+    private static func makeDecoder() -> JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .custom { decoder in
+            let container = try decoder.singleValueContainer()
+            let raw = try container.decode(String.self)
+            // Formatters are created fresh here (not captured from an outer
+            // scope) so this closure — which JSONDecoder requires to be
+            // @Sendable — never crosses a non-Sendable value across an
+            // isolation boundary.
+            let withFraction = ISO8601DateFormatter()
+            withFraction.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+            if let date = withFraction.date(from: raw) { return date }
+            let plain = ISO8601DateFormatter()
+            plain.formatOptions = [.withInternetDateTime]
+            if let date = plain.date(from: raw) { return date }
+            throw DecodingError.dataCorruptedError(in: container, debugDescription: "Unrecognized date format: \(raw)")
+        }
+        return decoder
+    }
+
+    private func baseURL(host: String, port: Int) -> String {
+        "https://\(host):\(port)"
+    }
+
+    /// Exchanges a pairing code (scanned or typed from the QR payload) for a
+    /// long-lived device session, via `POST /api/v1/devices/enroll`.
+    func enroll(payload: ApprovalPairingPayload, deviceName: String) async throws -> ApprovalSession {
+        guard let url = URL(string: baseURL(host: payload.host, port: payload.port) + "/api/v1/devices/enroll") else {
+            throw ApprovalClientError.invalidResponse
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try encoder.encode([
+            "code": payload.code,
+            "device_name": deviceName,
+            "public_key": "",
+        ])
+
+        let (data, response) = try await transportFactory(payload.fingerprint).send(request)
+        try Self.checkStatus(response, data: data, decoder: decoder)
+        let decoded = try decoder.decode(ApprovalEnrollResponse.self, from: data)
+        return ApprovalSession(
+            token: decoded.token,
+            deviceID: decoded.deviceID,
+            host: payload.host,
+            port: payload.port,
+            fingerprint: payload.fingerprint,
+            expiresAt: decoded.expiresAt
+        )
+    }
+
+    /// Lists pending approval requests via `GET /api/v1/approvals`.
+    func fetchPendingApprovals(session: ApprovalSession) async throws -> [ApprovalRequest] {
+        guard let url = URL(string: baseURL(host: session.host, port: session.port) + "/api/v1/approvals") else {
+            throw ApprovalClientError.invalidResponse
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(session.token)", forHTTPHeaderField: "Authorization")
+
+        let (data, response) = try await transportFactory(session.fingerprint).send(request)
+        try Self.checkStatus(response, data: data, decoder: decoder)
+        let decoded = try decoder.decode(PendingApprovalsResponse.self, from: data)
+        return decoded.requests
+    }
+
+    /// Approves or denies one pending request via
+    /// `POST /api/v1/approvals/{id}/approve|deny`.
+    func decide(session: ApprovalSession, requestID: String, approve: Bool) async throws {
+        let action = approve ? "approve" : "deny"
+        guard let url = URL(string: baseURL(host: session.host, port: session.port) + "/api/v1/approvals/\(requestID)/\(action)") else {
+            throw ApprovalClientError.invalidResponse
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(session.token)", forHTTPHeaderField: "Authorization")
+
+        let (data, response) = try await transportFactory(session.fingerprint).send(request)
+        try Self.checkStatus(response, data: data, decoder: decoder)
+    }
+
+    private static func checkStatus(_ response: HTTPURLResponse, data: Data, decoder: JSONDecoder) throws {
+        guard (200...299).contains(response.statusCode) else {
+            if let apiError = try? decoder.decode(APIErrorResponse.self, from: data) {
+                throw ApprovalClientError.server(apiError.error)
+            }
+            throw ApprovalClientError.server("Request failed with status \(response.statusCode).")
+        }
+    }
+}
+
+private struct PendingApprovalsResponse: Codable {
+    let requests: [ApprovalRequest]
+}
+
+private struct APIErrorResponse: Codable {
+    let error: String
+}

--- a/client/Sources/SymvaultIOS/ApprovalModels.swift
+++ b/client/Sources/SymvaultIOS/ApprovalModels.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+/// A pending (or decided) agent credential request, as returned by
+/// `GET /api/v1/approvals`. Field names match the Go `approval.Entry`
+/// struct's default (untagged) JSON encoding — PascalCase, not snake_case.
+struct ApprovalRequest: Identifiable, Codable, Equatable {
+    let id: String
+    let agentName: String
+    let path: String
+    let write: Bool
+    let reason: String
+    let createdAt: Date
+    let expiresAt: Date
+    let status: String
+
+    enum CodingKeys: String, CodingKey {
+        case id = "ID"
+        case agentName = "AgentName"
+        case path = "Path"
+        case write = "Write"
+        case reason = "Reason"
+        case createdAt = "CreatedAt"
+        case expiresAt = "ExpiresAt"
+        case status = "Status"
+    }
+}
+
+/// The pairing payload scanned from (or manually entered from) the QR code
+/// shown by `symvault device approval-pair`. Carries the entire trust story
+/// for the connection: where to reach the server, the one-time code to
+/// redeem, and the certificate fingerprint to pin to.
+struct ApprovalPairingPayload: Codable, Equatable {
+    let host: String
+    let port: Int
+    let code: String
+    let fingerprint: String
+}
+
+/// An enrolled approval-device session, persisted in the Keychain via
+/// ApprovalSessionStore. Everything a subsequent request needs to reach and
+/// authenticate against the paired server.
+struct ApprovalSession: Codable, Equatable {
+    let token: String
+    let deviceID: String
+    let host: String
+    let port: Int
+    let fingerprint: String
+    let expiresAt: Date
+}
+
+/// The response body of `POST /api/v1/devices/enroll`.
+struct ApprovalEnrollResponse: Codable, Equatable {
+    let token: String
+    let deviceID: String
+    let expiresAt: Date
+
+    enum CodingKeys: String, CodingKey {
+        case token
+        case deviceID = "device_id"
+        case expiresAt = "expires_at"
+    }
+}

--- a/client/Sources/SymvaultIOS/ApprovalSessionStore.swift
+++ b/client/Sources/SymvaultIOS/ApprovalSessionStore.swift
@@ -1,0 +1,57 @@
+import Foundation
+import Security
+
+/// Keychain storage for the enrolled approval-device session. Unlike
+/// DeviceIdentityStore's master identity, this item deliberately has NO
+/// biometric ACL: ApprovalsStore polls it every few seconds in the
+/// background, and a biometric-gated read would prompt Face ID on every
+/// poll. Face ID gating happens instead at the moment of approving a
+/// request (see ApprovalsStore.approve), not at reading this session.
+@MainActor
+enum ApprovalSessionStore {
+    static let service = "com.symaira.vault.approvalSession"
+    static let account = "session"
+
+    static func save(_ session: ApprovalSession) throws {
+        let data = try JSONEncoder().encode(session)
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecValueData as String: data,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
+        ]
+        SecItemDelete(query as CFDictionary)
+        let status = SecItemAdd(query as CFDictionary, nil)
+        guard status == errSecSuccess else {
+            throw NSError(domain: "ApprovalSessionStore", code: Int(status),
+                          userInfo: [NSLocalizedDescriptionKey: "Could not store approval session (\(status))"])
+        }
+    }
+
+    static func read() throws -> ApprovalSession {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        guard status == errSecSuccess, let data = item as? Data else {
+            throw NSError(domain: "ApprovalSessionStore", code: Int(status),
+                          userInfo: [NSLocalizedDescriptionKey: "No approval session available (\(status))"])
+        }
+        return try JSONDecoder().decode(ApprovalSession.self, from: data)
+    }
+
+    static func clear() {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+        ]
+        SecItemDelete(query as CFDictionary)
+    }
+}

--- a/client/Sources/SymvaultIOS/ApprovalsListView.swift
+++ b/client/Sources/SymvaultIOS/ApprovalsListView.swift
@@ -1,0 +1,91 @@
+import SwiftUI
+
+/// The pending-approvals screen: either a pairing prompt (no approval
+/// device enrolled yet) or the live list of pending agent requests, with
+/// Face-ID-gated approve and plain deny actions.
+struct ApprovalsListView: View {
+    @EnvironmentObject private var approvalsStore: ApprovalsStore
+    @State private var showPairing = false
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if !approvalsStore.isPaired {
+                    ContentUnavailableView {
+                        Label("Not Paired", systemImage: "iphone.and.arrow.forward")
+                    } description: {
+                        Text("Pair this phone as an approval device to approve or deny agent credential requests.")
+                    } actions: {
+                        Button("Pair Device") { showPairing = true }
+                            .buttonStyle(.borderedProminent)
+                    }
+                } else if approvalsStore.pending.isEmpty {
+                    ContentUnavailableView("No Pending Requests", systemImage: "checkmark.shield")
+                } else {
+                    List(approvalsStore.pending) { request in
+                        ApprovalRow(request: request)
+                    }
+                }
+            }
+            .navigationTitle("Approvals")
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    if approvalsStore.isBusy { ProgressView().controlSize(.small) }
+                }
+            }
+            .refreshable { await approvalsStore.refresh() }
+            .task { if approvalsStore.isPaired { approvalsStore.startPolling() } }
+            .onDisappear { approvalsStore.stopPolling() }
+            .sheet(isPresented: $showPairing) {
+                PairingScanView()
+                    .environmentObject(approvalsStore)
+                    .onDisappear {
+                        if approvalsStore.isPaired { approvalsStore.startPolling() }
+                    }
+            }
+            .alert("Error", isPresented: Binding(
+                get: { approvalsStore.error != nil },
+                set: { if !$0 { approvalsStore.error = nil } }
+            )) {
+                Button("OK", role: .cancel) {}
+            } message: {
+                Text(approvalsStore.error ?? "")
+            }
+        }
+    }
+}
+
+private struct ApprovalRow: View {
+    @EnvironmentObject private var approvalsStore: ApprovalsStore
+    let request: ApprovalRequest
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(request.agentName)
+                .font(.headline)
+            Text(request.path)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+            if !request.reason.isEmpty {
+                Text(request.reason)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+            HStack {
+                Label(request.write ? "Write" : "Read", systemImage: request.write ? "pencil" : "eye")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Button("Deny", role: .destructive) {
+                    Task { await approvalsStore.deny(request) }
+                }
+                .buttonStyle(.bordered)
+                Button("Approve") {
+                    Task { await approvalsStore.approve(request) }
+                }
+                .buttonStyle(.borderedProminent)
+            }
+        }
+        .padding(.vertical, 4)
+    }
+}

--- a/client/Sources/SymvaultIOS/ApprovalsStore.swift
+++ b/client/Sources/SymvaultIOS/ApprovalsStore.swift
@@ -1,0 +1,104 @@
+import Foundation
+import LocalAuthentication
+import SwiftUI
+
+/// Drives the pending-approvals screen: polls the paired server, and
+/// approves/denies requests. Mirrors VaultStore's shape (published state +
+/// async methods that set `error` on failure) for consistency with the rest
+/// of the app.
+@MainActor
+final class ApprovalsStore: ObservableObject {
+    @Published var pending: [ApprovalRequest] = []
+    @Published var isBusy = false
+    @Published var error: String?
+
+    private let client: ApprovalDeviceClient
+    private var pollTask: Task<Void, Never>?
+    private let pollInterval: Duration
+
+    /// Injected so tests can bypass the real LAContext biometric prompt.
+    /// Production default performs a real Face ID/Touch ID/passcode check.
+    var biometricAuthenticator: (String) async -> Bool = { reason in
+        await withCheckedContinuation { continuation in
+            let context = LAContext()
+            context.evaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, localizedReason: reason) { success, _ in
+                continuation.resume(returning: success)
+            }
+        }
+    }
+
+    init(client: ApprovalDeviceClient = ApprovalDeviceClient(), pollInterval: Duration = .seconds(4)) {
+        self.client = client
+        self.pollInterval = pollInterval
+    }
+
+    var isPaired: Bool {
+        (try? ApprovalSessionStore.read()) != nil
+    }
+
+    func pair(with payload: ApprovalPairingPayload, deviceName: String) async {
+        isBusy = true
+        error = nil
+        defer { isBusy = false }
+        do {
+            let session = try await client.enroll(payload: payload, deviceName: deviceName)
+            try ApprovalSessionStore.save(session)
+        } catch {
+            self.error = error.localizedDescription
+        }
+    }
+
+    func startPolling() {
+        stopPolling()
+        pollTask = Task { [weak self] in
+            while let self, !Task.isCancelled {
+                await self.refresh()
+                try? await Task.sleep(for: self.pollInterval)
+            }
+        }
+    }
+
+    func stopPolling() {
+        pollTask?.cancel()
+        pollTask = nil
+    }
+
+    func refresh() async {
+        guard let session = try? ApprovalSessionStore.read() else {
+            pending = []
+            return
+        }
+        do {
+            pending = try await client.fetchPendingApprovals(session: session)
+        } catch {
+            self.error = error.localizedDescription
+        }
+    }
+
+    /// Approves a pending request. Requires a fresh biometric confirmation —
+    /// matches the issue's "Face ID to approve" scope; deny does not gate on
+    /// biometrics since it grants nothing.
+    func approve(_ request: ApprovalRequest) async {
+        guard let session = try? ApprovalSessionStore.read() else { return }
+        let reason = "Approve \(request.agentName)'s request to \(request.write ? "write" : "read") \(request.path)"
+        guard await biometricAuthenticator(reason) else { return }
+        await decide(session: session, request: request, approve: true)
+    }
+
+    func deny(_ request: ApprovalRequest) async {
+        guard let session = try? ApprovalSessionStore.read() else { return }
+        await decide(session: session, request: request, approve: false)
+    }
+
+    private func decide(session: ApprovalSession, request: ApprovalRequest, approve: Bool) async {
+        isBusy = true
+        error = nil
+        defer { isBusy = false }
+        do {
+            try await client.decide(session: session, requestID: request.id, approve: approve)
+            pending.removeAll { $0.id == request.id }
+        } catch {
+            self.error = error.localizedDescription
+        }
+    }
+}

--- a/client/Sources/SymvaultIOS/EntryListView.swift
+++ b/client/Sources/SymvaultIOS/EntryListView.swift
@@ -3,6 +3,8 @@ import SwiftUI
 /// Read-only browse list. Selecting an entry shows its detail (copy enabled).
 struct EntryListView: View {
     @EnvironmentObject private var store: VaultStore
+    @EnvironmentObject private var approvalsStore: ApprovalsStore
+    @State private var showApprovals = false
 
     var body: some View {
         NavigationStack {
@@ -32,8 +34,30 @@ struct EntryListView: View {
                 ToolbarItem(placement: .topBarTrailing) {
                     if store.isBusy { ProgressView().controlSize(.small) }
                 }
+                ToolbarItem(placement: .topBarLeading) {
+                    Button {
+                        showApprovals = true
+                    } label: {
+                        ZStack(alignment: .topTrailing) {
+                            Image(systemName: "checkmark.shield")
+                            if approvalsStore.pending.count > 0 {
+                                Text("\(approvalsStore.pending.count)")
+                                    .font(.caption2.bold())
+                                    .foregroundStyle(.white)
+                                    .padding(3)
+                                    .background(Circle().fill(.red))
+                                    .offset(x: 10, y: -8)
+                            }
+                        }
+                    }
+                    .accessibilityLabel("Approvals")
+                }
             }
             .refreshable { await store.loadEntries() }
+            .sheet(isPresented: $showApprovals) {
+                ApprovalsListView()
+                    .environmentObject(approvalsStore)
+            }
         }
     }
 }

--- a/client/Sources/SymvaultIOS/PairingScanView.swift
+++ b/client/Sources/SymvaultIOS/PairingScanView.swift
@@ -1,0 +1,140 @@
+import SwiftUI
+import UIKit
+import VisionKit
+
+/// Pairing entry point: scan the QR code shown by
+/// `symvault device approval-pair`, or paste/type its JSON payload manually.
+/// Manual entry exists both as an accessibility fallback and because QR
+/// scanning needs a real camera — it never works in the iOS Simulator.
+struct PairingScanView: View {
+    @EnvironmentObject private var approvalsStore: ApprovalsStore
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var manualPayload: String = ""
+    @State private var deviceName: String = UIDevice.current.name
+    @State private var showScanner = false
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    TextField("Device name", text: $deviceName)
+                } header: {
+                    Text("This device")
+                }
+
+                Section {
+                    if DataScannerViewController.isSupported && DataScannerViewController.isAvailable {
+                        Button {
+                            showScanner = true
+                        } label: {
+                            Label("Scan QR Code", systemImage: "qrcode.viewfinder")
+                        }
+                    } else {
+                        Text("Camera scanning is not available on this device.")
+                            .foregroundStyle(.secondary)
+                    }
+                } header: {
+                    Text("Scan")
+                }
+
+                Section {
+                    TextEditor(text: $manualPayload)
+                        .frame(minHeight: 100)
+                        .font(.system(.body, design: .monospaced))
+                    Button("Pair") {
+                        Task { await pairManually() }
+                    }
+                    .disabled(manualPayload.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || approvalsStore.isBusy)
+                } header: {
+                    Text("Or enter manually")
+                } footer: {
+                    Text("Paste the text shown below the QR code on your Mac.")
+                }
+
+                if let error = approvalsStore.error {
+                    Section {
+                        Text(error).foregroundStyle(.red)
+                    }
+                }
+            }
+            .navigationTitle("Pair Approval Device")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+            }
+            .overlay {
+                if approvalsStore.isBusy {
+                    ProgressView()
+                }
+            }
+            .sheet(isPresented: $showScanner) {
+                QRScannerRepresentable { scanned in
+                    showScanner = false
+                    Task { await pair(scanned) }
+                }
+            }
+        }
+    }
+
+    private func pairManually() async {
+        await pair(manualPayload)
+    }
+
+    private func pair(_ raw: String) async {
+        guard let data = raw.trimmingCharacters(in: .whitespacesAndNewlines).data(using: .utf8),
+              let payload = try? JSONDecoder().decode(ApprovalPairingPayload.self, from: data)
+        else {
+            approvalsStore.error = "Could not read the pairing code. Copy the exact text shown by 'symvault device approval-pair'."
+            return
+        }
+        await approvalsStore.pair(with: payload, deviceName: deviceName)
+        if approvalsStore.error == nil {
+            dismiss()
+        }
+    }
+}
+
+/// Wraps VisionKit's DataScannerViewController to recognize a QR code and
+/// hand its raw payload string back to SwiftUI.
+private struct QRScannerRepresentable: UIViewControllerRepresentable {
+    let onScan: (String) -> Void
+
+    func makeUIViewController(context: Context) -> DataScannerViewController {
+        let controller = DataScannerViewController(
+            recognizedDataTypes: [.barcode(symbologies: [.qr])],
+            qualityLevel: .balanced,
+            isHighlightingEnabled: true
+        )
+        controller.delegate = context.coordinator
+        try? controller.startScanning()
+        return controller
+    }
+
+    func updateUIViewController(_ uiViewController: DataScannerViewController, context: Context) {}
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onScan: onScan)
+    }
+
+    final class Coordinator: NSObject, DataScannerViewControllerDelegate {
+        private let onScan: (String) -> Void
+        private var handled = false
+
+        init(onScan: @escaping (String) -> Void) {
+            self.onScan = onScan
+        }
+
+        func dataScanner(_ dataScanner: DataScannerViewController, didAdd addedItems: [RecognizedItem], allItems: [RecognizedItem]) {
+            guard !handled else { return }
+            for item in addedItems {
+                if case let .barcode(barcode) = item, let payload = barcode.payloadStringValue {
+                    handled = true
+                    onScan(payload)
+                    return
+                }
+            }
+        }
+    }
+}

--- a/client/Sources/SymvaultIOS/SymvaultApp.swift
+++ b/client/Sources/SymvaultIOS/SymvaultApp.swift
@@ -3,6 +3,7 @@ import SwiftUI
 @main
 struct SymvaultIOSApp: App {
     @StateObject private var store = VaultStore()
+    @StateObject private var approvalsStore = ApprovalsStore()
 
     var body: some Scene {
         WindowGroup {
@@ -16,6 +17,7 @@ struct SymvaultIOSApp: App {
                 }
             }
             .environmentObject(store)
+            .environmentObject(approvalsStore)
             .alert("Error", isPresented: Binding(
                 get: { store.error != nil },
                 set: { if !$0 { store.error = nil } }

--- a/client/Tests/SymvaultIOSTests/ApprovalDeviceClientTests.swift
+++ b/client/Tests/SymvaultIOSTests/ApprovalDeviceClientTests.swift
@@ -1,0 +1,115 @@
+import Foundation
+import Testing
+
+@testable import SymvaultIOS
+
+/// Records every request it sees and replays canned responses in order.
+/// Marked @unchecked Sendable: tests drive it sequentially with `await`, so
+/// there is no real concurrent access despite the protocol requiring
+/// Sendable for production use across actor boundaries.
+private final class FakeTransport: ApprovalTransport, @unchecked Sendable {
+    private(set) var requests: [URLRequest] = []
+    private var responses: [(Data, HTTPURLResponse)]
+
+    init(responses: [(Data, HTTPURLResponse)]) {
+        self.responses = responses
+    }
+
+    func send(_ request: URLRequest) async throws -> (Data, HTTPURLResponse) {
+        requests.append(request)
+        guard !responses.isEmpty else {
+            fatalError("FakeTransport ran out of canned responses")
+        }
+        return responses.removeFirst()
+    }
+}
+
+private func jsonResponse(_ status: Int, _ body: [String: Any]) -> (Data, HTTPURLResponse) {
+    let data = try! JSONSerialization.data(withJSONObject: body)
+    let response = HTTPURLResponse(url: URL(string: "https://127.0.0.1:1")!, statusCode: status, httpVersion: nil, headerFields: nil)!
+    return (data, response)
+}
+
+@Test func enrollSendsExpectedRequestAndParsesResponse() async throws {
+    let transport = FakeTransport(responses: [
+        jsonResponse(200, ["token": "tok-abc", "device_id": "dev-1", "expires_at": "2026-08-30T12:00:00Z"]),
+    ])
+    let client = ApprovalDeviceClient(transportFactory: { _ in transport })
+    let payload = ApprovalPairingPayload(host: "192.168.1.42", port: 8443, code: "CODE123", fingerprint: "fp-1")
+
+    let session = try await client.enroll(payload: payload, deviceName: "iPhone")
+
+    #expect(session.token == "tok-abc")
+    #expect(session.deviceID == "dev-1")
+    #expect(session.host == "192.168.1.42")
+    #expect(session.port == 8443)
+    #expect(session.fingerprint == "fp-1")
+
+    #expect(transport.requests.count == 1)
+    let request = transport.requests[0]
+    #expect(request.httpMethod == "POST")
+    #expect(request.url?.absoluteString == "https://192.168.1.42:8443/api/v1/devices/enroll")
+    let body = try #require(request.httpBody)
+    let decoded = try JSONSerialization.jsonObject(with: body) as? [String: String]
+    #expect(decoded?["code"] == "CODE123")
+    #expect(decoded?["device_name"] == "iPhone")
+}
+
+@Test func enrollThrowsServerErrorMessage() async throws {
+    let transport = FakeTransport(responses: [
+        jsonResponse(401, ["error": "invalid or expired pairing code"]),
+    ])
+    let client = ApprovalDeviceClient(transportFactory: { _ in transport })
+    let payload = ApprovalPairingPayload(host: "127.0.0.1", port: 1, code: "bad", fingerprint: "fp")
+
+    await #expect(throws: ApprovalClientError.self) {
+        _ = try await client.enroll(payload: payload, deviceName: "iPhone")
+    }
+}
+
+@Test func fetchPendingApprovalsSendsBearerTokenAndParsesEntries() async throws {
+    let transport = FakeTransport(responses: [
+        jsonResponse(200, [
+            "requests": [
+                [
+                    "ID": "apr-1",
+                    "AgentName": "agent-a",
+                    "Path": "work/creds",
+                    "Write": true,
+                    "Reason": "test",
+                    "CreatedAt": "2026-08-30T12:00:00.123456+02:00",
+                    "ExpiresAt": "2026-08-30T12:05:00Z",
+                    "Status": "pending",
+                ],
+            ],
+        ]),
+    ])
+    let client = ApprovalDeviceClient(transportFactory: { _ in transport })
+    let session = ApprovalSession(token: "tok-1", deviceID: "dev-1", host: "127.0.0.1", port: 8443, fingerprint: "fp-1", expiresAt: Date())
+
+    let pending = try await client.fetchPendingApprovals(session: session)
+
+    #expect(pending.count == 1)
+    #expect(pending[0].id == "apr-1")
+    #expect(pending[0].agentName == "agent-a")
+    #expect(pending[0].path == "work/creds")
+    #expect(pending[0].write == true)
+
+    let request = transport.requests[0]
+    #expect(request.httpMethod == "GET")
+    #expect(request.url?.absoluteString == "https://127.0.0.1:8443/api/v1/approvals")
+    #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer tok-1")
+}
+
+@Test func decideSendsApproveAndDenyToCorrectPaths() async throws {
+    let transport = FakeTransport(responses: [jsonResponse(200, [:]), jsonResponse(200, [:])])
+    let client = ApprovalDeviceClient(transportFactory: { _ in transport })
+    let session = ApprovalSession(token: "tok-1", deviceID: "dev-1", host: "127.0.0.1", port: 1, fingerprint: "fp", expiresAt: Date())
+
+    try await client.decide(session: session, requestID: "apr-1", approve: true)
+    try await client.decide(session: session, requestID: "apr-1", approve: false)
+
+    #expect(transport.requests[0].url?.absoluteString == "https://127.0.0.1:1/api/v1/approvals/apr-1/approve")
+    #expect(transport.requests[1].url?.absoluteString == "https://127.0.0.1:1/api/v1/approvals/apr-1/deny")
+    #expect(transport.requests[0].httpMethod == "POST")
+}

--- a/client/Tests/SymvaultIOSTests/ApprovalSessionStoreTests.swift
+++ b/client/Tests/SymvaultIOSTests/ApprovalSessionStoreTests.swift
@@ -1,0 +1,68 @@
+import Foundation
+import Testing
+
+@testable import SymvaultIOS
+
+/// Spike: confirms a non-biometric-ACL Keychain item round-trips in the SPM
+/// test sandbox on this host, before ApprovalsStore is built on top of that
+/// assumption. Unlike DeviceIdentityStore's biometric-gated item (which can
+/// only be tested via failure injection), ApprovalSessionStore uses
+/// kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly with no biometry flag,
+/// so a real save/read/clear should not require any UI interaction.
+@MainActor
+@Test func approvalSessionStoreRoundTrips() throws {
+    ApprovalSessionStore.clear()
+    defer { ApprovalSessionStore.clear() }
+
+    let session = ApprovalSession(
+        token: "tok-123",
+        deviceID: "dev-abc",
+        host: "192.168.1.42",
+        port: 8443,
+        fingerprint: "deadbeef",
+        expiresAt: Date(timeIntervalSince1970: 1_800_000_000)
+    )
+    try ApprovalSessionStore.save(session)
+
+    let read = try ApprovalSessionStore.read()
+    #expect(read == session)
+}
+
+@MainActor
+@Test func approvalSessionStoreReadFailsWhenEmpty() {
+    ApprovalSessionStore.clear()
+    #expect(throws: (any Error).self) {
+        try ApprovalSessionStore.read()
+    }
+}
+
+@MainActor
+@Test func approvalSessionStoreClearRemovesSession() throws {
+    let session = ApprovalSession(
+        token: "tok-123", deviceID: "dev-abc", host: "127.0.0.1", port: 1,
+        fingerprint: "fp", expiresAt: Date()
+    )
+    try ApprovalSessionStore.save(session)
+    ApprovalSessionStore.clear()
+    #expect(throws: (any Error).self) {
+        try ApprovalSessionStore.read()
+    }
+}
+
+@MainActor
+@Test func approvalSessionStoreOverwritesExistingSession() throws {
+    defer { ApprovalSessionStore.clear() }
+    let first = ApprovalSession(
+        token: "tok-1", deviceID: "dev-1", host: "127.0.0.1", port: 1,
+        fingerprint: "fp1", expiresAt: Date()
+    )
+    let second = ApprovalSession(
+        token: "tok-2", deviceID: "dev-2", host: "127.0.0.1", port: 2,
+        fingerprint: "fp2", expiresAt: Date()
+    )
+    try ApprovalSessionStore.save(first)
+    try ApprovalSessionStore.save(second)
+
+    let read = try ApprovalSessionStore.read()
+    #expect(read == second)
+}

--- a/client/Tests/SymvaultIOSTests/CertificatePinningTests.swift
+++ b/client/Tests/SymvaultIOSTests/CertificatePinningTests.swift
@@ -1,0 +1,57 @@
+import Foundation
+import Security
+import Testing
+
+@testable import SymvaultIOS
+
+/// A short-lived, throwaway self-signed test certificate (P-256, CN=test),
+/// generated once via `openssl req -x509 -newkey ec ...` purely as DER bytes
+/// to feed into SecCertificateCreateWithData — it is never used to actually
+/// terminate TLS, so its validity period does not matter.
+private let testCertificateDER = Data(base64Encoded: """
+MIIBcjCCARmgAwIBAgIUbIPB+TCDg6Qvp9JopVtO7ClBs9cwCgYIKoZIzj0EAwIw\
+DzENMAsGA1UEAwwEdGVzdDAeFw0yNjA4MzAxMDQwNTJaFw0yNjA4MzExMDQwNTJa\
+MA8xDTALBgNVBAMMBHRlc3QwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAShQ9VM\
+BB6FuEbqHEiiCbhbB/uYaW64ZpRtM6Fp4csRrJ+yigYMjhlMgD5ssNIQaCMzfdPj\
+ZIwg1lWRQYcMfdQXo1MwUTAdBgNVHQ4EFgQUve5LUCsd4OS7sLpaJEPSLr5i6jww\
+HwYDVR0jBBgwFoAUve5LUCsd4OS7sLpaJEPSLr5i6jwwDwYDVR0TAQH/BAUwAwEB\
+/zAKBggqhkjOPQQDAgNHADBEAiArLCtQQyPRguc4M0TbYO2lZSCFL4adWKg0XaqC\
+1dPvzAIgf5iToo5iv9q+QHdP4zmUAEP/zVwFvXQEnUFCgr64TY0=
+""")!
+
+/// Ground truth computed independently via `shasum -a 256` on the raw DER
+/// bytes above, not via any code in this repo — this is what makes the test
+/// meaningful (it would not catch a bug shared between the fixture and the
+/// code under test if both used the same computation).
+private let expectedFingerprint = "59498b4dea6fa14b0939d69f2d4e395f08a7edc7171bcc80481c4f79916aa5e9"
+
+private func makeTestCertificate() throws -> SecCertificate {
+    guard let cert = SecCertificateCreateWithData(nil, testCertificateDER as CFData) else {
+        throw TestSetupError.certificateCreationFailed
+    }
+    return cert
+}
+
+private enum TestSetupError: Error {
+    case certificateCreationFailed
+}
+
+@Test func fingerprintMatchesIndependentlyComputedValue() throws {
+    let cert = try makeTestCertificate()
+    #expect(CertificatePinning.fingerprint(of: cert) == expectedFingerprint)
+}
+
+@Test func matchesAcceptsCorrectFingerprint() throws {
+    let cert = try makeTestCertificate()
+    #expect(CertificatePinning.matches(cert, expected: expectedFingerprint))
+}
+
+@Test func matchesIsCaseInsensitive() throws {
+    let cert = try makeTestCertificate()
+    #expect(CertificatePinning.matches(cert, expected: expectedFingerprint.uppercased()))
+}
+
+@Test func matchesRejectsWrongFingerprint() throws {
+    let cert = try makeTestCertificate()
+    #expect(!CertificatePinning.matches(cert, expected: "0000000000000000000000000000000000000000000000000000000000000000"))
+}

--- a/client/project.yml
+++ b/client/project.yml
@@ -89,6 +89,8 @@ targets:
         product: SymvaultFeature
       - sdk: LocalAuthentication.framework
       - sdk: Security.framework
+      - sdk: VisionKit.framework
+      - sdk: CryptoKit.framework
     sources:
       - path: Sources/SymvaultIOS
     entitlements:
@@ -103,5 +105,8 @@ targets:
         INFOPLIST_KEY_CFBundleName: Symaira Vault
         INFOPLIST_KEY_UIApplicationSceneManifest_Generation: NO
         INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents: YES
+        INFOPLIST_KEY_NSCameraUsageDescription: "Symaira Vault uses the camera to scan a pairing QR code shown on your Mac."
+        INFOPLIST_KEY_NSFaceIDUsageDescription: "Symaira Vault uses Face ID to unlock your device identity and to confirm approval decisions."
+        INFOPLIST_KEY_NSLocalNetworkUsageDescription: "Symaira Vault connects to your Mac on the local network to pair as an approval device and to check for pending approval requests."
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         ENABLE_HARDENED_RUNTIME: NO

--- a/cmd/cmd_reg_test.go
+++ b/cmd/cmd_reg_test.go
@@ -140,7 +140,7 @@ func TestSubcommandRegistration(t *testing.T) {
 		}
 	}
 
-	deviceSubcommands := []string{"pair", "join", "accept", "list", "revoke"}
+	deviceSubcommands := []string{"pair", "join", "accept", "list", "revoke", "approval-pair", "approval-list", "approval-revoke"}
 	for _, sub := range deviceSubcommands {
 		found := false
 		deviceCmd, _, _ := NewRootCmd().Find([]string{"device"})

--- a/cmd/device.go
+++ b/cmd/device.go
@@ -52,6 +52,9 @@ and 'symvault device join' on the new device to join the vault.`,
 	c.AddCommand(newDeviceListCmd())
 	c.AddCommand(newDeviceRevokeCmd())
 	c.AddCommand(newDeviceAddCmd())
+	c.AddCommand(newDeviceApprovalPairCmd())
+	c.AddCommand(newDeviceApprovalListCmd())
+	c.AddCommand(newDeviceApprovalRevokeCmd())
 	return c
 }
 

--- a/cmd/device_approval.go
+++ b/cmd/device_approval.go
@@ -127,7 +127,7 @@ func mintApprovalEnrollCode(vaultDir string, port int) (code string, expiresAt t
 	if err != nil {
 		return "", time.Time{}, "", fmt.Errorf("ensure TLS certificate: %w", err)
 	}
-	pemBytes, err := os.ReadFile(certFile)
+	pemBytes, err := os.ReadFile(certFile) // #nosec G304 -- certFile is EnsureTLSCert's own fixed filename under vaultDir, same security domain
 	if err != nil {
 		return "", time.Time{}, "", fmt.Errorf("read TLS certificate: %w", err)
 	}

--- a/cmd/device_approval.go
+++ b/cmd/device_approval.go
@@ -1,0 +1,274 @@
+package cmd
+
+import (
+	"bytes"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/danieljustus/symaira-vault/internal/approval"
+	cli "github.com/danieljustus/symaira-vault/internal/cli"
+	errorspkg "github.com/danieljustus/symaira-vault/internal/errors"
+	mcputil "github.com/danieljustus/symaira-vault/internal/mcp"
+	"github.com/danieljustus/symaira-vault/internal/mcp/serverbootstrap"
+	"github.com/danieljustus/symaira-vault/internal/pairing"
+	"github.com/danieljustus/symaira-vault/internal/ui"
+	"github.com/danieljustus/symaira-vault/internal/ui/cliout"
+	vaultpkg "github.com/danieljustus/symaira-vault/internal/vault"
+)
+
+var approvalPairHost string
+
+// approvalPairingPayload is the JSON scanned/pasted by the iOS app to pair
+// as an approval device. It carries the entire trust story for the
+// connection: host/port to reach the server, the one-time code to redeem,
+// and the SHA-256 fingerprint the phone pins its TLS connection to.
+type approvalPairingPayload struct {
+	Host        string `json:"host"`
+	Port        int    `json:"port"`
+	Code        string `json:"code"`
+	Fingerprint string `json:"fingerprint"`
+}
+
+func newDeviceApprovalPairCmd() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "approval-pair",
+		Short: "Pair a phone as an approval device for agent credential requests",
+		Long: `Generate a QR code a phone can scan to become an approval device: a
+device that can approve or deny agent write requests when approval mode is
+"prompt". This is unrelated to 'symvault device pair', which pairs a
+second computer for vault-content sync and re-encrypts every entry —
+approval-pair only grants the ability to approve/deny agent requests and
+never touches vault encryption or entry content.
+
+Requires 'symvault serve' to already be running with TLS (the default),
+since the phone pins its connection to the server's certificate
+fingerprint rather than trusting a certificate authority.`,
+		Example: `  symvault device approval-pair
+  symvault device approval-pair --host 192.168.1.42`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			vaultDir, err := cli.VaultPath()
+			if err != nil {
+				return err
+			}
+			if !vaultpkg.IsInitialized(vaultDir) {
+				return errorspkg.NewVaultNotInitialized()
+			}
+
+			port, ok := cli.LoadRuntimePort(vaultDir)
+			if !ok {
+				return fmt.Errorf("could not find the running server's port — is 'symvault serve' running?")
+			}
+
+			host := strings.TrimSpace(approvalPairHost)
+			if host == "" {
+				candidates, detectErr := mcputil.DetectLANIPv4()
+				if detectErr != nil || len(candidates) == 0 {
+					return fmt.Errorf("could not auto-detect a LAN address; pass --host <ip> explicitly")
+				}
+				if len(candidates) > 1 {
+					var b strings.Builder
+					b.WriteString("multiple network addresses found; pass --host to pick one:\n")
+					for _, ip := range candidates {
+						fmt.Fprintf(&b, "  %s\n", ip)
+					}
+					return fmt.Errorf("%s", b.String())
+				}
+				host = candidates[0].String()
+			}
+
+			code, expiresAt, fingerprint, err := mintApprovalEnrollCode(vaultDir, port)
+			if err != nil {
+				return fmt.Errorf("mint pairing code: %w", err)
+			}
+
+			payload := approvalPairingPayload{Host: host, Port: port, Code: code, Fingerprint: fingerprint}
+			payloadJSON, err := json.Marshal(payload)
+			if err != nil {
+				return fmt.Errorf("marshal pairing payload: %w", err)
+			}
+
+			qrArt, qrErr := ui.RenderQRCodeForWidth(string(payloadJSON), cliout.TermWidth())
+
+			printQuietAware("\n=== Approval Device Pairing ===\n\n")
+			if qrErr != nil {
+				printQuietAware("(QR code not shown: %v)\n\n", qrErr)
+			} else {
+				printQuietAware("%s\n", qrArt)
+			}
+			printQuietAware("Scan this with the Symaira Vault iOS app, or enter it manually:\n\n")
+			printQuietAware("  Host:        %s\n", host)
+			printQuietAware("  Port:        %d\n", port)
+			printQuietAware("  Code:        %s\n", code)
+			printQuietAware("  Fingerprint: %s\n", fingerprint)
+			printQuietAware("\nExpires: %s\n", expiresAt.Format(time.RFC3339))
+			return nil
+		},
+	}
+	c.Flags().StringVar(&approvalPairHost, "host", "", "LAN address the phone should connect to (auto-detected when omitted)")
+	return c
+}
+
+// mintApprovalEnrollCode asks the already-running "symvault serve" process,
+// over its localhost-only enroll-code endpoint, to mint a short-lived
+// pairing code. It trusts exactly the certificate cached in vaultDir (the
+// same one the server presents), not the system trust store — this is a
+// same-machine call to the server's own loopback address, not the LAN path
+// a phone would take.
+func mintApprovalEnrollCode(vaultDir string, port int) (code string, expiresAt time.Time, fingerprint string, err error) {
+	certFile, _, err := serverbootstrap.EnsureTLSCert(vaultDir)
+	if err != nil {
+		return "", time.Time{}, "", fmt.Errorf("ensure TLS certificate: %w", err)
+	}
+	pemBytes, err := os.ReadFile(certFile)
+	if err != nil {
+		return "", time.Time{}, "", fmt.Errorf("read TLS certificate: %w", err)
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(pemBytes) {
+		return "", time.Time{}, "", fmt.Errorf("parse TLS certificate")
+	}
+	client := &http.Client{
+		Timeout: 10 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{RootCAs: pool, MinVersion: tls.VersionTLS12},
+		},
+	}
+
+	url := fmt.Sprintf("https://127.0.0.1:%d%s", port, approval.PathDeviceEnrollCode)
+	resp, err := client.Post(url, "application/json", bytes.NewReader(nil))
+	if err != nil {
+		return "", time.Time{}, "", fmt.Errorf("call %s (is 'symvault serve' running with TLS?): %w", approval.PathDeviceEnrollCode, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		var apiErr struct {
+			Error string `json:"error"`
+		}
+		_ = json.NewDecoder(resp.Body).Decode(&apiErr)
+		if apiErr.Error != "" {
+			return "", time.Time{}, "", fmt.Errorf("%s", apiErr.Error)
+		}
+		return "", time.Time{}, "", fmt.Errorf("unexpected status %d", resp.StatusCode)
+	}
+
+	var out struct {
+		Code        string    `json:"code"`
+		ExpiresAt   time.Time `json:"expires_at"`
+		Fingerprint string    `json:"fingerprint"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return "", time.Time{}, "", fmt.Errorf("decode response: %w", err)
+	}
+	return out.Code, out.ExpiresAt, out.Fingerprint, nil
+}
+
+func newDeviceApprovalListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "approval-list",
+		Short: "List devices enrolled as approval devices",
+		Long: `List devices that can approve or deny agent credential requests
+(enrolled via 'symvault device approval-pair'). This is a different device
+registry from 'symvault device list', which shows vault-content sync
+devices — an approval device cannot decrypt vault entries, it can only
+approve or deny agent requests.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			vaultDir, err := cli.VaultPath()
+			if err != nil {
+				return err
+			}
+			store, err := pairing.NewDeviceSessionStore(vaultDir)
+			if err != nil {
+				return fmt.Errorf("load approval device store: %w", err)
+			}
+			sessions := store.List()
+			if len(sessions) == 0 {
+				printQuietAware("No approval devices enrolled.\n")
+				return nil
+			}
+			printQuietAware("%-24s %-24s %-20s %-20s %s\n", "DEVICE ID", "NAME", "ENROLLED", "EXPIRES", "STATUS")
+			for _, s := range sessions {
+				status := "active"
+				switch {
+				case s.Revoked:
+					status = "revoked"
+				case time.Now().After(s.ExpiresAt):
+					status = "expired"
+				}
+				name := s.Name
+				if name == "" {
+					name = "(unnamed)"
+				}
+				printQuietAware("%-24s %-24s %-20s %-20s %s\n",
+					s.DeviceID, name, s.CreatedAt.Format("2006-01-02 15:04"), s.ExpiresAt.Format("2006-01-02 15:04"), status)
+			}
+			return nil
+		},
+	}
+}
+
+func newDeviceApprovalRevokeCmd() *cobra.Command {
+	var yes bool
+	c := &cobra.Command{
+		Use:   "approval-revoke <device-id>",
+		Short: "Revoke an approval device's ability to approve/deny requests",
+		Long: `Revoke a device enrolled via 'symvault device approval-pair', so it can
+no longer approve or deny agent credential requests. This does NOT
+re-encrypt or otherwise affect vault entries — it only invalidates that
+device's approval-decision bearer token. For revoking a vault-content sync
+device instead, use 'symvault device revoke <name>' (a different, more
+destructive command that re-encrypts every entry).`,
+		Example: `  symvault device approval-list
+  symvault device approval-revoke dev-abc123`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			deviceID := args[0]
+			vaultDir, err := cli.VaultPath()
+			if err != nil {
+				return err
+			}
+			store, err := pairing.NewDeviceSessionStore(vaultDir)
+			if err != nil {
+				return fmt.Errorf("load approval device store: %w", err)
+			}
+
+			found := false
+			for _, s := range store.List() {
+				if s.DeviceID == deviceID {
+					found = true
+					break
+				}
+			}
+			if !found {
+				return fmt.Errorf("approval device %q not found", deviceID)
+			}
+
+			if !yes {
+				fmt.Fprintf(os.Stderr, "This will revoke approval device %q. Continue? [y/N]: ", deviceID)
+				var answer string
+				_, _ = fmt.Fscanln(os.Stdin, &answer)
+				if strings.ToLower(strings.TrimSpace(answer)) != "y" {
+					fmt.Fprintln(os.Stderr, "Canceled")
+					return nil
+				}
+			}
+
+			store.Revoke(deviceID)
+			if err := store.Save(); err != nil {
+				return fmt.Errorf("save approval device store: %w", err)
+			}
+			printQuietAware("Approval device %q revoked.\n", deviceID)
+			return nil
+		},
+	}
+	c.Flags().BoolVarP(&yes, "yes", "y", false, "Skip confirmation prompt")
+	return c
+}

--- a/cmd/device_approval_test.go
+++ b/cmd/device_approval_test.go
@@ -1,0 +1,115 @@
+package cmd
+
+import (
+	"crypto/tls"
+	"encoding/json"
+	"net"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/danieljustus/symaira-vault/internal/approval"
+	"github.com/danieljustus/symaira-vault/internal/mcp/serverbootstrap"
+	"github.com/danieljustus/symaira-vault/internal/pairing"
+)
+
+func TestApprovalPairingPayload_JSONShape(t *testing.T) {
+	payload := approvalPairingPayload{Host: "192.168.1.42", Port: 8443, Code: "ABCD1234", Fingerprint: "deadbeef"}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for _, key := range []string{"host", "port", "code", "fingerprint"} {
+		if _, ok := decoded[key]; !ok {
+			t.Errorf("expected JSON key %q in pairing payload, got %v", key, decoded)
+		}
+	}
+}
+
+// TestMintApprovalEnrollCode_RoundTrip exercises the full HTTPS call
+// mintApprovalEnrollCode makes to the local enroll-code endpoint, using the
+// exact same cert-generation/pinning code paths serve_deps.go and
+// device_approval.go use in production: a real TLS listener presenting the
+// vault directory's cached certificate, trusted only because
+// mintApprovalEnrollCode loads that same certificate file — not the system
+// trust store.
+func TestMintApprovalEnrollCode_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+
+	certFile, keyFile, err := serverbootstrap.EnsureTLSCert(dir)
+	if err != nil {
+		t.Fatalf("EnsureTLSCert: %v", err)
+	}
+	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+	if err != nil {
+		t.Fatalf("LoadX509KeyPair: %v", err)
+	}
+
+	codes := pairing.NewTokenStore()
+	handler := approval.NewEnrollCodeHTTPHandler(codes, "fp-test", func(string) bool { return true })
+
+	srv := httptest.NewUnstartedServer(handler)
+	srv.TLS = &tls.Config{Certificates: []tls.Certificate{cert}}
+	srv.StartTLS()
+	defer srv.Close()
+
+	_, portStr, err := net.SplitHostPort(srv.Listener.Addr().String())
+	if err != nil {
+		t.Fatalf("split host port: %v", err)
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		t.Fatalf("parse port: %v", err)
+	}
+
+	code, expiresAt, fingerprint, err := mintApprovalEnrollCode(dir, port)
+	if err != nil {
+		t.Fatalf("mintApprovalEnrollCode: %v", err)
+	}
+	if code == "" {
+		t.Error("expected a non-empty code")
+	}
+	if fingerprint != "fp-test" {
+		t.Errorf("fingerprint = %q, want fp-test", fingerprint)
+	}
+	if expiresAt.IsZero() {
+		t.Error("expected a non-zero expiry")
+	}
+
+	if _, ok := codes.Validate(code); !ok {
+		t.Error("minted code did not validate against the same store")
+	}
+}
+
+func TestMintApprovalEnrollCode_RejectsUntrustedServer(t *testing.T) {
+	dir := t.TempDir()
+	// Deliberately do NOT create a cert in dir before starting the test
+	// server with its own self-generated (different) certificate, so the
+	// pinned client should refuse to trust it.
+	codes := pairing.NewTokenStore()
+	handler := approval.NewEnrollCodeHTTPHandler(codes, "fp-test", func(string) bool { return true })
+
+	srv := httptest.NewTLSServer(handler)
+	defer srv.Close()
+
+	_, portStr, err := net.SplitHostPort(srv.Listener.Addr().String())
+	if err != nil {
+		t.Fatalf("split host port: %v", err)
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		t.Fatalf("parse port: %v", err)
+	}
+
+	if _, _, err := serverbootstrap.EnsureTLSCert(dir); err != nil {
+		t.Fatalf("EnsureTLSCert: %v", err)
+	}
+
+	if _, _, _, err := mintApprovalEnrollCode(dir, port); err == nil {
+		t.Fatal("expected an error connecting to a server presenting an untrusted certificate")
+	}
+}

--- a/cmd/mcp/serve_deps.go
+++ b/cmd/mcp/serve_deps.go
@@ -19,6 +19,7 @@ import (
 	"github.com/danieljustus/symaira-vault/internal/approval"
 	"github.com/danieljustus/symaira-vault/internal/config"
 	errorspkg "github.com/danieljustus/symaira-vault/internal/errors"
+	mcputil "github.com/danieljustus/symaira-vault/internal/mcp"
 	server "github.com/danieljustus/symaira-vault/internal/mcp/server"
 	"github.com/danieljustus/symaira-vault/internal/mcp/serverbootstrap"
 	"github.com/danieljustus/symaira-vault/internal/pairing"
@@ -46,8 +47,14 @@ var RunStdioServerFunc = func(ctx context.Context, vault *vaultpkg.Vault, agentN
 // decides) and is exposed to devices via the /api/v1/approvals transport.
 var ApprovalQueue = approval.NewQueue()
 
+// EnrollCodes is the shared short-lived pairing-code store for the serve
+// process. "symvault device approval-pair" mints a code through the
+// localhost-only enroll-code endpoint; a device redeems it via the public
+// enroll endpoint to become an approval device.
+var EnrollCodes = pairing.NewTokenStore()
+
 // RunHTTPServerWithApproval starts the HTTP server with the device approval
-// transport mounted alongside the MCP endpoints.
+// and enrollment transports mounted alongside the MCP endpoints.
 func RunHTTPServerWithApproval(ctx context.Context, bind string, port int, vault *vaultpkg.Vault) error {
 	vaultDir, _ := cli.VaultPath()
 	sessionStore, err := NewDeviceSessionStoreFunc(vaultDir)
@@ -56,8 +63,22 @@ func RunHTTPServerWithApproval(ctx context.Context, bind string, port int, vault
 	}
 	_ = sessionStore.StartCleanup(ctx, 15*time.Minute)
 	approvalHandler := approval.NewHTTPHandler(ApprovalQueue, approval.NewPairingTokenValidator(sessionStore))
+
+	// The fingerprint is computed once at server startup (the cert is cached
+	// to disk and only regenerated if deleted) and handed to every minted
+	// pairing code, so a phone that scans the QR pins to the exact cert this
+	// server is presenting.
+	fingerprint, fpErr := serverbootstrap.CertFingerprint(vaultDir)
+	if fpErr != nil {
+		cliout.Warnf("could not compute TLS certificate fingerprint; device pairing is disabled: %v", fpErr)
+	}
+	enrollCodeHandler := approval.NewEnrollCodeHTTPHandler(EnrollCodes, fingerprint, mcputil.IsLoopbackHost)
+	enrollHandler := approval.NewEnrollHTTPHandler(EnrollCodes, sessionStore)
+
 	return serverbootstrap.RunHTTPServer(ctx, bind, port, vault, vaultDir, Version, newServerWithApproval,
-		serverbootstrap.WithApprovalAPI(approvalHandler))
+		serverbootstrap.WithApprovalAPI(approvalHandler),
+		serverbootstrap.WithDeviceEnrollAPI(enrollHandler),
+		serverbootstrap.WithDeviceEnrollCodeAPI(enrollCodeHandler))
 }
 
 var RunHTTPServerFunc = RunHTTPServerWithApproval

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -1588,7 +1588,7 @@ func TestRunHTTPServerFunc_ApprovalDeviceSession(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewDeviceSessionStore: %v", err)
 	}
-	enrolledToken, err := store.Enroll("device-1", "age1testpublickey")
+	enrolledToken, err := store.Enroll("device-1", "Test Device One", "age1testpublickey")
 	if err != nil {
 		t.Fatalf("Enroll: %v", err)
 	}
@@ -1729,7 +1729,7 @@ func TestRunHTTPServerFunc_ApprovalDeviceSession(t *testing.T) {
 	// Per-device failed attempts: device-2 should not be affected by
 	// device-1's failures (if any). We verify this by enrolling device-2
 	// after device-1 was revoked and confirming it can still list.
-	device2Token, err := store.Enroll("device-2", "age1device2key")
+	device2Token, err := store.Enroll("device-2", "Test Device Two", "age1device2key")
 	if err != nil {
 		t.Fatalf("Enroll device-2: %v", err)
 	}

--- a/internal/approval/enroll.go
+++ b/internal/approval/enroll.go
@@ -1,0 +1,151 @@
+package approval
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/danieljustus/symaira-vault/internal/pairing"
+)
+
+// HTTP paths for device enrollment.
+const (
+	// PathDeviceEnrollCode mints a short-lived pairing code. Localhost-only:
+	// it is how "symvault device approval-pair" asks the already-running
+	// server for a code to embed in the pairing QR code.
+	PathDeviceEnrollCode = "/api/v1/devices/enroll-code"
+	// PathDeviceEnroll exchanges a pairing code for a long-lived device
+	// session bearer token. Reachable from the LAN, like PathApprovals.
+	PathDeviceEnroll = "/api/v1/devices/enroll"
+)
+
+// loopbackChecker is the minimal surface EnrollCodeHTTPHandler needs to
+// decide whether a request's remote address is loopback. Satisfied by
+// internal/mcp.IsLoopbackHost; abstracted here purely to avoid importing
+// net/http-adjacent packages, not for testability beyond the default.
+type loopbackChecker func(host string) bool
+
+// EnrollCodeHTTPHandler mints short-lived device-pairing codes for
+// PathDeviceEnrollCode. It must only ever be reachable from loopback — the
+// caller (cmd/mcp/serve_deps.go) is responsible for constructing it with a
+// fingerprint computed once at server startup, since a nil/empty fingerprint
+// means TLS isn't configured and pairing must be refused rather than handing
+// out a code that can't be safely used.
+type EnrollCodeHTTPHandler struct {
+	codes       *pairing.TokenStore
+	fingerprint string
+	isLoopback  loopbackChecker
+}
+
+// NewEnrollCodeHTTPHandler creates the local-only pairing-code minting
+// handler. fingerprint is the SHA-256 fingerprint of the server's current
+// TLS certificate (see internal/mcp/serverbootstrap.CertFingerprint); an
+// empty fingerprint means TLS isn't available and every mint request is
+// refused, since a device pairing without a pinned fingerprint would have no
+// trust anchor.
+func NewEnrollCodeHTTPHandler(codes *pairing.TokenStore, fingerprint string, isLoopback func(host string) bool) *EnrollCodeHTTPHandler {
+	return &EnrollCodeHTTPHandler{codes: codes, fingerprint: fingerprint, isLoopback: isLoopback}
+}
+
+func (h *EnrollCodeHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.NotFound(w, r)
+		return
+	}
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		host = r.RemoteAddr
+	}
+	if h.isLoopback == nil || !h.isLoopback(host) {
+		writeApprovalError(w, http.StatusForbidden, "device pairing codes can only be minted from localhost")
+		return
+	}
+	if h.fingerprint == "" {
+		writeApprovalError(w, http.StatusServiceUnavailable, "TLS is not configured; device pairing requires TLS")
+		return
+	}
+	token, err := pairing.GenerateToken()
+	if err != nil {
+		writeApprovalError(w, http.StatusInternalServerError, "generate pairing code")
+		return
+	}
+	if err := h.codes.Store(token, ""); err != nil {
+		writeApprovalError(w, http.StatusInternalServerError, "store pairing code")
+		return
+	}
+	writeApprovalJSON(w, http.StatusOK, map[string]any{
+		"code":        token.String(),
+		"expires_at":  time.Now().UTC().Add(pairing.TokenTTL),
+		"fingerprint": h.fingerprint,
+	})
+}
+
+// EnrollHTTPHandler exchanges a pairing code minted by EnrollCodeHTTPHandler
+// for a long-lived device session bearer token, via PathDeviceEnroll.
+type EnrollHTTPHandler struct {
+	codes    *pairing.TokenStore
+	sessions *pairing.DeviceSessionStore
+}
+
+// NewEnrollHTTPHandler creates the device-enrollment handler. sessions
+// should be the same DeviceSessionStore instance the approval HTTP handler
+// validates bearer tokens against, so an enrolled device can use its token
+// immediately.
+func NewEnrollHTTPHandler(codes *pairing.TokenStore, sessions *pairing.DeviceSessionStore) *EnrollHTTPHandler {
+	return &EnrollHTTPHandler{codes: codes, sessions: sessions}
+}
+
+type enrollRequest struct {
+	Code       string `json:"code"`
+	DeviceName string `json:"device_name"`
+	PublicKey  string `json:"public_key"`
+}
+
+func (h *EnrollHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.NotFound(w, r)
+		return
+	}
+	var req enrollRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeApprovalError(w, http.StatusBadRequest, "malformed request body")
+		return
+	}
+	req.Code = strings.TrimSpace(req.Code)
+	if req.Code == "" {
+		writeApprovalError(w, http.StatusBadRequest, "missing pairing code")
+		return
+	}
+	if _, ok := h.codes.Validate(req.Code); !ok {
+		writeApprovalError(w, http.StatusUnauthorized, "invalid or expired pairing code")
+		return
+	}
+	deviceID, err := generateDeviceID()
+	if err != nil {
+		writeApprovalError(w, http.StatusInternalServerError, "generate device id")
+		return
+	}
+	token, err := h.sessions.Enroll(deviceID, req.DeviceName, req.PublicKey)
+	if err != nil {
+		writeApprovalError(w, http.StatusInternalServerError, "enroll device")
+		return
+	}
+	writeApprovalJSON(w, http.StatusOK, map[string]any{
+		"token":      token,
+		"device_id":  deviceID,
+		"expires_at": time.Now().UTC().Add(pairing.DefaultSessionTTL),
+	})
+}
+
+func generateDeviceID() (string, error) {
+	b := make([]byte, 8)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("generate device id: %w", err)
+	}
+	return "dev-" + hex.EncodeToString(b), nil
+}

--- a/internal/approval/enroll_test.go
+++ b/internal/approval/enroll_test.go
@@ -1,0 +1,218 @@
+package approval
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/danieljustus/symaira-vault/internal/pairing"
+)
+
+func alwaysLoopback(string) bool { return true }
+func neverLoopback(string) bool  { return false }
+
+func TestEnrollCodeHTTPHandler_RejectsNonLoopback(t *testing.T) {
+	codes := pairing.NewTokenStore()
+	h := NewEnrollCodeHTTPHandler(codes, "fp-1", neverLoopback)
+
+	req := httptest.NewRequest(http.MethodPost, PathDeviceEnrollCode, nil)
+	req.RemoteAddr = "203.0.113.5:1234"
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", rec.Code)
+	}
+}
+
+func TestEnrollCodeHTTPHandler_RejectsWithoutFingerprint(t *testing.T) {
+	codes := pairing.NewTokenStore()
+	h := NewEnrollCodeHTTPHandler(codes, "", alwaysLoopback)
+
+	req := httptest.NewRequest(http.MethodPost, PathDeviceEnrollCode, nil)
+	req.RemoteAddr = "127.0.0.1:1234"
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", rec.Code)
+	}
+}
+
+func TestEnrollCodeHTTPHandler_RejectsNonPost(t *testing.T) {
+	codes := pairing.NewTokenStore()
+	h := NewEnrollCodeHTTPHandler(codes, "fp-1", alwaysLoopback)
+
+	req := httptest.NewRequest(http.MethodGet, PathDeviceEnrollCode, nil)
+	req.RemoteAddr = "127.0.0.1:1234"
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+}
+
+func TestEnrollCodeHTTPHandler_MintsCode(t *testing.T) {
+	codes := pairing.NewTokenStore()
+	h := NewEnrollCodeHTTPHandler(codes, "fp-1", alwaysLoopback)
+
+	req := httptest.NewRequest(http.MethodPost, PathDeviceEnrollCode, nil)
+	req.RemoteAddr = "127.0.0.1:1234"
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body %s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Code        string `json:"code"`
+		Fingerprint string `json:"fingerprint"`
+		ExpiresAt   string `json:"expires_at"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.Code == "" {
+		t.Fatal("expected a non-empty code")
+	}
+	if resp.Fingerprint != "fp-1" {
+		t.Fatalf("fingerprint = %q, want fp-1", resp.Fingerprint)
+	}
+	if resp.ExpiresAt == "" {
+		t.Fatal("expected a non-empty expires_at")
+	}
+
+	// The minted code must actually validate against the same store.
+	if _, ok := codes.Validate(resp.Code); !ok {
+		t.Fatal("minted code did not validate")
+	}
+}
+
+func TestEnrollHTTPHandler_RejectsMalformedBody(t *testing.T) {
+	codes := pairing.NewTokenStore()
+	sessions, err := pairing.NewDeviceSessionStore("")
+	if err != nil {
+		t.Fatalf("NewDeviceSessionStore: %v", err)
+	}
+	h := NewEnrollHTTPHandler(codes, sessions)
+
+	req := httptest.NewRequest(http.MethodPost, PathDeviceEnroll, bytes.NewBufferString("not json"))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+}
+
+func TestEnrollHTTPHandler_RejectsMissingCode(t *testing.T) {
+	codes := pairing.NewTokenStore()
+	sessions, err := pairing.NewDeviceSessionStore("")
+	if err != nil {
+		t.Fatalf("NewDeviceSessionStore: %v", err)
+	}
+	h := NewEnrollHTTPHandler(codes, sessions)
+
+	body, _ := json.Marshal(map[string]string{"device_name": "iPhone"})
+	req := httptest.NewRequest(http.MethodPost, PathDeviceEnroll, bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+}
+
+func TestEnrollHTTPHandler_RejectsInvalidCode(t *testing.T) {
+	codes := pairing.NewTokenStore()
+	sessions, err := pairing.NewDeviceSessionStore("")
+	if err != nil {
+		t.Fatalf("NewDeviceSessionStore: %v", err)
+	}
+	h := NewEnrollHTTPHandler(codes, sessions)
+
+	body, _ := json.Marshal(map[string]string{"code": "bogus-code", "device_name": "iPhone"})
+	req := httptest.NewRequest(http.MethodPost, PathDeviceEnroll, bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rec.Code)
+	}
+}
+
+func TestEnrollHTTPHandler_Success(t *testing.T) {
+	codes := pairing.NewTokenStore()
+	sessions, err := pairing.NewDeviceSessionStore("")
+	if err != nil {
+		t.Fatalf("NewDeviceSessionStore: %v", err)
+	}
+	h := NewEnrollHTTPHandler(codes, sessions)
+
+	token, err := pairing.GenerateToken()
+	if err != nil {
+		t.Fatalf("GenerateToken: %v", err)
+	}
+	if err := codes.Store(token, ""); err != nil {
+		t.Fatalf("Store: %v", err)
+	}
+
+	body, _ := json.Marshal(map[string]string{"code": token.String(), "device_name": "Daniel's iPhone"})
+	req := httptest.NewRequest(http.MethodPost, PathDeviceEnroll, bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body %s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Token    string `json:"token"`
+		DeviceID string `json:"device_id"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.Token == "" || resp.DeviceID == "" {
+		t.Fatalf("expected non-empty token and device_id, got %+v", resp)
+	}
+
+	deviceID, ok := sessions.Validate(resp.Token)
+	if !ok || deviceID != resp.DeviceID {
+		t.Fatalf("issued token did not validate: deviceID=%q ok=%v", deviceID, ok)
+	}
+}
+
+func TestEnrollHTTPHandler_CodeIsSingleUse(t *testing.T) {
+	codes := pairing.NewTokenStore()
+	sessions, err := pairing.NewDeviceSessionStore("")
+	if err != nil {
+		t.Fatalf("NewDeviceSessionStore: %v", err)
+	}
+	h := NewEnrollHTTPHandler(codes, sessions)
+
+	token, err := pairing.GenerateToken()
+	if err != nil {
+		t.Fatalf("GenerateToken: %v", err)
+	}
+	if err := codes.Store(token, ""); err != nil {
+		t.Fatalf("Store: %v", err)
+	}
+	body, _ := json.Marshal(map[string]string{"code": token.String(), "device_name": "iPhone"})
+
+	req1 := httptest.NewRequest(http.MethodPost, PathDeviceEnroll, bytes.NewReader(body))
+	rec1 := httptest.NewRecorder()
+	h.ServeHTTP(rec1, req1)
+	if rec1.Code != http.StatusOK {
+		t.Fatalf("first enroll status = %d, want 200", rec1.Code)
+	}
+
+	req2 := httptest.NewRequest(http.MethodPost, PathDeviceEnroll, bytes.NewReader(body))
+	rec2 := httptest.NewRecorder()
+	h.ServeHTTP(rec2, req2)
+	if rec2.Code != http.StatusUnauthorized {
+		t.Fatalf("second enroll (reused code) status = %d, want 401", rec2.Code)
+	}
+}

--- a/internal/mcp/serverbootstrap/http.go
+++ b/internal/mcp/serverbootstrap/http.go
@@ -35,11 +35,31 @@ var bufferPool = sync.Pool{
 
 // serverOptions carries optional extensions for the HTTP server.
 type serverOptions struct {
-	approvalHandler http.Handler
+	approvalHandler         http.Handler
+	deviceEnrollHandler     http.Handler
+	deviceEnrollCodeHandler http.Handler
 }
 
 // HTTPServerOption configures an optional extension of the HTTP server.
 type HTTPServerOption func(*serverOptions)
+
+// WithDeviceEnrollAPI mounts the device-enrollment transport
+// (internal/approval) under /api/v1/devices/enroll, letting a device
+// exchange a pairing code for a long-lived approval-device bearer token.
+func WithDeviceEnrollAPI(handler http.Handler) HTTPServerOption {
+	return func(o *serverOptions) {
+		o.deviceEnrollHandler = handler
+	}
+}
+
+// WithDeviceEnrollCodeAPI mounts the localhost-only pairing-code minting
+// endpoint under /api/v1/devices/enroll-code, used by
+// "symvault device approval-pair" to obtain a code for the pairing QR code.
+func WithDeviceEnrollCodeAPI(handler http.Handler) HTTPServerOption {
+	return func(o *serverOptions) {
+		o.deviceEnrollCodeHandler = handler
+	}
+}
 
 // WithApprovalAPI mounts the device-approval transport (internal/approval)
 // under /api/v1/approvals on the MCP HTTP server, so an enrolled approval
@@ -288,6 +308,15 @@ func RunHTTPServerOnListener(ctx context.Context, listener net.Listener, v *vaul
 		mux.Handle(approval.PathApprovalAction, options.approvalHandler)
 	}
 
+	// Device enrollment transport (optional): lets a device exchange a
+	// pairing code for an approval-device bearer token.
+	if options.deviceEnrollHandler != nil {
+		mux.Handle(approval.PathDeviceEnroll, options.deviceEnrollHandler)
+	}
+	if options.deviceEnrollCodeHandler != nil {
+		mux.Handle(approval.PathDeviceEnrollCode, options.deviceEnrollCodeHandler)
+	}
+
 	timeouts := resolveServerTimeouts(v)
 	shutdownTimeout := timeouts.shutdown
 
@@ -315,7 +344,7 @@ func RunHTTPServerOnListener(ctx context.Context, listener net.Listener, v *vaul
 	}
 
 	if !allowInsecure && (tlsCert == "" || tlsKey == "") {
-		autoCert, autoKey, autoErr := ensureTLSCert(vaultDir)
+		autoCert, autoKey, autoErr := EnsureTLSCert(vaultDir)
 		if autoErr != nil {
 			cliout.Warnf("could not generate self-signed TLS certificate for MCP server: %v", autoErr)
 		}

--- a/internal/mcp/serverbootstrap/tls.go
+++ b/internal/mcp/serverbootstrap/tls.go
@@ -127,7 +127,7 @@ func CertFingerprint(vaultDir string) (string, error) {
 	if certFile == "" {
 		return "", fmt.Errorf("no TLS certificate available for vault directory")
 	}
-	pemBytes, err := os.ReadFile(certFile)
+	pemBytes, err := os.ReadFile(certFile) // #nosec G304 -- certFile is EnsureTLSCert's own fixed filename under vaultDir, same security domain
 	if err != nil {
 		return "", fmt.Errorf("read TLS certificate: %w", err)
 	}

--- a/internal/mcp/serverbootstrap/tls.go
+++ b/internal/mcp/serverbootstrap/tls.go
@@ -5,8 +5,10 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"crypto/sha256"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/hex"
 	"encoding/pem"
 	"fmt"
 	"math/big"
@@ -25,12 +27,12 @@ const (
 	autoKeyFile = "mcp-server.key"
 )
 
-// ensureTLSCert returns the paths to a usable TLS certificate and key for the
+// EnsureTLSCert returns the paths to a usable TLS certificate and key for the
 // MCP HTTP server. If the vault directory already contains a cached cert+key
 // pair they are reused; otherwise a new self-signed certificate is generated
 // for loopback addresses (127.0.0.1, ::1, localhost). Returns empty strings
 // when vaultDir is empty.
-func ensureTLSCert(vaultDir string) (certFile, keyFile string, err error) {
+func EnsureTLSCert(vaultDir string) (certFile, keyFile string, err error) {
 	if vaultDir == "" {
 		return "", "", nil
 	}
@@ -109,4 +111,34 @@ func generateSelfSignedCert(certFile, keyFile string) error {
 func fileExists(path string) bool {
 	info, err := os.Stat(path)
 	return err == nil && !info.IsDir()
+}
+
+// CertFingerprint returns the hex-encoded SHA-256 fingerprint of the MCP
+// server's current leaf certificate, generating one via EnsureTLSCert first
+// if none is cached yet. Callers that hand this fingerprint to a device for
+// certificate pinning (see internal/approval device enrollment) must treat
+// it as the entire trust story for that pairing: any mismatch on the
+// receiving end must fail closed.
+func CertFingerprint(vaultDir string) (string, error) {
+	certFile, _, err := EnsureTLSCert(vaultDir)
+	if err != nil {
+		return "", fmt.Errorf("ensure TLS certificate: %w", err)
+	}
+	if certFile == "" {
+		return "", fmt.Errorf("no TLS certificate available for vault directory")
+	}
+	pemBytes, err := os.ReadFile(certFile)
+	if err != nil {
+		return "", fmt.Errorf("read TLS certificate: %w", err)
+	}
+	block, _ := pem.Decode(pemBytes)
+	if block == nil {
+		return "", fmt.Errorf("decode TLS certificate PEM")
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return "", fmt.Errorf("parse TLS certificate: %w", err)
+	}
+	sum := sha256.Sum256(cert.Raw)
+	return hex.EncodeToString(sum[:]), nil
 }

--- a/internal/mcp/serverbootstrap/tls_test.go
+++ b/internal/mcp/serverbootstrap/tls_test.go
@@ -1,0 +1,59 @@
+package serverbootstrap
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCertFingerprint_StableAcrossRepeatedCalls(t *testing.T) {
+	dir := t.TempDir()
+
+	fp1, err := CertFingerprint(dir)
+	if err != nil {
+		t.Fatalf("CertFingerprint: %v", err)
+	}
+	if fp1 == "" {
+		t.Fatal("expected non-empty fingerprint")
+	}
+
+	fp2, err := CertFingerprint(dir)
+	if err != nil {
+		t.Fatalf("CertFingerprint (second call): %v", err)
+	}
+	if fp1 != fp2 {
+		t.Fatalf("expected stable fingerprint for cached cert, got %q then %q", fp1, fp2)
+	}
+}
+
+func TestCertFingerprint_ChangesWhenCertRegenerated(t *testing.T) {
+	dir := t.TempDir()
+
+	fp1, err := CertFingerprint(dir)
+	if err != nil {
+		t.Fatalf("CertFingerprint: %v", err)
+	}
+
+	certFile := filepath.Join(dir, autoCertFile)
+	keyFile := filepath.Join(dir, autoKeyFile)
+	if err := os.Remove(certFile); err != nil {
+		t.Fatalf("remove cert: %v", err)
+	}
+	if err := os.Remove(keyFile); err != nil {
+		t.Fatalf("remove key: %v", err)
+	}
+
+	fp2, err := CertFingerprint(dir)
+	if err != nil {
+		t.Fatalf("CertFingerprint (after regeneration): %v", err)
+	}
+	if fp1 == fp2 {
+		t.Fatal("expected a new fingerprint after cert regeneration, got the same value")
+	}
+}
+
+func TestCertFingerprint_EmptyVaultDir(t *testing.T) {
+	if _, err := CertFingerprint(""); err == nil {
+		t.Fatal("expected an error for an empty vault directory")
+	}
+}

--- a/internal/mcp/util.go
+++ b/internal/mcp/util.go
@@ -33,6 +33,44 @@ func IsLoopbackHost(host string) bool {
 	return ip != nil && ip.IsLoopback()
 }
 
+// DetectLANIPv4 returns the machine's non-loopback IPv4 addresses, suitable
+// for advertising to a device pairing over the local network (e.g. a QR
+// pairing payload). Loopback, down, and link-local interfaces are excluded.
+// Returns an empty slice (not an error) when no LAN-reachable address is
+// found; callers should treat that as "ask the user for --host explicitly"
+// rather than a hard failure.
+func DetectLANIPv4() ([]net.IP, error) {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return nil, err
+	}
+	var out []net.IP
+	for _, iface := range ifaces {
+		if iface.Flags&net.FlagUp == 0 || iface.Flags&net.FlagLoopback != 0 {
+			continue
+		}
+		addrs, err := iface.Addrs()
+		if err != nil {
+			continue
+		}
+		for _, addr := range addrs {
+			var ip net.IP
+			switch v := addr.(type) {
+			case *net.IPNet:
+				ip = v.IP
+			case *net.IPAddr:
+				ip = v.IP
+			}
+			ip4 := ip.To4()
+			if ip4 == nil || ip4.IsLoopback() || ip4.IsLinkLocalUnicast() {
+				continue
+			}
+			out = append(out, ip4)
+		}
+	}
+	return out, nil
+}
+
 // IsTrustedProxy checks if the given remote address belongs to a trusted proxy.
 func IsTrustedProxy(remoteAddr string, trustedProxies []string) bool {
 	if len(trustedProxies) == 0 {

--- a/internal/mcp/util_test.go
+++ b/internal/mcp/util_test.go
@@ -1,0 +1,21 @@
+package mcp
+
+import "testing"
+
+func TestDetectLANIPv4_ExcludesLoopbackAndLinkLocal(t *testing.T) {
+	ips, err := DetectLANIPv4()
+	if err != nil {
+		t.Fatalf("DetectLANIPv4: %v", err)
+	}
+	for _, ip := range ips {
+		if ip.IsLoopback() {
+			t.Fatalf("did not expect a loopback address in results, got %s", ip)
+		}
+		if ip.IsLinkLocalUnicast() {
+			t.Fatalf("did not expect a link-local address in results, got %s", ip)
+		}
+		if ip.To4() == nil {
+			t.Fatalf("expected only IPv4 addresses, got %s", ip)
+		}
+	}
+}

--- a/internal/pairing/devicesession.go
+++ b/internal/pairing/devicesession.go
@@ -34,6 +34,7 @@ const (
 type DeviceSession struct {
 	Token     string    `json:"token"`
 	DeviceID  string    `json:"device_id"`
+	Name      string    `json:"name,omitempty"`
 	PublicKey string    `json:"public_key"`
 	CreatedAt time.Time `json:"created_at"`
 	ExpiresAt time.Time `json:"expires_at"`
@@ -78,8 +79,8 @@ func NewDeviceSessionStore(vaultDir string) (*DeviceSessionStore, error) {
 }
 
 // Enroll creates a new long-lived session token for deviceID with the given
-// publicKey. The token is returned and persisted.
-func (s *DeviceSessionStore) Enroll(deviceID, publicKey string) (string, error) {
+// human-readable name and publicKey. The token is returned and persisted.
+func (s *DeviceSessionStore) Enroll(deviceID, name, publicKey string) (string, error) {
 	token, err := GenerateSessionToken()
 	if err != nil {
 		return "", fmt.Errorf("generate session token: %w", err)
@@ -88,6 +89,7 @@ func (s *DeviceSessionStore) Enroll(deviceID, publicKey string) (string, error) 
 	session := &DeviceSession{
 		Token:     token.String(),
 		DeviceID:  deviceID,
+		Name:      name,
 		PublicKey: publicKey,
 		CreatedAt: now,
 		ExpiresAt: now.Add(DefaultSessionTTL),
@@ -100,6 +102,19 @@ func (s *DeviceSessionStore) Enroll(deviceID, publicKey string) (string, error) 
 		return "", fmt.Errorf("persist device session: %w", err)
 	}
 	return token.String(), nil
+}
+
+// List returns a snapshot of every session in the store, including revoked
+// and expired ones, for display in a device-management UI. Callers that only
+// want live sessions should filter on Revoked and ExpiresAt themselves.
+func (s *DeviceSessionStore) List() []DeviceSession {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]DeviceSession, 0, len(s.sessions))
+	for _, session := range s.sessions {
+		out = append(out, *session)
+	}
+	return out
 }
 
 // Validate checks a session token and returns the deviceID if the session

--- a/internal/pairing/devicesession_test.go
+++ b/internal/pairing/devicesession_test.go
@@ -13,7 +13,7 @@ func TestDeviceSessionStore_EnrollAndValidate(t *testing.T) {
 		t.Fatalf("NewDeviceSessionStore: %v", err)
 	}
 
-	token, err := store.Enroll("device-1", "age1pubkey")
+	token, err := store.Enroll("device-1", "Device One", "age1pubkey")
 	if err != nil {
 		t.Fatalf("Enroll: %v", err)
 	}
@@ -33,7 +33,7 @@ func TestDeviceSessionStore_PersistsAcrossLoad(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewDeviceSessionStore: %v", err)
 	}
-	token, err := store.Enroll("device-1", "age1pubkey")
+	token, err := store.Enroll("device-1", "Device One", "age1pubkey")
 	if err != nil {
 		t.Fatalf("Enroll: %v", err)
 	}
@@ -55,7 +55,7 @@ func TestDeviceSessionStore_Revoke(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewDeviceSessionStore: %v", err)
 	}
-	token, err := store.Enroll("device-1", "age1pubkey")
+	token, err := store.Enroll("device-1", "Device One", "age1pubkey")
 	if err != nil {
 		t.Fatalf("Enroll: %v", err)
 	}
@@ -92,7 +92,7 @@ func TestDeviceSessionStore_PerDeviceFailedAttempts(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewDeviceSessionStore: %v", err)
 	}
-	token, err := store.Enroll("device-1", "age1pubkey")
+	token, err := store.Enroll("device-1", "Device One", "age1pubkey")
 	if err != nil {
 		t.Fatalf("Enroll: %v", err)
 	}
@@ -113,7 +113,7 @@ func TestDeviceSessionStore_PerDeviceFailedAttempts(t *testing.T) {
 	// by expiring the session. We can't easily do that without waiting,
 	// so instead we test per-device cooldown by creating a second device
 	// and verifying that failures on one device don't affect the other.
-	token2, err := store.Enroll("device-2", "age1pubkey2")
+	token2, err := store.Enroll("device-2", "Device Two", "age1pubkey2")
 	if err != nil {
 		t.Fatalf("Enroll device-2: %v", err)
 	}
@@ -139,7 +139,7 @@ func TestDeviceSessionStore_ExpiredSession(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewDeviceSessionStore: %v", err)
 	}
-	token, err := store.Enroll("device-1", "age1pubkey")
+	token, err := store.Enroll("device-1", "Device One", "age1pubkey")
 	if err != nil {
 		t.Fatalf("Enroll: %v", err)
 	}
@@ -161,7 +161,7 @@ func TestDeviceSessionStore_CleanupExpired(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewDeviceSessionStore: %v", err)
 	}
-	token, err := store.Enroll("device-1", "age1pubkey")
+	token, err := store.Enroll("device-1", "Device One", "age1pubkey")
 	if err != nil {
 		t.Fatalf("Enroll: %v", err)
 	}
@@ -186,7 +186,7 @@ func TestDeviceSessionStore_NoVaultDir(t *testing.T) {
 	if store == nil {
 		t.Fatal("nil store for empty dir")
 	}
-	token, err := store.Enroll("device-1", "age1pubkey")
+	token, err := store.Enroll("device-1", "Device One", "age1pubkey")
 	if err != nil {
 		t.Fatalf("Enroll: %v", err)
 	}
@@ -202,7 +202,7 @@ func TestDeviceSessionStore_StartCleanup(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewDeviceSessionStore: %v", err)
 	}
-	_, err = store.Enroll("device-1", "age1pubkey")
+	_, err = store.Enroll("device-1", "Device One", "age1pubkey")
 	if err != nil {
 		t.Fatalf("Enroll: %v", err)
 	}
@@ -221,6 +221,66 @@ func TestDeviceSessionStore_StartCleanup(t *testing.T) {
 // contextWithCancel is a test-local helper to avoid importing context in
 // _test.go when not needed by other tests.
 func contextWithCancel() context.Context {
-	ctx, _ := context.WithCancel(context.Background())
-	return ctx
+	return context.Background()
+}
+
+func TestDeviceSessionStore_NameRoundTripsAcrossLoad(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewDeviceSessionStore(dir)
+	if err != nil {
+		t.Fatalf("NewDeviceSessionStore: %v", err)
+	}
+	token, err := store.Enroll("device-1", "Daniel's iPhone", "")
+	if err != nil {
+		t.Fatalf("Enroll: %v", err)
+	}
+
+	store2, err := NewDeviceSessionStore(dir)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	sessions := store2.List()
+	found := false
+	for _, s := range sessions {
+		if s.Token == token {
+			found = true
+			if s.Name != "Daniel's iPhone" {
+				t.Fatalf("Name = %q, want %q", s.Name, "Daniel's iPhone")
+			}
+		}
+	}
+	if !found {
+		t.Fatal("enrolled session not found after reload")
+	}
+}
+
+func TestDeviceSessionStore_List(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewDeviceSessionStore(dir)
+	if err != nil {
+		t.Fatalf("NewDeviceSessionStore: %v", err)
+	}
+
+	if got := store.List(); len(got) != 0 {
+		t.Fatalf("List on empty store = %d entries, want 0", len(got))
+	}
+
+	if _, err := store.Enroll("device-1", "Device One", "age1pubkey"); err != nil {
+		t.Fatalf("Enroll device-1: %v", err)
+	}
+	if _, err := store.Enroll("device-2", "Device Two", "age1pubkey2"); err != nil {
+		t.Fatalf("Enroll device-2: %v", err)
+	}
+
+	sessions := store.List()
+	if len(sessions) != 2 {
+		t.Fatalf("List = %d entries, want 2", len(sessions))
+	}
+	names := map[string]bool{}
+	for _, s := range sessions {
+		names[s.DeviceID] = true
+	}
+	if !names["device-1"] || !names["device-2"] {
+		t.Fatalf("List missing expected device IDs: %+v", sessions)
+	}
 }


### PR DESCRIPTION
Closes device enrollment, the last gap keeping approval mode "prompt"
unusable: DeviceSessionStore.Enroll had no caller, and the iOS app had
no networking, pairing, or approvals UI at all.

Server: a new localhost-only endpoint mints a short-lived pairing code
for `symvault device approval-pair` to render as a QR code (falling
back to plain text); a public enroll endpoint exchanges that code for
a long-lived device bearer token. The phone pins its TLS connection to
the server's certificate fingerprint (carried in the QR payload)
rather than relying on hostname verification, since the server's
self-signed certificate only covers loopback SANs. Adds
`device approval-list`/`approval-revoke` to manage enrolled devices.

iOS: a QR scanner (with manual-entry fallback, since scanning needs a
real camera), a pinned HTTPS client, Keychain session storage, and an
approvals list with Face-ID-gated approve wired into the vault screen.

Closes #871
