### PR TITLE
fix(deps): pin corekit SafeRemove repair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- MCP HTTP startup no longer fails intermittently with `bad file descriptor`
+  while migrating a legacy token. The shared Unix `SafeRemove` helper closed
+  its validated descriptor twice, allowing the second close to hit an audit
+  log that had reused the descriptor under concurrent load (#972).
 - Agent token and profile subcommands now use executable action-first syntax
   (`symvault agent token new|list|revoke|rotate <name>` and
   `symvault agent profile show|edit|export <name>`). The previous name-first
@@ -58,7 +62,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   until the server is restarted.
 
 ### Dependencies
-- Bumped `corekit` from `v0.9.1` to `v0.11.0` (pulls in latest audit/security improvements from the corekit module).
+- Bumped `corekit` from `v0.16.3` to the verified post-`v0.17.0` fix at
+  `f3d3eb79b9b1`, which closes Unix `SafeRemove` descriptors exactly once.
 - Bumped `appkit` from `0.4.0` to `0.10.0` in `client/Package.swift` (latest Swift Package release, includes `CLIRunnerError` plaintext-redaction security fix).
 
 ### Documentation

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
           src = ./.;
 
           # Resolved via `go mod vendor; nix hash path --sri vendor/`
-          vendorHash = "sha256-zJcXMlY/2QWmaNGPSKF+djHcGjThInGJUgB5WJ7XAQc=";
+          vendorHash = "sha256-/cTuiackYtJZlnN68ZmlrYbQzXy+XE45bwslO2wN8dM=";
 
           # Disable CGO for Linux — reduces distributability and is not needed
           # (keyring integration requires CGO only on darwin).

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/creack/pty v1.1.24
-	github.com/danieljustus/symaira-corekit v0.16.3
+	github.com/danieljustus/symaira-corekit v0.17.1-0.20260904101640-f3d3eb79b9b1
 	github.com/go-git/go-billy/v5 v5.9.1
 	github.com/go-git/go-git/v5 v5.19.2
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -92,8 +92,8 @@ github.com/cyphar/filepath-securejoin v0.6.1 h1:5CeZ1jPXEiYt3+Z6zqprSAgSWiggmpVy
 github.com/cyphar/filepath-securejoin v0.6.1/go.mod h1:A8hd4EnAeyujCJRrICiOWqjS1AX0a9kM5XL+NwKoYSc=
 github.com/danieljoos/wincred v1.2.3 h1:v7dZC2x32Ut3nEfRH+vhoZGvN72+dQ/snVXo/vMFLdQ=
 github.com/danieljoos/wincred v1.2.3/go.mod h1:6qqX0WNrS4RzPZ1tnroDzq9kY3fu1KwE7MRLQK4X0bs=
-github.com/danieljustus/symaira-corekit v0.16.3 h1:COO2u0E/yud0tGXyBm7j6AYO0zgNQDlMqXkaqC0Dop0=
-github.com/danieljustus/symaira-corekit v0.16.3/go.mod h1:fza/0RvUl5ODDdjic2scDinTBhRBK79+aILmXCshqxg=
+github.com/danieljustus/symaira-corekit v0.17.1-0.20260904101640-f3d3eb79b9b1 h1:PTJHSup1YfDsv6P8MLIkTbZ/72jzr3YmMwzDoWq+z3g=
+github.com/danieljustus/symaira-corekit v0.17.1-0.20260904101640-f3d3eb79b9b1/go.mod h1:fza/0RvUl5ODDdjic2scDinTBhRBK79+aILmXCshqxg=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/elazarl/goproxy v1.8.3 h1:XhiZpzW0NvsGOqSv/F3v4+1F29842yYaJNN+In5Fnuc=


### PR DESCRIPTION
## Summary

- pin `symaira-corekit` to the merged `SafeRemove` descriptor-lifecycle fix
- refresh the Nix `vendorHash` required by the module pin
- document the release-blocking HTTP startup repair in the unreleased changelog
- replace the stale unreleased corekit dependency note with the actual verified pin

## Root cause

Corekit's Unix `SafeRemove` registered a deferred descriptor close and explicitly closed the same descriptor before unlinking. Under concurrent descriptor reuse, the second close could invalidate a newly opened audit log. The first `v0.22.0` tag run reproduced that failure as `fstat(...)=EBADF` during MCP HTTP startup.

Upstream dependency: danieljustus/symaira-corekit#220 / danieljustus/symaira-corekit#221 (`f3d3eb79b9b1f31b4f973d2ed518a8292cedf588`).

## Verification

- upstream deterministic RED→GREEN descriptor-close tests
- upstream full race suite, lint, build, and CGO-free cross-compiles
- `GOGC=1 go test -race -count=200` over Vault HTTP/serve lifecycle tests in Linux
- focused Vault race tests for `cmd`, `internal/fsutil`, `internal/mcp/auth`, and `internal/mcp/serverbootstrap`
- full `GOTOOLCHAIN=go1.26.6 make test`
- `make fmt-check`, `make vet`, `make build`, `make lint`, and `make docs-check`
- `go mod verify`
- Nix `vendorHash` recomputed and matched with `go mod vendor` plus `nix hash path --sri vendor/`

Closes #972
