### PR TITLE
fix(agent): route token and profile subcommands

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -199,7 +199,7 @@ brews:
         symvault get github.com/username # Retrieve it
 
       For MCP server setup:
-        symvault mcp-config <name>
+        symvault agent install <name> --config-only
 
       Documentation: https://github.com/danieljustus/symaira-vault#readme
     test: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Agent token and profile subcommands now use executable action-first syntax
+  (`symvault agent token new|list|revoke|rotate <name>` and
+  `symvault agent profile show|edit|export <name>`). The previous name-first
+  examples could not reach Cobra subcommands, while action-first calls silently
+  operated on agent `unknown`. Release, Homebrew, security, migration, generated
+  skill, health, and man-page guidance now matches the working CLI.
 - The macOS app could no longer unlock the vault: entering the passphrase and
   pressing "Entsperren" appeared to do nothing while the CLI kept working.
   `symvault unlock` short-circuited on the cached age identity and returned
@@ -473,7 +479,7 @@ preview, then `symvault migrate v4` to apply.
 - **`symvault agent doctor <name>` / `--all`** — end-to-end diagnostic for one
   or all agent integrations; detects skill drift via hash comparison.
 - **`symvault agent list`** — installed agents with tier, token status, last-seen.
-- **`symvault agent token <name> new|list|revoke|rotate`** — token management
+- **`symvault agent token new|list|revoke|rotate <name>`** — token management
   per agent.
 - **`symvault agent audit <name>` / `audit self`** — per-agent audit log with
   `--since` and `--format table|json`.

--- a/Makefile
+++ b/Makefile
@@ -223,7 +223,7 @@ docs-check:
 		fi; \
 	done; \
 	for pattern in "symvault mcp-config" "symvault mcp token" "symvault mcp-token-rotate"; do \
-		if grep -r "$$pattern" README.md docs \
+		if grep -r "$$pattern" README.md SECURITY.md .goreleaser.yml docs homebrew internal/agentskill \
 			--exclude="migration-v3-to-v4.md" \
 			--exclude="MIGRATION-RENAME.md" \
 			--exclude-dir=adr \
@@ -236,6 +236,27 @@ docs-check:
 			errors=$$((errors + 1)); \
 		fi; \
 	done; \
+	for pattern in 'symvault agent token [^[:space:]`]+ (new|list|revoke|rotate)' 'symvault agent profile [^[:space:]`]+ (show|edit|export)'; do \
+		if grep -rE "$$pattern" README.md SECURITY.md .goreleaser.yml docs homebrew internal/agentskill \
+			--exclude-dir=man \
+			--exclude-dir=dist \
+			--exclude-dir=coverage \
+			--exclude-dir=node_modules 2>/dev/null; then \
+			echo "Found agent argument before its action; use action-first command order: $$pattern"; \
+			errors=$$((errors + 1)); \
+		fi; \
+	done; \
+	if grep -rE 'symvault agent token new [^[:space:]`]+ .*--expires' README.md SECURITY.md docs homebrew internal/agentskill \
+		--exclude="migration-v3-to-v4.md" \
+		--exclude-dir=adr \
+		--exclude-dir=man \
+		--exclude-dir=skills \
+		--exclude-dir=dist \
+		--exclude-dir=coverage \
+		--exclude-dir=node_modules 2>/dev/null; then \
+		echo "Found deprecated --expires flag on agent token command; use --ttl"; \
+		errors=$$((errors + 1)); \
+	fi; \
 	for tool in "openpass_list" "openpass_get" "openpass_generate" "openpass_health"; do \
 		if grep -rE "\b$$tool\b" README.md docs homebrew .gitignore --exclude-dir=dist --exclude-dir=coverage --exclude-dir=node_modules 2>/dev/null; then \
 			echo "Found deprecated tool name: $$tool"; \

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ symvault mcp --stdio --agent claude-code
 symvault mcp --port 8080
 ```
 
-Use `symvault agent install` to generate ready-to-paste client config:
+Use `symvault agent install` to write the detected client's MCP configuration:
 
 ```bash
 symvault agent install claude-code --config-only
@@ -248,9 +248,9 @@ HTTP mode binds to `127.0.0.1` by default and uses bearer token authentication. 
 
 **Scoped Token Management**: Create fine-grained access tokens for agents:
 ```bash
-symvault agent token hermes new --tools list_entries,get_entry --expires 24h
-symvault agent token list
-symvault agent token hermes revoke <token-id>
+symvault agent token new hermes --tools list_entries,get_entry --ttl 24h
+symvault agent token list hermes
+symvault agent token revoke hermes <token-id>
 ```
 
 For detailed agent setup, profiles, token management, and observability, see [docs/agent-integration.md](docs/agent-integration.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -171,31 +171,37 @@ mcp:
 
 Setting `metrics_auth_required: false` allows anonymous access to `/metrics` when bound to non-local addresses. Only disable this if you have other access controls (e.g., firewall rules or reverse-proxy auth) in place.
 
-#### Token Rotation
+#### Scoped Token Rotation
 
-Bearer tokens can be rotated using the `mcp-token-rotate` command:
-
-```bash
-symvault mcp-token-rotate
-```
-
-This invalidates the previous token and generates a new one. Any MCP clients using the old token will need to be updated with the new token.
-
-#### Safer Token Export
-
-When generating MCP configurations that may be displayed in terminals or committed to version control, use the `--redact` flag:
+Use a separate scoped token for each HTTP agent and rotate it by agent name:
 
 ```bash
-symvault mcp-config claude-code --http --redact
+symvault agent token rotate <agent>
 ```
 
-This outputs `env:SYMVAULT_MCP_TOKEN` instead of the actual token value. Clients using redacted configs must set the `SYMVAULT_MCP_TOKEN` environment variable.
+This revokes every active scoped token for that agent and prints the replacement
+raw token exactly once. Update the agent's configuration immediately, and do not
+put the token in shell history, logs, source control, or chat.
 
-For scripts that need the raw token:
+#### Safe Agent Setup and Explicit Token Export
+
+Normal HTTP setup creates a scoped token, stores it in a private per-agent token
+file, and updates the detected client configuration without printing the raw
+token:
 
 ```bash
-symvault mcp-config <agent> --token-only
+symvault agent install claude-code --http --config-only
 ```
+
+The command reports only the token ID and affected paths. If you explicitly need
+a new raw token for manual configuration, create it directly:
+
+```bash
+symvault agent token new <agent> --tools list_entries --ttl 24h
+```
+
+The raw token is shown exactly once. Copy it directly to the intended client;
+do not capture it in shell history, logs, source control, or chat.
 
 ### Multi-User Vaults and MCP
 

--- a/cmd/mcp/agent.go
+++ b/cmd/mcp/agent.go
@@ -24,10 +24,10 @@ func newAgentCmd() *cobra.Command {
 		Short: "Manage agent profiles",
 		Long: `Configure AI agent profiles with scoped permissions, tokens, and MCP integration.
 
-Use 'symvault agent setup <name>' to create a new agent with an interactive wizard
-that guides you through security tier selection, vault path scoping, and approval mode.`,
-		Example: `  # Interactive new-agent wizard
-  symvault agent setup claude-code
+Use 'symvault agent install <name>' to create a security profile, scoped token,
+MCP configuration, and agent skill package.`,
+		Example: `  # Install and configure an agent
+  symvault agent install claude-code
 
   # List configured agents
   symvault agent list

--- a/cmd/mcp/agent_profile.go
+++ b/cmd/mcp/agent_profile.go
@@ -18,21 +18,21 @@ import (
 
 func newAgentProfileCmd() *cobra.Command {
 	agentProfileCmd := &cobra.Command{
-		Use:   "profile <name>",
+		Use:   "profile",
 		Short: "Manage agent profiles",
 		Long:  `Show, edit, and export agent profiles.`,
-		Args:  cobra.ExactArgs(1),
+		Args:  cobra.NoArgs,
 		Example: `  # Show agent profile
-  symvault agent profile my-agent show
+  symvault agent profile show my-agent
 
   # Show profile as JSON
-  symvault agent profile my-agent show --output json
+  symvault agent profile show my-agent --output json
 
   # Edit agent profile in $EDITOR
-  symvault agent profile my-agent edit
+  symvault agent profile edit my-agent
 
   # Export profile as YAML to stdout
-  symvault agent profile my-agent export`,
+  symvault agent profile export my-agent`,
 	}
 	agentProfileCmd.AddCommand(newAgentProfileShowCmd())
 	agentProfileCmd.AddCommand(newAgentProfileEditCmd())
@@ -42,11 +42,12 @@ func newAgentProfileCmd() *cobra.Command {
 
 func newAgentProfileShowCmd() *cobra.Command {
 	agentProfileShowCmd := &cobra.Command{
-		Use:   "show",
+		Use:   "show <name>",
 		Short: "Display agent profile",
 		Long:  `Display the agent profile in YAML or JSON format.`,
+		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			agentName := mustGetProfileAgentName(cmd)
+			agentName := args[0]
 			output, _ := cmd.Flags().GetString("output")
 
 			profile, err := loadAgentProfile(agentName)
@@ -73,12 +74,13 @@ func newAgentProfileShowCmd() *cobra.Command {
 
 func newAgentProfileEditCmd() *cobra.Command {
 	agentProfileEditCmd := &cobra.Command{
-		Use:   "edit",
+		Use:   "edit <name>",
 		Short: "Edit agent profile in $EDITOR",
 		Long: `Open the agent profile in your configured editor ($EDITOR or $VISUAL).
 After saving, the profile is validated and you are prompted to apply changes.`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			agentName := mustGetProfileAgentName(cmd)
+			agentName := args[0]
 
 			editor := os.Getenv("EDITOR")
 			if editor == "" {
@@ -170,12 +172,13 @@ After saving, the profile is validated and you are prompted to apply changes.`,
 
 func newAgentProfileExportCmd() *cobra.Command {
 	agentProfileExportCmd := &cobra.Command{
-		Use:   "export",
+		Use:   "export <name>",
 		Short: "Export agent profile as YAML",
 		Long: `Export the agent profile to stdout or to a file.
 Output is in YAML format by default.`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			agentName := mustGetProfileAgentName(cmd)
+			agentName := args[0]
 			outputPath, _ := cmd.Flags().GetString("output")
 
 			profile, err := loadAgentProfile(agentName)
@@ -218,17 +221,6 @@ func loadAgentProfile(agentName string) (*configpkg.AgentProfile, error) {
 	}
 	profile.Name = agentName
 	return &profile, nil
-}
-
-func mustGetProfileAgentName(cmd *cobra.Command) string {
-	parent := cmd.Parent()
-	if parent != nil {
-		parentArgs := parent.Flags().Args()
-		if len(parentArgs) > 0 {
-			return parentArgs[0]
-		}
-	}
-	return "unknown"
 }
 
 func extractAgentSection(data []byte, agentName string) ([]byte, error) {

--- a/cmd/mcp/agent_profile_test.go
+++ b/cmd/mcp/agent_profile_test.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"bytes"
+	"encoding/json"
 	"path/filepath"
 	"testing"
 
@@ -117,5 +118,65 @@ vaultDir: /tmp/test
 	_, err := extractAgentSection(configData, "agent")
 	if err == nil {
 		t.Fatal("expected error when no agents section")
+	}
+}
+
+func TestAgentProfileShowRoutesAgentName(t *testing.T) {
+	vaultDir := t.TempDir()
+	cfg := configpkg.Default()
+	cfg.VaultDir = vaultDir
+	cfg.Agents["test-agent"] = configpkg.AgentProfile{
+		Tier:         configpkg.StrPtr("standard"),
+		AllowedPaths: []string{"test/*"},
+	}
+	if err := cfg.SaveTo(filepath.Join(vaultDir, "config.yaml")); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+	t.Setenv("SYMVAULT_VAULT", vaultDir)
+
+	var output bytes.Buffer
+	cmd := newAgentCmd()
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+	cmd.SetArgs([]string{"profile", "show", "test-agent", "--output", "json"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute profile show: %v", err)
+	}
+
+	var profile configpkg.AgentProfile
+	if err := json.Unmarshal(output.Bytes(), &profile); err != nil {
+		t.Fatalf("decode profile output: %v\n%s", err, output.String())
+	}
+	if profile.Name != "test-agent" {
+		t.Fatalf("profile name = %q, want %q", profile.Name, "test-agent")
+	}
+}
+
+func TestAgentProfileSubcommandsUseActionFirstArguments(t *testing.T) {
+	cmd := newAgentProfileCmd()
+	for _, action := range []string{"show", "edit", "export"} {
+		t.Run(action, func(t *testing.T) {
+			found, args, err := cmd.Find([]string{action, "test-agent"})
+			if err != nil {
+				t.Fatalf("find %s: %v", action, err)
+			}
+			if found.Name() != action {
+				t.Fatalf("found command = %q, want %q", found.Name(), action)
+			}
+			if err := found.Args(found, args); err != nil {
+				t.Fatalf("validate %s args %v: %v", action, args, err)
+			}
+		})
+	}
+
+	found, args, err := cmd.Find([]string{"test-agent", "show"})
+	if err != nil {
+		t.Fatalf("find legacy ordering: %v", err)
+	}
+	if found != cmd {
+		t.Fatalf("legacy ordering unexpectedly selected %q", found.Name())
+	}
+	if err := found.Args(found, args); err == nil {
+		t.Fatal("legacy name-first ordering should fail instead of silently selecting an unknown profile")
 	}
 }

--- a/cmd/mcp/agent_token.go
+++ b/cmd/mcp/agent_token.go
@@ -14,21 +14,21 @@ import (
 
 func newAgentTokenCmd() *cobra.Command {
 	agentTokenCmd := &cobra.Command{
-		Use:   "token <name>",
+		Use:   "token",
 		Short: "Manage tokens for an agent",
 		Long:  `Create, list, revoke, and rotate scoped tokens for a specific agent.`,
-		Args:  cobra.ExactArgs(1),
+		Args:  cobra.NoArgs,
 		Example: `  # Create a scoped token for an agent
-  symvault agent token my-agent new
+  symvault agent token new my-agent
 
   # List tokens for an agent
-  symvault agent token my-agent list
+  symvault agent token list my-agent
 
   # Revoke a token by ID
-  symvault agent token my-agent revoke <token-id>
+  symvault agent token revoke my-agent <token-id>
 
   # Rotate an agent's token (revoke + create new)
-  symvault agent token my-agent rotate`,
+  symvault agent token rotate my-agent`,
 	}
 	agentTokenCmd.AddCommand(newAgentTokenNewCmd())
 	agentTokenCmd.AddCommand(newAgentTokenListCmd())
@@ -39,14 +39,15 @@ func newAgentTokenCmd() *cobra.Command {
 
 func newAgentTokenNewCmd() *cobra.Command {
 	agentTokenNewCmd := &cobra.Command{
-		Use:   "new",
+		Use:   "new <name>",
 		Short: "Create a new scoped token for the agent",
 		Long: `Create a new scoped MCP token associated with the named agent.
 
 The raw token is printed exactly once — copy it immediately. It cannot be
 retrieved later.`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			agentName := mustGetAgentName(cmd)
+			agentName := args[0]
 			tools, _ := cmd.Flags().GetStringSlice("tools")
 			ttlStr, _ := cmd.Flags().GetString("ttl")
 			label, _ := cmd.Flags().GetString("label")
@@ -109,11 +110,12 @@ retrieved later.`,
 
 func newAgentTokenListCmd() *cobra.Command {
 	agentTokenListCmd := &cobra.Command{
-		Use:   "list",
+		Use:   "list <name>",
 		Short: "List tokens for this agent",
 		Long:  `List all scoped tokens associated with the given agent name.`,
+		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			agentName := mustGetAgentName(cmd)
+			agentName := args[0]
 
 			vDir, err := cli.VaultPath()
 			if err != nil {
@@ -176,12 +178,13 @@ func newAgentTokenListCmd() *cobra.Command {
 
 func newAgentTokenRevokeCmd() *cobra.Command {
 	agentTokenRevokeCmd := &cobra.Command{
-		Use:   "revoke <token-id>",
+		Use:   "revoke <name> <token-id>",
 		Short: "Revoke a scoped token",
 		Long:  `Revoke a scoped token by its ID. Revoked tokens are immediately invalidated.`,
-		Args:  cobra.ExactArgs(1),
+		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			tokenID := args[0]
+			agentName := args[0]
+			tokenID := args[1]
 
 			vDir, err := cli.VaultPath()
 			if err != nil {
@@ -194,7 +197,14 @@ func newAgentTokenRevokeCmd() *cobra.Command {
 				return fmt.Errorf("load token registry: %w", err)
 			}
 
-			if !reg.Revoke(tokenID) {
+			var owned bool
+			for _, token := range reg.List() {
+				if token.ID == tokenID && token.AgentName == agentName {
+					owned = true
+					break
+				}
+			}
+			if !owned || !reg.Revoke(tokenID) {
 				return fmt.Errorf("token %q not found or already revoked", tokenID)
 			}
 
@@ -211,12 +221,13 @@ func newAgentTokenRevokeCmd() *cobra.Command {
 
 func newAgentTokenRotateCmd() *cobra.Command {
 	agentTokenRotateCmd := &cobra.Command{
-		Use:   "rotate",
+		Use:   "rotate <name>",
 		Short: "Rotate the agent's token",
 		Long: `Revoke the current token for this agent and create a new one.
 The new raw token is printed exactly once.`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			agentName := mustGetAgentName(cmd)
+			agentName := args[0]
 			tools, _ := cmd.Flags().GetStringSlice("tools")
 			ttlStr, _ := cmd.Flags().GetString("ttl")
 			label, _ := cmd.Flags().GetString("label")
@@ -279,15 +290,4 @@ The new raw token is printed exactly once.`,
 	agentTokenRotateCmd.Flags().String("ttl", "", "Token TTL (e.g. 24h, 7d); defaults to mcp.scoped_token_ttl from config")
 	agentTokenRotateCmd.Flags().String("label", "", "Human-readable label")
 	return agentTokenRotateCmd
-}
-
-func mustGetAgentName(cmd *cobra.Command) string {
-	parent := cmd.Parent()
-	if parent != nil {
-		parentArgs := parent.Flags().Args()
-		if len(parentArgs) > 0 {
-			return parentArgs[0]
-		}
-	}
-	return "unknown"
 }

--- a/cmd/mcp/agent_token_test.go
+++ b/cmd/mcp/agent_token_test.go
@@ -1,6 +1,7 @@
 package mcp
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -111,4 +112,121 @@ func TestResolveTokenTTL_EmptyDefault(t *testing.T) {
 	if d.Hours() != 24 {
 		t.Errorf("duration = %v hours, want 24", d.Hours())
 	}
+}
+
+func TestAgentTokenCommandRoutesAgentName(t *testing.T) {
+	vaultDir := t.TempDir()
+	t.Setenv("SYMVAULT_VAULT", vaultDir)
+
+	output, err := os.CreateTemp(t.TempDir(), "agent-token-output")
+	if err != nil {
+		t.Fatalf("create output file: %v", err)
+	}
+	originalStdout := os.Stdout
+	os.Stdout = output
+	t.Cleanup(func() {
+		os.Stdout = originalStdout
+		_ = output.Close()
+	})
+
+	cmd := newAgentCmd()
+	cmd.SetArgs([]string{"token", "new", "hermes", "--tools", "list_entries", "--ttl", "1h"})
+	if err := cmd.Execute(); err != nil {
+		os.Stdout = originalStdout
+		t.Fatalf("execute token command: %v", err)
+	}
+	os.Stdout = originalStdout
+	if err := output.Close(); err != nil {
+		t.Fatalf("close output file: %v", err)
+	}
+
+	reg := auth.NewTokenRegistry(auth.TokenRegistryFilePath(vaultDir))
+	if err := reg.Load(); err != nil {
+		t.Fatalf("load registry: %v", err)
+	}
+	for _, token := range reg.List() {
+		if token.AgentName == "hermes" {
+			return
+		}
+	}
+	t.Fatalf("token command did not persist a token for agent %q", "hermes")
+}
+
+func TestAgentTokenSubcommandsUseActionFirstArguments(t *testing.T) {
+	cmd := newAgentTokenCmd()
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "new", args: []string{"new", "hermes"}},
+		{name: "list", args: []string{"list", "hermes"}},
+		{name: "revoke", args: []string{"revoke", "hermes", "token-id"}},
+		{name: "rotate", args: []string{"rotate", "hermes"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			found, args, err := cmd.Find(tt.args)
+			if err != nil {
+				t.Fatalf("find %s: %v", tt.name, err)
+			}
+			if found.Name() != tt.name {
+				t.Fatalf("found command = %q, want %q", found.Name(), tt.name)
+			}
+			if err := found.Args(found, args); err != nil {
+				t.Fatalf("validate %s args %v: %v", tt.name, args, err)
+			}
+		})
+	}
+
+	found, args, err := cmd.Find([]string{"hermes", "new"})
+	if err != nil {
+		t.Fatalf("find legacy ordering: %v", err)
+	}
+	if found != cmd {
+		t.Fatalf("legacy ordering unexpectedly selected %q", found.Name())
+	}
+	if err := found.Args(found, args); err == nil {
+		t.Fatal("legacy name-first ordering should fail instead of silently using the wrong agent")
+	}
+}
+
+func TestAgentTokenRevokeRequiresMatchingAgent(t *testing.T) {
+	vaultDir := t.TempDir()
+	t.Setenv("SYMVAULT_VAULT", vaultDir)
+	reg := auth.NewTokenRegistry(auth.TokenRegistryFilePath(vaultDir))
+	token, _, err := reg.Create("test", []string{"list_entries"}, "hermes", 0)
+	if err != nil {
+		t.Fatalf("create token: %v", err)
+	}
+	if err := reg.Save(); err != nil {
+		t.Fatalf("save token: %v", err)
+	}
+
+	cmd := newAgentTokenRevokeCmd()
+	if err := cmd.RunE(cmd, []string{"other-agent", token.ID}); err == nil {
+		t.Fatal("revoke accepted a token owned by another agent")
+	}
+	assertAgentTokenRevoked(t, vaultDir, token.ID, false)
+
+	if err := cmd.RunE(cmd, []string{"hermes", token.ID}); err != nil {
+		t.Fatalf("revoke matching token: %v", err)
+	}
+	assertAgentTokenRevoked(t, vaultDir, token.ID, true)
+}
+
+func assertAgentTokenRevoked(t *testing.T, vaultDir, tokenID string, want bool) {
+	t.Helper()
+	reg := auth.NewTokenRegistry(auth.TokenRegistryFilePath(vaultDir))
+	if err := reg.Load(); err != nil {
+		t.Fatalf("load token registry: %v", err)
+	}
+	for _, token := range reg.List() {
+		if token.ID == tokenID {
+			if token.Revoked != want {
+				t.Fatalf("token revoked = %v, want %v", token.Revoked, want)
+			}
+			return
+		}
+	}
+	t.Fatalf("token %q not found", tokenID)
 }

--- a/cmd/mcp/mcp_config.go
+++ b/cmd/mcp/mcp_config.go
@@ -48,17 +48,17 @@ Use 'symvault agent install <agent> --config-only' to output MCP config snippets
 func newMcpTokenRotateCmd() *cobra.Command {
 	mcpTokenRotateCmd := &cobra.Command{
 		Use:   "mcp-token-rotate",
-		Short: "[Deprecated v4.0, removed in v4.1] Use 'symvault agent token <name> rotate'",
+		Short: "[Deprecated v4.0, removed in v4.1] Use 'symvault agent token rotate <name>'",
 		Long: `This command was deprecated in Symaira Vault v4.0 and will be removed in v4.1.
 
-Token rotation is now managed per-agent via 'symvault agent token <name> rotate'.`,
-		Example: `  symvault agent token my-agent rotate`,
+Token rotation is now managed per-agent via 'symvault agent token rotate <name>'.`,
+		Example: `  symvault agent token rotate my-agent`,
 		Hidden:  true,
 		Args:    cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cliout.Warnf("This command is deprecated in v4.0. Use: symvault agent token <name> rotate")
+			cliout.Warnf("This command is deprecated in v4.0. Use: symvault agent token rotate <name>")
 			return errorspkg.NewCLIError(errorspkg.ExitNotFound,
-				"This command is deprecated in v4.0. Use: symvault agent token <name> rotate", nil)
+				"This command is deprecated in v4.0. Use: symvault agent token rotate <name>", nil)
 		},
 	}
 	mcpTokenRotateCmd.GroupID = cli.GroupIDAgentsMCP
@@ -96,7 +96,7 @@ func resolveHTTPConfig(agentName string, tokenID string) (*httpConfig, error) {
 
 	var token string
 	if tokenID != "" {
-		return nil, fmt.Errorf("token %q cannot be used for config generation because scoped token raw values are only shown at creation time; create a fresh token with 'symvault agent token %s new'", tokenID, agentName)
+		return nil, fmt.Errorf("token %q cannot be used for config generation because scoped token raw values are only shown at creation time; create a fresh token with 'symvault agent token new %s'", tokenID, agentName)
 	}
 
 	tokenPath := filepath.Join(vDir, "mcp-token")
@@ -266,7 +266,7 @@ func OutputHermesHTTPConfig(agentName, serverName string, redact bool, tokenID s
 // serverKey is the key name in mcp_servers (e.g., "claude_code", "codex").
 // agentName is passed to symvault mcp (e.g., "claude-code", "codex").
 //
-// Verification: symvault mcp-config claude-code --format claude-code | paste into Claude Desktop config
+// Legacy formatter retained for callers that need an agent-specific YAML snippet.
 func OutputAgentStdioConfig(agentName, serverKey string) error {
 	config := map[string]any{
 		"mcp_servers": map[string]any{
@@ -288,8 +288,7 @@ func OutputAgentStdioConfig(agentName, serverKey string) error {
 // agentName is passed to symvault mcp and X-Symaira-Agent header.
 // redact outputs env:SYMVAULT_MCP_TOKEN instead of the actual token.
 //
-// Verification: symvault mcp-config claude-code --http --format claude-code | paste into Claude Desktop config
-// Then verify: curl -H "Authorization: Bearer $(cat ~/.symvault/mcp-token)" http://127.0.0.1:8080/mcp
+// Legacy formatter retained for callers that need an agent-specific HTTP snippet.
 func OutputAgentHTTPConfig(agentName, serverKey, displayName string, redact bool, tokenID string) error {
 	httpCfg, err := resolveHTTPConfig(agentName, tokenID)
 	if err != nil {

--- a/cmd/mcp/mcp_token.go
+++ b/cmd/mcp/mcp_token.go
@@ -18,17 +18,17 @@ var McpTokenCmd = newMcpTokenCmd()
 func newMcpTokenCmd() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "token",
-		Short: "[Deprecated v4.0, removed in v4.1] Use 'symvault agent token <name>'",
+		Short: "[Deprecated v4.0, removed in v4.1] Use 'symvault agent token <action> <name>'",
 		Long: `This command was deprecated in Symaira Vault v4.0 and will be removed in v4.1.
 
-Scoped token management is now available via 'symvault agent token <name>'
+Scoped token management is now available via 'symvault agent token <action> <name>'
 with subcommands new, list, revoke, and rotate.`,
-		Example: `  symvault agent token my-agent new`,
+		Example: `  symvault agent token new my-agent`,
 		Hidden:  true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cliout.Warnf("This command is deprecated in v4.0. Use: symvault agent token <name> new/list/revoke")
+			cliout.Warnf("This command is deprecated in v4.0. Use: symvault agent token <new|list|revoke|rotate> <name>")
 			return errorspkg.NewCLIError(errorspkg.ExitNotFound,
-				"This command is deprecated in v4.0. Use: symvault agent token <name> new/list/revoke", nil)
+				"This command is deprecated in v4.0. Use: symvault agent token <new|list|revoke|rotate> <name>", nil)
 		},
 	}
 	c.AddCommand(newTokenCreateCmd())
@@ -44,15 +44,15 @@ var TokenCreateCmd = newTokenCreateCmd()
 func newTokenCreateCmd() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "create",
-		Short: "[Deprecated v4.0, removed in v4.1] Use 'symvault agent token <name> new'",
+		Short: "[Deprecated v4.0, removed in v4.1] Use 'symvault agent token new <name>'",
 		Long: `This command was deprecated in Symaira Vault v4.0 and will be removed in v4.1.
 
-Create scoped tokens via 'symvault agent token <name> new'.`,
+Create scoped tokens via 'symvault agent token new <name>'.`,
 		Hidden: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cliout.Warnf("This command is deprecated in v4.0. Use: symvault agent token <name> new")
+			cliout.Warnf("This command is deprecated in v4.0. Use: symvault agent token new <name>")
 			return errorspkg.NewCLIError(errorspkg.ExitNotFound,
-				"This command is deprecated in v4.0. Use: symvault agent token <name> new", nil)
+				"This command is deprecated in v4.0. Use: symvault agent token new <name>", nil)
 		},
 	}
 	return c
@@ -61,15 +61,15 @@ Create scoped tokens via 'symvault agent token <name> new'.`,
 func newTokenListCmd() *cobra.Command {
 	tokenListCmd := &cobra.Command{
 		Use:   "list",
-		Short: "[Deprecated v4.0, removed in v4.1] Use 'symvault agent token <name> list'",
+		Short: "[Deprecated v4.0, removed in v4.1] Use 'symvault agent token list <name>'",
 		Long: `This command was deprecated in Symaira Vault v4.0 and will be removed in v4.1.
 
-List tokens via 'symvault agent token <name> list'.`,
+List tokens via 'symvault agent token list <name>'.`,
 		Hidden: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cliout.Warnf("This command is deprecated in v4.0. Use: symvault agent token <name> list")
+			cliout.Warnf("This command is deprecated in v4.0. Use: symvault agent token list <name>")
 			return errorspkg.NewCLIError(errorspkg.ExitNotFound,
-				"This command is deprecated in v4.0. Use: symvault agent token <name> list", nil)
+				"This command is deprecated in v4.0. Use: symvault agent token list <name>", nil)
 		},
 	}
 	return tokenListCmd
@@ -78,16 +78,16 @@ List tokens via 'symvault agent token <name> list'.`,
 func newTokenRevokeCmd() *cobra.Command {
 	tokenRevokeCmd := &cobra.Command{
 		Use:   "revoke <token-id>",
-		Short: "[Deprecated v4.0, removed in v4.1] Use 'symvault agent token <name> revoke'",
+		Short: "[Deprecated v4.0, removed in v4.1] Use 'symvault agent token revoke <name> <token-id>'",
 		Long: `This command was deprecated in Symaira Vault v4.0 and will be removed in v4.1.
 
-Revoke tokens via 'symvault agent token <name> revoke'.`,
+Revoke tokens via 'symvault agent token revoke <name> <token-id>'.`,
 		Hidden: true,
 		Args:   cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cliout.Warnf("This command is deprecated in v4.0. Use: symvault agent token <name> revoke")
+			cliout.Warnf("This command is deprecated in v4.0. Use: symvault agent token revoke <name> <token-id>")
 			return errorspkg.NewCLIError(errorspkg.ExitNotFound,
-				"This command is deprecated in v4.0. Use: symvault agent token <name> revoke", nil)
+				"This command is deprecated in v4.0. Use: symvault agent token revoke <name> <token-id>", nil)
 		},
 	}
 	return tokenRevokeCmd

--- a/docs/adr/0004-cli-agent-optimization-v4.md
+++ b/docs/adr/0004-cli-agent-optimization-v4.md
@@ -88,8 +88,8 @@ symvault serve                         # MCP server (unchanged)
 | `symvault mcp install <agent>` | `symvault agent install <agent>` | stub, exit 2 | removed |
 | `symvault mcp install --auto-detect` | `symvault agent install --auto-detect` | stub, exit 2 | removed |
 | `symvault mcp token create` | `symvault agent token new <name>` | stub, exit 2 | removed |
-| `symvault mcp token list` | `symvault agent token list` | stub, exit 2 | removed |
-| `symvault mcp token revoke` | `symvault agent token revoke` | stub, exit 2 | removed |
+| `symvault mcp token list` | `symvault agent token list <name>` | stub, exit 2 | removed |
+| `symvault mcp token revoke` | `symvault agent token revoke <name> <token-id>` | stub, exit 2 | removed |
 | `symvault mcp-token-rotate` | `symvault agent token rotate <name>` | stub, exit 2 | removed |
 | `symvault agent setup <name>` | `symvault agent install <name>` (tier override) | stub, exit 2 | removed |
 | `symvault mcp` (subcommand tree) | folded into `symvault agent` | stub on each subcommand, exit 2 | removed |

--- a/docs/agent-integration.md
+++ b/docs/agent-integration.md
@@ -53,9 +53,9 @@ token in config:
 symvault --vault ~/.symvault agent install hermes --config-only
 ```
 
-Add the output under `mcp_servers` in `~/.hermes/config.yaml` only after the
-human adoption gate approves a live Hermes config change, then restart Hermes or
-reload MCP tools from Hermes. Verify the connection:
+Run the command only after the human adoption gate approves a live Hermes config
+change. It writes the `mcp_servers` entry in `~/.hermes/config.yaml`; review that
+entry, then restart Hermes or reload its MCP tools. Verify the connection:
 
 ```bash
 hermes mcp test symvault
@@ -317,13 +317,13 @@ Create fine-grained access tokens with restricted tool access and optional expir
 
 ```bash
 # Create a token limited to specific tools
-symvault agent token hermes new --tools list_entries,get_entry --expires 24h
+symvault agent token new hermes --tools list_entries,get_entry --ttl 24h
 
-# List all active tokens
-symvault agent token list
+# List this agent's tokens
+symvault agent token list hermes
 
 # Revoke a token
-symvault agent token hermes revoke <token-id>
+symvault agent token revoke hermes <token-id>
 ```
 
 Scoped tokens are stored with SHA-256 hashing and can be restricted to specific MCP tools
@@ -334,29 +334,33 @@ and time windows. This is safer than the global bearer token for multi-agent set
 If you suspect your MCP token has been compromised, rotate it:
 
 ```bash
-symvault agent token hermes rotate
+symvault agent token rotate hermes
 ```
 
-This invalidates the old token and generates a new one. Update any agent configurations
-with the new token.
+This revokes every active token for the named agent and generates one replacement.
+Update the agent configuration with the new token.
 
 ### Safer Token Export
 
-When generating MCP configurations that might be displayed in terminals or committed
-to version control, use the `--redact` flag:
+Normal HTTP setup creates a scoped token, stores it in a private per-agent token
+file, and writes the detected client's MCP configuration without printing the raw
+token:
 
 ```bash
 symvault agent install claude-code --http --config-only
 ```
 
-This outputs `env:SYMVAULT_MCP_TOKEN` instead of the actual token. Agents using
-redacted configs must have `SYMVAULT_MCP_TOKEN` set in their environment.
+The command reports the token ID and affected paths only. This is safer than
+copying a bearer token through terminal output or a committed configuration file.
 
-For automated scripts that need the raw token:
+If you explicitly need the raw token for manual configuration:
 
 ```bash
-TOKEN=$(symvault agent token <agent> new --tools list_entries --expires 24h --json | jq -r .token)
+symvault agent token new <agent> --tools list_entries --ttl 24h
 ```
+
+The raw token is shown once. Copy it directly to the intended client; do not log,
+commit, or paste it into chat.
 
 ## OAuth Dynamic Client Registration
 

--- a/docs/man/symvault-agent-profile-edit.1
+++ b/docs/man/symvault-agent-profile-edit.1
@@ -6,7 +6,7 @@ symvault-agent-profile-edit - Edit agent profile in $EDITOR
 
 
 .SH SYNOPSIS
-\fBsymvault agent profile edit [flags]\fP
+\fBsymvault agent profile edit  [flags]\fP
 
 
 .SH DESCRIPTION

--- a/docs/man/symvault-agent-profile-export.1
+++ b/docs/man/symvault-agent-profile-export.1
@@ -6,7 +6,7 @@ symvault-agent-profile-export - Export agent profile as YAML
 
 
 .SH SYNOPSIS
-\fBsymvault agent profile export [flags]\fP
+\fBsymvault agent profile export  [flags]\fP
 
 
 .SH DESCRIPTION

--- a/docs/man/symvault-agent-profile-show.1
+++ b/docs/man/symvault-agent-profile-show.1
@@ -6,7 +6,7 @@ symvault-agent-profile-show - Display agent profile
 
 
 .SH SYNOPSIS
-\fBsymvault agent profile show [flags]\fP
+\fBsymvault agent profile show  [flags]\fP
 
 
 .SH DESCRIPTION

--- a/docs/man/symvault-agent-profile.1
+++ b/docs/man/symvault-agent-profile.1
@@ -6,7 +6,7 @@ symvault-agent-profile - Manage agent profiles
 
 
 .SH SYNOPSIS
-\fBsymvault agent profile  [flags]\fP
+\fBsymvault agent profile [flags]\fP
 
 
 .SH DESCRIPTION
@@ -54,16 +54,16 @@ Show, edit, and export agent profiles.
 .SH EXAMPLE
 .EX
   # Show agent profile
-  symvault agent profile my-agent show
+  symvault agent profile show my-agent
 
   # Show profile as JSON
-  symvault agent profile my-agent show --output json
+  symvault agent profile show my-agent --output json
 
   # Edit agent profile in $EDITOR
-  symvault agent profile my-agent edit
+  symvault agent profile edit my-agent
 
   # Export profile as YAML to stdout
-  symvault agent profile my-agent export
+  symvault agent profile export my-agent
 .EE
 
 

--- a/docs/man/symvault-agent-token-list.1
+++ b/docs/man/symvault-agent-token-list.1
@@ -6,7 +6,7 @@ symvault-agent-token-list - List tokens for this agent
 
 
 .SH SYNOPSIS
-\fBsymvault agent token list [flags]\fP
+\fBsymvault agent token list  [flags]\fP
 
 
 .SH DESCRIPTION

--- a/docs/man/symvault-agent-token-new.1
+++ b/docs/man/symvault-agent-token-new.1
@@ -6,7 +6,7 @@ symvault-agent-token-new - Create a new scoped token for the agent
 
 
 .SH SYNOPSIS
-\fBsymvault agent token new [flags]\fP
+\fBsymvault agent token new  [flags]\fP
 
 
 .SH DESCRIPTION

--- a/docs/man/symvault-agent-token-revoke.1
+++ b/docs/man/symvault-agent-token-revoke.1
@@ -6,7 +6,7 @@ symvault-agent-token-revoke - Revoke a scoped token
 
 
 .SH SYNOPSIS
-\fBsymvault agent token revoke  [flags]\fP
+\fBsymvault agent token revoke   [flags]\fP
 
 
 .SH DESCRIPTION

--- a/docs/man/symvault-agent-token-rotate.1
+++ b/docs/man/symvault-agent-token-rotate.1
@@ -6,7 +6,7 @@ symvault-agent-token-rotate - Rotate the agent's token
 
 
 .SH SYNOPSIS
-\fBsymvault agent token rotate [flags]\fP
+\fBsymvault agent token rotate  [flags]\fP
 
 
 .SH DESCRIPTION

--- a/docs/man/symvault-agent-token.1
+++ b/docs/man/symvault-agent-token.1
@@ -6,7 +6,7 @@ symvault-agent-token - Manage tokens for an agent
 
 
 .SH SYNOPSIS
-\fBsymvault agent token  [flags]\fP
+\fBsymvault agent token [flags]\fP
 
 
 .SH DESCRIPTION
@@ -54,16 +54,16 @@ Create, list, revoke, and rotate scoped tokens for a specific agent.
 .SH EXAMPLE
 .EX
   # Create a scoped token for an agent
-  symvault agent token my-agent new
+  symvault agent token new my-agent
 
   # List tokens for an agent
-  symvault agent token my-agent list
+  symvault agent token list my-agent
 
   # Revoke a token by ID
-  symvault agent token my-agent revoke <token-id>
+  symvault agent token revoke my-agent <token-id>
 
   # Rotate an agent's token (revoke + create new)
-  symvault agent token my-agent rotate
+  symvault agent token rotate my-agent
 .EE
 
 

--- a/docs/man/symvault-agent.1
+++ b/docs/man/symvault-agent.1
@@ -13,8 +13,8 @@ symvault-agent - Manage agent profiles
 Configure AI agent profiles with scoped permissions, tokens, and MCP integration.
 
 .PP
-Use 'symvault agent setup \&' to create a new agent with an interactive wizard
-that guides you through security tier selection, vault path scoping, and approval mode.
+Use 'symvault agent install \&' to create a security profile, scoped token,
+MCP configuration, and agent skill package.
 
 
 .SH OPTIONS
@@ -57,8 +57,8 @@ that guides you through security tier selection, vault path scoping, and approva
 
 .SH EXAMPLE
 .EX
-  # Interactive new-agent wizard
-  symvault agent setup claude-code
+  # Install and configure an agent
+  symvault agent install claude-code
 
   # List configured agents
   symvault agent list

--- a/docs/mcp-api.md
+++ b/docs/mcp-api.md
@@ -322,16 +322,19 @@ symvault agent install <agent-name> --config-only
 symvault mcp --port 8080 --agent <profile-name>
 ```
 
-**Generate configuration** (token redacted by default):
+**Install HTTP configuration**:
 
 ```bash
 symvault agent install <agent-name> --http --config-only
 ```
 
-**Include token in output**:
+The installer writes a scoped token to private per-agent storage and updates the
+detected client configuration without printing the raw token.
+
+**Create a token for manual configuration** (shown once):
 
 ```bash
-symvault agent token <agent-name> new --tools list_entries,get_entry --expires 24h
+symvault agent token new <agent-name> --tools list_entries,get_entry --ttl 24h
 ```
 
 ---

--- a/docs/migration-v3-to-v4.md
+++ b/docs/migration-v3-to-v4.md
@@ -187,10 +187,10 @@ Replace these old commands in your scripts and documentation:
 | `symvault mcp install <name>` | `symvault agent install <name>` |
 | `symvault mcp install --auto-detect` | `symvault agent install --auto-detect` |
 | `symvault mcp-config <agent>` | `symvault agent install <agent> --config-only` |
-| `symvault mcp token create` | `symvault agent token <name> new` |
-| `symvault mcp token list` | `symvault agent token list` |
-| `symvault mcp token revoke` | `symvault agent token revoke` |
-| `symvault mcp-token-rotate` | `symvault agent token <name> rotate` |
+| `symvault mcp token create` | `symvault agent token new <name>` |
+| `symvault mcp token list` | `symvault agent token list <name>` |
+| `symvault mcp token revoke` | `symvault agent token revoke <name> <token-id>` |
+| `symvault mcp-token-rotate` | `symvault agent token rotate <name>` |
 
 Deprecation stubs are in place for v4.0. Calling any of the old commands prints
 the replacement and exits with code 2. The stubs will be removed in v4.1.
@@ -207,10 +207,10 @@ The full mapping of deprecated commands to their v4.0 replacements:
 | `symvault mcp install <name>` | `symvault agent install <name>` | Same flags: `--tier`, `--http`, `--force` |
 | `symvault mcp install --auto-detect` | `symvault agent install --auto-detect` | Detects all installed agents |
 | `symvault mcp-config <agent>` | `symvault agent install <agent> --config-only` | MCP config only, no skill |
-| `symvault mcp token create` | `symvault agent token <name> new` | Scope and expiry flags unchanged |
-| `symvault mcp token list` | `symvault agent token list` | Output unchanged |
-| `symvault mcp token revoke <id>` | `symvault agent token revoke <id>` | Output unchanged |
-| `symvault mcp-token-rotate` | `symvault agent token <name> rotate` | Output unchanged |
+| `symvault mcp token create` | `symvault agent token new <name>` | Scope and TTL flags remain available |
+| `symvault mcp token list` | `symvault agent token list <name>` | Listing is now agent-scoped |
+| `symvault mcp token revoke <id>` | `symvault agent token revoke <name> <id>` | Revocation verifies token ownership |
+| `symvault mcp-token-rotate` | `symvault agent token rotate <name>` | Rotation is now agent-scoped |
 | `symvault mcp` (any subcommand) | Folded into `symvault agent` | See rows above |
 
 ### New commands in v4.0
@@ -325,7 +325,7 @@ symvault mcp token create --agent hermes --tools list_entries --expires 24h
 
 # After
 symvault agent install hermes
-symvault agent token hermes new --tools list_entries --expires 24h
+symvault agent token new hermes --tools list_entries --ttl 24h
 ```
 
 ### Configuration management (GitOps)

--- a/docs/skills/symaira-agent/UPGRADE-TO-V4.md
+++ b/docs/skills/symaira-agent/UPGRADE-TO-V4.md
@@ -163,7 +163,7 @@ For each agent that comes back with warnings or errors:
 - **Missing MCP config entry** — re-inject:
   `symvault agent install <name> --config-only`
 - **Token invalid / expired** — rotate:
-  `symvault agent token <name> rotate`
+  `symvault agent token rotate <name>`
 - **Profile classified `custom` but user wants a preset** — explicit upgrade:
   `symvault agent upgrade <name> --tier <safe|standard|admin>` (interactive)
 
@@ -184,10 +184,10 @@ commands. Show the user any matches and propose replacements before editing.
 | `symvault mcp install <name>` | `symvault agent install <name>` |
 | `symvault mcp install --auto-detect` | `symvault agent install --auto-detect` |
 | `symvault mcp-config <agent>` | `symvault agent install <agent> --config-only` |
-| `symvault mcp token create …` | `symvault agent token <name> new …` |
-| `symvault mcp token list` | `symvault agent token list` |
-| `symvault mcp token revoke <id>` | `symvault agent token revoke <id>` |
-| `symvault mcp-token-rotate` | `symvault agent token <name> rotate` |
+| `symvault mcp token create …` | `symvault agent token new <name> …` |
+| `symvault mcp token list` | `symvault agent token list <name>` |
+| `symvault mcp token revoke <id>` | `symvault agent token revoke <name> <id>` |
+| `symvault mcp-token-rotate` | `symvault agent token rotate <name>` |
 
 For CI/automation scripts that upgrade tiers, add `--reason` (now required
 with `--yes`):

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -161,9 +161,10 @@ binary at runtime.
   hash lookup for scoped tokens — neither path is timing-attackable.
 - **127.0.0.1 binding by default.** HTTP transport binds to loopback unless
   the operator opts into a non-loopback address via TLS-required mode.
-- **Token rotation.** `mcp-token-rotate` CLI command supports zero-downtime
-  rotation. Revocation is tracked in the token registry and consulted on
-  every request.
+- **Per-agent token rotation.** `symvault agent token rotate <name>` revokes
+  every active scoped token for that agent and mints one replacement token,
+  shown exactly once. Revocation is tracked in the token registry and checked
+  on every request.
 - **Refresh-token flow.** Long-lived bearer tokens are discouraged in favor
   of short-lived access tokens with refresh tokens (`token.go`
   `RefreshToken*`).

--- a/homebrew/Formula/symvault.rb
+++ b/homebrew/Formula/symvault.rb
@@ -10,7 +10,7 @@ class Symvault < Formula
   version "{{ .Version }}"
   sha256 "{{ .Checksum }}"
 
-  license "MIT"
+  license "Apache-2.0"
 
   depends_on "go" => :build
 
@@ -41,7 +41,7 @@ class Symvault < Formula
         symvault get github.com/username # Retrieve it
 
       For MCP server setup:
-        symvault mcp-config <name>
+        symvault agent install <name> --config-only
 
       Documentation: https://github.com/danieljustus/symaira-vault#readme
     EOS

--- a/homebrew/README.md
+++ b/homebrew/README.md
@@ -64,7 +64,7 @@ symvault get github.com/username
 symvault generate
 
 # Set up MCP server for AI agents
-symvault mcp-config claude-code
+symvault agent install claude-code --config-only
 ```
 
 ## Documentation

--- a/internal/agentskill/skill.go
+++ b/internal/agentskill/skill.go
@@ -221,7 +221,7 @@ This skill was exported by Symaira Vault v%s.
 
 1. Place %[3]s in your agent's skill directory.
 2. Create a scoped access token:
-   symvault mcp token create --agent %[1]s --tools list,get --expires 90d
+   symvault agent token new %[1]s --tools list_entries,get_entry --ttl 90d
 3. Restart your agent.
 
 ## Verification

--- a/internal/agentskill/skill_test.go
+++ b/internal/agentskill/skill_test.go
@@ -662,6 +662,7 @@ func TestExport(t *testing.T) {
 	tr := tar.NewReader(gr)
 
 	var foundFiles []string
+	var installContent []byte
 	for {
 		hdr, err := tr.Next()
 		if err == io.EOF {
@@ -680,6 +681,9 @@ func TestExport(t *testing.T) {
 		}
 		if len(content) == 0 {
 			t.Errorf("tar entry %s is empty", hdr.Name)
+		}
+		if hdr.Name == "INSTALL.md" {
+			installContent = append([]byte(nil), content...)
 		}
 	}
 
@@ -703,6 +707,9 @@ func TestExport(t *testing.T) {
 	}
 	if !hasInstall {
 		t.Errorf("tar archive missing INSTALL.md; found: %v", foundFiles)
+	}
+	if !bytes.Contains(installContent, []byte("symvault agent token new hermes --tools list_entries,get_entry --ttl 90d")) {
+		t.Errorf("INSTALL.md does not contain the supported scoped-token command: %q", installContent)
 	}
 }
 

--- a/internal/health/doctor_mcp.go
+++ b/internal/health/doctor_mcp.go
@@ -54,7 +54,7 @@ func checkMCPTokens(vaultDir string, _ Options) Result {
 			parts = append(parts, fmt.Sprintf("%d expired/revoked", expired))
 		}
 		r.Message = strings.Join(parts, ", ")
-		r.Hint = "rotate old tokens with `symvault mcp-token-rotate`"
+		r.Hint = "rotate old tokens per agent with `symvault agent token rotate <name>`"
 	} else {
 		r.Status = StatusOK
 		r.Message = fmt.Sprintf("%d active token(s), all within rotation policy", active)
@@ -216,7 +216,7 @@ func checkMCPServer(vaultDir string, _ Options) Result {
 		r.Message += ", token present"
 	} else {
 		r.Message += ", no token file"
-		r.Hint = "generate an MCP token with `symvault agent token <name> new`"
+		r.Hint = "generate an MCP token with `symvault agent token new <name>`"
 	}
 	return r
 }
@@ -331,7 +331,7 @@ func checkMCPAgents(vaultDir string, _ Options) Result {
 	} else {
 		r.Status = StatusOK
 		r.Message = "no AI agent MCP configs found"
-		r.Hint = "run `symvault mcp-config <agent>` to generate config"
+		r.Hint = "run `symvault agent install <agent> --config-only` to install MCP config"
 	}
 	return r
 }

--- a/internal/mcp/auth/token.go
+++ b/internal/mcp/auth/token.go
@@ -803,13 +803,13 @@ func LoadTokenSystemWithIdentity(identity *age.X25519Identity, vaultDir string, 
 			// so the next restart can retry.
 			if saveErr := reg.Save(); saveErr == nil {
 				// Loud, one-time warning: the legacy token was migrated with
-				// wildcard tool scope. Operators should rotate it via
-				// `symvault mcp token create` with an explicit allow-list and
+				// wildcard tool scope. Operators should replace it via
+				// `symvault agent token new` with an explicit allow-list and
 				// then revoke the legacy entry.
 				cliout.Warnf(
 					"WARNING: legacy MCP token migrated to scoped registry with wildcard (*) tool access (id=%s).\n"+
-						"         To restrict scope, run: symvault mcp token create --label <name> --tools <list>\n"+
-						"         Then revoke the legacy token: symvault mcp token revoke %s",
+						"         To restrict scope, run: symvault agent token new <agent> --label <label> --tools <list>\n"+
+						"         Then revoke the legacy token: symvault agent token revoke legacy %s",
 					id, id)
 				if rmErr := fsutil.SafeRemove(legacyPath); rmErr != nil {
 					// Tolerate ENOENT: a concurrent process may have removed

--- a/internal/mcp/server/server_dispatch.go
+++ b/internal/mcp/server/server_dispatch.go
@@ -200,10 +200,10 @@ func (s *Server) validateToolAccess(ctx context.Context, def toolDefinition, nam
 		span.SetStatus(codes.Error, "tool registry drift")
 		metrics.RecordMCPRequest(name, agentName, "error", time.Since(start))
 		s.logAudit(ctx, "tool_registry_drift", name, false)
-		return callToolResultPayload(toolError(
-			"tool registry has changed since this token was issued — " +
-				"re-issue the token with 'symvault mcp token create'",
-		))
+		return callToolResultPayload(toolError(fmt.Sprintf(
+			"tool registry has changed since this token was issued — "+
+				"re-issue the token with 'symvault agent token new %s'", agentName,
+		)))
 	}
 
 	if entryPath != "" {


### PR DESCRIPTION
## Summary

- make agent token and profile commands use executable action-first syntax and pass each validated agent name directly to its handler
- prevent a token ID from being revoked through a different agent name
- update deprecation, health, registry-drift, generated-skill, release, Homebrew, security, migration, and MCP guidance to the working command contract
- regenerate affected man pages and extend `make docs-check` to reject stale commands, name-first routing, and the removed `--expires` flag

## Verification

- focused action-first routing tests reproduce the former `unknown` agent behavior and now pass
- `GOTOOLCHAIN=go1.26.6 go test -race -count=1 ./cmd/mcp ./internal/agentskill ./internal/health ./internal/mcp/auth ./internal/mcp/server`
- full non-race suite: `GOTOOLCHAIN=go1.26.6 make test-fast` (69 packages)
- `make docs-check`, including negative fixtures for name-first ordering and `--expires`
- `make fmt-check`, `make vet`, `make build`, `make lint`
- Windows amd64 test-binary cross-compilation for `./cmd/mcp`
- Homebrew formula Ruby syntax and GoReleaser configuration validation (the existing `brews` deprecation remains informational)
- two monolithic local race-suite attempts hit four unrelated load-sensitive failures; every failing test passed immediately in isolated race-enabled reruns. Exact-head CI remains the merge gate.

Closes #970
