### PR TITLE
fix(nix): make flake executable and reproducible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,6 +187,11 @@ jobs:
           fi
           echo "PASS: flake.nix vendorHash matches the current go.mod/go.sum tree"
 
+      - name: Build and run Nix flake
+        run: |
+          nix --extra-experimental-features 'nix-command flakes' build .#
+          nix --extra-experimental-features 'nix-command flakes' run .# -- version
+
   # ── PR-fast jobs ─────────────────────────────────────────────────────────
 
   test-pr:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   while migrating a legacy token. The shared Unix `SafeRemove` helper closed
   its validated descriptor twice, allowing the second close to hit an audit
   log that had reused the descriptor under concurrent load (#972).
+- The advertised Nix flake now builds and runs `symvault`, pins its inputs,
+  carries the Apache-2.0 license metadata, and is exercised end to end in CI.
+  Previously it failed during non-hermetic host-oriented tests and pointed
+  `nix run` at a nonexistent executable (#974).
 - Agent token and profile subcommands now use executable action-first syntax
   (`symvault agent token new|list|revoke|rotate <name>` and
   `symvault agent profile show|edit|export <name>`). The previous name-first

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1788316716,
+        "narHash": "sha256-bc7rSpXIdn9QWGNqfWcPZWOhEVF8NoeAZkWq0XWnf/k=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "3ed67ec0a4d3c7ab4ae1f04f8ee8df07bfa506a2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -15,10 +15,16 @@
       in
       {
         packages.default = pkgs.buildGoModule {
-          pname = "symaira";
+          pname = "symvault";
           version = self.version or "dev";
 
           src = ./.;
+          subPackages = [ "." ];
+
+          # The canonical CI suite already runs before this package gate. The
+          # tests are intentionally host-oriented (`/bin/echo`, Git/SSH, TTYs)
+          # and cannot run inside Nix's pure build sandbox.
+          doCheck = false;
 
           # Resolved via `go mod vendor; nix hash path --sri vendor/`
           vendorHash = "sha256-/cTuiackYtJZlnN68ZmlrYbQzXy+XE45bwslO2wN8dM=";
@@ -35,13 +41,17 @@
             "-X main.date=unknown"
           ];
 
+          postInstall = ''
+            mv "$out/bin/symaira-vault" "$out/bin/symvault"
+          '';
+
           meta = with pkgs.lib; {
             description = "Modern CLI password manager with age encryption";
             homepage = "https://github.com/danieljustus/symaira-vault";
-            license = licenses.mit;
+            license = licenses.asl20;
             maintainers = [ ];
             platforms = platforms.linux ++ platforms.darwin;
-            mainProgram = "symaira";
+            mainProgram = "symvault";
           };
         };
 


### PR DESCRIPTION
## Summary

- make the flake build only the root CLI and install it as `symvault`
- point `nix run` at the real binary and correct package/license metadata
- pin Nix inputs with `flake.lock`
- add a real Nix build and runtime smoke test to the existing vendor-hash CI job
- keep the canonical Go suite in its dedicated CI jobs instead of rerunning host-oriented tests inside Nix's pure sandbox

## Root cause

The existing CI checked only `vendorHash`. A clean `nix run` showed four independent defects: Nix tried to rerun tests that require host paths and tools (`/bin/echo`, Git/SSH, TTY behavior), `buildGoModule` installed `symaira-vault` while `mainProgram` named nonexistent `symaira`, metadata still declared MIT, and no lock file pinned `nixos-unstable`.

## Verification

- pre-fix `nix run` reproduced the pure-build failure
- `nix build path:/work#packages.aarch64-linux.default`
- `nix run path:/work -- version` → `symvault dev`
- `nix flake check --no-build path:/work`
- evaluated metadata: `pname=symvault`, `mainProgram=symvault`, `license=Apache-2.0`
- `go mod vendor` hash equals the tracked `vendorHash`
- `make test-fast`, `make fmt-check`, `make vet`, `make build`, `make lint`, and `make docs-check`
- `actionlint .github/workflows/ci.yml`

Closes #974
