### PR TITLE
fix(security): store device-session bearer tokens hashed on disk

### DIFF
--- a/cmd/device_approval.go
+++ b/cmd/device_approval.go
@@ -208,7 +208,7 @@ approve or deny agent requests.`,
 				printQuietAware("No approval devices enrolled.\n")
 				return nil
 			}
-			printQuietAware("%-24s %-24s %-20s %-20s %s\n", "DEVICE ID", "NAME", "ENROLLED", "EXPIRES", "STATUS")
+			printQuietAware("%-24s %-6s %-24s %-20s %-20s %s\n", "DEVICE ID", "TOKEN", "NAME", "ENROLLED", "EXPIRES", "STATUS")
 			for _, s := range sessions {
 				status := "active"
 				switch {
@@ -221,8 +221,8 @@ approve or deny agent requests.`,
 				if name == "" {
 					name = "(unnamed)"
 				}
-				printQuietAware("%-24s %-24s %-20s %-20s %s\n",
-					s.DeviceID, name, s.CreatedAt.Format("2006-01-02 15:04"), s.ExpiresAt.Format("2006-01-02 15:04"), status)
+				printQuietAware("%-24s %-6s %-24s %-20s %-20s %s\n",
+					s.DeviceID, s.Prefix+"…", name, s.CreatedAt.Format("2006-01-02 15:04"), s.ExpiresAt.Format("2006-01-02 15:04"), status)
 			}
 			return nil
 		},

--- a/internal/mcp/auth/token.go
+++ b/internal/mcp/auth/token.go
@@ -712,6 +712,15 @@ func GenerateTokenID() string {
 
 // sha256Hex returns the lowercase hex-encoded SHA-256 digest of s.
 func sha256Hex(s string) string {
+	return SHA256Hex(s)
+}
+
+// SHA256Hex returns the lowercase hex-encoded SHA-256 digest of s. It is the
+// hashing scheme this package's own bearer/refresh tokens are stored under
+// (see TokenData.Hash), exported so other on-disk bearer-token stores (e.g.
+// internal/pairing's device sessions) can use the same scheme instead of
+// growing a second one.
+func SHA256Hex(s string) string {
 	h := sha256.Sum256([]byte(s))
 	return hex.EncodeToString(h[:])
 }

--- a/internal/pairing/devicesession.go
+++ b/internal/pairing/devicesession.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/base32"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -17,6 +18,7 @@ import (
 	"time"
 
 	"github.com/danieljustus/symaira-vault/internal/config"
+	"github.com/danieljustus/symaira-vault/internal/mcp/auth"
 )
 
 const (
@@ -30,9 +32,12 @@ const (
 	SessionFailedAttemptCooldown = 30 * time.Second
 )
 
-// DeviceSession represents an enrolled device session token.
+// DeviceSession represents an enrolled device session token. The bearer
+// token itself is never persisted — only its SHA-256 hash, keyed identically
+// to internal/mcp/auth's scoped-token registry, plus Prefix (the first few
+// characters of the raw token) for display in "approval-list".
 type DeviceSession struct {
-	Token     string    `json:"token"`
+	Prefix    string    `json:"prefix"`
 	DeviceID  string    `json:"device_id"`
 	Name      string    `json:"name,omitempty"`
 	PublicKey string    `json:"public_key"`
@@ -52,7 +57,7 @@ type deviceFailure struct {
 type DeviceSessionStore struct {
 	path     string
 	mu       sync.RWMutex
-	sessions map[string]*DeviceSession // token -> session
+	sessions map[string]*DeviceSession // sha256Hex(token) -> session
 	failures map[string]deviceFailure  // deviceID -> failure state
 	mtime    time.Time                 // mtime of path as of the last load/save
 }
@@ -80,15 +85,18 @@ func NewDeviceSessionStore(vaultDir string) (*DeviceSessionStore, error) {
 }
 
 // Enroll creates a new long-lived session token for deviceID with the given
-// human-readable name and publicKey. The token is returned and persisted.
+// human-readable name and publicKey. The raw token is returned to the caller
+// and never persisted — only its hash (see hashToken) is stored.
 func (s *DeviceSessionStore) Enroll(deviceID, name, publicKey string) (string, error) {
 	token, err := GenerateSessionToken()
 	if err != nil {
 		return "", fmt.Errorf("generate session token: %w", err)
 	}
+	rawToken := token.String()
+	hash := hashToken(rawToken)
 	now := time.Now().UTC()
 	session := &DeviceSession{
-		Token:     token.String(),
+		Prefix:    tokenPrefix(rawToken),
 		DeviceID:  deviceID,
 		Name:      name,
 		PublicKey: publicKey,
@@ -96,13 +104,13 @@ func (s *DeviceSessionStore) Enroll(deviceID, name, publicKey string) (string, e
 		ExpiresAt: now.Add(DefaultSessionTTL),
 	}
 	s.mu.Lock()
-	s.sessions[token.String()] = session
+	s.sessions[hash] = session
 	s.mu.Unlock()
 	if err := s.save(); err != nil {
-		delete(s.sessions, token.String())
+		delete(s.sessions, hash)
 		return "", fmt.Errorf("persist device session: %w", err)
 	}
-	return token.String(), nil
+	return rawToken, nil
 }
 
 // List returns a snapshot of every session in the store, including revoked
@@ -127,7 +135,7 @@ func (s *DeviceSessionStore) Validate(token string) (string, bool) {
 
 	s.mergeRevocationsFromDisk()
 
-	session, ok := s.sessions[token]
+	session, ok := s.sessions[hashToken(token)]
 	if !ok {
 		return "", false
 	}
@@ -160,7 +168,7 @@ func (s *DeviceSessionStore) RecordFailure(token string) {
 
 	s.mergeRevocationsFromDisk()
 
-	session, ok := s.sessions[token]
+	session, ok := s.sessions[hashToken(token)]
 	if !ok {
 		return
 	}
@@ -279,13 +287,37 @@ func (s *DeviceSessionStore) load() error {
 		}
 		return err
 	}
-	var sessions map[string]*DeviceSession
-	if err := json.Unmarshal(data, &sessions); err != nil {
+	var raw map[string]*DeviceSession
+	if err := json.Unmarshal(data, &raw); err != nil {
 		return fmt.Errorf("parse device sessions: %w", err)
+	}
+
+	// Migrate legacy entries keyed by the raw bearer token (from before
+	// tokens were hashed at rest) to hash-keyed entries. A legacy key is the
+	// base32 session token itself, which never looks like a SHA-256 hex
+	// digest.
+	migrated := false
+	sessions := make(map[string]*DeviceSession, len(raw))
+	for key, session := range raw {
+		if session == nil {
+			continue
+		}
+		if looksLikeSHA256Hex(key) {
+			sessions[key] = session
+			continue
+		}
+		if session.Prefix == "" {
+			session.Prefix = tokenPrefix(key)
+		}
+		sessions[hashToken(key)] = session
+		migrated = true
 	}
 	s.sessions = sessions
 	if info, statErr := os.Stat(s.path); statErr == nil {
 		s.mtime = info.ModTime()
+	}
+	if migrated {
+		return s.save()
 	}
 	return nil
 }
@@ -361,3 +393,46 @@ func GenerateSessionToken() (Token, error) {
 	token := base32.HexEncoding.WithPadding(base32.NoPadding).EncodeToString(b)
 	return Token(token), nil
 }
+
+// tokenPrefixLen is how many characters of the raw token are kept as the
+// display-only Prefix, matching internal/mcp/auth.TokenData's Prefix
+// convention (see TokenRegistry.Create).
+const tokenPrefixLen = 4
+
+// hashToken returns the storage key for rawToken: the same SHA-256 hex
+// scheme internal/mcp/auth's scoped-token registry stores its own bearer
+// tokens under, so a leaked backup or vault-dir read yields no usable
+// credential — only whoever presents the matching raw token again can be
+// looked up.
+func hashToken(rawToken string) string {
+	return auth.SHA256Hex(rawToken)
+}
+
+// tokenPrefix returns the short, non-secret display prefix stored alongside
+// a hashed session so "approval-list" can show which device is which
+// without ever persisting the usable token.
+func tokenPrefix(rawToken string) string {
+	if len(rawToken) <= tokenPrefixLen {
+		return rawToken
+	}
+	return rawToken[:tokenPrefixLen]
+}
+
+// looksLikeSHA256Hex reports whether s has the shape of a lowercase
+// hex-encoded SHA-256 digest (64 hex characters), used to distinguish
+// already-hashed storage keys from legacy keys that are still the raw
+// base32 session token itself (see (*DeviceSessionStore).load).
+func looksLikeSHA256Hex(s string) bool {
+	if len(s) != hex.EncodedLen(sha256DigestSize) {
+		return false
+	}
+	for _, r := range s {
+		if (r < '0' || r > '9') && (r < 'a' || r > 'f') {
+			return false
+		}
+	}
+	return true
+}
+
+// sha256DigestSize is the size in bytes of a SHA-256 digest.
+const sha256DigestSize = 32

--- a/internal/pairing/devicesession_test.go
+++ b/internal/pairing/devicesession_test.go
@@ -2,6 +2,9 @@ package pairing
 
 import (
 	"context"
+	"encoding/json"
+	"os"
+	"strings"
 	"testing"
 	"time"
 )
@@ -129,6 +132,125 @@ func TestDeviceSessionStore_CleanupExpired_NoOpDoesNotRewriteFile(t *testing.T) 
 	}
 }
 
+func TestDeviceSessionStore_PersistedFileContainsOnlyHashedValues(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewDeviceSessionStore(dir)
+	if err != nil {
+		t.Fatalf("NewDeviceSessionStore: %v", err)
+	}
+	token, err := store.Enroll("device-1", "Device One", "age1pubkey")
+	if err != nil {
+		t.Fatalf("Enroll: %v", err)
+	}
+
+	data, err := os.ReadFile(store.path)
+	if err != nil {
+		t.Fatalf("read persisted file: %v", err)
+	}
+	raw := string(data)
+	if strings.Contains(raw, token) {
+		t.Fatalf("persisted file contains the raw token: %s", raw)
+	}
+
+	var onDisk map[string]json.RawMessage
+	if err := json.Unmarshal(data, &onDisk); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(onDisk) != 1 {
+		t.Fatalf("expected exactly one persisted session, got %d", len(onDisk))
+	}
+	for key := range onDisk {
+		if !looksLikeSHA256Hex(key) {
+			t.Fatalf("persisted key %q does not look like a SHA-256 hex digest", key)
+		}
+	}
+
+	// Every value's own fields must not carry a usable token either.
+	for _, entry := range onDisk {
+		var fields map[string]any
+		if err := json.Unmarshal(entry, &fields); err != nil {
+			t.Fatalf("unmarshal entry: %v", err)
+		}
+		if _, hasToken := fields["token"]; hasToken {
+			t.Fatalf("persisted entry still has a raw 'token' field: %v", fields)
+		}
+		prefix, _ := fields["prefix"].(string)
+		if prefix == "" || prefix == token {
+			t.Fatalf("prefix = %q, want a short non-empty prefix distinct from the full token", prefix)
+		}
+	}
+}
+
+func TestDeviceSessionStore_MigratesLegacyRawTokenKeys(t *testing.T) {
+	dir := t.TempDir()
+
+	// Write a pre-migration file exactly as the old code would have: keyed
+	// by the raw token, with a "token" field carrying the same value.
+	legacyToken := "LEGACY0123456789ABCDEFGHJKMNPQRS"
+	legacy := map[string]map[string]any{
+		legacyToken: {
+			"token":      legacyToken,
+			"device_id":  "device-legacy",
+			"name":       "Old Phone",
+			"public_key": "",
+			"created_at": time.Now().UTC().Format(time.RFC3339),
+			"expires_at": time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339),
+			"revoked":    false,
+		},
+	}
+	data, err := json.MarshalIndent(legacy, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal legacy fixture: %v", err)
+	}
+
+	// Create a store once to learn its real on-disk path, then overwrite
+	// that exact file with the legacy fixture before reloading.
+	bootstrap, err := NewDeviceSessionStore(dir)
+	if err != nil {
+		t.Fatalf("NewDeviceSessionStore (bootstrap): %v", err)
+	}
+	path := bootstrap.path
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write legacy fixture: %v", err)
+	}
+
+	store, err := NewDeviceSessionStore(dir)
+	if err != nil {
+		t.Fatalf("NewDeviceSessionStore: %v", err)
+	}
+
+	// The legacy raw token must still validate after migration.
+	deviceID, ok := store.Validate(legacyToken)
+	if !ok || deviceID != "device-legacy" {
+		t.Fatalf("Validate(legacyToken) = %q, %v, want device-legacy, true", deviceID, ok)
+	}
+
+	// The on-disk file must now be rewritten hash-keyed, with no raw token
+	// anywhere in it.
+	migratedData, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read migrated file: %v", err)
+	}
+	if strings.Contains(string(migratedData), legacyToken) {
+		t.Fatalf("migrated file still contains the raw legacy token: %s", migratedData)
+	}
+	var onDisk map[string]json.RawMessage
+	if err := json.Unmarshal(migratedData, &onDisk); err != nil {
+		t.Fatalf("unmarshal migrated file: %v", err)
+	}
+	if len(onDisk) != 1 {
+		t.Fatalf("expected exactly one migrated session, got %d", len(onDisk))
+	}
+	for key := range onDisk {
+		if !looksLikeSHA256Hex(key) {
+			t.Fatalf("migrated key %q does not look like a SHA-256 hex digest", key)
+		}
+		if key != hashToken(legacyToken) {
+			t.Fatalf("migrated key = %q, want %q", key, hashToken(legacyToken))
+		}
+	}
+}
+
 func TestDeviceSessionStore_UnknownToken(t *testing.T) {
 	dir := t.TempDir()
 	store, err := NewDeviceSessionStore(dir)
@@ -202,7 +324,7 @@ func TestDeviceSessionStore_ExpiredSession(t *testing.T) {
 
 	// Manually expire the session.
 	store.mu.Lock()
-	store.sessions[token].ExpiresAt = time.Now().Add(-time.Hour)
+	store.sessions[hashToken(token)].ExpiresAt = time.Now().Add(-time.Hour)
 	store.mu.Unlock()
 
 	deviceID, ok := store.Validate(token)
@@ -223,7 +345,7 @@ func TestDeviceSessionStore_CleanupExpired(t *testing.T) {
 	}
 
 	store.mu.Lock()
-	store.sessions[token].ExpiresAt = time.Now().Add(-time.Hour)
+	store.sessions[hashToken(token)].ExpiresAt = time.Now().Add(-time.Hour)
 	store.mu.Unlock()
 
 	store.CleanupExpired()
@@ -286,7 +408,7 @@ func TestDeviceSessionStore_NameRoundTripsAcrossLoad(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewDeviceSessionStore: %v", err)
 	}
-	token, err := store.Enroll("device-1", "Daniel's iPhone", "")
+	_, err = store.Enroll("device-1", "Daniel's iPhone", "")
 	if err != nil {
 		t.Fatalf("Enroll: %v", err)
 	}
@@ -298,7 +420,7 @@ func TestDeviceSessionStore_NameRoundTripsAcrossLoad(t *testing.T) {
 	sessions := store2.List()
 	found := false
 	for _, s := range sessions {
-		if s.Token == token {
+		if s.DeviceID == "device-1" {
 			found = true
 			if s.Name != "Daniel's iPhone" {
 				t.Fatalf("Name = %q, want %q", s.Name, "Daniel's iPhone")


### PR DESCRIPTION
## Summary

`DeviceSessionStore.save` wrote `map[token]*DeviceSession` to `.symvault/device-sessions.json` with the raw 160-bit bearer token as both the JSON map key and the `token` field. The MCP scoped-token registry (`internal/mcp/auth`) stores only a hash plus a display prefix for the equivalent bearer credential. A vault backup, a git sync of the vault directory, or any read of the 0600 file yielded ready-to-use 90-day approval credentials — tokens that can approve or deny every agent write.

## Change

- Exported `internal/mcp/auth.SHA256Hex` (previously the unexported `sha256Hex`) and reused it here instead of growing a second hashing helper, per the issue's explicit ask.
- `DeviceSessionStore` now keys its map by `SHA256Hex(token)`. `DeviceSession` drops the raw `Token` field in favor of a short `Prefix` (first 4 characters of the raw token — the same convention `TokenData.Prefix` uses), now shown as a `TOKEN` column in `symvault device approval-list`.
- `Validate` and `RecordFailure` hash the presented bearer before the map lookup.
- `load()` migrates legacy files in place: a map key that doesn't look like a 64-character lowercase hex SHA-256 digest is treated as a legacy raw token, hashed, given a derived `Prefix`, and the file is rewritten once. Already-enrolled devices keep validating with no re-pairing needed.

## Testing

- `TestDeviceSessionStore_PersistedFileContainsOnlyHashedValues`: enrolls a device, asserts the raw token appears nowhere in the on-disk file, every key looks like a SHA-256 hex digest, and no entry carries a raw `token` field.
- `TestDeviceSessionStore_MigratesLegacyRawTokenKeys`: writes a pre-migration fixture keyed by a raw token (as the old code would have), reloads, asserts the legacy token still validates and the rewritten file is fully hash-keyed with the raw token gone.
- Updated existing tests that poked `store.sessions[token]` directly to use the hashed key.
- `go build ./...`, `go vet ./...`: clean. `go test ./internal/pairing/... ./internal/mcp/auth/... ./internal/approval/... ./cmd/...` and the same with `-race`: all pass.
- `golangci-lint run` on the changed packages: 0 issues (the one pre-existing `unparam` finding in `cmd/admin/export_test.go` is untouched by this change).
- `gosec` (pinned to the CI version, v2.22.0, under the CI Go toolchain 1.26.6 to match exactly): 0 findings.

Closes #946

🤖 Generated with [Claude Code](https://claude.com/claude-code)