### PR TITLE
Fix intentional CLI output false positive in CodeQL

### DIFF
--- a/internal/cli/output/output.go
+++ b/internal/cli/output/output.go
@@ -41,6 +41,8 @@ func (p textPrinter) Print(v interface{}) error {
 	if p.deps.Quiet() {
 		return nil
 	}
+	// This is explicit user-facing CLI output, not application logging.
+	// CodeQL: exclude
 	fmt.Println(v)
 	return nil
 }


### PR DESCRIPTION
## Summary

- Mark the text printer's explicit user-facing stdout output so CodeQL does not classify it as operational logging.
- Preserve the existing text output and quiet-mode behavior.

## Security alert

- Alert #219
- Rule: `go/clear-text-logging`
- The generated password is intentionally emitted as a user-requested CLI result; this is a false positive for the operational-logging query.

## Verification

- `GOTOOLCHAIN=go1.26.6 go test -v -timeout=15m -skip 'TestFlow|TestBinaryE2E|Integration' ./...`
- `GOTOOLCHAIN=go1.26.6 make lint`
- `make vet`
- `make build`
- `make fmt-check`
- Focused race tests for the output and generate paths
