### PR TITLE
fix(pairing): make revocation refresh deterministic on Windows

### DIFF
--- a/internal/mcp/serverbootstrap/tls_test.go
+++ b/internal/mcp/serverbootstrap/tls_test.go
@@ -10,6 +10,7 @@ import (
 	"math/big"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 )
@@ -250,6 +251,9 @@ func TestEnsureEnrollSecret_DistinctPerVaultDir(t *testing.T) {
 }
 
 func TestEnsureEnrollSecret_FilePermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows does not expose POSIX file permission bits")
+	}
 	dir := t.TempDir()
 	if _, err := EnsureEnrollSecret(dir); err != nil {
 		t.Fatalf("EnsureEnrollSecret: %v", err)

--- a/internal/pairing/devicesession.go
+++ b/internal/pairing/devicesession.go
@@ -292,20 +292,21 @@ func (s *DeviceSessionStore) save() error {
 	return nil
 }
 
-// mergeRevocationsFromDisk re-reads the on-disk store when it is newer than
-// the last load/save this instance observed, and applies any revocation
-// found there onto the in-memory copy. Revocation only ever moves from false
-// to true here, so a concurrent writer (typically the "approval-revoke" CLI,
-// which opens its own store instance against the same file) can never have
-// its revocation silently undone by this instance's next save. Callers must
-// hold s.mu for writing. Returns whether any in-memory session was newly
-// marked revoked.
+// mergeRevocationsFromDisk re-reads the on-disk store and applies any
+// revocation found there onto the in-memory copy. It must not use the file's
+// modification time as a read guard: filesystems with coarse timestamps can
+// replace the same-size JSON file without advancing its observed mtime.
+// Revocation only ever moves from false to true here, so a concurrent writer
+// (typically the "approval-revoke" CLI, which opens its own store instance
+// against the same file) can never have its revocation silently undone by
+// this instance's next save. Callers must hold s.mu for writing. Returns
+// whether any in-memory session was newly marked revoked.
 func (s *DeviceSessionStore) mergeRevocationsFromDisk() bool {
 	if s.path == "" {
 		return false
 	}
 	info, err := os.Stat(s.path)
-	if err != nil || !info.ModTime().After(s.mtime) {
+	if err != nil {
 		return false
 	}
 	data, err := os.ReadFile(s.path)


### PR DESCRIPTION
## Summary

- refresh persisted device revocations without relying on filesystem modification-time granularity
- skip the POSIX-only enroll-secret permission assertion on Windows
- preserve immediate cross-process token revocation semantics

## Verification

- `GOTOOLCHAIN=go1.26.6 go test ./internal/pairing ./internal/approval ./internal/mcp/serverbootstrap`
- `GOTOOLCHAIN=go1.26.6 make lint`
- `GOTOOLCHAIN=go1.26.6 make build`
- required PR check `CI Success` passed for exact head `556a0ec797d2d1071c5b93a705811c2bcf4e68ad`

The full local race suite also ran. It failed in unrelated pre-existing timing-sensitive tests under `internal/mcp/server` and `internal/secrets`; all changed and directly dependent packages passed. The post-merge main workflow owns exact Windows execution.

Fixes #966