### PR TITLE
fix(pairing): make device revocation take effect against a running server

### DIFF
--- a/internal/approval/enroll_test.go
+++ b/internal/approval/enroll_test.go
@@ -185,6 +185,81 @@ func TestEnrollHTTPHandler_Success(t *testing.T) {
 	}
 }
 
+func TestEnrollHTTPHandler_RevocationTakesEffectAcrossStoreInstances(t *testing.T) {
+	dir := t.TempDir()
+	codes := pairing.NewTokenStore()
+	sessions, err := pairing.NewDeviceSessionStore(dir)
+	if err != nil {
+		t.Fatalf("NewDeviceSessionStore: %v", err)
+	}
+	h := NewEnrollHTTPHandler(codes, sessions)
+
+	token, err := pairing.GenerateToken()
+	if err != nil {
+		t.Fatalf("GenerateToken: %v", err)
+	}
+	if err := codes.Store(token, ""); err != nil {
+		t.Fatalf("Store: %v", err)
+	}
+
+	body, _ := json.Marshal(map[string]string{"code": token.String(), "device_name": "Daniel's iPhone"})
+	req := httptest.NewRequest(http.MethodPost, PathDeviceEnroll, bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body %s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Token    string `json:"token"`
+		DeviceID string `json:"device_id"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	// Sanity: the server's own long-lived store instance accepts the token
+	// immediately after enrolment, as "symvault serve" would.
+	if deviceID, ok := sessions.Validate(resp.Token); !ok || deviceID != resp.DeviceID {
+		t.Fatalf("issued token did not validate before revoke: deviceID=%q ok=%v", deviceID, ok)
+	}
+
+	// A second, independent store instance is exactly what
+	// "symvault device approval-revoke" opens: its own process, its own
+	// DeviceSessionStore, pointed at the same vault directory.
+	revoker, err := pairing.NewDeviceSessionStore(dir)
+	if err != nil {
+		t.Fatalf("NewDeviceSessionStore (revoker): %v", err)
+	}
+	revoker.Revoke(resp.DeviceID)
+
+	// The server's original, still-running store instance must reject the
+	// token without needing a restart.
+	if deviceID, ok := sessions.Validate(resp.Token); ok {
+		t.Fatalf("revoked token still validated: deviceID=%q", deviceID)
+	}
+
+	// The revocation on disk must survive the server's own store persisting
+	// state again (e.g. a cleanup tick), rather than being clobbered back to
+	// unrevoked by the server's stale in-memory copy.
+	sessions.CleanupExpired()
+	onDisk, err := pairing.NewDeviceSessionStore(dir)
+	if err != nil {
+		t.Fatalf("NewDeviceSessionStore (reload): %v", err)
+	}
+	found := false
+	for _, s := range onDisk.List() {
+		if s.DeviceID == resp.DeviceID {
+			found = true
+			if !s.Revoked {
+				t.Fatalf("device %q not revoked on disk after cleanup tick", resp.DeviceID)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("device %q not found on disk after cleanup tick", resp.DeviceID)
+	}
+}
+
 func TestEnrollHTTPHandler_CodeIsSingleUse(t *testing.T) {
 	codes := pairing.NewTokenStore()
 	sessions, err := pairing.NewDeviceSessionStore("")

--- a/internal/pairing/devicesession.go
+++ b/internal/pairing/devicesession.go
@@ -54,6 +54,7 @@ type DeviceSessionStore struct {
 	mu       sync.RWMutex
 	sessions map[string]*DeviceSession // token -> session
 	failures map[string]deviceFailure  // deviceID -> failure state
+	mtime    time.Time                 // mtime of path as of the last load/save
 }
 
 // NewDeviceSessionStore loads the device session store from vaultDir.
@@ -124,6 +125,8 @@ func (s *DeviceSessionStore) Validate(token string) (string, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	s.mergeRevocationsFromDisk()
+
 	session, ok := s.sessions[token]
 	if !ok {
 		return "", false
@@ -155,6 +158,8 @@ func (s *DeviceSessionStore) RecordFailure(token string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	s.mergeRevocationsFromDisk()
+
 	session, ok := s.sessions[token]
 	if !ok {
 		return
@@ -173,7 +178,7 @@ func (s *DeviceSessionStore) Revoke(deviceID string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	changed := false
+	changed := s.mergeRevocationsFromDisk()
 	for _, session := range s.sessions {
 		if session.DeviceID == deviceID && !session.Revoked {
 			session.Revoked = true
@@ -190,6 +195,7 @@ func (s *DeviceSessionStore) RevokeAll() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	s.mergeRevocationsFromDisk()
 	for _, session := range s.sessions {
 		if !session.Revoked {
 			session.Revoked = true
@@ -204,18 +210,24 @@ func (s *DeviceSessionStore) CleanupExpired() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	changed := s.mergeRevocationsFromDisk()
+
 	now := time.Now()
 	for token, session := range s.sessions {
 		if now.After(session.ExpiresAt) {
 			delete(s.sessions, token)
+			changed = true
 		}
 	}
 	for deviceID, f := range s.failures {
 		if f.Count >= MaxSessionFailedAttempts && now.After(f.CooldownUntil) {
 			delete(s.failures, deviceID)
+			changed = true
 		}
 	}
-	_ = s.save()
+	if changed {
+		_ = s.save()
+	}
 }
 
 // Save persists the store to disk.
@@ -272,6 +284,9 @@ func (s *DeviceSessionStore) load() error {
 		return fmt.Errorf("parse device sessions: %w", err)
 	}
 	s.sessions = sessions
+	if info, statErr := os.Stat(s.path); statErr == nil {
+		s.mtime = info.ModTime()
+	}
 	return nil
 }
 
@@ -290,7 +305,51 @@ func (s *DeviceSessionStore) save() error {
 	if err := os.WriteFile(tmp, data, 0o600); err != nil {
 		return err
 	}
-	return os.Rename(tmp, s.path)
+	if err := os.Rename(tmp, s.path); err != nil {
+		return err
+	}
+	if info, statErr := os.Stat(s.path); statErr == nil {
+		s.mtime = info.ModTime()
+	}
+	return nil
+}
+
+// mergeRevocationsFromDisk re-reads the on-disk store when it is newer than
+// the last load/save this instance observed, and applies any revocation
+// found there onto the in-memory copy. Revocation only ever moves from false
+// to true here, so a concurrent writer (typically the "approval-revoke" CLI,
+// which opens its own store instance against the same file) can never have
+// its revocation silently undone by this instance's next save. Callers must
+// hold s.mu for writing. Returns whether any in-memory session was newly
+// marked revoked.
+func (s *DeviceSessionStore) mergeRevocationsFromDisk() bool {
+	if s.path == "" {
+		return false
+	}
+	info, err := os.Stat(s.path)
+	if err != nil || !info.ModTime().After(s.mtime) {
+		return false
+	}
+	data, err := os.ReadFile(s.path)
+	if err != nil {
+		return false
+	}
+	var onDisk map[string]*DeviceSession
+	if err := json.Unmarshal(data, &onDisk); err != nil {
+		return false
+	}
+	changed := false
+	for token, diskSession := range onDisk {
+		if diskSession == nil || !diskSession.Revoked {
+			continue
+		}
+		if mem, ok := s.sessions[token]; ok && !mem.Revoked {
+			mem.Revoked = true
+			changed = true
+		}
+	}
+	s.mtime = info.ModTime()
+	return changed
 }
 
 // GenerateSessionToken creates a high-entropy session token.

--- a/internal/pairing/devicesession_test.go
+++ b/internal/pairing/devicesession_test.go
@@ -73,6 +73,62 @@ func TestDeviceSessionStore_Revoke(t *testing.T) {
 	}
 }
 
+func TestDeviceSessionStore_RevokeByOtherInstanceTakesEffect(t *testing.T) {
+	dir := t.TempDir()
+	server, err := NewDeviceSessionStore(dir)
+	if err != nil {
+		t.Fatalf("NewDeviceSessionStore: %v", err)
+	}
+	token, err := server.Enroll("device-1", "Device One", "age1pubkey")
+	if err != nil {
+		t.Fatalf("Enroll: %v", err)
+	}
+
+	// A separate instance, as the "approval-revoke" CLI opens against the
+	// same vault directory while a long-lived "serve" process holds its own.
+	cli, err := NewDeviceSessionStore(dir)
+	if err != nil {
+		t.Fatalf("NewDeviceSessionStore (cli): %v", err)
+	}
+	cli.Revoke("device-1")
+
+	// The long-lived instance must see the revocation without a restart.
+	if deviceID, ok := server.Validate(token); ok {
+		t.Fatalf("revoked token still validated by other instance: deviceID=%q", deviceID)
+	}
+
+	// A later save by the long-lived instance (e.g. a cleanup tick) must not
+	// clobber the revocation back to unrevoked.
+	server.CleanupExpired()
+	reload, err := NewDeviceSessionStore(dir)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	sessions := reload.List()
+	if len(sessions) != 1 || !sessions[0].Revoked {
+		t.Fatalf("sessions after cleanup tick = %+v, want single revoked session", sessions)
+	}
+}
+
+func TestDeviceSessionStore_CleanupExpired_NoOpDoesNotRewriteFile(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewDeviceSessionStore(dir)
+	if err != nil {
+		t.Fatalf("NewDeviceSessionStore: %v", err)
+	}
+	if _, err := store.Enroll("device-1", "Device One", "age1pubkey"); err != nil {
+		t.Fatalf("Enroll: %v", err)
+	}
+
+	before := store.mtime
+	time.Sleep(10 * time.Millisecond)
+	store.CleanupExpired()
+
+	if !store.mtime.Equal(before) {
+		t.Fatalf("CleanupExpired rewrote the file with nothing to clean up: mtime %v -> %v", before, store.mtime)
+	}
+}
+
 func TestDeviceSessionStore_UnknownToken(t *testing.T) {
 	dir := t.TempDir()
 	store, err := NewDeviceSessionStore(dir)


### PR DESCRIPTION
## Summary

`symvault device approval-revoke` opened its own `DeviceSessionStore` instance, flipped `Revoked`, and saved `device-sessions.json` — but the running `symvault serve` process held a separate in-memory copy loaded once at startup and never re-read the file. The server's 15-minute cleanup ticker then unconditionally saved its own stale in-memory state, overwriting the operator's revocation back to "not revoked" on disk on every tick and again at shutdown. In practice, the only control for a device that can approve every agent write was a no-op.

## Change

- `DeviceSessionStore` now tracks the mtime of the file it last loaded or saved, and re-reads the file (merging any on-disk revocation onto its in-memory copy) whenever the file has changed underneath it. Revocation only ever moves false→true through this merge, so it can never undo a revocation another process wrote.
- The merge runs before `Validate`, `RecordFailure`, `Revoke`, `RevokeAll`, and `CleanupExpired`, so a revoked device is rejected immediately by an already-running server — no restart and no wait for the next cleanup tick.
- `CleanupExpired` now only calls `save()` when it actually removed an expired session or merged a change; a routine tick with nothing to do no longer touches the file.

## Testing

- `internal/pairing/devicesession_test.go`: two `DeviceSessionStore` instances against the same directory — one revokes, the other (already holding a valid token in memory) must reject it, and the revocation must survive a subsequent `CleanupExpired` tick from the first instance. Plus a test asserting a no-op cleanup tick does not rewrite the file.
- `internal/approval/enroll_test.go`: end-to-end version of the same scenario — enroll a device through `EnrollHTTPHandler`, revoke it through a second store instance, assert the original handler's store rejects the token and the on-disk state stays revoked after a cleanup tick.
- `go test ./internal/pairing/... ./internal/approval/...` and the same with `-race`: pass.
- `golangci-lint run ./internal/pairing/... ./internal/approval/...`: 0 issues.

Closes #944