### PR TITLE
Wait for the HTTP server goroutine during shutdown

### DIFF
--- a/cmd/mcp/serve_deps.go
+++ b/cmd/mcp/serve_deps.go
@@ -272,8 +272,10 @@ func runServe(cmd *cobra.Command, args []string) error {
 		}
 	case err := <-errCh:
 		cancel()
+		wg.Wait()
 		return err
 	case <-ctx.Done():
+		wg.Wait()
 		if vDir, err := cli.VaultPath(); err == nil {
 			_ = cli.ClearRuntimePort(vDir)
 		}


### PR DESCRIPTION
## Summary

- Wait for serving goroutines before `runServe` returns after cancellation or a server error.
- Prevent shutdown output from racing with subsequent CLI invocations while preserving runtime-port cleanup.

## Evidence

The race detector showed `cmd.captureStderr` racing with shutdown output from `serverbootstrap.RunHTTPServerOnListener` after `TestServe_HTTPSignalShutdown` returned.

Fixes #942

## Verification

- `GOTOOLCHAIN=go1.26.6 go test -race ./cmd -run 'TestServe_HTTPSignalShutdown|TestCmdServe_NonLoopbackWarning|TestCmdServe_TLSFlagsOverride|TestCmdServe_TLSFlagsOnlyCert' -count=1`
- `GOTOOLCHAIN=go1.26.6 go test -v -race -timeout=30m -skip 'TestFlow|TestBinaryE2E|Integration' ./...`
- `GOTOOLCHAIN=go1.26.6 make vet`
- `GOTOOLCHAIN=go1.26.6 make build`
- `GOTOOLCHAIN=go1.26.6 make fmt-check`
- `GOTOOLCHAIN=go1.26.6 make lint` still reports the pre-existing `internal/cli/cli.go:274` `goconst` finding, outside this change
