### PR TITLE
fix(mcp): regenerate the MCP TLS certificate before it expires, surface expiry in doctor

### DIFF
--- a/internal/health/doctor.go
+++ b/internal/health/doctor.go
@@ -107,6 +107,7 @@ var allChecks = []checkDef{
 	{fn: checkClipboardBackend},
 	{fn: checkDaemonStatus},
 	{fn: checkMCPServer, tags: []string{"network"}},
+	{fn: checkMCPApprovalTLS},
 	{fn: checkDynamicSecretEngines},
 	{fn: checkMCPAgents},
 	{fn: checkSecureUI},

--- a/internal/health/doctor_mcp.go
+++ b/internal/health/doctor_mcp.go
@@ -13,6 +13,8 @@ import (
 	"github.com/danieljustus/symaira-vault/internal/audit"
 	configpkg "github.com/danieljustus/symaira-vault/internal/config"
 	auth "github.com/danieljustus/symaira-vault/internal/mcp/auth"
+	"github.com/danieljustus/symaira-vault/internal/mcp/serverbootstrap"
+	"github.com/danieljustus/symaira-vault/internal/pairing"
 	"github.com/danieljustus/symaira-vault/internal/update"
 )
 
@@ -217,6 +219,67 @@ func checkMCPServer(vaultDir string, _ Options) Result {
 		r.Hint = "generate an MCP token with `symvault agent token <name> new`"
 	}
 	return r
+}
+
+func checkMCPApprovalTLS(vaultDir string, _ Options) Result {
+	r := Result{ID: "mcp.approval.tls", Name: "Approval-device TLS certificate"}
+
+	exists, expiry, err := serverbootstrap.CertStatus(vaultDir)
+	if err != nil {
+		r.Status = StatusWarn
+		r.Message = "cannot read MCP TLS certificate: " + err.Error()
+		return r
+	}
+
+	active, expiredDevices, revoked, sessErr := approvalDeviceCounts(vaultDir)
+	deviceSummary := fmt.Sprintf("%d approval device(s) active, %d expired, %d revoked", active, expiredDevices, revoked)
+	if sessErr != nil {
+		deviceSummary = "approval devices: cannot load (" + sessErr.Error() + ")"
+	}
+
+	if !exists {
+		r.Status = StatusOK
+		r.Message = "no TLS certificate generated yet (server not started); " + deviceSummary
+		return r
+	}
+
+	daysLeft := int(time.Until(expiry).Hours() / 24)
+	reissueHint := "it regenerates automatically the next time the server starts; every paired approval device must be re-paired afterward"
+	switch {
+	case time.Now().After(expiry):
+		r.Status = StatusWarn
+		r.Message = fmt.Sprintf("cert expired %s; %s", expiry.Format("2006-01-02"), deviceSummary)
+		r.Hint = reissueHint
+	case time.Until(expiry) <= serverbootstrap.CertRenewalWindow:
+		r.Status = StatusWarn
+		r.Message = fmt.Sprintf("cert expires %s (%d day(s)); %s", expiry.Format("2006-01-02"), daysLeft, deviceSummary)
+		r.Hint = reissueHint
+	default:
+		r.Status = StatusOK
+		r.Message = fmt.Sprintf("cert expires %s (%d days); %s", expiry.Format("2006-01-02"), daysLeft, deviceSummary)
+	}
+	return r
+}
+
+// approvalDeviceCounts summarizes the approval-device session store by
+// status, for checkMCPApprovalTLS.
+func approvalDeviceCounts(vaultDir string) (active, expired, revoked int, err error) {
+	store, err := pairing.NewDeviceSessionStore(vaultDir)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	now := time.Now()
+	for _, s := range store.List() {
+		switch {
+		case s.Revoked:
+			revoked++
+		case now.After(s.ExpiresAt):
+			expired++
+		default:
+			active++
+		}
+	}
+	return active, expired, revoked, nil
 }
 
 func checkDynamicSecretEngines(vaultDir string, _ Options) Result {

--- a/internal/health/doctor_mcp_approval_tls_test.go
+++ b/internal/health/doctor_mcp_approval_tls_test.go
@@ -1,0 +1,148 @@
+package health_test
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/danieljustus/symaira-vault/internal/health"
+	"github.com/danieljustus/symaira-vault/internal/mcp/serverbootstrap"
+	"github.com/danieljustus/symaira-vault/internal/pairing"
+)
+
+// writeNearExpiryCert writes a self-signed cert+key pair with the given
+// NotAfter directly under vaultDir, at the exact paths EnsureTLSCert/
+// CertStatus use, so this doctor-check test can exercise the near-expiry
+// warning without depending on serverbootstrap's unexported test helpers.
+func writeNearExpiryCert(t *testing.T, vaultDir string, notAfter time.Time) {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		t.Fatalf("generate serial: %v", err)
+	}
+	template := x509.Certificate{
+		SerialNumber:          serial,
+		Subject:               pkix.Name{CommonName: "test-fixture"},
+		NotBefore:             notAfter.Add(-365 * 24 * time.Hour),
+		NotAfter:              notAfter,
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatalf("create certificate: %v", err)
+	}
+	privBytes, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		t.Fatalf("marshal key: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(vaultDir, "mcp-server.key"), pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privBytes}), 0o600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(vaultDir, "mcp-server.crt"), pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER}), 0o644); err != nil {
+		t.Fatalf("write cert: %v", err)
+	}
+}
+
+func runMCPApprovalTLSCheck(t *testing.T, vaultDir string) health.Result {
+	t.Helper()
+	results := health.RunChecks(vaultDir, health.Options{Only: []string{"mcp.approval.tls"}, NoNetwork: true})
+	if len(results) != 1 {
+		t.Fatalf("expected exactly 1 result for mcp.approval.tls, got %d: %+v", len(results), results)
+	}
+	return results[0]
+}
+
+func TestCheckMCPApprovalTLS_NoCertYet(t *testing.T) {
+	dir := t.TempDir()
+
+	r := runMCPApprovalTLSCheck(t, dir)
+	if r.Status != health.StatusOK {
+		t.Fatalf("status = %v, want OK; message = %q", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "no TLS certificate generated yet") {
+		t.Fatalf("message = %q, want it to mention no cert yet", r.Message)
+	}
+}
+
+func TestCheckMCPApprovalTLS_HealthyCert(t *testing.T) {
+	dir := t.TempDir()
+	if _, _, err := serverbootstrap.EnsureTLSCert(dir); err != nil {
+		t.Fatalf("EnsureTLSCert: %v", err)
+	}
+
+	r := runMCPApprovalTLSCheck(t, dir)
+	if r.Status != health.StatusOK {
+		t.Fatalf("status = %v, want OK; message = %q", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "cert expires") {
+		t.Fatalf("message = %q, want it to report the cert's expiry", r.Message)
+	}
+}
+
+func TestCheckMCPApprovalTLS_ReportsDeviceCounts(t *testing.T) {
+	dir := t.TempDir()
+	if _, _, err := serverbootstrap.EnsureTLSCert(dir); err != nil {
+		t.Fatalf("EnsureTLSCert: %v", err)
+	}
+
+	store, err := pairing.NewDeviceSessionStore(dir)
+	if err != nil {
+		t.Fatalf("NewDeviceSessionStore: %v", err)
+	}
+	if _, err := store.Enroll("device-active", "Active Phone", ""); err != nil {
+		t.Fatalf("Enroll active: %v", err)
+	}
+	if _, err := store.Enroll("device-revoked", "Revoked Phone", ""); err != nil {
+		t.Fatalf("Enroll revoked: %v", err)
+	}
+	store.Revoke("device-revoked")
+
+	r := runMCPApprovalTLSCheck(t, dir)
+	if !strings.Contains(r.Message, "1 approval device(s) active") {
+		t.Fatalf("message = %q, want it to report 1 active device", r.Message)
+	}
+	if !strings.Contains(r.Message, "1 revoked") {
+		t.Fatalf("message = %q, want it to report 1 revoked device", r.Message)
+	}
+}
+
+func TestCheckMCPApprovalTLS_WarnsWhenCertNearExpiry(t *testing.T) {
+	dir := t.TempDir()
+	writeNearExpiryCert(t, dir, time.Now().Add(10*24*time.Hour)) // inside the 30-day renewal window
+
+	r := runMCPApprovalTLSCheck(t, dir)
+	if r.Status != health.StatusWarn {
+		t.Fatalf("status = %v, want Warn for a cert expiring in 10 days; message = %q", r.Status, r.Message)
+	}
+	if r.Hint == "" {
+		t.Fatal("expected a hint explaining the automatic regeneration and re-pairing requirement")
+	}
+}
+
+func TestCheckMCPApprovalTLS_WarnsWhenCertExpired(t *testing.T) {
+	dir := t.TempDir()
+	writeNearExpiryCert(t, dir, time.Now().Add(-24*time.Hour)) // already expired
+
+	r := runMCPApprovalTLSCheck(t, dir)
+	if r.Status != health.StatusWarn {
+		t.Fatalf("status = %v, want Warn for an already-expired cert; message = %q", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "expired") {
+		t.Fatalf("message = %q, want it to say the cert expired", r.Message)
+	}
+}

--- a/internal/mcp/serverbootstrap/tls.go
+++ b/internal/mcp/serverbootstrap/tls.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/danieljustus/symaira-vault/internal/fsutil"
+	"github.com/danieljustus/symaira-vault/internal/ui/cliout"
 )
 
 const (
@@ -31,13 +32,20 @@ const (
 	enrollSecretFile = "mcp-server.enroll-secret" // #nosec G101 -- filename, not a credential
 	// enrollSecretSize is the size in bytes of the generated enroll secret.
 	enrollSecretSize = 32
+	// CertRenewalWindow is how long before a cached certificate's expiry
+	// EnsureTLSCert regenerates it, so operators have advance warning before
+	// paired approval devices (and any other pinned client) stop connecting.
+	CertRenewalWindow = 30 * 24 * time.Hour
 )
 
 // EnsureTLSCert returns the paths to a usable TLS certificate and key for the
 // MCP HTTP server. If the vault directory already contains a cached cert+key
-// pair they are reused; otherwise a new self-signed certificate is generated
-// for loopback addresses (127.0.0.1, ::1, localhost). Returns empty strings
-// when vaultDir is empty.
+// pair, and that certificate is not expired or within CertRenewalWindow of
+// expiring, it is reused; otherwise a new self-signed certificate is
+// generated for loopback addresses (127.0.0.1, ::1, localhost). Regenerating
+// invalidates every device that pinned the previous certificate's
+// fingerprint (see internal/approval device enrollment) — those devices
+// must be re-paired. Returns empty strings when vaultDir is empty.
 func EnsureTLSCert(vaultDir string) (certFile, keyFile string, err error) {
 	if vaultDir == "" {
 		return "", "", nil
@@ -46,13 +54,47 @@ func EnsureTLSCert(vaultDir string) (certFile, keyFile string, err error) {
 	keyFile = filepath.Join(vaultDir, autoKeyFile)
 
 	if fileExists(certFile) && fileExists(keyFile) {
-		return certFile, keyFile, nil
+		nearExpiry, checkErr := certNearExpiry(certFile, CertRenewalWindow)
+		if checkErr != nil {
+			return "", "", fmt.Errorf("check cached TLS certificate: %w", checkErr)
+		}
+		if !nearExpiry {
+			return certFile, keyFile, nil
+		}
+		cliout.Warnf("cached MCP TLS certificate is expired or expires within %d days; regenerating — every paired approval device must be re-paired, since its pinned certificate fingerprint will no longer match", int(CertRenewalWindow.Hours()/24))
 	}
 
 	if err := generateSelfSignedCert(certFile, keyFile); err != nil {
 		return "", "", fmt.Errorf("generate self-signed TLS certificate: %w", err)
 	}
 	return certFile, keyFile, nil
+}
+
+// certNearExpiry reports whether the certificate at certFile is already
+// expired or will expire within window.
+func certNearExpiry(certFile string, window time.Duration) (bool, error) {
+	cert, err := loadCertificate(certFile)
+	if err != nil {
+		return false, err
+	}
+	return !time.Now().Add(window).Before(cert.NotAfter), nil
+}
+
+// loadCertificate reads and parses the PEM-encoded certificate at certFile.
+func loadCertificate(certFile string) (*x509.Certificate, error) {
+	pemBytes, err := os.ReadFile(certFile) // #nosec G304 -- certFile is EnsureTLSCert's own fixed filename under vaultDir
+	if err != nil {
+		return nil, fmt.Errorf("read TLS certificate: %w", err)
+	}
+	block, _ := pem.Decode(pemBytes)
+	if block == nil {
+		return nil, fmt.Errorf("decode TLS certificate PEM")
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse TLS certificate: %w", err)
+	}
+	return cert, nil
 }
 
 // generateSelfSignedCert creates a self-signed ECDSA P-256 certificate valid for
@@ -133,20 +175,32 @@ func CertFingerprint(vaultDir string) (string, error) {
 	if certFile == "" {
 		return "", fmt.Errorf("no TLS certificate available for vault directory")
 	}
-	pemBytes, err := os.ReadFile(certFile) // #nosec G304 -- certFile is EnsureTLSCert's own fixed filename under vaultDir, same security domain
+	cert, err := loadCertificate(certFile)
 	if err != nil {
-		return "", fmt.Errorf("read TLS certificate: %w", err)
-	}
-	block, _ := pem.Decode(pemBytes)
-	if block == nil {
-		return "", fmt.Errorf("decode TLS certificate PEM")
-	}
-	cert, err := x509.ParseCertificate(block.Bytes)
-	if err != nil {
-		return "", fmt.Errorf("parse TLS certificate: %w", err)
+		return "", err
 	}
 	sum := sha256.Sum256(cert.Raw)
 	return hex.EncodeToString(sum[:]), nil
+}
+
+// CertStatus reports whether a cached MCP TLS certificate exists for
+// vaultDir and, if so, its expiry time. Unlike EnsureTLSCert, it never
+// generates a certificate — this is the read-only status check
+// "symvault doctor" uses; callers that need a certificate to exist should
+// call EnsureTLSCert instead. Returns exists=false for an empty vaultDir.
+func CertStatus(vaultDir string) (exists bool, expiry time.Time, err error) {
+	if vaultDir == "" {
+		return false, time.Time{}, nil
+	}
+	certFile := filepath.Join(vaultDir, autoCertFile)
+	if !fileExists(certFile) {
+		return false, time.Time{}, nil
+	}
+	cert, err := loadCertificate(certFile)
+	if err != nil {
+		return true, time.Time{}, err
+	}
+	return true, cert.NotAfter, nil
 }
 
 // EnsureEnrollSecret returns a random secret cached at

--- a/internal/mcp/serverbootstrap/tls_test.go
+++ b/internal/mcp/serverbootstrap/tls_test.go
@@ -1,10 +1,57 @@
 package serverbootstrap
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
+
+// writeCertWithExpiry writes a self-signed cert+key pair with the given
+// NotAfter directly to disk, bypassing EnsureTLSCert/generateSelfSignedCert
+// (which always mint a fresh ~1-year-valid cert), so tests can exercise
+// expiry-driven regeneration.
+func writeCertWithExpiry(t *testing.T, certFile, keyFile string, notAfter time.Time) {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		t.Fatalf("generate serial: %v", err)
+	}
+	template := x509.Certificate{
+		SerialNumber:          serial,
+		Subject:               pkix.Name{CommonName: "test-fixture"},
+		NotBefore:             notAfter.Add(-365 * 24 * time.Hour),
+		NotAfter:              notAfter,
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatalf("create certificate: %v", err)
+	}
+	privBytes, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		t.Fatalf("marshal key: %v", err)
+	}
+	if err := os.WriteFile(keyFile, pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privBytes}), 0o600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+	if err := os.WriteFile(certFile, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER}), 0o644); err != nil {
+		t.Fatalf("write cert: %v", err)
+	}
+}
 
 func TestCertFingerprint_StableAcrossRepeatedCalls(t *testing.T) {
 	dir := t.TempDir()
@@ -55,6 +102,116 @@ func TestCertFingerprint_ChangesWhenCertRegenerated(t *testing.T) {
 func TestCertFingerprint_EmptyVaultDir(t *testing.T) {
 	if _, err := CertFingerprint(""); err == nil {
 		t.Fatal("expected an error for an empty vault directory")
+	}
+}
+
+func TestEnsureTLSCert_RegeneratesExpiredCert(t *testing.T) {
+	dir := t.TempDir()
+	certFile := filepath.Join(dir, autoCertFile)
+	keyFile := filepath.Join(dir, autoKeyFile)
+	writeCertWithExpiry(t, certFile, keyFile, time.Now().Add(-24*time.Hour))
+
+	gotCertFile, gotKeyFile, err := EnsureTLSCert(dir)
+	if err != nil {
+		t.Fatalf("EnsureTLSCert: %v", err)
+	}
+	if gotCertFile != certFile || gotKeyFile != keyFile {
+		t.Fatalf("paths = (%q, %q), want (%q, %q)", gotCertFile, gotKeyFile, certFile, keyFile)
+	}
+
+	cert, err := loadCertificate(certFile)
+	if err != nil {
+		t.Fatalf("loadCertificate: %v", err)
+	}
+	if !cert.NotAfter.After(time.Now().Add(CertRenewalWindow)) {
+		t.Fatalf("expected a freshly regenerated cert well beyond the renewal window, got NotAfter=%v", cert.NotAfter)
+	}
+}
+
+func TestEnsureTLSCert_RegeneratesCertNearExpiry(t *testing.T) {
+	dir := t.TempDir()
+	certFile := filepath.Join(dir, autoCertFile)
+	keyFile := filepath.Join(dir, autoKeyFile)
+	writeCertWithExpiry(t, certFile, keyFile, time.Now().Add(10*24*time.Hour)) // inside the 30-day window
+
+	if _, _, err := EnsureTLSCert(dir); err != nil {
+		t.Fatalf("EnsureTLSCert: %v", err)
+	}
+
+	cert, err := loadCertificate(certFile)
+	if err != nil {
+		t.Fatalf("loadCertificate: %v", err)
+	}
+	if time.Until(cert.NotAfter) <= CertRenewalWindow {
+		t.Fatalf("expected regeneration to push expiry beyond the renewal window, got NotAfter=%v", cert.NotAfter)
+	}
+}
+
+func TestEnsureTLSCert_ReusesCertOutsideRenewalWindow(t *testing.T) {
+	dir := t.TempDir()
+	certFile := filepath.Join(dir, autoCertFile)
+	keyFile := filepath.Join(dir, autoKeyFile)
+	notAfter := time.Now().Add(60 * 24 * time.Hour) // outside the 30-day window
+	writeCertWithExpiry(t, certFile, keyFile, notAfter)
+
+	if _, _, err := EnsureTLSCert(dir); err != nil {
+		t.Fatalf("EnsureTLSCert: %v", err)
+	}
+
+	cert, err := loadCertificate(certFile)
+	if err != nil {
+		t.Fatalf("loadCertificate: %v", err)
+	}
+	if diff := cert.NotAfter.Sub(notAfter); diff > time.Second || diff < -time.Second {
+		t.Fatalf("cert was regenerated when it should have been reused: NotAfter = %v, want %v", cert.NotAfter, notAfter)
+	}
+}
+
+func TestCertStatus_NoCert(t *testing.T) {
+	dir := t.TempDir()
+	exists, _, err := CertStatus(dir)
+	if err != nil {
+		t.Fatalf("CertStatus: %v", err)
+	}
+	if exists {
+		t.Fatal("CertStatus reported a certificate for an empty vault directory")
+	}
+}
+
+func TestCertStatus_ExistingCert(t *testing.T) {
+	dir := t.TempDir()
+	notAfter := time.Now().Add(60 * 24 * time.Hour)
+	writeCertWithExpiry(t, filepath.Join(dir, autoCertFile), filepath.Join(dir, autoKeyFile), notAfter)
+
+	exists, expiry, err := CertStatus(dir)
+	if err != nil {
+		t.Fatalf("CertStatus: %v", err)
+	}
+	if !exists {
+		t.Fatal("CertStatus reported no certificate for a directory with one")
+	}
+	if diff := expiry.Sub(notAfter); diff > time.Second || diff < -time.Second {
+		t.Fatalf("expiry = %v, want %v", expiry, notAfter)
+	}
+}
+
+func TestCertStatus_DoesNotGenerateACert(t *testing.T) {
+	dir := t.TempDir()
+	if _, _, err := CertStatus(dir); err != nil {
+		t.Fatalf("CertStatus: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, autoCertFile)); !os.IsNotExist(err) {
+		t.Fatal("CertStatus must not generate a certificate as a side effect")
+	}
+}
+
+func TestCertStatus_EmptyVaultDir(t *testing.T) {
+	exists, _, err := CertStatus("")
+	if err != nil {
+		t.Fatalf("CertStatus: %v", err)
+	}
+	if exists {
+		t.Fatal("CertStatus reported a certificate for an empty vault directory string")
 	}
 }
 


### PR DESCRIPTION
## Summary

`EnsureTLSCert` reused `mcp-server.crt`/`.key` whenever both files existed; `generateSelfSignedCert` sets `NotAfter` to one year, but nothing anywhere inspected it afterward, and `internal/health` had no check for the certificate or approval-device state. `mintApprovalEnrollCode` (the CLI side of `symvault device approval-pair`) trusts exactly that cached certificate, and every already-paired phone pins its fingerprint — so one year after first `symvault serve`, every HTTPS MCP client and every paired approval device would start failing with opaque TLS errors, with no warning beforehand.

## Change

- `EnsureTLSCert` now regenerates the certificate when it's expired or within 30 days of expiry (`CertRenewalWindow`), logging a warning that every paired approval device must be re-paired (its pinned fingerprint will no longer match the new cert). Reuse is unchanged otherwise.
- Added `CertStatus(vaultDir)`: a read-only counterpart to `EnsureTLSCert` — reports whether a cert exists and its expiry, without ever generating one as a side effect (important since `symvault doctor` is a diagnostic command, not something that should silently create files).
- Added a new `symvault doctor` check, `mcp.approval.tls`: reports the certificate's expiry date, warns when it's expired or near expiry (with a hint about the automatic regeneration + re-pairing requirement), and reports the count of active/expired/revoked approval devices alongside it (per the issue's explicit ask for one check covering both).
- Deduplicated the PEM-read-and-parse logic (previously copy-pasted into `CertFingerprint`) into a shared `loadCertificate` helper, now used by `EnsureTLSCert`, `CertFingerprint`, and `CertStatus`.

## Testing

- `TestEnsureTLSCert_RegeneratesExpiredCert` / `RegeneratesCertNearExpiry` / `ReusesCertOutsideRenewalWindow`: a pre-expired/near-expiry/healthy cert fixture (written directly to disk, bypassing the normal ~1-year generator) asserts regeneration does or doesn't happen as expected — the issue's core acceptance criterion.
- `TestCertStatus_*`: exists/doesn't-exist, correct expiry, never generates a certificate as a side effect, empty-vaultDir handling.
- `TestCheckMCPApprovalTLS_*`: no cert yet (OK), healthy cert (OK), device-count reporting, warns on a near-expiry cert, warns on an expired cert — all through the real `health.RunChecks` doctor pipeline.
- `go build ./...`, `go vet ./...`: clean. `go test ./internal/mcp/serverbootstrap/... ./internal/health/... ./cmd/...` and the same with `-race`: all pass.
- `golangci-lint run` on changed packages: 0 new issues (2 pre-existing `goconst` findings in `internal/health/doctor.go`, already present before this change — confirmed via `git show HEAD:...`, not introduced here).
- `gosec` (pinned to the CI version/toolchain): 0 findings.

Closes #948

🤖 Generated with [Claude Code](https://claude.com/claude-code)