### PR TITLE
refactor(pairing): delete dead per-device failure counter, rate-limit approval routes instead

### DIFF
--- a/cmd/mcp/serve_deps.go
+++ b/cmd/mcp/serve_deps.go
@@ -62,7 +62,7 @@ func RunHTTPServerWithApproval(ctx context.Context, bind string, port int, vault
 		return fmt.Errorf("load device session store: %w", err)
 	}
 	_ = sessionStore.StartCleanup(ctx, 15*time.Minute)
-	approvalHandler := approval.NewHTTPHandler(ApprovalQueue, approval.NewPairingTokenValidator(sessionStore))
+	approvalHandler := approval.NewHTTPHandler(ApprovalQueue, sessionStore)
 
 	// The fingerprint is computed once at server startup (the cert is cached
 	// to disk and only regenerated if deleted) and handed to every minted

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -1726,17 +1726,16 @@ func TestRunHTTPServerFunc_ApprovalDeviceSession(t *testing.T) {
 		t.Errorf("revoked device status = %d, want 401", revokedResp.StatusCode)
 	}
 
-	// Per-device failed attempts: device-2 should not be affected by
-	// device-1's failures (if any). We verify this by enrolling device-2
-	// after device-1 was revoked and confirming it can still list.
+	// device-2 is unaffected by device-1's revocation: verify it can still
+	// enroll and list after device-1 was revoked.
 	device2Token, err := store.Enroll("device-2", "Test Device Two", "age1device2key")
 	if err != nil {
 		t.Fatalf("Enroll device-2: %v", err)
 	}
 	_ = store.Save()
 
-	// Drive a few invalid attempts against device-2's token to populate
-	// its failure counter without touching device-1.
+	// A few invalid-token attempts against device-2's near-miss token must
+	// not affect device-2's own valid token.
 	for i := 0; i < 3; i++ {
 		failReq, _ := http.NewRequest(http.MethodGet, baseURL+approval.PathApprovals, nil)
 		failReq.Header.Set("Authorization", "Bearer "+device2Token+"x")
@@ -1758,5 +1757,118 @@ func TestRunHTTPServerFunc_ApprovalDeviceSession(t *testing.T) {
 	if list2Resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(list2Resp.Body)
 		t.Errorf("device-2 list status = %d, body %s", list2Resp.StatusCode, string(body))
+	}
+}
+
+// TestRunHTTPServerFunc_ApprovalRoutesAreRateLimited confirms the approval
+// and device-enroll routes share the same per-client-IP rate limiter as
+// /mcp, rather than being reachable at an unbounded rate. Rate limiting is
+// the outermost middleware layer, so it must trigger before the routes'
+// own auth checks — this test drives PathApprovals unauthenticated and
+// still expects 429 once the (deliberately tiny) limit is exceeded.
+func TestRunHTTPServerFunc_ApprovalRoutesAreRateLimited(t *testing.T) {
+	resetVaultState(t)
+
+	tmpDir := t.TempDir()
+	restoreVaultFlag := setupVaultFlag(t, tmpDir)
+	defer restoreVaultFlag()
+	_ = os.Setenv("SYMVAULT_VAULT", tmpDir)
+	_ = os.Setenv("SYMVAULT_PASSPHRASE", "test")
+	defer func() {
+		_ = os.Unsetenv("SYMVAULT_VAULT")
+		_ = os.Unsetenv("SYMVAULT_PASSPHRASE")
+	}()
+
+	cfg := config.Default()
+	_, _ = vaultpkg.InitWithPassphrase(tmpDir, []byte("test"), cfg)
+
+	store, err := pairing.NewDeviceSessionStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewDeviceSessionStore: %v", err)
+	}
+
+	origQueue := mcpcmd.ApprovalQueue
+	mcpcmd.ApprovalQueue = approval.NewQueue()
+	defer func() { mcpcmd.ApprovalQueue = origQueue }()
+	origStoreFactory := mcpcmd.NewDeviceSessionStoreFunc
+	mcpcmd.NewDeviceSessionStoreFunc = func(string) (*pairing.DeviceSessionStore, error) {
+		return store, nil
+	}
+	defer func() { mcpcmd.NewDeviceSessionStoreFunc = origStoreFactory }()
+	origHTTP := mcpcmd.RunHTTPServerFunc
+	mcpcmd.RunHTTPServerFunc = mcpcmd.RunHTTPServerWithApproval
+	defer func() { mcpcmd.RunHTTPServerFunc = origHTTP }()
+
+	port := findFreePort(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		v, err := vaultpkg.OpenWithPassphrase(tmpDir, []byte("test"))
+		if err != nil {
+			t.Logf("open vault: %v", err)
+			return
+		}
+		if v.Config.MCP == nil {
+			v.Config.MCP = &config.MCPConfig{}
+		}
+		v.Config.MCP.AllowInsecureBind = true
+		v.Config.MCP.HTTPTokenFile = filepath.Join(tmpDir, "mcp-token")
+		v.Config.MCP.RateLimit = 1 // one request per minute
+		if err := mcpcmd.RunHTTPServerFunc(ctx, "127.0.0.1", port, v); err != nil {
+			t.Logf("RunHTTPServerFunc: %v", err)
+		}
+	}()
+
+	addr := net.JoinHostPort("127.0.0.1", strconv.Itoa(port))
+	client := newTestHTTPClient()
+	for i := 0; i < 50; i++ {
+		conn, err := net.DialTimeout("tcp", addr, 100*time.Millisecond)
+		if err == nil {
+			_ = conn.Close()
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	for i := 0; i < 20; i++ {
+		resp, err := client.Get("http://" + addr + "/health")
+		if err == nil {
+			_ = resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				break
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	baseURL := "http://" + addr
+
+	get := func() int {
+		req, _ := http.NewRequest(http.MethodGet, baseURL+approval.PathApprovals, nil)
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatalf("request: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		return resp.StatusCode
+	}
+
+	first := get()
+	if first == http.StatusTooManyRequests {
+		t.Fatal("first request was already rate-limited; the limiter is not scoped to this test's client")
+	}
+
+	var sawRateLimited bool
+	for i := 0; i < 5; i++ {
+		if get() == http.StatusTooManyRequests {
+			sawRateLimited = true
+			break
+		}
+	}
+	if !sawRateLimited {
+		t.Fatal("expected a 429 after exceeding the rate limit on the approval route, never saw one")
 	}
 }

--- a/internal/approval/http.go
+++ b/internal/approval/http.go
@@ -30,8 +30,9 @@ type HTTPHandler struct {
 }
 
 // NewHTTPHandler creates the approval API handler. tokens validates device
-// pairing tokens (nil disables the device auth gate, causing all requests
-// to receive 401 Unauthorized).
+// pairing tokens; every request requires a valid one, so a nil tokens value
+// fails every request closed with 401 Unauthorized rather than bypassing
+// the check.
 func NewHTTPHandler(queue *Queue, tokens tokenValidator) *HTTPHandler {
 	return &HTTPHandler{queue: queue, tokens: tokens}
 }
@@ -126,9 +127,4 @@ func writeApprovalJSON(w http.ResponseWriter, status int, payload any) {
 
 func writeApprovalError(w http.ResponseWriter, status int, message string) {
 	writeApprovalJSON(w, status, map[string]any{"error": message})
-}
-
-// NewPairingTokenValidator returns v unchanged if non-nil, or nil if v is nil.
-func NewPairingTokenValidator(v tokenValidator) tokenValidator {
-	return v
 }

--- a/internal/mcp/serverbootstrap/http.go
+++ b/internal/mcp/serverbootstrap/http.go
@@ -302,19 +302,33 @@ func RunHTTPServerOnListener(ctx context.Context, listener net.Listener, v *vaul
 	mux.Handle("/mcp", mcpChain)
 
 	// Device approval transport (optional): mounted when an approval queue
-	// and device-token validator are wired in by the caller.
+	// and device-token validator are wired in by the caller. Rate-limited
+	// the same way as /mcp, since these routes are LAN-reachable like /mcp
+	// and accept a bearer token an attacker could try to brute-force.
 	if options.approvalHandler != nil {
-		mux.Handle(approval.PathApprovals, options.approvalHandler)
-		mux.Handle(approval.PathApprovalAction, options.approvalHandler)
+		approvalChain := options.approvalHandler
+		if rateLimiter != nil {
+			approvalChain = auth.RateLimiterMiddleware(rateLimiter, approvalChain)
+		}
+		mux.Handle(approval.PathApprovals, approvalChain)
+		mux.Handle(approval.PathApprovalAction, approvalChain)
 	}
 
 	// Device enrollment transport (optional): lets a device exchange a
 	// pairing code for an approval-device bearer token.
 	if options.deviceEnrollHandler != nil {
-		mux.Handle(approval.PathDeviceEnroll, options.deviceEnrollHandler)
+		enrollChain := options.deviceEnrollHandler
+		if rateLimiter != nil {
+			enrollChain = auth.RateLimiterMiddleware(rateLimiter, enrollChain)
+		}
+		mux.Handle(approval.PathDeviceEnroll, enrollChain)
 	}
 	if options.deviceEnrollCodeHandler != nil {
-		mux.Handle(approval.PathDeviceEnrollCode, options.deviceEnrollCodeHandler)
+		enrollCodeChain := options.deviceEnrollCodeHandler
+		if rateLimiter != nil {
+			enrollCodeChain = auth.RateLimiterMiddleware(rateLimiter, enrollCodeChain)
+		}
+		mux.Handle(approval.PathDeviceEnrollCode, enrollCodeChain)
 	}
 
 	timeouts := resolveServerTimeouts(v)

--- a/internal/pairing/devicesession.go
+++ b/internal/pairing/devicesession.go
@@ -21,16 +21,8 @@ import (
 	"github.com/danieljustus/symaira-vault/internal/mcp/auth"
 )
 
-const (
-	// DefaultSessionTTL is the default TTL for enrolled device sessions.
-	DefaultSessionTTL = 90 * 24 * time.Hour // 90 days
-	// MaxSessionFailedAttempts is the number of failed validation attempts
-	// allowed per device before a cooldown is applied.
-	MaxSessionFailedAttempts = 5
-	// SessionFailedAttemptCooldown is how long a device's attempts are
-	// rejected after MaxSessionFailedAttempts failures.
-	SessionFailedAttemptCooldown = 30 * time.Second
-)
+// DefaultSessionTTL is the default TTL for enrolled device sessions.
+const DefaultSessionTTL = 90 * 24 * time.Hour // 90 days
 
 // DeviceSession represents an enrolled device session token. The bearer
 // token itself is never persisted — only its SHA-256 hash, keyed identically
@@ -46,19 +38,12 @@ type DeviceSession struct {
 	Revoked   bool      `json:"revoked"`
 }
 
-// deviceFailure tracks failed validation attempts for a single device.
-type deviceFailure struct {
-	Count         int
-	CooldownUntil time.Time
-}
-
 // DeviceSessionStore holds long-lived device session tokens on disk.
 // It is safe for concurrent use.
 type DeviceSessionStore struct {
 	path     string
 	mu       sync.RWMutex
 	sessions map[string]*DeviceSession // sha256Hex(token) -> session
-	failures map[string]deviceFailure  // deviceID -> failure state
 	mtime    time.Time                 // mtime of path as of the last load/save
 }
 
@@ -69,14 +54,12 @@ func NewDeviceSessionStore(vaultDir string) (*DeviceSessionStore, error) {
 	if vaultDir == "" {
 		return &DeviceSessionStore{
 			sessions: make(map[string]*DeviceSession),
-			failures: make(map[string]deviceFailure),
 		}, nil
 	}
 	path := filepath.Join(vaultDir, config.DefaultVaultSubdir, "device-sessions.json")
 	s := &DeviceSessionStore{
 		path:     path,
 		sessions: make(map[string]*DeviceSession),
-		failures: make(map[string]deviceFailure),
 	}
 	if err := s.load(); err != nil {
 		return nil, fmt.Errorf("load device session store: %w", err)
@@ -105,9 +88,12 @@ func (s *DeviceSessionStore) Enroll(deviceID, name, publicKey string) (string, e
 	}
 	s.mu.Lock()
 	s.sessions[hash] = session
-	s.mu.Unlock()
-	if err := s.save(); err != nil {
+	err = s.save()
+	if err != nil {
 		delete(s.sessions, hash)
+	}
+	s.mu.Unlock()
+	if err != nil {
 		return "", fmt.Errorf("persist device session: %w", err)
 	}
 	return rawToken, nil
@@ -127,8 +113,7 @@ func (s *DeviceSessionStore) List() []DeviceSession {
 }
 
 // Validate checks a session token and returns the deviceID if the session
-// is valid (not revoked, not expired, device not in cooldown).
-// Successful validation resets the device's failure counter.
+// is valid (not revoked, not expired).
 func (s *DeviceSessionStore) Validate(token string) (string, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -146,39 +131,7 @@ func (s *DeviceSessionStore) Validate(token string) (string, bool) {
 		return "", false
 	}
 
-	f, hasFailures := s.failures[session.DeviceID]
-	if hasFailures && time.Now().Before(f.CooldownUntil) {
-		return "", false
-	}
-	if hasFailures && time.Now().After(f.CooldownUntil) {
-		delete(s.failures, session.DeviceID)
-	}
-
-	s.failures[session.DeviceID] = deviceFailure{}
 	return session.DeviceID, true
-}
-
-// RecordFailure records a validation failure for the device associated with
-// the token. If the token is unknown, no failure is recorded (unknown-token
-// brute-force is bounded by the store's file-read path and the validator's
-// caller).
-func (s *DeviceSessionStore) RecordFailure(token string) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	s.mergeRevocationsFromDisk()
-
-	session, ok := s.sessions[hashToken(token)]
-	if !ok {
-		return
-	}
-	f := s.failures[session.DeviceID]
-	f.Count++
-	if f.Count >= MaxSessionFailedAttempts {
-		f.CooldownUntil = time.Now().Add(SessionFailedAttemptCooldown)
-	}
-	s.failures[session.DeviceID] = f
-	_ = s.save()
 }
 
 // Revoke revokes all sessions for deviceID.
@@ -212,8 +165,7 @@ func (s *DeviceSessionStore) RevokeAll() {
 	_ = s.save()
 }
 
-// CleanupExpired removes expired sessions and resets stale device failure
-// counters.
+// CleanupExpired removes expired sessions.
 func (s *DeviceSessionStore) CleanupExpired() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -224,12 +176,6 @@ func (s *DeviceSessionStore) CleanupExpired() {
 	for token, session := range s.sessions {
 		if now.After(session.ExpiresAt) {
 			delete(s.sessions, token)
-			changed = true
-		}
-	}
-	for deviceID, f := range s.failures {
-		if f.Count >= MaxSessionFailedAttempts && now.After(f.CooldownUntil) {
-			delete(s.failures, deviceID)
 			changed = true
 		}
 	}

--- a/internal/pairing/devicesession_test.go
+++ b/internal/pairing/devicesession_test.go
@@ -3,8 +3,12 @@ package pairing
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -251,6 +255,50 @@ func TestDeviceSessionStore_MigratesLegacyRawTokenKeys(t *testing.T) {
 	}
 }
 
+// skipIfRoot skips permission-based failure-injection tests when running as
+// root, since root bypasses the write-permission checks these tests rely on.
+func skipIfRoot(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS != "windows" && os.Geteuid() == 0 {
+		t.Skip("skipping permission-based test: running as root")
+	}
+}
+
+// TestDeviceSessionStore_EnrollRollbackIsRaceFree exercises Enroll's
+// save-failure rollback (delete(s.sessions, hash) on a failed save)
+// concurrently with readers, under `go test -race`. Making every save fail
+// forces every concurrent Enroll call down the rollback path, so a
+// regression back to mutating s.sessions outside the lock would be caught
+// as a data race here.
+func TestDeviceSessionStore_EnrollRollbackIsRaceFree(t *testing.T) {
+	skipIfRoot(t)
+	dir := t.TempDir()
+	store, err := NewDeviceSessionStore(dir)
+	if err != nil {
+		t.Fatalf("NewDeviceSessionStore: %v", err)
+	}
+
+	sessionsDir := filepath.Dir(store.path)
+	if err := os.Chmod(sessionsDir, 0o500); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(sessionsDir, 0o700) })
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(2)
+		go func(i int) {
+			defer wg.Done()
+			_, _ = store.Enroll(fmt.Sprintf("device-%d", i), "", "")
+		}(i)
+		go func() {
+			defer wg.Done()
+			_ = store.List()
+		}()
+	}
+	wg.Wait()
+}
+
 func TestDeviceSessionStore_UnknownToken(t *testing.T) {
 	dir := t.TempDir()
 	store, err := NewDeviceSessionStore(dir)
@@ -261,53 +309,6 @@ func TestDeviceSessionStore_UnknownToken(t *testing.T) {
 	deviceID, ok := store.Validate("unknown-token")
 	if ok || deviceID != "" {
 		t.Fatalf("unknown Validate = %q, %v", deviceID, ok)
-	}
-}
-
-func TestDeviceSessionStore_PerDeviceFailedAttempts(t *testing.T) {
-	dir := t.TempDir()
-	store, err := NewDeviceSessionStore(dir)
-	if err != nil {
-		t.Fatalf("NewDeviceSessionStore: %v", err)
-	}
-	token, err := store.Enroll("device-1", "Device One", "age1pubkey")
-	if err != nil {
-		t.Fatalf("Enroll: %v", err)
-	}
-
-	// Drive max failed attempts with wrong tokens for device-1's session.
-	// Because the token is unknown, RecordFailure won't find the session
-	// and won't increment the counter. We verify that a valid token still
-	// works after unknown-token noise.
-	for i := 0; i < MaxSessionFailedAttempts+2; i++ {
-		store.Validate("bogus-" + string(rune(i)))
-	}
-	deviceID, ok := store.Validate(token)
-	if !ok || deviceID != "device-1" {
-		t.Fatalf("valid token after noise = %q, %v", deviceID, ok)
-	}
-
-	// Now drive failures using the valid token but wrong validation path
-	// by expiring the session. We can't easily do that without waiting,
-	// so instead we test per-device cooldown by creating a second device
-	// and verifying that failures on one device don't affect the other.
-	token2, err := store.Enroll("device-2", "Device Two", "age1pubkey2")
-	if err != nil {
-		t.Fatalf("Enroll device-2: %v", err)
-	}
-
-	// Simulate device-1 hitting cooldown by directly manipulating.
-	store.mu.Lock()
-	store.failures["device-1"] = deviceFailure{
-		Count:         MaxSessionFailedAttempts,
-		CooldownUntil: time.Now().Add(time.Hour),
-	}
-	store.mu.Unlock()
-
-	// device-2 should still validate fine.
-	deviceID, ok = store.Validate(token2)
-	if !ok || deviceID != "device-2" {
-		t.Fatalf("device-2 Validate after device-1 cooldown = %q, %v", deviceID, ok)
 	}
 }
 


### PR DESCRIPTION
## Summary

`RecordFailure` and the `failures`/`deviceFailure` machinery in `DeviceSessionStore` had zero non-test callers — `HTTPHandler.deviceFromRequest` only ever calls `Validate`. The limiter also could not fire by construction: a failure was only ever recorded for a token already present in the map, which is precisely the case `Validate` accepts (an unknown-token brute-force attempt never reaches `RecordFailure` since nothing calls it). `NewPairingTokenValidator` returned its argument unchanged and existed only as a leftover from earlier wiring. `Enroll` also mutated `s.sessions` outside the mutex on its save-error rollback path, and `NewHTTPHandler`'s doc comment described a nil validator as "disabling" the auth gate when the code has always failed closed on nil.

## Change

- Deleted `RecordFailure`, `deviceFailure`, the `failures` map, and `MaxSessionFailedAttempts`/`SessionFailedAttemptCooldown`.
- Applied the existing per-client-IP `auth.RateLimiterMiddleware` (already wired to `/mcp`) to the approval and device-enroll routes too, so repeated bearer-token guesses against these LAN-reachable endpoints are actually bounded — replacing the dead per-device counter with a real, working mechanism.
- Removed `NewPairingTokenValidator`; `cmd/mcp/serve_deps.go` now passes the device-session store directly to `approval.NewHTTPHandler`, since it already satisfies the handler's minimal `tokenValidator` interface.
- Took the lock around `Enroll`'s save-error rollback (`delete(s.sessions, hash)` now happens under `s.mu`, not after unlocking).
- Fixed `NewHTTPHandler`'s stale doc comment.

## Testing

- `TestDeviceSessionStore_EnrollRollbackIsRaceFree`: forces every concurrent `Enroll` call down the rollback path (via a read-only vault directory) while concurrent `List()` calls run, under `-race`. Verified this test actually catches the original bug — temporarily reverting the lock fix reproduces a concurrent-map-write panic reliably; restoring the fix passes consistently.
- `TestRunHTTPServerFunc_ApprovalRoutesAreRateLimited`: drives the real HTTP server with `RateLimit: 1`, confirms the approval route returns 429 once the limit is exceeded (rate limiting is the outermost middleware layer, so this holds even unauthenticated).
- Deleted `TestDeviceSessionStore_PerDeviceFailedAttempts`, which only exercised the now-removed machinery.
- `go build ./...`, `go vet ./...`: clean. `go test ./internal/pairing/... ./internal/approval/... ./internal/mcp/serverbootstrap/... ./cmd/...` and the same with `-race`: all pass.
- `golangci-lint run` on changed packages: 0 new issues (1 pre-existing, unrelated `unparam` finding in `cmd/admin/export_test.go`).
- `gosec` (pinned to the CI version/toolchain): 0 findings.

Closes #949

🤖 Generated with [Claude Code](https://claude.com/claude-code)