### PR TITLE
fix(security): require proof of vault ownership to mint an approval-device pairing code

### DIFF
--- a/client/Sources/SymvaultIOS/ApprovalDeviceClient.swift
+++ b/client/Sources/SymvaultIOS/ApprovalDeviceClient.swift
@@ -148,7 +148,6 @@ struct ApprovalDeviceClient: @unchecked Sendable {
         request.httpBody = try encoder.encode([
             "code": payload.code,
             "device_name": deviceName,
-            "public_key": "",
         ])
 
         let (data, response) = try await transportFactory(payload.fingerprint).send(request)

--- a/cmd/device_approval.go
+++ b/cmd/device_approval.go
@@ -142,8 +142,22 @@ func mintApprovalEnrollCode(vaultDir string, port int) (code string, expiresAt t
 		},
 	}
 
+	secret, err := serverbootstrap.EnsureEnrollSecret(vaultDir)
+	if err != nil {
+		return "", time.Time{}, "", fmt.Errorf("ensure vault-ownership proof secret: %w", err)
+	}
+	now := time.Now().UTC()
+
 	url := fmt.Sprintf("https://127.0.0.1:%d%s", port, approval.PathDeviceEnrollCode)
-	resp, err := client.Post(url, "application/json", bytes.NewReader(nil))
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(nil))
+	if err != nil {
+		return "", time.Time{}, "", fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(approval.HeaderEnrollTimestamp, now.Format(time.RFC3339))
+	req.Header.Set(approval.HeaderEnrollProof, approval.EnrollProof(secret, now))
+
+	resp, err := client.Do(req)
 	if err != nil {
 		return "", time.Time{}, "", fmt.Errorf("call %s (is 'symvault serve' running with TLS?): %w", approval.PathDeviceEnrollCode, err)
 	}

--- a/cmd/device_approval_test.go
+++ b/cmd/device_approval_test.go
@@ -49,8 +49,12 @@ func TestMintApprovalEnrollCode_RoundTrip(t *testing.T) {
 		t.Fatalf("LoadX509KeyPair: %v", err)
 	}
 
+	secret, err := serverbootstrap.EnsureEnrollSecret(dir)
+	if err != nil {
+		t.Fatalf("EnsureEnrollSecret: %v", err)
+	}
 	codes := pairing.NewTokenStore()
-	handler := approval.NewEnrollCodeHTTPHandler(codes, "fp-test", func(string) bool { return true })
+	handler := approval.NewEnrollCodeHTTPHandler(codes, "fp-test", func(string) bool { return true }, secret)
 
 	srv := httptest.NewUnstartedServer(handler)
 	srv.TLS = &tls.Config{Certificates: []tls.Certificate{cert}}
@@ -90,8 +94,12 @@ func TestMintApprovalEnrollCode_RejectsUntrustedServer(t *testing.T) {
 	// Deliberately do NOT create a cert in dir before starting the test
 	// server with its own self-generated (different) certificate, so the
 	// pinned client should refuse to trust it.
+	secret, err := serverbootstrap.EnsureEnrollSecret(dir)
+	if err != nil {
+		t.Fatalf("EnsureEnrollSecret: %v", err)
+	}
 	codes := pairing.NewTokenStore()
-	handler := approval.NewEnrollCodeHTTPHandler(codes, "fp-test", func(string) bool { return true })
+	handler := approval.NewEnrollCodeHTTPHandler(codes, "fp-test", func(string) bool { return true }, secret)
 
 	srv := httptest.NewTLSServer(handler)
 	defer srv.Close()

--- a/cmd/mcp/serve_deps.go
+++ b/cmd/mcp/serve_deps.go
@@ -72,7 +72,11 @@ func RunHTTPServerWithApproval(ctx context.Context, bind string, port int, vault
 	if fpErr != nil {
 		cliout.Warnf("could not compute TLS certificate fingerprint; device pairing is disabled: %v", fpErr)
 	}
-	enrollCodeHandler := approval.NewEnrollCodeHTTPHandler(EnrollCodes, fingerprint, mcputil.IsLoopbackHost)
+	enrollSecret, esErr := serverbootstrap.EnsureEnrollSecret(vaultDir)
+	if esErr != nil {
+		cliout.Warnf("could not set up vault-ownership proof secret; device pairing is disabled: %v", esErr)
+	}
+	enrollCodeHandler := approval.NewEnrollCodeHTTPHandler(EnrollCodes, fingerprint, mcputil.IsLoopbackHost, enrollSecret)
 	enrollHandler := approval.NewEnrollHTTPHandler(EnrollCodes, sessionStore)
 
 	return serverbootstrap.RunHTTPServer(ctx, bind, port, vault, vaultDir, Version, newServerWithApproval,

--- a/internal/approval/enroll.go
+++ b/internal/approval/enroll.go
@@ -1,7 +1,9 @@
 package approval
 
 import (
+	"crypto/hmac"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -24,6 +26,49 @@ const (
 	PathDeviceEnroll = "/api/v1/devices/enroll"
 )
 
+const (
+	// HeaderEnrollTimestamp carries the RFC3339 UTC timestamp signed by
+	// EnrollProof, mirrored back so the server can bound how old a proof it
+	// accepts.
+	HeaderEnrollTimestamp = "X-Enroll-Timestamp"
+	// HeaderEnrollProof carries the hex-encoded HMAC-SHA256 proof computed
+	// by EnrollProof.
+	HeaderEnrollProof = "X-Enroll-Proof"
+)
+
+// enrollProofWindow bounds how far the timestamp in a mint request may drift
+// from the server's clock before the proof is rejected, so a captured
+// header pair cannot be replayed indefinitely.
+const enrollProofWindow = 30 * time.Second
+
+// EnrollProof computes the vault-ownership proof for a pairing-code mint
+// request: an HMAC-SHA256 over ts, keyed by secret (see
+// serverbootstrap.EnsureEnrollSecret). Only a caller that can read the
+// 0600 vault directory — the same trust domain as the TLS private key and
+// age identities — can produce a proof EnrollCodeHTTPHandler accepts.
+func EnrollProof(secret []byte, ts time.Time) string {
+	mac := hmac.New(sha256.New, secret)
+	mac.Write([]byte(ts.UTC().Format(time.RFC3339)))
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+// verifyEnrollProof checks a proof produced by EnrollProof against secret
+// and the server's current time.
+func verifyEnrollProof(secret []byte, tsHeader, proofHeader string, now time.Time) bool {
+	if len(secret) == 0 || tsHeader == "" || proofHeader == "" {
+		return false
+	}
+	ts, err := time.Parse(time.RFC3339, tsHeader)
+	if err != nil {
+		return false
+	}
+	if diff := now.UTC().Sub(ts.UTC()); diff > enrollProofWindow || diff < -enrollProofWindow {
+		return false
+	}
+	expected := EnrollProof(secret, ts)
+	return hmac.Equal([]byte(expected), []byte(proofHeader))
+}
+
 // loopbackChecker is the minimal surface EnrollCodeHTTPHandler needs to
 // decide whether a request's remote address is loopback. Satisfied by
 // internal/mcp.IsLoopbackHost; abstracted here purely to avoid importing
@@ -35,11 +80,16 @@ type loopbackChecker func(host string) bool
 // caller (cmd/mcp/serve_deps.go) is responsible for constructing it with a
 // fingerprint computed once at server startup, since a nil/empty fingerprint
 // means TLS isn't configured and pairing must be refused rather than handing
-// out a code that can't be safely used.
+// out a code that can't be safely used. Loopback alone is not sufficient
+// authorization: every mint request must also carry a valid EnrollProof
+// proving possession of the vault directory's enroll secret, since any
+// local process — under any user account — can otherwise reach a loopback
+// listener.
 type EnrollCodeHTTPHandler struct {
 	codes       *pairing.TokenStore
 	fingerprint string
 	isLoopback  loopbackChecker
+	secret      []byte
 }
 
 // NewEnrollCodeHTTPHandler creates the local-only pairing-code minting
@@ -47,9 +97,11 @@ type EnrollCodeHTTPHandler struct {
 // TLS certificate (see internal/mcp/serverbootstrap.CertFingerprint); an
 // empty fingerprint means TLS isn't available and every mint request is
 // refused, since a device pairing without a pinned fingerprint would have no
-// trust anchor.
-func NewEnrollCodeHTTPHandler(codes *pairing.TokenStore, fingerprint string, isLoopback func(host string) bool) *EnrollCodeHTTPHandler {
-	return &EnrollCodeHTTPHandler{codes: codes, fingerprint: fingerprint, isLoopback: isLoopback}
+// trust anchor. secret is the vault's enroll secret (see
+// serverbootstrap.EnsureEnrollSecret); a mint request without a valid
+// EnrollProof against it is refused with 401.
+func NewEnrollCodeHTTPHandler(codes *pairing.TokenStore, fingerprint string, isLoopback func(host string) bool, secret []byte) *EnrollCodeHTTPHandler {
+	return &EnrollCodeHTTPHandler{codes: codes, fingerprint: fingerprint, isLoopback: isLoopback, secret: secret}
 }
 
 func (h *EnrollCodeHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -63,6 +115,10 @@ func (h *EnrollCodeHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 	}
 	if h.isLoopback == nil || !h.isLoopback(host) {
 		writeApprovalError(w, http.StatusForbidden, "device pairing codes can only be minted from localhost")
+		return
+	}
+	if !verifyEnrollProof(h.secret, r.Header.Get(HeaderEnrollTimestamp), r.Header.Get(HeaderEnrollProof), time.Now()) {
+		writeApprovalError(w, http.StatusUnauthorized, "missing or invalid proof of vault-directory ownership")
 		return
 	}
 	if h.fingerprint == "" {
@@ -103,7 +159,6 @@ func NewEnrollHTTPHandler(codes *pairing.TokenStore, sessions *pairing.DeviceSes
 type enrollRequest struct {
 	Code       string `json:"code"`
 	DeviceName string `json:"device_name"`
-	PublicKey  string `json:"public_key"`
 }
 
 func (h *EnrollHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -130,7 +185,7 @@ func (h *EnrollHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		writeApprovalError(w, http.StatusInternalServerError, "generate device id")
 		return
 	}
-	token, err := h.sessions.Enroll(deviceID, req.DeviceName, req.PublicKey)
+	token, err := h.sessions.Enroll(deviceID, req.DeviceName, "")
 	if err != nil {
 		writeApprovalError(w, http.StatusInternalServerError, "enroll device")
 		return

--- a/internal/approval/enroll_test.go
+++ b/internal/approval/enroll_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/danieljustus/symaira-vault/internal/pairing"
 )
@@ -13,9 +14,19 @@ import (
 func alwaysLoopback(string) bool { return true }
 func neverLoopback(string) bool  { return false }
 
+var testEnrollSecret = []byte("test-enroll-secret-32-bytes-long")
+
+// setValidEnrollProof attaches a proof computed against testEnrollSecret for
+// the current time, as a real "symvault device approval-pair" caller would.
+func setValidEnrollProof(req *http.Request) {
+	now := time.Now().UTC()
+	req.Header.Set(HeaderEnrollTimestamp, now.Format(time.RFC3339))
+	req.Header.Set(HeaderEnrollProof, EnrollProof(testEnrollSecret, now))
+}
+
 func TestEnrollCodeHTTPHandler_RejectsNonLoopback(t *testing.T) {
 	codes := pairing.NewTokenStore()
-	h := NewEnrollCodeHTTPHandler(codes, "fp-1", neverLoopback)
+	h := NewEnrollCodeHTTPHandler(codes, "fp-1", neverLoopback, testEnrollSecret)
 
 	req := httptest.NewRequest(http.MethodPost, PathDeviceEnrollCode, nil)
 	req.RemoteAddr = "203.0.113.5:1234"
@@ -27,12 +38,61 @@ func TestEnrollCodeHTTPHandler_RejectsNonLoopback(t *testing.T) {
 	}
 }
 
-func TestEnrollCodeHTTPHandler_RejectsWithoutFingerprint(t *testing.T) {
+func TestEnrollCodeHTTPHandler_RejectsWithoutProof(t *testing.T) {
 	codes := pairing.NewTokenStore()
-	h := NewEnrollCodeHTTPHandler(codes, "", alwaysLoopback)
+	h := NewEnrollCodeHTTPHandler(codes, "fp-1", alwaysLoopback, testEnrollSecret)
 
 	req := httptest.NewRequest(http.MethodPost, PathDeviceEnrollCode, nil)
 	req.RemoteAddr = "127.0.0.1:1234"
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401 (unproven request from loopback must still be rejected)", rec.Code)
+	}
+}
+
+func TestEnrollCodeHTTPHandler_RejectsWrongProof(t *testing.T) {
+	codes := pairing.NewTokenStore()
+	h := NewEnrollCodeHTTPHandler(codes, "fp-1", alwaysLoopback, testEnrollSecret)
+
+	req := httptest.NewRequest(http.MethodPost, PathDeviceEnrollCode, nil)
+	req.RemoteAddr = "127.0.0.1:1234"
+	now := time.Now().UTC()
+	req.Header.Set(HeaderEnrollTimestamp, now.Format(time.RFC3339))
+	req.Header.Set(HeaderEnrollProof, EnrollProof([]byte("wrong-secret"), now))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rec.Code)
+	}
+}
+
+func TestEnrollCodeHTTPHandler_RejectsStaleProof(t *testing.T) {
+	codes := pairing.NewTokenStore()
+	h := NewEnrollCodeHTTPHandler(codes, "fp-1", alwaysLoopback, testEnrollSecret)
+
+	req := httptest.NewRequest(http.MethodPost, PathDeviceEnrollCode, nil)
+	req.RemoteAddr = "127.0.0.1:1234"
+	stale := time.Now().UTC().Add(-time.Hour)
+	req.Header.Set(HeaderEnrollTimestamp, stale.Format(time.RFC3339))
+	req.Header.Set(HeaderEnrollProof, EnrollProof(testEnrollSecret, stale))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401 for a proof outside the freshness window", rec.Code)
+	}
+}
+
+func TestEnrollCodeHTTPHandler_RejectsWithoutFingerprint(t *testing.T) {
+	codes := pairing.NewTokenStore()
+	h := NewEnrollCodeHTTPHandler(codes, "", alwaysLoopback, testEnrollSecret)
+
+	req := httptest.NewRequest(http.MethodPost, PathDeviceEnrollCode, nil)
+	req.RemoteAddr = "127.0.0.1:1234"
+	setValidEnrollProof(req)
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, req)
 
@@ -43,7 +103,7 @@ func TestEnrollCodeHTTPHandler_RejectsWithoutFingerprint(t *testing.T) {
 
 func TestEnrollCodeHTTPHandler_RejectsNonPost(t *testing.T) {
 	codes := pairing.NewTokenStore()
-	h := NewEnrollCodeHTTPHandler(codes, "fp-1", alwaysLoopback)
+	h := NewEnrollCodeHTTPHandler(codes, "fp-1", alwaysLoopback, testEnrollSecret)
 
 	req := httptest.NewRequest(http.MethodGet, PathDeviceEnrollCode, nil)
 	req.RemoteAddr = "127.0.0.1:1234"
@@ -57,10 +117,11 @@ func TestEnrollCodeHTTPHandler_RejectsNonPost(t *testing.T) {
 
 func TestEnrollCodeHTTPHandler_MintsCode(t *testing.T) {
 	codes := pairing.NewTokenStore()
-	h := NewEnrollCodeHTTPHandler(codes, "fp-1", alwaysLoopback)
+	h := NewEnrollCodeHTTPHandler(codes, "fp-1", alwaysLoopback, testEnrollSecret)
 
 	req := httptest.NewRequest(http.MethodPost, PathDeviceEnrollCode, nil)
 	req.RemoteAddr = "127.0.0.1:1234"
+	setValidEnrollProof(req)
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, req)
 

--- a/internal/mcp/serverbootstrap/tls.go
+++ b/internal/mcp/serverbootstrap/tls.go
@@ -28,7 +28,7 @@ const (
 	// enrollSecretFile is the filename for the random secret that proves
 	// vault-directory ownership when minting an approval-device pairing
 	// code (see EnsureEnrollSecret).
-	enrollSecretFile = "mcp-server.enroll-secret"
+	enrollSecretFile = "mcp-server.enroll-secret" // #nosec G101 -- filename, not a credential
 	// enrollSecretSize is the size in bytes of the generated enroll secret.
 	enrollSecretSize = 32
 )
@@ -163,9 +163,11 @@ func EnsureEnrollSecret(vaultDir string) ([]byte, error) {
 		return nil, nil
 	}
 	path := filepath.Join(vaultDir, enrollSecretFile)
-	if secret, err := os.ReadFile(path); err == nil { // #nosec G304 -- path is this function's own fixed filename under vaultDir
-		return secret, nil
-	} else if !os.IsNotExist(err) {
+	existing, err := os.ReadFile(path) // #nosec G304 -- path is this function's own fixed filename under vaultDir
+	if err == nil {
+		return existing, nil
+	}
+	if !os.IsNotExist(err) {
 		return nil, fmt.Errorf("read enroll secret: %w", err)
 	}
 	secret := make([]byte, enrollSecretSize)

--- a/internal/mcp/serverbootstrap/tls.go
+++ b/internal/mcp/serverbootstrap/tls.go
@@ -25,6 +25,12 @@ const (
 	autoCertFile = "mcp-server.crt"
 	// autoKeyFile is the filename for the auto-generated TLS private key in the vault directory.
 	autoKeyFile = "mcp-server.key"
+	// enrollSecretFile is the filename for the random secret that proves
+	// vault-directory ownership when minting an approval-device pairing
+	// code (see EnsureEnrollSecret).
+	enrollSecretFile = "mcp-server.enroll-secret"
+	// enrollSecretSize is the size in bytes of the generated enroll secret.
+	enrollSecretSize = 32
 )
 
 // EnsureTLSCert returns the paths to a usable TLS certificate and key for the
@@ -141,4 +147,33 @@ func CertFingerprint(vaultDir string) (string, error) {
 	}
 	sum := sha256.Sum256(cert.Raw)
 	return hex.EncodeToString(sum[:]), nil
+}
+
+// EnsureEnrollSecret returns a random secret cached at
+// "<vaultDir>/mcp-server.enroll-secret" (0600, generated on first use),
+// proof of possession of which stands in for proof of vault-directory
+// ownership: only whoever can already read the 0600 vault directory (the
+// same trust domain as the TLS private key and age identities) can read
+// this file. It is used to authenticate "symvault device approval-pair"'s
+// request to mint a pairing code, so a local process without vault-directory
+// access cannot self-enroll as an approval device merely by reaching the
+// server's loopback listener. Returns nil for an empty vaultDir.
+func EnsureEnrollSecret(vaultDir string) ([]byte, error) {
+	if vaultDir == "" {
+		return nil, nil
+	}
+	path := filepath.Join(vaultDir, enrollSecretFile)
+	if secret, err := os.ReadFile(path); err == nil { // #nosec G304 -- path is this function's own fixed filename under vaultDir
+		return secret, nil
+	} else if !os.IsNotExist(err) {
+		return nil, fmt.Errorf("read enroll secret: %w", err)
+	}
+	secret := make([]byte, enrollSecretSize)
+	if _, err := rand.Read(secret); err != nil {
+		return nil, fmt.Errorf("generate enroll secret: %w", err)
+	}
+	if err := fsutil.SafeWriteFile(path, secret, 0o600); err != nil {
+		return nil, fmt.Errorf("write enroll secret: %w", err)
+	}
+	return secret, nil
 }

--- a/internal/mcp/serverbootstrap/tls_test.go
+++ b/internal/mcp/serverbootstrap/tls_test.go
@@ -57,3 +57,61 @@ func TestCertFingerprint_EmptyVaultDir(t *testing.T) {
 		t.Fatal("expected an error for an empty vault directory")
 	}
 }
+
+func TestEnsureEnrollSecret_PersistsAcrossCalls(t *testing.T) {
+	dir := t.TempDir()
+
+	secret1, err := EnsureEnrollSecret(dir)
+	if err != nil {
+		t.Fatalf("EnsureEnrollSecret: %v", err)
+	}
+	if len(secret1) != enrollSecretSize {
+		t.Fatalf("secret length = %d, want %d", len(secret1), enrollSecretSize)
+	}
+
+	secret2, err := EnsureEnrollSecret(dir)
+	if err != nil {
+		t.Fatalf("EnsureEnrollSecret (second call): %v", err)
+	}
+	if string(secret1) != string(secret2) {
+		t.Fatal("expected the same secret across calls for the same vault directory")
+	}
+}
+
+func TestEnsureEnrollSecret_DistinctPerVaultDir(t *testing.T) {
+	secret1, err := EnsureEnrollSecret(t.TempDir())
+	if err != nil {
+		t.Fatalf("EnsureEnrollSecret: %v", err)
+	}
+	secret2, err := EnsureEnrollSecret(t.TempDir())
+	if err != nil {
+		t.Fatalf("EnsureEnrollSecret: %v", err)
+	}
+	if string(secret1) == string(secret2) {
+		t.Fatal("expected distinct secrets for distinct vault directories")
+	}
+}
+
+func TestEnsureEnrollSecret_FilePermissions(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := EnsureEnrollSecret(dir); err != nil {
+		t.Fatalf("EnsureEnrollSecret: %v", err)
+	}
+	info, err := os.Stat(filepath.Join(dir, enrollSecretFile))
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("permissions = %v, want 0600", info.Mode().Perm())
+	}
+}
+
+func TestEnsureEnrollSecret_EmptyVaultDir(t *testing.T) {
+	secret, err := EnsureEnrollSecret("")
+	if err != nil {
+		t.Fatalf("EnsureEnrollSecret: %v", err)
+	}
+	if secret != nil {
+		t.Fatalf("expected a nil secret for an empty vault directory, got %d bytes", len(secret))
+	}
+}


### PR DESCRIPTION
## Summary

`EnrollCodeHTTPHandler.ServeHTTP` gated minting a device-pairing code purely on `isLoopback(remoteHost)` — no bearer token, no proof of vault-directory access, no CSRF/origin check. `PathDeviceEnroll` is LAN-reachable and unauthenticated by design, so any process on the machine, under any user account, could `POST /api/v1/devices/enroll-code` then `POST /api/v1/devices/enroll` and receive a 90-day token that approves every agent write under approval mode "prompt" — bypassing the human-in-the-loop control in `internal/policy/authorizer.go` entirely. Every other privileged surface on the same listener (`/mcp`) is bearer-authenticated; this endpoint wasn't.

## Change

- `serverbootstrap.EnsureEnrollSecret` (`internal/mcp/serverbootstrap/tls.go`, alongside `EnsureTLSCert`): a random 32-byte secret cached at `<vaultDir>/mcp-server.enroll-secret`, 0600 — the same trust domain as the TLS private key and age identities.
- `approval.EnrollProof(secret, ts)`: HMAC-SHA256 over an RFC3339 timestamp, keyed by that secret. `EnrollCodeHTTPHandler` now requires a valid, fresh (±30s) proof via `X-Enroll-Timestamp`/`X-Enroll-Proof` headers, rejecting with 401 otherwise. The loopback check stays in place as defence in depth.
- `mintApprovalEnrollCode` (the CLI side of `symvault device approval-pair`) reads the same secret from the vault directory it already has access to, and sends the proof automatically — the pairing flow is unchanged from the operator's perspective.
- Dropped the enrollment request's unused `public_key` field: the server never verified it, and the iOS client already sent an empty string.

## Testing

- New tests: `TestEnrollCodeHTTPHandler_RejectsWithoutProof` (unproven request from loopback → 401), `RejectsWrongProof`, `RejectsStaleProof`, plus updated `RejectsWithoutFingerprint`/`RejectsNonPost`/`MintsCode` to carry a valid proof where appropriate.
- `TestMintApprovalEnrollCode_RoundTrip` exercises the real CLI→server call end-to-end against a real TLS listener, confirming the existing pairing flow still works.
- `TestEnsureEnrollSecret_*` (persistence, distinct-per-vault-dir, 0600 permissions, empty-vaultDir handling).
- `go build ./...`, `go vet ./...`: clean. `go test ./internal/approval/... ./internal/mcp/serverbootstrap/... ./cmd/...` and the same with `-race`: all pass. `golangci-lint run` on the changed packages: 0 issues (one pre-existing, unrelated `unparam` finding in `cmd/admin/export_test.go`, not touched by this change).
- `swiftc -parse` on the edited Swift file: clean (full `swift build`/`swift test` needs the Vaultcore.xcframework native build, which CI's "Vaultcore (macOS)" job covers).

Closes #945

🤖 Generated with [Claude Code](https://claude.com/claude-code)