### PR TITLE
fix(update): complete corekit self-update migration

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
           src = ./.;
 
           # Resolved via `go mod vendor; nix hash path --sri vendor/`
-          vendorHash = "sha256-5cA3OiRPyVIKx01rN9kgb5WgGwQq21CPLmUyK4w5plU=";
+          vendorHash = "sha256-OwDTTAUMriCbqB1wl0DfuguVtp81rlmR9mcmugutXZw=";
 
           # Disable CGO for Linux — reduces distributability and is not needed
           # (keyring integration requires CGO only on darwin).

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/creack/pty v1.1.24
-	github.com/danieljustus/symaira-corekit v0.16.1
+	github.com/danieljustus/symaira-corekit v0.16.3
 	github.com/go-git/go-billy/v5 v5.9.1
 	github.com/go-git/go-git/v5 v5.19.2
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -92,8 +92,8 @@ github.com/cyphar/filepath-securejoin v0.6.1 h1:5CeZ1jPXEiYt3+Z6zqprSAgSWiggmpVy
 github.com/cyphar/filepath-securejoin v0.6.1/go.mod h1:A8hd4EnAeyujCJRrICiOWqjS1AX0a9kM5XL+NwKoYSc=
 github.com/danieljoos/wincred v1.2.3 h1:v7dZC2x32Ut3nEfRH+vhoZGvN72+dQ/snVXo/vMFLdQ=
 github.com/danieljoos/wincred v1.2.3/go.mod h1:6qqX0WNrS4RzPZ1tnroDzq9kY3fu1KwE7MRLQK4X0bs=
-github.com/danieljustus/symaira-corekit v0.16.1 h1:bTIBNP8RfiknBmukSMMPNZLQ8KvbcoYZL3z4RPaQshU=
-github.com/danieljustus/symaira-corekit v0.16.1/go.mod h1:fza/0RvUl5ODDdjic2scDinTBhRBK79+aILmXCshqxg=
+github.com/danieljustus/symaira-corekit v0.16.3 h1:COO2u0E/yud0tGXyBm7j6AYO0zgNQDlMqXkaqC0Dop0=
+github.com/danieljustus/symaira-corekit v0.16.3/go.mod h1:fza/0RvUl5ODDdjic2scDinTBhRBK79+aILmXCshqxg=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/update/apply.go
+++ b/internal/update/apply.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 
@@ -13,7 +14,10 @@ import (
 	"github.com/danieljustus/symaira-vault/internal/update/installmethod"
 )
 
-const binaryName = "symvault"
+const (
+	binaryName = "symvault"
+	windowsOS  = "windows"
+)
 
 // ApplyResult contains details about a completed self-update.
 type ApplyResult struct {
@@ -56,10 +60,22 @@ func getBinaryPath() (string, error) {
 }
 
 func binaryFileName() string {
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == windowsOS {
 		return binaryName + ".exe"
 	}
 	return binaryName
+}
+
+// verifyBinary runs the installed binary with the version subcommand. Corekit
+// invokes this after the atomic swap and restores the previous binary when
+// validation fails.
+func verifyBinary(binaryPath string) error {
+	cmd := exec.Command(binaryPath, "version")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("verify %q version: %w (output: %s)", binaryPath, err, string(output))
+	}
+	return nil
 }
 
 func newCorekitApplier() *corekitupdateapply.Applier {
@@ -69,6 +85,7 @@ func newCorekitApplier() *corekitupdateapply.Applier {
 	applier.BinaryName = binaryName
 	applier.CosignConfig = &cfg
 	applier.ExtractBinary = binaryFileName()
+	applier.ValidateBinary = verifyBinary
 	return applier
 }
 

--- a/internal/update/apply_test.go
+++ b/internal/update/apply_test.go
@@ -3,6 +3,9 @@ package update
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -198,6 +201,36 @@ func TestApply_EmptyVersion(t *testing.T) {
 	}
 }
 
+func TestVerifyBinary(t *testing.T) {
+	if runtime.GOOS == windowsOS {
+		t.Skip("skipping: shell script binaries are not supported on windows")
+	}
+
+	path := filepath.Join(t.TempDir(), "symvault")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nprintf '%s\\n' symvault-test\n"), 0o755); err != nil { //nolint:gosec
+		t.Fatalf("write test binary: %v", err)
+	}
+
+	if err := verifyBinary(path); err != nil {
+		t.Fatalf("verifyBinary() error = %v", err)
+	}
+}
+
+func TestVerifyBinary_Failure(t *testing.T) {
+	if runtime.GOOS == windowsOS {
+		t.Skip("skipping: shell script binaries are not supported on windows")
+	}
+
+	path := filepath.Join(t.TempDir(), "symvault")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 1\n"), 0o755); err != nil { //nolint:gosec
+		t.Fatalf("write test binary: %v", err)
+	}
+
+	if err := verifyBinary(path); err == nil {
+		t.Fatal("verifyBinary() error = nil, want command failure")
+	}
+}
+
 func TestNewCorekitApplierConfig(t *testing.T) {
 	applier := newCorekitApplier()
 	if applier == nil {
@@ -209,8 +242,17 @@ func TestNewCorekitApplierConfig(t *testing.T) {
 	if applier.BinaryName != binaryName {
 		t.Fatalf("BinaryName = %q, want %q", applier.BinaryName, binaryName)
 	}
+	if applier.CosignConfig == nil {
+		t.Fatal("CosignConfig = nil, want release artifact configuration")
+	}
+	if applier.CosignConfig.BinaryName != releaseArtifactName {
+		t.Fatalf("CosignConfig.BinaryName = %q, want %q", applier.CosignConfig.BinaryName, releaseArtifactName)
+	}
 	if applier.ExtractBinary != binaryFileName() {
 		t.Fatalf("ExtractBinary = %q, want %q", applier.ExtractBinary, binaryFileName())
+	}
+	if applier.ValidateBinary == nil {
+		t.Fatal("ValidateBinary = nil, want post-swap executable validation")
 	}
 	if applier.CosignConfig == nil {
 		t.Fatal("CosignConfig = nil, want repository-specific verification config")

--- a/internal/update/cosign.go
+++ b/internal/update/cosign.go
@@ -12,6 +12,10 @@ import (
 // repository-specific Cosign configuration.
 var DefaultDownloadBaseURL = "https://github.com/danieljustus/symaira-vault/releases/download"
 
+// releaseArtifactName is the GoReleaser project name used in checksums and
+// Cosign artifact filenames. It differs from the installed CLI binary name.
+const releaseArtifactName = "symaira-vault"
+
 var (
 	testHTTPClient httpDoer
 	mu             sync.Mutex
@@ -61,7 +65,7 @@ func cosignHTTPClient() *http.Client {
 func cosignConfig() corekitcosign.Config {
 	cfg := corekitcosign.Config{
 		Repo:            "danieljustus/symaira-vault",
-		BinaryName:      binaryName,
+		BinaryName:      releaseArtifactName,
 		DownloadBaseURL: DefaultDownloadBaseURL,
 		IdentityRegexp:  CosignIdentityRegexp,
 	}

--- a/internal/update/cosign_test.go
+++ b/internal/update/cosign_test.go
@@ -14,6 +14,10 @@ func TestFetchCosignSignature_Success(t *testing.T) {
 	mu.Lock()
 	testHTTPClient = stubHTTPDoer{
 		do: func(req *http.Request) (*http.Response, error) {
+			wantPath := "/danieljustus/symaira-vault/releases/download/v0.5.0/symaira-vault_0.5.0_checksums.txt.sig"
+			if req.URL.Path != wantPath {
+				t.Errorf("request path = %q, want %q", req.URL.Path, wantPath)
+			}
 			return &http.Response{
 				StatusCode: http.StatusOK,
 				Body:       io.NopCloser(strings.NewReader(string(expectedBody))),
@@ -93,6 +97,10 @@ func TestFetchCosignCertificate_Success(t *testing.T) {
 	mu.Lock()
 	testHTTPClient = stubHTTPDoer{
 		do: func(req *http.Request) (*http.Response, error) {
+			wantPath := "/danieljustus/symaira-vault/releases/download/v0.5.0/symaira-vault_0.5.0_checksums.txt.pem"
+			if req.URL.Path != wantPath {
+				t.Errorf("request path = %q, want %q", req.URL.Path, wantPath)
+			}
 			return &http.Response{
 				StatusCode: http.StatusOK,
 				Body:       io.NopCloser(strings.NewReader(string(expectedBody))),


### PR DESCRIPTION
## Summary

- Update `symaira-corekit` to v0.16.3 and use its self-update applier.
- Configure Cosign artefact lookup with the GoReleaser project name (`symaira-vault`) while retaining the installed binary name (`symvault`).
- Validate the swapped binary with `symvault version` and restore on failure.
- Add regression coverage for the release asset paths and binary validation.

## Verification

- `GOTOOLCHAIN=go1.26.6 make test`
- `make fmt-check`
- `make build`
- `GOTOOLCHAIN=go1.26.6 make lint`
- `make docs-check`
- Real temporary-target update from released tag `v0.21.1` on macOS arm64, including checksum/Cosign verification, atomic swap, and `symvault version`.

Closes #936
