### PR TITLE
feat(rust): port initial core contracts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build install test test-fast test-coverage test-verbose test-race test-ci cover clean lint lint-fix fmt fmt-check vet passlint completions manpages port-fixtures-generate port-fixtures-check differential-go-selftest port-contract rust-build rust-check rust-lint rust-test rust-features rust-coverage rust-security rust-version-contract rust-gates help docs-check
+.PHONY: all build install test test-fast test-coverage test-verbose test-race test-ci cover clean lint lint-fix fmt fmt-check vet passlint completions manpages port-fixtures-generate port-fixtures-check core-fixtures-generate core-fixtures-check differential-go-selftest port-contract rust-build rust-check rust-lint rust-test rust-features rust-coverage rust-security rust-version-contract rust-gates help docs-check
 
 # Variables
 BINARY_NAME := symvault
@@ -157,6 +157,7 @@ PORT_ORACLE_COMMIT ?= $(shell git rev-parse --short HEAD)
 PORT_ORACLE_RELEASE ?= v0.22.1
 PORT_CLI_FIXTURE := testdata/port/cli/command-tree.json
 PORT_CLI_CASES := testdata/port/cli/cases.json
+PORT_ERROR_FIXTURE := testdata/port/core/error-contract.json
 PORT_GO_BINARY := target/port/symvault-go
 RUST_BINARY := target/debug/symvault
 PORT_CONTRACT_VERSION ?= v0.0.0-port
@@ -171,12 +172,22 @@ port-fixtures-check:
 	GOTOOLCHAIN=$(GO_TOOLCHAIN) $(GO) run ./scripts/rust-port/cmd/portgen \
 		--check --output $(PORT_CLI_FIXTURE)
 
+core-fixtures-generate:
+	GOTOOLCHAIN=$(GO_TOOLCHAIN) $(GO) run ./scripts/rust-port/cmd/coregen \
+		--output $(PORT_ERROR_FIXTURE) \
+		--oracle-commit $(PORT_ORACLE_COMMIT) \
+		--oracle-release $(PORT_ORACLE_RELEASE)
+
+core-fixtures-check:
+	GOTOOLCHAIN=$(GO_TOOLCHAIN) $(GO) run ./scripts/rust-port/cmd/coregen \
+		--check --output $(PORT_ERROR_FIXTURE)
+
 differential-go-selftest:
 	GOTOOLCHAIN=$(GO_TOOLCHAIN) $(MAKE) build
 	GOTOOLCHAIN=$(GO_TOOLCHAIN) $(GO) run ./scripts/rust-port/cmd/diffharness \
 		--left ./$(BINARY_NAME) --right ./$(BINARY_NAME) --cases $(PORT_CLI_CASES)
 
-port-contract: port-fixtures-check differential-go-selftest
+port-contract: port-fixtures-check core-fixtures-check differential-go-selftest
 
 rust-build:
 	$(CARGO) build --workspace --locked
@@ -253,6 +264,8 @@ help:
 	@echo "  manpages           - Generate manual pages"
 	@echo "  port-fixtures-generate - Regenerate frozen Go-oracle CLI fixtures"
 	@echo "  port-fixtures-check    - Verify Go-oracle CLI fixtures have not drifted"
+	@echo "  core-fixtures-generate - Regenerate frozen Go-oracle core fixtures"
+	@echo "  core-fixtures-check    - Verify Go-oracle core fixtures have not drifted"
 	@echo "  differential-go-selftest - Compare the Go oracle with itself in isolated sandboxes"
 	@echo "  port-contract      - Run all Rust-port contract preparation gates"
 	@echo "  rust-build         - Build the staged Rust workspace"

--- a/Makefile
+++ b/Makefile
@@ -153,11 +153,13 @@ manpages: build
 	./$(BINARY_NAME) generate manpages docs/man
 
 # Go-oracle fixtures and neutral black-box harness for the staged Rust port.
-PORT_ORACLE_COMMIT ?= $(shell git rev-parse --short HEAD)
+PORT_ORACLE_COMMIT ?= caadd5e
 PORT_ORACLE_RELEASE ?= v0.22.1
 PORT_CLI_FIXTURE := testdata/port/cli/command-tree.json
 PORT_CLI_CASES := testdata/port/cli/cases.json
 PORT_ERROR_FIXTURE := testdata/port/core/error-contract.json
+PORT_SECRET_REF_FIXTURE := testdata/port/core/secret-ref-contract.json
+PORT_REDACT_FIXTURE := testdata/port/core/redact-contract.json
 PORT_GO_BINARY := target/port/symvault-go
 RUST_BINARY := target/debug/symvault
 PORT_CONTRACT_VERSION ?= v0.0.0-port
@@ -174,13 +176,18 @@ port-fixtures-check:
 
 core-fixtures-generate:
 	GOTOOLCHAIN=$(GO_TOOLCHAIN) $(GO) run ./scripts/rust-port/cmd/coregen \
-		--output $(PORT_ERROR_FIXTURE) \
+		--error-output $(PORT_ERROR_FIXTURE) \
+		--secret-ref-output $(PORT_SECRET_REF_FIXTURE) \
+		--redact-output $(PORT_REDACT_FIXTURE) \
 		--oracle-commit $(PORT_ORACLE_COMMIT) \
 		--oracle-release $(PORT_ORACLE_RELEASE)
 
 core-fixtures-check:
 	GOTOOLCHAIN=$(GO_TOOLCHAIN) $(GO) run ./scripts/rust-port/cmd/coregen \
-		--check --output $(PORT_ERROR_FIXTURE)
+		--check \
+		--error-output $(PORT_ERROR_FIXTURE) \
+		--secret-ref-output $(PORT_SECRET_REF_FIXTURE) \
+		--redact-output $(PORT_REDACT_FIXTURE)
 
 differential-go-selftest:
 	GOTOOLCHAIN=$(GO_TOOLCHAIN) $(MAKE) build

--- a/crates/symvault-core/src/error.rs
+++ b/crates/symvault-core/src/error.rs
@@ -1,0 +1,484 @@
+use std::{error::Error, fmt};
+
+/// Stable Symaira Vault process exit categories.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u8)]
+pub enum ExitCode {
+    Success = 0,
+    General = 1,
+    NotFound = 2,
+    NotInitialized = 3,
+    Locked = 4,
+    PermissionDenied = 5,
+    Config = 6,
+    DoctorWarn = 7,
+    DoctorFail = 8,
+    InvalidInput = 9,
+    UpdateAvailable = 10,
+}
+
+impl ExitCode {
+    /// Alias used for flag and usage validation errors.
+    pub const USAGE: Self = Self::InvalidInput;
+
+    /// Returns the stable numeric process code.
+    #[must_use]
+    pub const fn value(self) -> u8 {
+        self as u8
+    }
+
+    /// Resolves a stable numeric process code.
+    #[must_use]
+    pub const fn from_u8(value: u8) -> Option<Self> {
+        match value {
+            0 => Some(Self::Success),
+            1 => Some(Self::General),
+            2 => Some(Self::NotFound),
+            3 => Some(Self::NotInitialized),
+            4 => Some(Self::Locked),
+            5 => Some(Self::PermissionDenied),
+            6 => Some(Self::Config),
+            7 => Some(Self::DoctorWarn),
+            8 => Some(Self::DoctorFail),
+            9 => Some(Self::InvalidInput),
+            10 => Some(Self::UpdateAvailable),
+            _ => None,
+        }
+    }
+}
+
+/// Stable service-level error classification.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[repr(u8)]
+pub enum ErrorKind {
+    #[default]
+    None = 0,
+    NotFound = 1,
+    FieldNotFound = 2,
+    ReadFailed = 3,
+    WriteFailed = 4,
+}
+
+impl ErrorKind {
+    /// Returns the stable numeric classification.
+    #[must_use]
+    pub const fn value(self) -> u8 {
+        self as u8
+    }
+}
+
+/// Sentinel category retained across adapter-specific error chains.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CauseKind {
+    EntryNotFound,
+    VaultNotInitialized,
+    VaultLocked,
+    PermissionDenied,
+    Other,
+}
+
+impl CauseKind {
+    /// Returns the language-neutral fixture name.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::EntryNotFound => "entry_not_found",
+            Self::VaultNotInitialized => "vault_not_initialized",
+            Self::VaultLocked => "vault_locked",
+            Self::PermissionDenied => "permission_denied",
+            Self::Other => "other",
+        }
+    }
+}
+
+/// An adapter-provided cause summary owned by the domain error.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ErrorCause {
+    kind: CauseKind,
+    message: String,
+}
+
+impl ErrorCause {
+    #[must_use]
+    pub fn new(kind: CauseKind, message: impl Into<String>) -> Self {
+        Self {
+            kind,
+            message: message.into(),
+        }
+    }
+
+    #[must_use]
+    pub const fn kind(&self) -> CauseKind {
+        self.kind
+    }
+
+    #[must_use]
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+}
+
+impl fmt::Display for ErrorCause {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl Error for ErrorCause {}
+
+/// Structured CLI error preserving the Go oracle's code, kind, cause, and hint.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CliError {
+    code: ExitCode,
+    kind: ErrorKind,
+    message: String,
+    cause: Option<ErrorCause>,
+    hint: Option<String>,
+}
+
+impl CliError {
+    #[must_use]
+    pub fn new(code: ExitCode, message: impl Into<String>, cause: Option<ErrorCause>) -> Self {
+        Self {
+            code,
+            kind: ErrorKind::None,
+            message: message.into(),
+            cause,
+            hint: None,
+        }
+    }
+
+    #[must_use]
+    pub fn wrap(
+        code: ExitCode,
+        kind: ErrorKind,
+        message: impl Into<String>,
+        cause: Option<ErrorCause>,
+    ) -> Self {
+        Self {
+            code,
+            kind,
+            message: message.into(),
+            cause,
+            hint: None,
+        }
+    }
+
+    #[must_use]
+    pub fn not_found(message: impl Into<String>) -> Self {
+        Self::wrap(
+            ExitCode::NotFound,
+            ErrorKind::NotFound,
+            message,
+            Some(ErrorCause::new(CauseKind::EntryNotFound, "entry not found")),
+        )
+        .with_hint(
+            "Try: symvault list to browse entries, or symvault find <term> to search by keyword.",
+        )
+    }
+
+    #[must_use]
+    pub fn read_failed(message: impl Into<String>, cause: Option<String>) -> Self {
+        Self::wrap(
+            ExitCode::General,
+            ErrorKind::ReadFailed,
+            message,
+            cause.map(|message| ErrorCause::new(CauseKind::Other, message)),
+        )
+    }
+
+    #[must_use]
+    pub fn write_failed(message: impl Into<String>, cause: Option<String>) -> Self {
+        Self::wrap(
+            ExitCode::General,
+            ErrorKind::WriteFailed,
+            message,
+            cause.map(|message| ErrorCause::new(CauseKind::Other, message)),
+        )
+    }
+
+    #[must_use]
+    pub fn not_initialized(message: impl Into<String>) -> Self {
+        Self::new(
+            ExitCode::NotInitialized,
+            message,
+            Some(ErrorCause::new(
+                CauseKind::VaultNotInitialized,
+                "vault not initialized",
+            )),
+        )
+        .with_hint("Run: symvault init to initialize a new vault.")
+    }
+
+    #[must_use]
+    pub fn vault_not_initialized() -> Self {
+        Self::new(
+            ExitCode::NotInitialized,
+            "vault not initialized. Run 'symvault init' first",
+            Some(ErrorCause::new(
+                CauseKind::VaultNotInitialized,
+                "vault not initialized",
+            )),
+        )
+    }
+
+    #[must_use]
+    pub fn locked(message: impl Into<String>) -> Self {
+        Self::new(
+            ExitCode::Locked,
+            message,
+            Some(ErrorCause::new(CauseKind::VaultLocked, "vault locked")),
+        )
+        .with_hint(
+            "Run: symvault unlock to unlock the vault, or set a passphrase via 'symvault auth set passphrase'.",
+        )
+    }
+
+    #[must_use]
+    pub fn permission_denied(message: impl Into<String>) -> Self {
+        Self::new(
+            ExitCode::PermissionDenied,
+            message,
+            Some(ErrorCause::new(
+                CauseKind::PermissionDenied,
+                "permission denied",
+            )),
+        )
+    }
+
+    #[must_use]
+    pub fn invalid_input(message: impl Into<String>) -> Self {
+        Self::new(ExitCode::InvalidInput, message, None)
+    }
+
+    #[must_use]
+    pub fn config(message: impl Into<String>) -> Self {
+        Self::new(ExitCode::Config, message, None)
+    }
+
+    #[must_use]
+    pub fn internal(message: impl Into<String>) -> Self {
+        Self::new(ExitCode::General, message, None)
+    }
+
+    #[must_use]
+    pub fn already_exists(message: impl Into<String>) -> Self {
+        Self::new(ExitCode::General, message, None)
+    }
+
+    #[must_use]
+    pub fn with_hint(mut self, hint: impl Into<String>) -> Self {
+        self.hint = Some(hint.into());
+        self
+    }
+
+    #[must_use]
+    pub const fn code(&self) -> ExitCode {
+        self.code
+    }
+
+    #[must_use]
+    pub const fn kind(&self) -> ErrorKind {
+        self.kind
+    }
+
+    #[must_use]
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+
+    #[must_use]
+    pub fn cause(&self) -> Option<&ErrorCause> {
+        self.cause.as_ref()
+    }
+
+    #[must_use]
+    pub fn hint(&self) -> Option<&str> {
+        self.hint.as_deref()
+    }
+
+    #[must_use]
+    pub const fn is_not_found(&self) -> bool {
+        matches!(self.kind, ErrorKind::NotFound | ErrorKind::FieldNotFound)
+    }
+
+    #[must_use]
+    pub const fn is_write_error(&self) -> bool {
+        matches!(self.kind, ErrorKind::WriteFailed)
+    }
+
+    #[must_use]
+    pub fn effective_exit_code(&self) -> ExitCode {
+        exit_code_from_error(Some(self))
+    }
+
+    #[must_use]
+    pub fn formatted(&self) -> String {
+        match self.hint() {
+            Some(hint) => format!("{}\nHint: {hint}", self),
+            None => self.to_string(),
+        }
+    }
+}
+
+impl fmt::Display for CliError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.cause {
+            Some(cause)
+                if cause.kind() == CauseKind::VaultNotInitialized
+                    && self
+                        .message
+                        .to_lowercase()
+                        .contains("vault not initialized") =>
+            {
+                formatter.write_str(&self.message)
+            }
+            Some(cause) => write!(formatter, "{}: {cause}", self.message),
+            None => formatter.write_str(&self.message),
+        }
+    }
+}
+
+impl Error for CliError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        self.cause.as_ref().map(|cause| cause as &dyn Error)
+    }
+}
+
+/// Resolves sentinel causes before typed CLI codes, matching Go `errors.Is`/`errors.As` order.
+#[must_use]
+pub fn exit_code_from_error(error: Option<&(dyn Error + 'static)>) -> ExitCode {
+    let Some(error) = error else {
+        return ExitCode::Success;
+    };
+
+    let mut current = Some(error);
+    while let Some(item) = current {
+        if let Some(cause) = item.downcast_ref::<ErrorCause>() {
+            match cause.kind() {
+                CauseKind::EntryNotFound => return ExitCode::NotFound,
+                CauseKind::VaultNotInitialized => return ExitCode::NotInitialized,
+                CauseKind::VaultLocked => return ExitCode::Locked,
+                CauseKind::PermissionDenied => return ExitCode::PermissionDenied,
+                CauseKind::Other => {}
+            }
+        }
+        current = item.source();
+    }
+
+    current = Some(error);
+    while let Some(item) = current {
+        if let Some(cli_error) = item.downcast_ref::<CliError>() {
+            return cli_error.code();
+        }
+        current = item.source();
+    }
+    ExitCode::General
+}
+
+/// Formats a plain or nested CLI error with the typed error's remediation hint.
+#[must_use]
+pub fn format_cli_error(error: Option<&(dyn Error + 'static)>) -> String {
+    let Some(error) = error else {
+        return String::new();
+    };
+    let mut current = Some(error);
+    while let Some(item) = current {
+        if let Some(cli_error) = item.downcast_ref::<CliError>() {
+            return cli_error.formatted();
+        }
+        current = item.source();
+    }
+    error.to_string()
+}
+
+/// Returns whether an arbitrary error chain contains a typed not-found error.
+#[must_use]
+pub fn is_not_found(error: &(dyn Error + 'static)) -> bool {
+    let mut current = Some(error);
+    while let Some(item) = current {
+        if let Some(cli_error) = item.downcast_ref::<CliError>() {
+            return cli_error.is_not_found();
+        }
+        current = item.source();
+    }
+    false
+}
+
+/// Returns whether an arbitrary error chain contains a typed write failure.
+#[must_use]
+pub fn is_write_error(error: &(dyn Error + 'static)) -> bool {
+    let mut current = Some(error);
+    while let Some(item) = current {
+        if let Some(cli_error) = item.downcast_ref::<CliError>() {
+            return cli_error.is_write_error();
+        }
+        current = item.source();
+    }
+    false
+}
+
+/// Maps a vault exit code onto the historical corekit numeric category.
+#[must_use]
+pub const fn to_corekit_exit_code(code: ExitCode) -> u8 {
+    match code {
+        ExitCode::Success => 0,
+        ExitCode::NotFound => 5,
+        ExitCode::PermissionDenied => 4,
+        ExitCode::Config => 9,
+        ExitCode::InvalidInput => 2,
+        ExitCode::General
+        | ExitCode::NotInitialized
+        | ExitCode::Locked
+        | ExitCode::DoctorWarn
+        | ExitCode::DoctorFail
+        | ExitCode::UpdateAvailable => 1,
+    }
+}
+
+/// Maps a historical corekit numeric category onto the vault exit taxonomy.
+#[must_use]
+pub const fn from_corekit_exit_code(code: u8) -> ExitCode {
+    match code {
+        0 => ExitCode::Success,
+        5 => ExitCode::NotFound,
+        4 => ExitCode::PermissionDenied,
+        9 => ExitCode::Config,
+        2 => ExitCode::InvalidInput,
+        _ => ExitCode::General,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        CauseKind, CliError, ErrorCause, ExitCode, exit_code_from_error, format_cli_error,
+    };
+
+    #[test]
+    fn optional_io_causes_preserve_display_shape() {
+        let without = CliError::write_failed("write failed", None);
+        let with = CliError::write_failed("write failed", Some("disk full".into()));
+        assert_eq!(without.to_string(), "write failed");
+        assert!(std::error::Error::source(&without).is_none());
+        assert_eq!(with.to_string(), "write failed: disk full");
+        assert!(std::error::Error::source(&with).is_some());
+    }
+
+    #[test]
+    fn sentinel_cause_precedes_cli_code() {
+        let error = CliError::new(
+            ExitCode::General,
+            "wrapper",
+            Some(ErrorCause::new(CauseKind::VaultLocked, "vault locked")),
+        );
+        assert_eq!(exit_code_from_error(Some(&error)), ExitCode::Locked);
+    }
+
+    #[test]
+    fn generic_formatter_handles_nil_and_typed_errors() {
+        let error = CliError::internal("failed").with_hint("repair");
+        assert_eq!(format_cli_error(None), "");
+        assert_eq!(format_cli_error(Some(&error)), "failed\nHint: repair");
+    }
+}

--- a/crates/symvault-core/src/lib.rs
+++ b/crates/symvault-core/src/lib.rs
@@ -5,6 +5,8 @@
 use serde::Serialize;
 
 pub mod error;
+pub mod redact;
+pub mod secret_ref;
 
 /// Public binary and protocol tool name.
 pub const TOOL_NAME: &str = "symvault";

--- a/crates/symvault-core/src/lib.rs
+++ b/crates/symvault-core/src/lib.rs
@@ -4,6 +4,8 @@
 
 use serde::Serialize;
 
+pub mod error;
+
 /// Public binary and protocol tool name.
 pub const TOOL_NAME: &str = "symvault";
 

--- a/crates/symvault-core/src/redact.rs
+++ b/crates/symvault-core/src/redact.rs
@@ -1,0 +1,565 @@
+#![deny(unsafe_code)]
+
+//! Secret redaction core: detectors, Shannon entropy heuristic, and fail-closed scanner.
+
+use core::fmt;
+use serde::{Deserialize, Serialize};
+
+/// Marker substituted for detected secret values.
+pub const MARKER: &str = "[REDACTED]";
+
+/// Marker returned when scanner output is withheld/blocked.
+pub const BLOCKED_TEXT: &str = "[REDACTED: output withheld]";
+
+/// Opt-in environment variable name enabling strict blocking mode.
+pub const ENV_STRICT_MODE: &str = "SYMVAULT_REDACT_STRICT_MODE";
+
+/// Minimum length for a literal exact-value detector match.
+pub const MIN_EXACT_VALUE_LEN: usize = 4;
+
+/// Minimum token length for the entropy heuristic detector.
+pub const MIN_TOKEN_LEN: usize = 20;
+
+/// Shannon entropy floor in bits per character for the entropy heuristic.
+pub const MIN_ENTROPY_BITS_PER_CHAR: f64 = 4.85;
+
+/// Confidence classification of a detector match.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Confidence {
+    /// High-confidence match (exact value, verified credential format).
+    High,
+    /// Low-confidence heuristic match (entropy-based candidate).
+    Low,
+}
+
+impl Confidence {
+    /// Human-readable label for confidence tier.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::High => "high",
+            Self::Low => "low",
+        }
+    }
+}
+
+impl fmt::Display for Confidence {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+/// Error returned when a detector fails during scanning.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RedactError(String);
+
+impl RedactError {
+    /// Creates a new detector error.
+    #[must_use]
+    pub fn new(msg: impl Into<String>) -> Self {
+        Self(msg.into())
+    }
+}
+
+impl fmt::Display for RedactError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl std::error::Error for RedactError {}
+
+/// Detector scans text for secrets and replaces matches with `MARKER`.
+pub trait Detector: Send + Sync {
+    /// Canonical detector name for audit metadata.
+    fn name(&self) -> &str;
+    /// Confidence tier of this detector.
+    fn confidence(&self) -> Confidence;
+    /// Redacts matches in place, returning the redacted text and match count.
+    fn redact(&self, text: &str) -> Result<(String, usize), RedactError>;
+}
+
+/// Detector matching literal occurrences of known secrets.
+pub struct ExactValueDetector {
+    values: Vec<String>,
+}
+
+impl ExactValueDetector {
+    /// Creates a new `ExactValueDetector`, filtering out secrets shorter than `MIN_EXACT_VALUE_LEN`.
+    #[must_use]
+    pub fn new<I, S>(values: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let filtered = values
+            .into_iter()
+            .filter_map(|s| {
+                let s = s.as_ref();
+                if s.len() >= MIN_EXACT_VALUE_LEN {
+                    Some(s.to_string())
+                } else {
+                    None
+                }
+            })
+            .collect();
+        Self { values: filtered }
+    }
+}
+
+// Custom Debug implementation to prevent secret values from leaking into logs/snapshots.
+impl fmt::Debug for ExactValueDetector {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ExactValueDetector")
+            .field("pattern_count", &self.values.len())
+            .field("min_len", &MIN_EXACT_VALUE_LEN)
+            .finish()
+    }
+}
+
+impl Detector for ExactValueDetector {
+    fn name(&self) -> &str {
+        "exact_value"
+    }
+
+    fn confidence(&self) -> Confidence {
+        Confidence::High
+    }
+
+    fn redact(&self, text: &str) -> Result<(String, usize), RedactError> {
+        let mut current = text.to_string();
+        let mut total = 0;
+        for v in &self.values {
+            let (next, count) = replace_all_value(&current, v);
+            current = next;
+            total += count;
+        }
+        Ok((current, total))
+    }
+}
+
+fn replace_all_value(text: &str, value: &str) -> (String, usize) {
+    if value.is_empty() {
+        return (text.to_string(), 0);
+    }
+    let count = text.matches(value).count();
+    if count == 0 {
+        return (text.to_string(), 0);
+    }
+    (text.replace(value, MARKER), count)
+}
+
+/// Conservative Shannon entropy heuristic detector for random secret tokens.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub struct EntropyDetector;
+
+impl EntropyDetector {
+    /// Creates a new `EntropyDetector`.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+impl Detector for EntropyDetector {
+    fn name(&self) -> &str {
+        "entropy_heuristic"
+    }
+
+    fn confidence(&self) -> Confidence {
+        Confidence::Low
+    }
+
+    fn redact(&self, text: &str) -> Result<(String, usize), RedactError> {
+        let spans = tokenize(text);
+        if spans.is_empty() {
+            return Ok((text.to_string(), 0));
+        }
+
+        let mut out = String::with_capacity(text.len());
+        let mut last_end = 0;
+        let mut count = 0;
+
+        for (start, end) in spans {
+            if end - start < MIN_TOKEN_LEN {
+                continue;
+            }
+            if shannon_entropy(&text[start..end]) < MIN_ENTROPY_BITS_PER_CHAR {
+                continue;
+            }
+            out.push_str(&text[last_end..start]);
+            out.push_str(MARKER);
+            last_end = end;
+            count += 1;
+        }
+        out.push_str(&text[last_end..]);
+
+        if count == 0 {
+            Ok((text.to_string(), 0))
+        } else {
+            Ok((out, count))
+        }
+    }
+}
+
+/// Checks whether a character belongs to candidate entropy tokens.
+#[must_use]
+pub fn is_entropy_token_char(c: char) -> bool {
+    c.is_ascii_alphanumeric() || "+=_.~!@#$%^&*".contains(c)
+}
+
+fn tokenize(text: &str) -> Vec<(usize, usize)> {
+    let mut spans = Vec::new();
+    let mut start = None;
+
+    for (idx, c) in text.char_indices() {
+        if is_entropy_token_char(c) {
+            if start.is_none() {
+                start = Some(idx);
+            }
+        } else if let Some(s) = start.take() {
+            spans.push((s, idx));
+        }
+    }
+    if let Some(s) = start {
+        spans.push((s, text.len()));
+    }
+    spans
+}
+
+/// Computes empirical Shannon entropy in bits per character.
+#[must_use]
+pub fn shannon_entropy(s: &str) -> f64 {
+    if s.is_empty() {
+        return 0.0;
+    }
+    let mut counts = [0usize; 256];
+    for &b in s.as_bytes() {
+        counts[b as usize] += 1;
+    }
+    let total = s.len() as f64;
+    let mut entropy = 0.0;
+    for &count in &counts {
+        if count > 0 {
+            let p = count as f64 / total;
+            entropy -= p * p.log2();
+        }
+    }
+    entropy
+}
+
+/// Options configuring a scan invocation.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ScanOptions {
+    /// Strict mode blocks output when high-confidence secrets match.
+    pub strict: bool,
+    /// Correlation ID tied to audit events.
+    pub correlation_id: Option<String>,
+}
+
+/// Finding metadata produced by a detector during scanning.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Finding {
+    /// Detector that reported the match.
+    pub detector: String,
+    /// Confidence tier.
+    pub confidence: Confidence,
+    /// Number of matches.
+    pub count: usize,
+}
+
+/// Safe metadata-only audit event emitted on detection or block.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AuditEvent {
+    /// Detector that triggered the event.
+    pub detector: String,
+    /// Originating channel label (e.g. `stdout`).
+    pub channel: String,
+    /// Match confidence.
+    pub confidence: Confidence,
+    /// Number of redacted occurrences.
+    pub redacted_count: usize,
+    /// Whether output delivery was blocked.
+    pub blocked: bool,
+    /// Request correlation ID.
+    pub correlation_id: Option<String>,
+}
+
+/// Outcome of a scan invocation.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ScanResult {
+    /// Safe output text (original text, redacted text, or blocked marker).
+    pub text: String,
+    /// Findings reported during scanning.
+    pub findings: Vec<Finding>,
+    /// Whether output delivery was blocked.
+    pub blocked: bool,
+}
+
+/// Error returned on detector failure during scanning.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScanError {
+    /// Safe result that must be surfaced to avoid leaking partial secrets.
+    pub safe_result: ScanResult,
+    /// Failure message.
+    pub message: String,
+}
+
+impl fmt::Display for ScanError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl std::error::Error for ScanError {}
+
+/// Callback invoked for each emitted audit event.
+pub type AuditCallback = Box<dyn FnMut(&AuditEvent) + Send + Sync>;
+
+/// Scanner running a sequence of detectors over text with fail-closed semantics.
+pub struct Scanner {
+    detectors: Vec<Box<dyn Detector>>,
+    channel: String,
+    audit: Option<AuditCallback>,
+}
+
+impl Scanner {
+    /// Creates a new `Scanner` with the given detector sequence.
+    #[must_use]
+    pub fn new(detectors: Vec<Box<dyn Detector>>) -> Self {
+        Self {
+            detectors,
+            channel: String::new(),
+            audit: None,
+        }
+    }
+
+    /// Sets the channel label (e.g. `stdout`) for emitted audit events.
+    #[must_use]
+    pub fn with_channel(mut self, channel: impl Into<String>) -> Self {
+        self.channel = channel.into();
+        self
+    }
+
+    /// Sets the audit callback for emitted audit events.
+    pub fn set_audit<F>(&mut self, audit: F)
+    where
+        F: FnMut(&AuditEvent) + Send + Sync + 'static,
+    {
+        self.audit = Some(Box::new(audit));
+    }
+
+    /// Scans text through all configured detectors in sequence.
+    ///
+    /// # Errors
+    ///
+    /// Returns `ScanError` if any detector fails. The error carries a safe
+    /// `safe_result` with blocked text to guarantee fail-closed security.
+    pub fn scan(&mut self, text: &str, opts: &ScanOptions) -> Result<ScanResult, ScanError> {
+        if self.detectors.is_empty() {
+            return Ok(ScanResult {
+                text: text.to_string(),
+                findings: Vec::new(),
+                blocked: false,
+            });
+        }
+
+        let mut current = text.to_string();
+        let mut findings = Vec::new();
+        let mut high_confidence_hit = false;
+
+        for d in &self.detectors {
+            match d.redact(&current) {
+                Ok((redacted, count)) => {
+                    if count > 0 {
+                        findings.push(Finding {
+                            detector: d.name().to_string(),
+                            confidence: d.confidence(),
+                            count,
+                        });
+                        if d.confidence() == Confidence::High {
+                            high_confidence_hit = true;
+                        }
+                    }
+                    current = redacted;
+                }
+                Err(err) => {
+                    let event = AuditEvent {
+                        detector: d.name().to_string(),
+                        channel: self.channel.clone(),
+                        confidence: d.confidence(),
+                        redacted_count: 0,
+                        blocked: true,
+                        correlation_id: opts.correlation_id.clone(),
+                    };
+                    if let Some(ref mut audit_fn) = self.audit {
+                        audit_fn(&event);
+                    }
+                    return Err(ScanError {
+                        safe_result: ScanResult {
+                            text: BLOCKED_TEXT.to_string(),
+                            findings: Vec::new(),
+                            blocked: true,
+                        },
+                        message: format!("redact: detector {:?} failed: {}", d.name(), err),
+                    });
+                }
+            }
+        }
+
+        let blocked = opts.strict && high_confidence_hit;
+        for f in &findings {
+            let event = AuditEvent {
+                detector: f.detector.clone(),
+                channel: self.channel.clone(),
+                confidence: f.confidence,
+                redacted_count: f.count,
+                blocked,
+                correlation_id: opts.correlation_id.clone(),
+            };
+            if let Some(ref mut audit_fn) = self.audit {
+                audit_fn(&event);
+            }
+        }
+
+        if blocked {
+            Ok(ScanResult {
+                text: BLOCKED_TEXT.to_string(),
+                findings,
+                blocked: true,
+            })
+        } else {
+            Ok(ScanResult {
+                text: current,
+                findings,
+                blocked: false,
+            })
+        }
+    }
+}
+
+/// Evaluates if an environment variable string represents a truthy opt-in value.
+#[must_use]
+pub fn is_truthy(v: &str) -> bool {
+    matches!(
+        v,
+        "1" | "t" | "T" | "true" | "TRUE" | "True" | "yes" | "YES" | "Yes" | "on" | "ON" | "On"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exact_value_detector_masks_debug() {
+        let d = ExactValueDetector::new(["mysecretpass"]);
+        let debug_str = format!("{d:?}");
+        assert!(!debug_str.contains("mysecretpass"));
+        assert!(debug_str.contains("pattern_count: 1"));
+    }
+
+    #[test]
+    fn exact_value_detector_replaces_and_counts() {
+        let d = ExactValueDetector::new(["super-secret"]);
+        let (out, count) = d.redact("pass is super-secret!").expect("redact");
+        assert_eq!(count, 1);
+        assert_eq!(out, "pass is [REDACTED]!");
+    }
+
+    #[test]
+    fn exact_value_ignores_short_values() {
+        let d = ExactValueDetector::new(["abc", "a", ""]);
+        let (out, count) = d.redact("abc is short").expect("redact");
+        assert_eq!(count, 0);
+        assert_eq!(out, "abc is short");
+    }
+
+    #[test]
+    fn entropy_bounds_and_properties() {
+        assert_eq!(shannon_entropy(""), 0.0);
+        assert_eq!(shannon_entropy("aaaaaaa"), 0.0);
+        let e = shannon_entropy("0123456789abcdef");
+        assert!((e - 4.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn scanner_no_detectors_is_passthrough() {
+        let mut s = Scanner::new(vec![]);
+        let res = s
+            .scan("hello world", &ScanOptions::default())
+            .expect("scan");
+        assert_eq!(res.text, "hello world");
+        assert!(!res.blocked);
+        assert!(res.findings.is_empty());
+    }
+
+    #[test]
+    fn scanner_strict_mode_blocks_high_confidence() {
+        let mut s = Scanner::new(vec![Box::new(ExactValueDetector::new(["secretvalue"]))]);
+        let res = s
+            .scan(
+                "output secretvalue",
+                &ScanOptions {
+                    strict: true,
+                    correlation_id: Some("corr-test".into()),
+                },
+            )
+            .expect("scan");
+        assert!(res.blocked);
+        assert_eq!(res.text, BLOCKED_TEXT);
+        assert_eq!(res.findings.len(), 1);
+    }
+
+    #[test]
+    fn scanner_strict_mode_does_not_block_low_confidence() {
+        let mut s = Scanner::new(vec![Box::new(EntropyDetector::new())]);
+        let res = s
+            .scan(
+                "token: kQ7#zM2$pL9@rT4!vX8&wY6^bN3*cJ1~ end",
+                &ScanOptions {
+                    strict: true,
+                    correlation_id: None,
+                },
+            )
+            .expect("scan");
+        assert!(!res.blocked);
+        assert!(res.text.contains(MARKER));
+    }
+
+    struct FailingDetector;
+    impl Detector for FailingDetector {
+        fn name(&self) -> &str {
+            "failing"
+        }
+        fn confidence(&self) -> Confidence {
+            Confidence::High
+        }
+        fn redact(&self, _text: &str) -> Result<(String, usize), RedactError> {
+            Err(RedactError::new("boom"))
+        }
+    }
+
+    #[test]
+    fn scanner_fails_closed_on_detector_error() {
+        let mut s = Scanner::new(vec![Box::new(FailingDetector)]);
+        let err = s
+            .scan("unredacted secret", &ScanOptions::default())
+            .expect_err("should fail");
+        assert!(err.safe_result.blocked);
+        assert_eq!(err.safe_result.text, BLOCKED_TEXT);
+    }
+
+    #[test]
+    fn truthy_opt_in_table() {
+        for v in [
+            "1", "t", "T", "true", "TRUE", "True", "yes", "YES", "Yes", "on", "ON", "On",
+        ] {
+            assert!(is_truthy(v), "should be truthy: {v}");
+        }
+        for v in ["", "0", "false", "no", "off", "random", "TRUE "] {
+            assert!(!is_truthy(v), "should not be truthy: {v}");
+        }
+    }
+}

--- a/crates/symvault-core/src/secret_ref.rs
+++ b/crates/symvault-core/src/secret_ref.rs
@@ -1,0 +1,271 @@
+#![deny(unsafe_code)]
+
+//! Secret reference parsing and handle formatting contracts.
+
+use core::fmt;
+use core::str::FromStr;
+use serde::{Deserialize, Serialize};
+
+/// Error returned when parsing an invalid secret reference.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SecretRefError {
+    /// The reference string is empty.
+    Empty,
+    /// An `op://` reference did not specify a field component.
+    MissingFieldInOp(String),
+    /// Syntax neither matches `op://path/field` nor `path.field`.
+    InvalidSyntax(String),
+}
+
+impl fmt::Display for SecretRefError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Empty => write!(f, "empty reference"),
+            Self::MissingFieldInOp(s) => write!(f, "missing field in op:// reference: {s}"),
+            Self::InvalidSyntax(s) => {
+                write!(f, "expected path.field or op://path/field syntax, got: {s}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for SecretRefError {}
+
+/// Parsed secret reference with distinct vault entry path and field name.
+#[derive(Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct SecretRef {
+    pub path: String,
+    pub field: String,
+}
+
+impl fmt::Debug for SecretRef {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SecretRef")
+            .field("path", &self.path)
+            .field("field", &self.field)
+            .finish()
+    }
+}
+
+impl fmt::Display for SecretRef {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "op://{}/{}", self.path, self.field)
+    }
+}
+
+impl FromStr for SecretRef {
+    type Err = SecretRefError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::parse(s)
+    }
+}
+
+impl SecretRef {
+    /// Creates a new `SecretRef` from path and field components.
+    #[must_use]
+    pub fn new(path: impl Into<String>, field: impl Into<String>) -> Self {
+        Self {
+            path: path.into(),
+            field: field.into(),
+        }
+    }
+
+    /// Parses a secret reference string in either `op://path/field` or `path.field` format.
+    ///
+    /// # Errors
+    ///
+    /// Returns `SecretRefError` if the reference is empty or does not conform to either syntax.
+    pub fn parse(s: &str) -> Result<Self, SecretRefError> {
+        if s.is_empty() {
+            return Err(SecretRefError::Empty);
+        }
+
+        if let Some(rest) = s.strip_prefix("op://") {
+            let idx = match rest.rfind('/') {
+                Some(i) if i < rest.len() - 1 => i,
+                _ => return Err(SecretRefError::MissingFieldInOp(s.to_string())),
+            };
+            return Ok(Self {
+                path: rest[..idx].to_string(),
+                field: rest[idx + 1..].to_string(),
+            });
+        }
+
+        let idx = match s.rfind('.') {
+            Some(i) if i > 0 && i < s.len() - 1 => i,
+            _ => return Err(SecretRefError::InvalidSyntax(s.to_string())),
+        };
+
+        Ok(Self {
+            path: s[..idx].to_string(),
+            field: s[idx + 1..].to_string(),
+        })
+    }
+
+    /// Renders the reference in dot notation: `path.field`.
+    #[must_use]
+    pub fn to_dot_notation(&self) -> String {
+        format!("{}.{}", self.path, self.field)
+    }
+
+    /// Renders the reference in canonical `op://path/field` URI notation.
+    #[must_use]
+    pub fn to_op_uri(&self) -> String {
+        format!("op://{}/{}", self.path, self.field)
+    }
+
+    /// Converts this reference into a `SecretHandle`.
+    #[must_use]
+    pub fn to_handle(&self) -> SecretHandle {
+        SecretHandle {
+            path: self.path.clone(),
+            field: Some(self.field.clone()),
+        }
+    }
+}
+
+/// A secret handle safe for presentation or logs that does not contain secret values.
+#[derive(Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct SecretHandle {
+    pub path: String,
+    pub field: Option<String>,
+}
+
+impl fmt::Debug for SecretHandle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SecretHandle")
+            .field("path", &self.path)
+            .field("field", &self.field)
+            .finish()
+    }
+}
+
+impl fmt::Display for SecretHandle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.field {
+            Some(field) => write!(f, "op://{}/{}", self.path, field),
+            None => write!(f, "op://{}/", self.path),
+        }
+    }
+}
+
+impl SecretHandle {
+    /// Creates a new `SecretHandle`.
+    #[must_use]
+    pub fn new(path: impl Into<String>, field: Option<impl Into<String>>) -> Self {
+        Self {
+            path: path.into(),
+            field: field.map(Into::into),
+        }
+    }
+
+    /// Parses an `op://` handle string into components.
+    ///
+    /// Returns `None` if the input does not start with `op://`, has an empty body,
+    /// or starts with an unexpected slash.
+    #[must_use]
+    pub fn parse(s: &str) -> Option<Self> {
+        let rest = s.strip_prefix("op://")?;
+        if rest.is_empty() || rest.starts_with('/') {
+            return None;
+        }
+        if let Some(idx) = rest
+            .rfind('/')
+            .filter(|&idx| idx > 0 && idx < rest.len() - 1)
+        {
+            return Some(Self {
+                path: rest[..idx].to_string(),
+                field: Some(rest[idx + 1..].to_string()),
+            });
+        }
+        Some(Self {
+            path: rest.to_string(),
+            field: None,
+        })
+    }
+
+    /// Attempts to convert this handle into a `SecretRef`. Fails if field is omitted.
+    #[must_use]
+    pub fn to_secret_ref(&self) -> Option<SecretRef> {
+        self.field.as_ref().map(|f| SecretRef {
+            path: self.path.clone(),
+            field: f.clone(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_valid_op_ref() {
+        let r = SecretRef::parse("op://work/aws/password").expect("valid ref");
+        assert_eq!(r.path, "work/aws");
+        assert_eq!(r.field, "password");
+        assert_eq!(r.to_op_uri(), "op://work/aws/password");
+        assert_eq!(r.to_dot_notation(), "work/aws.password");
+    }
+
+    #[test]
+    fn parse_valid_dot_ref() {
+        let r = SecretRef::parse("work/aws.password").expect("valid ref");
+        assert_eq!(r.path, "work/aws");
+        assert_eq!(r.field, "password");
+    }
+
+    #[test]
+    fn parse_invalid_ref() {
+        assert_eq!(SecretRef::parse(""), Err(SecretRefError::Empty));
+        assert!(matches!(
+            SecretRef::parse("op://work/aws/"),
+            Err(SecretRefError::MissingFieldInOp(_))
+        ));
+        assert!(matches!(
+            SecretRef::parse("notavalidref"),
+            Err(SecretRefError::InvalidSyntax(_))
+        ));
+    }
+
+    #[test]
+    fn handle_roundtrip() {
+        let h = SecretHandle::new("work/aws", Some("password"));
+        assert_eq!(h.to_string(), "op://work/aws/password");
+        let parsed = SecretHandle::parse(&h.to_string()).expect("parsed");
+        assert_eq!(parsed, h);
+    }
+
+    #[test]
+    fn handle_path_only_roundtrip_formatting() {
+        let h = SecretHandle::new("personal/notes", None::<String>);
+        assert_eq!(h.to_string(), "op://personal/notes/");
+    }
+
+    #[test]
+    fn property_non_crashing_fuzz() {
+        // Property: parse must never panic on arbitrary strings
+        let candidates = [
+            "",
+            "op://",
+            "op:///",
+            "op://a",
+            "op://a/",
+            "op://a/b",
+            "op://a/b/c",
+            "...",
+            ".",
+            "a.",
+            ".b",
+            "a.b",
+            "a.b.c",
+            "op://work/team/aws/secret",
+            "中文/路径.字段",
+            "op://中文/路径/字段",
+        ];
+        for s in candidates {
+            let _ = SecretRef::parse(s);
+            let _ = SecretHandle::parse(s);
+        }
+    }
+}

--- a/crates/symvault-core/tests/error_contract.rs
+++ b/crates/symvault-core/tests/error_contract.rs
@@ -1,0 +1,345 @@
+#![deny(unsafe_code)]
+
+use serde::Deserialize;
+use symvault_core::error::{
+    CauseKind, CliError, ErrorCause, ErrorKind, ExitCode, exit_code_from_error, format_cli_error,
+    from_corekit_exit_code, is_not_found, is_write_error, to_corekit_exit_code,
+};
+
+#[derive(Debug, Deserialize)]
+struct Fixture {
+    schema_version: u8,
+    exit_codes: Vec<NamedInt>,
+    error_kinds: Vec<NamedInt>,
+    cases: Vec<ErrorCase>,
+    exit_resolutions: Vec<ExitResolution>,
+    corekit_mappings: Vec<CodeMapping>,
+    corekit_reverse_mappings: Vec<CodeMapping>,
+}
+
+#[derive(Debug, Deserialize)]
+struct NamedInt {
+    name: String,
+    value: u8,
+}
+
+#[derive(Debug, Deserialize)]
+struct ErrorCase {
+    name: String,
+    code: u8,
+    kind: u8,
+    message: String,
+    #[serde(default)]
+    cause_kind: String,
+    #[serde(default)]
+    cause_message: String,
+    #[serde(default)]
+    hint: String,
+    error: String,
+    formatted: String,
+    effective_exit_code: u8,
+    is_not_found: bool,
+    is_write_error: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExitResolution {
+    name: String,
+    code: u8,
+}
+
+#[derive(Debug, Deserialize)]
+struct CodeMapping {
+    vault: u8,
+    corekit: u8,
+}
+
+fn fixture() -> Fixture {
+    const CONTENT: &[u8] = include_bytes!("../../../testdata/port/core/error-contract.json");
+    serde_json::from_slice(CONTENT).expect("decode Go-generated error fixture")
+}
+
+#[test]
+fn stable_exit_codes_match_go() {
+    let fixture = fixture();
+    assert_eq!(fixture.schema_version, 1);
+    let names: Vec<&str> = fixture
+        .exit_codes
+        .iter()
+        .map(|item| item.name.as_str())
+        .collect();
+    assert_eq!(
+        names,
+        [
+            "success",
+            "general",
+            "not_found",
+            "not_initialized",
+            "locked",
+            "permission_denied",
+            "config",
+            "doctor_warn",
+            "doctor_fail",
+            "invalid_input",
+            "usage",
+            "update_available",
+        ]
+    );
+    for item in fixture.exit_codes {
+        let actual = match item.name.as_str() {
+            "success" => ExitCode::Success,
+            "general" => ExitCode::General,
+            "not_found" => ExitCode::NotFound,
+            "not_initialized" => ExitCode::NotInitialized,
+            "locked" => ExitCode::Locked,
+            "permission_denied" => ExitCode::PermissionDenied,
+            "config" => ExitCode::Config,
+            "doctor_warn" => ExitCode::DoctorWarn,
+            "doctor_fail" => ExitCode::DoctorFail,
+            "invalid_input" => ExitCode::InvalidInput,
+            "usage" => ExitCode::USAGE,
+            "update_available" => ExitCode::UpdateAvailable,
+            other => panic!("unknown exit-code fixture {other}"),
+        };
+        assert_eq!(actual.value(), item.value, "{}", item.name);
+        assert_eq!(ExitCode::from_u8(item.value), Some(actual), "{}", item.name);
+    }
+    assert_eq!(ExitCode::from_u8(11), None);
+}
+
+#[test]
+fn stable_error_kinds_match_go() {
+    let fixture = fixture();
+    let names: Vec<&str> = fixture
+        .error_kinds
+        .iter()
+        .map(|item| item.name.as_str())
+        .collect();
+    assert_eq!(
+        names,
+        [
+            "none",
+            "not_found",
+            "field_not_found",
+            "read_failed",
+            "write_failed"
+        ]
+    );
+    for item in fixture.error_kinds {
+        let actual = match item.name.as_str() {
+            "none" => ErrorKind::None,
+            "not_found" => ErrorKind::NotFound,
+            "field_not_found" => ErrorKind::FieldNotFound,
+            "read_failed" => ErrorKind::ReadFailed,
+            "write_failed" => ErrorKind::WriteFailed,
+            other => panic!("unknown error-kind fixture {other}"),
+        };
+        assert_eq!(actual.value(), item.value, "{}", item.name);
+    }
+}
+
+#[test]
+fn constructors_and_rendering_match_go() {
+    for expected in fixture().cases {
+        let actual = build_case(&expected);
+        assert_eq!(
+            actual.code().value(),
+            expected.code,
+            "{} code",
+            expected.name
+        );
+        assert_eq!(
+            actual.kind().value(),
+            expected.kind,
+            "{} kind",
+            expected.name
+        );
+        assert_eq!(
+            actual.message(),
+            expected.message,
+            "{} message",
+            expected.name
+        );
+        assert_eq!(
+            actual
+                .cause()
+                .map(|cause| cause.kind().as_str())
+                .unwrap_or(""),
+            expected.cause_kind,
+            "{} cause kind",
+            expected.name
+        );
+        assert_eq!(
+            actual.cause().map(ErrorCause::message).unwrap_or(""),
+            expected.cause_message,
+            "{} cause message",
+            expected.name
+        );
+        assert_eq!(
+            actual.hint().unwrap_or(""),
+            expected.hint,
+            "{} hint",
+            expected.name
+        );
+        assert_eq!(
+            actual.to_string(),
+            expected.error,
+            "{} error",
+            expected.name
+        );
+        assert_eq!(
+            actual.formatted(),
+            expected.formatted,
+            "{} formatted",
+            expected.name
+        );
+        assert_eq!(
+            actual.effective_exit_code().value(),
+            expected.effective_exit_code,
+            "{} effective exit",
+            expected.name
+        );
+        assert_eq!(
+            actual.is_not_found(),
+            expected.is_not_found,
+            "{} not found",
+            expected.name
+        );
+        assert_eq!(
+            actual.is_write_error(),
+            expected.is_write_error,
+            "{} write",
+            expected.name
+        );
+    }
+}
+
+#[test]
+fn sentinel_and_plain_exit_resolution_match_go() {
+    for expected in fixture().exit_resolutions {
+        let actual = match expected.name.as_str() {
+            "nil" => exit_code_from_error(None),
+            "plain" => {
+                let error = std::io::Error::other("plain");
+                exit_code_from_error(Some(&error))
+            }
+            "entry_not_found" => exit_code_from_error(Some(&ErrorCause::new(
+                CauseKind::EntryNotFound,
+                "entry not found",
+            ))),
+            "vault_not_initialized" => exit_code_from_error(Some(&ErrorCause::new(
+                CauseKind::VaultNotInitialized,
+                "vault not initialized",
+            ))),
+            "vault_locked" => exit_code_from_error(Some(&ErrorCause::new(
+                CauseKind::VaultLocked,
+                "vault locked",
+            ))),
+            "permission_denied" => exit_code_from_error(Some(&ErrorCause::new(
+                CauseKind::PermissionDenied,
+                "permission denied",
+            ))),
+            other => panic!("unknown exit-resolution fixture {other}"),
+        };
+        assert_eq!(actual.value(), expected.code, "{}", expected.name);
+    }
+}
+
+#[test]
+fn generic_formatting_matches_plain_nil_and_typed_behavior() {
+    #[derive(Debug)]
+    struct Outer(CliError);
+    impl std::fmt::Display for Outer {
+        fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            formatter.write_str("outer")
+        }
+    }
+    impl std::error::Error for Outer {
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            Some(&self.0)
+        }
+    }
+
+    let plain = std::io::Error::other("plain");
+    let typed = CliError::internal("typed").with_hint("repair");
+    let wrapped = Outer(CliError::locked("nested"));
+    let wrapped_not_found = Outer(CliError::not_found("missing"));
+    let wrapped_write = Outer(CliError::write_failed("write", None));
+    assert_eq!(format_cli_error(None), "");
+    assert_eq!(format_cli_error(Some(&plain)), "plain");
+    assert_eq!(format_cli_error(Some(&typed)), "typed\nHint: repair");
+    assert_eq!(
+        format_cli_error(Some(&wrapped)),
+        "nested: vault locked\nHint: Run: symvault unlock to unlock the vault, or set a passphrase via 'symvault auth set passphrase'."
+    );
+    assert_eq!(exit_code_from_error(Some(&wrapped)), ExitCode::Locked);
+    assert!(is_not_found(&wrapped_not_found));
+    assert!(!is_not_found(&plain));
+    assert!(is_write_error(&wrapped_write));
+    assert!(!is_write_error(&plain));
+}
+
+#[test]
+fn corekit_numeric_mapping_matches_go() {
+    for expected in fixture().corekit_mappings {
+        let code = ExitCode::from_u8(expected.vault).expect("known vault code");
+        assert_eq!(
+            to_corekit_exit_code(code),
+            expected.corekit,
+            "vault {}",
+            expected.vault
+        );
+    }
+}
+
+#[test]
+fn reverse_corekit_numeric_mapping_matches_go() {
+    for expected in fixture().corekit_reverse_mappings {
+        assert_eq!(
+            from_corekit_exit_code(expected.corekit).value(),
+            expected.vault,
+            "corekit {}",
+            expected.corekit
+        );
+    }
+}
+
+fn build_case(expected: &ErrorCase) -> CliError {
+    match expected.name.as_str() {
+        "new" => CliError::new(
+            ExitCode::Locked,
+            "vault locked",
+            Some(ErrorCause::new(CauseKind::Other, "passphrase missing")),
+        ),
+        "not_found" => CliError::not_found("entry \"github\" not found"),
+        "field_not_found" => CliError::wrap(
+            ExitCode::NotFound,
+            ErrorKind::FieldNotFound,
+            "field \"token\" missing",
+            None,
+        ),
+        "read_failed" => CliError::read_failed("cannot read entry", Some("disk read".into())),
+        "read_failed_nil" => CliError::read_failed("cannot read entry without cause", None),
+        "write_failed" => CliError::write_failed("cannot write entry", Some("disk full".into())),
+        "write_failed_nil" => CliError::write_failed("cannot write entry without cause", None),
+        "not_initialized" => CliError::not_initialized("vault not initialized at /vault"),
+        "new_vault_not_initialized" => CliError::vault_not_initialized(),
+        "locked" => CliError::locked("session expired"),
+        "permission_denied" => CliError::permission_denied("agent cannot write"),
+        "invalid_input" => CliError::invalid_input("length must be positive"),
+        "config_error" => CliError::config("config value is invalid"),
+        "internal" => CliError::internal("unexpected state"),
+        "already_exists" => CliError::already_exists("entry already exists"),
+        "custom_hint" => CliError::new(ExitCode::General, "operation failed", None)
+            .with_hint("Run symvault doctor"),
+        "sentinel_priority" => CliError::new(
+            ExitCode::General,
+            "locked wrapper",
+            Some(ErrorCause::new(
+                CauseKind::VaultLocked,
+                "outer: vault locked",
+            )),
+        ),
+        other => panic!("unknown error fixture case {other}"),
+    }
+}

--- a/crates/symvault-core/tests/redact_contract.rs
+++ b/crates/symvault-core/tests/redact_contract.rs
@@ -1,0 +1,285 @@
+#![deny(unsafe_code)]
+
+use std::sync::{Arc, Mutex};
+
+use serde::Deserialize;
+use symvault_core::redact::{
+    AuditEvent, BLOCKED_TEXT, Detector, EntropyDetector, ExactValueDetector, MARKER,
+    MIN_ENTROPY_BITS_PER_CHAR, MIN_EXACT_VALUE_LEN, MIN_TOKEN_LEN, ScanOptions, Scanner, is_truthy,
+    shannon_entropy,
+};
+
+#[derive(Debug, Deserialize)]
+struct Fixture {
+    schema_version: u8,
+    constants: Constants,
+    exact_value_cases: Vec<ExactValueCase>,
+    entropy_cases: Vec<EntropyCase>,
+    scanner_cases: Vec<ScannerCase>,
+    truthy_cases: Vec<TruthyCase>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Constants {
+    marker: String,
+    blocked_text: String,
+    min_exact_value_len: usize,
+    min_token_len: usize,
+    min_entropy_bits_per_char: f64,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExactValueCase {
+    name: String,
+    secrets: Vec<String>,
+    input: String,
+    expected_redacted: String,
+    expected_count: usize,
+}
+
+#[derive(Debug, Deserialize)]
+struct EntropyCase {
+    name: String,
+    input: String,
+    expected_redacted: String,
+    expected_count: usize,
+}
+
+#[derive(Debug, Deserialize)]
+struct ScannerCase {
+    name: String,
+    detectors: Vec<String>,
+    #[serde(default)]
+    secrets: Vec<String>,
+    strict: bool,
+    #[serde(default)]
+    correlation_id: String,
+    #[serde(default)]
+    channel: String,
+    input: String,
+    expected_text: String,
+    expected_blocked: bool,
+    findings: Vec<FixtureFinding>,
+    audit_events: Vec<FixtureAuditEvent>,
+}
+
+#[derive(Debug, Deserialize)]
+struct FixtureFinding {
+    detector: String,
+    confidence: String,
+    count: usize,
+}
+
+#[derive(Debug, Deserialize)]
+struct FixtureAuditEvent {
+    detector: String,
+    channel: String,
+    confidence: String,
+    redacted_count: usize,
+    blocked: bool,
+    #[serde(default)]
+    correlation_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct TruthyCase {
+    input: String,
+    expected: bool,
+}
+
+fn fixture() -> Fixture {
+    const CONTENT: &[u8] = include_bytes!("../../../testdata/port/core/redact-contract.json");
+    serde_json::from_slice(CONTENT).expect("decode Go-generated redact fixture")
+}
+
+#[test]
+fn constants_match_go_oracle() {
+    let fix = fixture();
+    assert_eq!(fix.schema_version, 1);
+    assert_eq!(fix.constants.marker, MARKER);
+    assert_eq!(fix.constants.blocked_text, BLOCKED_TEXT);
+    assert_eq!(fix.constants.min_exact_value_len, MIN_EXACT_VALUE_LEN);
+    assert_eq!(fix.constants.min_token_len, MIN_TOKEN_LEN);
+    assert!((fix.constants.min_entropy_bits_per_char - MIN_ENTROPY_BITS_PER_CHAR).abs() < 1e-9);
+}
+
+#[test]
+fn exact_value_cases_match_go_oracle() {
+    let fix = fixture();
+    for tc in fix.exact_value_cases {
+        let detector = ExactValueDetector::new(&tc.secrets);
+        let (redacted, count) = detector.redact(&tc.input).expect("redact exact value");
+        assert_eq!(
+            redacted, tc.expected_redacted,
+            "case {}: redacted mismatch",
+            tc.name
+        );
+        assert_eq!(count, tc.expected_count, "case {}: count mismatch", tc.name);
+
+        // Security assertion: never leak original secrets
+        for sec in &tc.secrets {
+            if sec.len() >= MIN_EXACT_VALUE_LEN {
+                assert!(
+                    !redacted.contains(sec),
+                    "case {}: secret {:?} leaked in output {:?}",
+                    tc.name,
+                    sec,
+                    redacted
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn entropy_cases_match_go_oracle() {
+    let fix = fixture();
+    let detector = EntropyDetector::new();
+    for tc in fix.entropy_cases {
+        let (redacted, count) = detector.redact(&tc.input).expect("redact entropy");
+        assert_eq!(
+            redacted, tc.expected_redacted,
+            "case {}: redacted mismatch",
+            tc.name
+        );
+        assert_eq!(count, tc.expected_count, "case {}: count mismatch", tc.name);
+    }
+}
+
+#[test]
+fn scanner_cases_match_go_oracle() {
+    let fix = fixture();
+    for tc in fix.scanner_cases {
+        let mut detectors: Vec<Box<dyn Detector>> = Vec::new();
+        for dname in &tc.detectors {
+            match dname.as_str() {
+                "exact_value" => detectors.push(Box::new(ExactValueDetector::new(&tc.secrets))),
+                "entropy_heuristic" => detectors.push(Box::new(EntropyDetector::new())),
+                other => panic!("unknown detector in fixture: {other}"),
+            }
+        }
+
+        let mut scanner = Scanner::new(detectors).with_channel(&tc.channel);
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let events_clone = Arc::clone(&events);
+        scanner.set_audit(move |e: &AuditEvent| {
+            events_clone.lock().unwrap().push(e.clone());
+        });
+
+        let opts = ScanOptions {
+            strict: tc.strict,
+            correlation_id: if tc.correlation_id.is_empty() {
+                None
+            } else {
+                Some(tc.correlation_id.clone())
+            },
+        };
+
+        let result = scanner.scan(&tc.input, &opts).expect("scan succeeds");
+        assert_eq!(
+            result.text, tc.expected_text,
+            "case {}: text mismatch",
+            tc.name
+        );
+        assert_eq!(
+            result.blocked, tc.expected_blocked,
+            "case {}: blocked mismatch",
+            tc.name
+        );
+
+        assert_eq!(
+            result.findings.len(),
+            tc.findings.len(),
+            "case {}: findings length mismatch",
+            tc.name
+        );
+        for (actual, expected) in result.findings.iter().zip(&tc.findings) {
+            assert_eq!(actual.detector, expected.detector, "case {}", tc.name);
+            assert_eq!(
+                actual.confidence.as_str(),
+                expected.confidence,
+                "case {}",
+                tc.name
+            );
+            assert_eq!(actual.count, expected.count, "case {}", tc.name);
+        }
+
+        let emitted = events.lock().unwrap();
+        assert_eq!(
+            emitted.len(),
+            tc.audit_events.len(),
+            "case {}: audit event count mismatch",
+            tc.name
+        );
+        for (actual, expected) in emitted.iter().zip(&tc.audit_events) {
+            assert_eq!(actual.detector, expected.detector, "case {}", tc.name);
+            assert_eq!(actual.channel, expected.channel, "case {}", tc.name);
+            assert_eq!(
+                actual.confidence.as_str(),
+                expected.confidence,
+                "case {}",
+                tc.name
+            );
+            assert_eq!(
+                actual.redacted_count, expected.redacted_count,
+                "case {}",
+                tc.name
+            );
+            assert_eq!(actual.blocked, expected.blocked, "case {}", tc.name);
+            assert_eq!(
+                actual.correlation_id.as_deref().unwrap_or(""),
+                expected.correlation_id,
+                "case {}",
+                tc.name
+            );
+        }
+    }
+}
+
+#[test]
+fn truthy_table_matches_go_oracle() {
+    let fix = fixture();
+    for tc in fix.truthy_cases {
+        assert_eq!(
+            is_truthy(&tc.input),
+            tc.expected,
+            "truthy mismatch for input {:?}",
+            tc.input
+        );
+    }
+}
+
+#[test]
+fn property_shannon_entropy_mathematical_bounds() {
+    assert_eq!(shannon_entropy(""), 0.0);
+    // Shannon entropy of uniform distribution over N symbols is log2(N)
+    for n in 1..=127 {
+        let bytes: Vec<u8> = (1..=n as u8).collect();
+        if let Ok(valid_str) = core::str::from_utf8(&bytes) {
+            let h = shannon_entropy(valid_str);
+            let expected = (valid_str.len() as f64).log2();
+            assert!((h - expected).abs() < 1e-6);
+        }
+    }
+}
+
+#[test]
+fn property_exact_value_leak_prevention() {
+    let secrets = [
+        "super-secret-passphrase",
+        concat!("gh", "p_1234567890abcdefghijklmnopqrstuvwxyz"),
+        "AKIAIOSFODNN7EXAMPLE",
+    ];
+    let d = ExactValueDetector::new(secrets);
+
+    for sec in secrets {
+        let text = format!("header {sec} trailer and {sec} again");
+        let (redacted, count) = d.redact(&text).expect("redact");
+        assert_eq!(count, 2);
+        assert!(!redacted.contains(sec), "leaked secret: {sec}");
+        assert_eq!(
+            redacted,
+            format!("header {MARKER} trailer and {MARKER} again")
+        );
+    }
+}

--- a/crates/symvault-core/tests/secret_ref_contract.rs
+++ b/crates/symvault-core/tests/secret_ref_contract.rs
@@ -1,0 +1,160 @@
+#![deny(unsafe_code)]
+
+use serde::Deserialize;
+use symvault_core::secret_ref::{SecretHandle, SecretRef};
+
+#[derive(Debug, Deserialize)]
+struct Fixture {
+    schema_version: u8,
+    parse_ref_cases: Vec<ParseRefCase>,
+    parse_handle_cases: Vec<ParseHandleCase>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ParseRefCase {
+    name: String,
+    input: String,
+    valid: bool,
+    path: String,
+    field: String,
+    #[serde(default)]
+    error_message: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ParseHandleCase {
+    name: String,
+    input: String,
+    valid: bool,
+    path: String,
+    field: String,
+    #[serde(default)]
+    string_repr: String,
+}
+
+fn fixture() -> Fixture {
+    const CONTENT: &[u8] = include_bytes!("../../../testdata/port/core/secret-ref-contract.json");
+    serde_json::from_slice(CONTENT).expect("decode Go-generated secret-ref fixture")
+}
+
+#[test]
+fn parse_ref_cases_match_go_oracle() {
+    let fix = fixture();
+    assert_eq!(fix.schema_version, 1);
+
+    for tc in fix.parse_ref_cases {
+        let result = SecretRef::parse(&tc.input);
+        if tc.valid {
+            let parsed = result.unwrap_or_else(|err| {
+                panic!("case {}: expected valid, got error: {}", tc.name, err);
+            });
+            assert_eq!(
+                parsed.path, tc.path,
+                "case {}: path mismatch (input={:?})",
+                tc.name, tc.input
+            );
+            assert_eq!(
+                parsed.field, tc.field,
+                "case {}: field mismatch (input={:?})",
+                tc.name, tc.input
+            );
+            assert_eq!(
+                parsed.to_op_uri(),
+                format!("op://{}/{}", tc.path, tc.field),
+                "case {}: to_op_uri mismatch",
+                tc.name
+            );
+        } else {
+            assert!(
+                !tc.error_message.is_empty(),
+                "case {}: missing error message in fixture",
+                tc.name
+            );
+            assert!(
+                result.is_err(),
+                "case {}: expected error for input {:?}, got {:?}",
+                tc.name,
+                tc.input,
+                result.unwrap()
+            );
+        }
+    }
+}
+
+#[test]
+fn parse_handle_cases_match_go_oracle() {
+    let fix = fixture();
+    assert_eq!(fix.schema_version, 1);
+
+    for tc in fix.parse_handle_cases {
+        let result = SecretHandle::parse(&tc.input);
+        if tc.valid {
+            let handle = result.unwrap_or_else(|| {
+                panic!("case {}: expected valid handle for {:?}", tc.name, tc.input);
+            });
+            assert_eq!(handle.path, tc.path, "case {}: path mismatch", tc.name);
+            let expected_field = if tc.field.is_empty() {
+                None
+            } else {
+                Some(tc.field.clone())
+            };
+            assert_eq!(
+                handle.field, expected_field,
+                "case {}: field mismatch",
+                tc.name
+            );
+            assert_eq!(
+                handle.to_string(),
+                tc.string_repr,
+                "case {}: string_repr mismatch",
+                tc.name
+            );
+        } else {
+            assert!(
+                result.is_none(),
+                "case {}: expected invalid handle for input {:?}, got {:?}",
+                tc.name,
+                tc.input,
+                result.unwrap()
+            );
+        }
+    }
+}
+
+#[test]
+fn secret_ref_to_handle_conversion_preserves_semantics() {
+    let r = SecretRef::new("work/aws", "password");
+    let h = r.to_handle();
+    assert_eq!(h.path, "work/aws");
+    assert_eq!(h.field.as_deref(), Some("password"));
+    assert_eq!(h.to_string(), "op://work/aws/password");
+
+    let back = h.to_secret_ref().expect("convert back");
+    assert_eq!(back, r);
+}
+
+#[test]
+fn property_handle_roundtrip_all_synthesized_pairs() {
+    let paths = [
+        "a",
+        "foo",
+        "foo/bar",
+        "long/nested/vault/path",
+        "service.account",
+    ];
+    let fields = ["token", "secret", "password", "api_key", "pin"];
+
+    for p in paths {
+        for f in fields {
+            let handle = SecretHandle::new(p, Some(f));
+            let s = handle.to_string();
+            let parsed = SecretHandle::parse(&s).expect("roundtrip parse");
+            assert_eq!(parsed.path, p);
+            assert_eq!(parsed.field.as_deref(), Some(f));
+
+            let r = SecretRef::new(p, f);
+            let parsed_ref = SecretRef::parse(&s).expect("parse op uri as ref");
+            assert_eq!(parsed_ref, r);
+        }
+    }
+}

--- a/docs/rust-port/README.md
+++ b/docs/rust-port/README.md
@@ -67,8 +67,10 @@ passes. The measured Go baseline is in
 - `RUST-002` passed: the pinned Rust workspace and byte-exact `version` slice
   passes all ten Go↔Rust cases plus format, Clippy, nextest, doctest, feature,
   coverage, audit, deny, and native macOS/Windows CI gates.
-- `RUST-003` is ready: pure error, secret-reference, redaction, policy, quota,
-  password, TOTP, and type contracts are the next vertical slices.
+- `RUST-003` is in progress: the Go-generated error taxonomy sub-slice is green
+  for codes, kinds, constructors, nested sentinel precedence, formatting,
+  hints, and both corekit mapping directions. Secret references, redaction,
+  policy, quotas, password/TOTP, and type inference remain in this work item.
 
 The tiny release-built version slice measured 577,104 bytes, 2,277,376 bytes
 maximum RSS in one sample, and 2.576 ms startup p95 over 120 runs after 20

--- a/docs/rust-port/README.md
+++ b/docs/rust-port/README.md
@@ -67,10 +67,10 @@ passes. The measured Go baseline is in
 - `RUST-002` passed: the pinned Rust workspace and byte-exact `version` slice
   passes all ten Go↔Rust cases plus format, Clippy, nextest, doctest, feature,
   coverage, audit, deny, and native macOS/Windows CI gates.
-- `RUST-003` is in progress: the Go-generated error taxonomy sub-slice is green
-  for codes, kinds, constructors, nested sentinel precedence, formatting,
-  hints, and both corekit mapping directions. Secret references, redaction,
-  policy, quotas, password/TOTP, and type inference remain in this work item.
+- `RUST-003` is in progress: error taxonomy, secret-reference parsing, and
+  secret redaction sub-slices are green against Go oracle fixtures, Miri,
+  and property tests. Policy, quotas, password/TOTP, and type inference
+  remain in this work item before closing RUST-003.
 
 The tiny release-built version slice measured 577,104 bytes, 2,277,376 bytes
 maximum RSS in one sample, and 2.576 ms startup p95 over 120 runs after 20

--- a/docs/rust-port/work-items.json
+++ b/docs/rust-port/work-items.json
@@ -26,7 +26,7 @@
     {
       "id": "RUST-003",
       "title": "Port pure core contracts",
-      "status": "ready",
+      "status": "in_progress",
       "depends_on": ["RUST-002"],
       "contract_rows": ["CLI-005", "CRYPTO-005"],
       "acceptance": ["cargo nextest run -p symvault-core", "cargo +nightly miri test -p symvault-core"]

--- a/scripts/rust-port/cmd/coregen/main.go
+++ b/scripts/rust-port/cmd/coregen/main.go
@@ -343,13 +343,13 @@ func buildSecretRefFixture(meta oracle) secretRefFixture {
 // ---------------------------------------------------------------------------
 
 type redactFixture struct {
-	SchemaVersion   int                `json:"schema_version"`
-	Oracle          oracle             `json:"oracle"`
-	Constants       redactConstants    `json:"constants"`
-	ExactValueCases []exactValueCase   `json:"exact_value_cases"`
-	EntropyCases    []entropyCase      `json:"entropy_cases"`
-	ScannerCases    []scannerCase      `json:"scanner_cases"`
-	TruthyCases     []truthyCase       `json:"truthy_cases"`
+	SchemaVersion   int              `json:"schema_version"`
+	Oracle          oracle           `json:"oracle"`
+	Constants       redactConstants  `json:"constants"`
+	ExactValueCases []exactValueCase `json:"exact_value_cases"`
+	EntropyCases    []entropyCase    `json:"entropy_cases"`
+	ScannerCases    []scannerCase    `json:"scanner_cases"`
+	TruthyCases     []truthyCase     `json:"truthy_cases"`
 }
 
 type redactConstants struct {

--- a/scripts/rust-port/cmd/coregen/main.go
+++ b/scripts/rust-port/cmd/coregen/main.go
@@ -13,9 +13,26 @@ import (
 	corekitexitcodes "github.com/danieljustus/symaira-corekit/exitcodes"
 
 	errorspkg "github.com/danieljustus/symaira-vault/internal/errors"
+	redactpkg "github.com/danieljustus/symaira-vault/internal/redact"
+	templatepkg "github.com/danieljustus/symaira-vault/internal/template"
+	taintpkg "github.com/danieljustus/symaira-vault/internal/vault/taint"
 )
 
-type fixture struct {
+type oracle struct {
+	Commit  string `json:"commit"`
+	Release string `json:"release"`
+}
+
+type headerOnly struct {
+	SchemaVersion int    `json:"schema_version"`
+	Oracle        oracle `json:"oracle"`
+}
+
+// ---------------------------------------------------------------------------
+// Error taxonomy fixture
+// ---------------------------------------------------------------------------
+
+type errorFixture struct {
 	SchemaVersion   int              `json:"schema_version"`
 	Oracle          oracle           `json:"oracle"`
 	ExitCodes       []namedInt       `json:"exit_codes"`
@@ -24,11 +41,6 @@ type fixture struct {
 	ExitResolutions []exitResolution `json:"exit_resolutions"`
 	CorekitMappings []codeMapping    `json:"corekit_mappings"`
 	CorekitReverse  []codeMapping    `json:"corekit_reverse_mappings"`
-}
-
-type oracle struct {
-	Commit  string `json:"commit"`
-	Release string `json:"release"`
 }
 
 type namedInt struct {
@@ -61,51 +73,12 @@ type codeMapping struct {
 	Corekit int `json:"corekit"`
 }
 
-func main() {
-	output := flag.String("output", "testdata/port/core/error-contract.json", "fixture path")
-	check := flag.Bool("check", false, "fail if the fixture differs")
-	commit := flag.String("oracle-commit", "", "Go oracle commit for a new fixture")
-	release := flag.String("oracle-release", "", "Go oracle release for a new fixture")
-	flag.Parse()
-
-	meta := oracle{Commit: *commit, Release: *release}
-	if *check {
-		existing, err := readFixture(*output)
-		if err != nil {
-			fatal("read existing fixture: %v", err)
-		}
-		meta = existing.Oracle
-	}
-	if meta.Commit == "" || meta.Release == "" {
-		fatal("--oracle-commit and --oracle-release are required when generating a fixture")
-	}
-
-	generated := buildFixture(meta)
-	content, err := marshalFixture(generated)
-	if err != nil {
-		fatal("encode fixture: %v", err)
-	}
-	if *check {
-		existing, err := os.ReadFile(*output) // #nosec G304 -- explicit operator-selected fixture path
-		if err != nil {
-			fatal("read fixture: %v", err)
-		}
-		if !bytes.Equal(existing, content) {
-			fatal("error-contract fixture is stale; run make core-fixtures-generate")
-		}
-		fmt.Printf("PASS error-contract fixture (%d cases)\n", len(generated.Cases))
-		return
-	}
-	if err := os.MkdirAll(filepath.Dir(*output), 0o750); err != nil {
-		fatal("create fixture directory: %v", err)
-	}
-	if err := os.WriteFile(*output, content, 0o600); err != nil {
-		fatal("write fixture: %v", err)
-	}
-	fmt.Printf("WROTE %s (%d cases)\n", *output, len(generated.Cases))
+type namedError struct {
+	Name  string
+	Error *errorspkg.CLIError
 }
 
-func buildFixture(meta oracle) fixture {
+func buildErrorFixture(meta oracle) errorFixture {
 	readCause := stderrors.New("disk read")
 	writeCause := stderrors.New("disk full")
 	cases := []namedError{
@@ -133,7 +106,7 @@ func buildFixture(meta oracle) fixture {
 		resultCases = append(resultCases, describeError(item.Name, item.Error))
 	}
 
-	return fixture{
+	return errorFixture{
 		SchemaVersion: 1,
 		Oracle:        meta,
 		ExitCodes: []namedInt{
@@ -169,11 +142,6 @@ func buildFixture(meta oracle) fixture {
 		CorekitMappings: corekitMappings(),
 		CorekitReverse:  corekitReverseMappings(),
 	}
-}
-
-type namedError struct {
-	Name  string
-	Error *errorspkg.CLIError
 }
 
 func describeError(name string, value *errorspkg.CLIError) errorCase {
@@ -250,7 +218,586 @@ func corekitReverseMappings() []codeMapping {
 	return result
 }
 
-func marshalFixture(value fixture) ([]byte, error) {
+// ---------------------------------------------------------------------------
+// Secret reference fixture
+// ---------------------------------------------------------------------------
+
+type secretRefFixture struct {
+	SchemaVersion    int               `json:"schema_version"`
+	Oracle           oracle            `json:"oracle"`
+	ParseRefCases    []parseRefCase    `json:"parse_ref_cases"`
+	ParseHandleCases []parseHandleCase `json:"parse_handle_cases"`
+}
+
+type parseRefCase struct {
+	Name         string `json:"name"`
+	Input        string `json:"input"`
+	Valid        bool   `json:"valid"`
+	Path         string `json:"path"`
+	Field        string `json:"field"`
+	ErrorMessage string `json:"error_message,omitempty"`
+}
+
+type parseHandleCase struct {
+	Name       string `json:"name"`
+	Input      string `json:"input"`
+	Valid      bool   `json:"valid"`
+	Path       string `json:"path"`
+	Field      string `json:"field"`
+	StringRepr string `json:"string_repr,omitempty"`
+}
+
+func buildSecretRefFixture(meta oracle) secretRefFixture {
+	refInputs := []struct {
+		name  string
+		input string
+	}{
+		{"op_full_path", "op://work/aws/password"},
+		{"op_simple_path", "op://github/token"},
+		{"op_nested_path", "op://work/team/aws/password"},
+		{"op_two_segments", "op://work/aws"},
+		{"op_deeply_nested", "op://org/team/project/service/api/key"},
+		{"op_trailing_slash", "op://work/aws/"},
+		{"op_single_segment", "op://work"},
+		{"op_empty_rest", "op://"},
+		{"op_slash_only", "op:///"},
+		{"op_leading_slash", "op:///github"},
+		{"dot_notation_nested", "work/aws.password"},
+		{"dot_notation_simple", "github.token"},
+		{"dot_notation_deep", "work/team/aws.password"},
+		{"dot_in_field", "work/aws.api.key"},
+		{"dot_minimal", "a.b"},
+		{"dot_missing_field", "work/aws"},
+		{"dot_leading_dot", ".password"},
+		{"dot_trailing_dot", "work/aws."},
+		{"empty", ""},
+		{"plain_word", "notavalidref"},
+		{"field_only", "password"},
+		{"invalid_scheme", "://path/field"},
+		{"missing_slashes", "op:path/field"},
+	}
+
+	refCases := make([]parseRefCase, 0, len(refInputs))
+	for _, tc := range refInputs {
+		parsed, err := templatepkg.ParseRef(tc.input)
+		c := parseRefCase{
+			Name:  tc.name,
+			Input: tc.input,
+			Valid: err == nil,
+		}
+		if err == nil {
+			c.Path = parsed.Path
+			c.Field = parsed.Field
+		} else {
+			c.ErrorMessage = err.Error()
+		}
+		refCases = append(refCases, c)
+	}
+
+	handleInputs := []struct {
+		name  string
+		input string
+	}{
+		{"handle_full_path", "op://work/aws/password"},
+		{"handle_simple_path", "op://github/token"},
+		{"handle_nested_path", "op://work/team/aws/password"},
+		{"handle_two_segments", "op://work/aws"},
+		{"handle_path_only", "op://work"},
+		{"handle_personal_notes", "op://personal/notes"},
+		{"handle_trailing_slash", "op://personal/notes/"},
+		{"handle_single", "op://single"},
+		{"handle_empty", ""},
+		{"handle_prefix_only", "op://"},
+		{"handle_prefix_slash", "op:///"},
+		{"handle_not_handle", "not-a-handle"},
+		{"handle_invalid_scheme", "://path/field"},
+		{"handle_dot_notation", "work/aws.password"},
+	}
+
+	handleCases := make([]parseHandleCase, 0, len(handleInputs))
+	for _, tc := range handleInputs {
+		h, ok := taintpkg.ParseSecretHandle(tc.input)
+		c := parseHandleCase{
+			Name:  tc.name,
+			Input: tc.input,
+			Valid: ok,
+		}
+		if ok {
+			c.Path = h.Path
+			c.Field = h.Field
+			c.StringRepr = h.String()
+		}
+		handleCases = append(handleCases, c)
+	}
+
+	return secretRefFixture{
+		SchemaVersion:    1,
+		Oracle:           meta,
+		ParseRefCases:    refCases,
+		ParseHandleCases: handleCases,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Secret redaction fixture
+// ---------------------------------------------------------------------------
+
+type redactFixture struct {
+	SchemaVersion   int                `json:"schema_version"`
+	Oracle          oracle             `json:"oracle"`
+	Constants       redactConstants    `json:"constants"`
+	ExactValueCases []exactValueCase   `json:"exact_value_cases"`
+	EntropyCases    []entropyCase      `json:"entropy_cases"`
+	ScannerCases    []scannerCase      `json:"scanner_cases"`
+	TruthyCases     []truthyCase       `json:"truthy_cases"`
+}
+
+type redactConstants struct {
+	Marker                string  `json:"marker"`
+	BlockedText           string  `json:"blocked_text"`
+	MinExactValueLen      int     `json:"min_exact_value_len"`
+	MinTokenLen           int     `json:"min_token_len"`
+	MinEntropyBitsPerChar float64 `json:"min_entropy_bits_per_char"`
+}
+
+type exactValueCase struct {
+	Name             string   `json:"name"`
+	Secrets          []string `json:"secrets"`
+	Input            string   `json:"input"`
+	ExpectedRedacted string   `json:"expected_redacted"`
+	ExpectedCount    int      `json:"expected_count"`
+}
+
+type entropyCase struct {
+	Name             string `json:"name"`
+	Input            string `json:"input"`
+	ExpectedRedacted string `json:"expected_redacted"`
+	ExpectedCount    int    `json:"expected_count"`
+}
+
+type scannerFinding struct {
+	Detector   string `json:"detector"`
+	Confidence string `json:"confidence"`
+	Count      int    `json:"count"`
+}
+
+type scannerAuditEvent struct {
+	Detector      string `json:"detector"`
+	Channel       string `json:"channel"`
+	Confidence    string `json:"confidence"`
+	RedactedCount int    `json:"redacted_count"`
+	Blocked       bool   `json:"blocked"`
+	CorrelationID string `json:"correlation_id"`
+}
+
+type scannerCase struct {
+	Name            string              `json:"name"`
+	Detectors       []string            `json:"detectors"`
+	Secrets         []string            `json:"secrets,omitempty"`
+	Strict          bool                `json:"strict"`
+	CorrelationID   string              `json:"correlation_id,omitempty"`
+	Channel         string              `json:"channel,omitempty"`
+	Input           string              `json:"input"`
+	ExpectedText    string              `json:"expected_text"`
+	ExpectedBlocked bool                `json:"expected_blocked"`
+	Findings        []scannerFinding    `json:"findings"`
+	AuditEvents     []scannerAuditEvent `json:"audit_events"`
+}
+
+type truthyCase struct {
+	Input    string `json:"input"`
+	Expected bool   `json:"expected"`
+}
+
+func buildRedactFixture(meta oracle) redactFixture {
+	exactInputs := []struct {
+		name    string
+		secrets []string
+		input   string
+	}{
+		{
+			name:    "single_secret",
+			secrets: []string{"sup3r-s3cret-value-xyz"},
+			input:   "the password is sup3r-s3cret-value-xyz and that's it",
+		},
+		{
+			name:    "repeat_secret",
+			secrets: []string{"sup3r-s3cret-value-xyz"},
+			input:   "token=sup3r-s3cret-value-xyz and repeat sup3r-s3cret-value-xyz end",
+		},
+		{
+			name:    "multiple_secrets",
+			secrets: []string{"first-secret-token", "second-secret-key"},
+			input:   "first: first-secret-token, second: second-secret-key",
+		},
+		{
+			name:    "short_and_empty_ignored",
+			secrets: []string{"", "a", "ab", "abc"},
+			input:   "ab is short and empty is nothing",
+		},
+		{
+			name:    "no_match",
+			secrets: []string{"absent-secret-token"},
+			input:   "clean text without secrets",
+		},
+		{
+			name:    "empty_input",
+			secrets: []string{"any-secret-token"},
+			input:   "",
+		},
+	}
+
+	exactCases := make([]exactValueCase, 0, len(exactInputs))
+	for _, tc := range exactInputs {
+		d := redactpkg.NewExactValueDetector(tc.secrets)
+		redacted, count, err := d.Redact(tc.input)
+		if err != nil {
+			panic(fmt.Sprintf("exact value detector failed unexpectedly: %v", err))
+		}
+		exactCases = append(exactCases, exactValueCase{
+			Name:             tc.name,
+			Secrets:          tc.secrets,
+			Input:            tc.input,
+			ExpectedRedacted: redacted,
+			ExpectedCount:    count,
+		})
+	}
+
+	entropyInputs := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "high_entropy_token",
+			input: "config value: kQ7#zM2$pL9@rT4!vX8&wY6^bN3*cJ1~ end",
+		},
+		{
+			name:  "ordinary_prose",
+			input: "This is a perfectly ordinary sentence about deploying the release pipeline on Friday afternoon.",
+		},
+		{
+			name:  "short_token",
+			input: "short=aB3$kZ9",
+		},
+		{
+			name:  "uuid_v4",
+			input: "request_id=f47ac10b-58cc-4372-a567-0e02b2c3d479",
+		},
+		{
+			name:  "sha256_hash",
+			input: "checksum=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+		},
+		{
+			name:  "base64_payload",
+			input: "payload=VGhpcyBpcyBqdXN0IGEgcGxhaW4gRW5nbGlzaCBzZW50ZW5jZSBlbmNvZGVkIGFzIGJhc2U2NA==",
+		},
+		{
+			name:  "long_numeric_identifier",
+			input: "order_id=12345678901234567890123456789012",
+		},
+		{
+			name:  "empty_input",
+			input: "",
+		},
+	}
+
+	entropyCases := make([]entropyCase, 0, len(entropyInputs))
+	for _, tc := range entropyInputs {
+		d := redactpkg.NewEntropyDetector()
+		redacted, count, err := d.Redact(tc.input)
+		if err != nil {
+			panic(fmt.Sprintf("entropy detector failed unexpectedly: %v", err))
+		}
+		entropyCases = append(entropyCases, entropyCase{
+			Name:             tc.name,
+			Input:            tc.input,
+			ExpectedRedacted: redacted,
+			ExpectedCount:    count,
+		})
+	}
+
+	scanInputs := []struct {
+		name          string
+		detectors     []string
+		secrets       []string
+		strict        bool
+		correlationID string
+		channel       string
+		input         string
+	}{
+		{
+			name:      "no_detectors",
+			detectors: []string{},
+			input:     "hello world",
+		},
+		{
+			name:          "exact_non_strict",
+			detectors:     []string{"exact_value"},
+			secrets:       []string{"redactmesoftvalue1"},
+			strict:        false,
+			correlationID: "corr-2",
+			channel:       "test.stdout",
+			input:         "output containing redactmesoftvalue1 here, and more text after",
+		},
+		{
+			name:          "exact_strict",
+			detectors:     []string{"exact_value"},
+			secrets:       []string{"blockmehardvalue1"},
+			strict:        true,
+			correlationID: "corr-1",
+			channel:       "test.stdout",
+			input:         "output containing blockmehardvalue1 here",
+		},
+		{
+			name:          "entropy_non_strict",
+			detectors:     []string{"entropy_heuristic"},
+			strict:        false,
+			correlationID: "corr-3",
+			channel:       "test.channel",
+			input:         "value: kQ7#zM2$pL9@rT4!vX8&wY6^bN3*cJ1~ end",
+		},
+		{
+			name:          "entropy_strict",
+			detectors:     []string{"entropy_heuristic"},
+			strict:        true,
+			correlationID: "corr-4",
+			channel:       "test.channel",
+			input:         "value: kQ7#zM2$pL9@rT4!vX8&wY6^bN3*cJ1~ end",
+		},
+		{
+			name:          "both_non_strict",
+			detectors:     []string{"exact_value", "entropy_heuristic"},
+			secrets:       []string{"mysecretpassword"},
+			strict:        false,
+			correlationID: "corr-5",
+			channel:       "test.stdout",
+			input:         "pass: mysecretpassword, blob: kQ7#zM2$pL9@rT4!vX8&wY6^bN3*cJ1~",
+		},
+		{
+			name:          "both_strict",
+			detectors:     []string{"exact_value", "entropy_heuristic"},
+			secrets:       []string{"mysecretpassword"},
+			strict:        true,
+			correlationID: "corr-6",
+			channel:       "test.stdout",
+			input:         "pass: mysecretpassword, blob: kQ7#zM2$pL9@rT4!vX8&wY6^bN3*cJ1~",
+		},
+		{
+			name:      "json_structure",
+			detectors: []string{"exact_value"},
+			secrets:   []string{"topsecretvalue1"},
+			input:     `{"stdout":"login ok, token=topsecretvalue1","exit_code":0}`,
+		},
+		{
+			name:      "multiline",
+			detectors: []string{"exact_value"},
+			secrets:   []string{"multilinesecretval"},
+			input:     "line one\nline two multilinesecretval\nline three (truncat",
+		},
+		{
+			name:      "no_matches",
+			detectors: []string{"exact_value", "entropy_heuristic"},
+			secrets:   []string{"absentpassword"},
+			strict:    true,
+			input:     "normal text with no secrets",
+		},
+	}
+
+	scanCases := make([]scannerCase, 0, len(scanInputs))
+	for _, tc := range scanInputs {
+		var detectors []redactpkg.Detector
+		for _, dname := range tc.detectors {
+			switch dname {
+			case "exact_value":
+				detectors = append(detectors, redactpkg.NewExactValueDetector(tc.secrets))
+			case "entropy_heuristic":
+				detectors = append(detectors, redactpkg.NewEntropyDetector())
+			default:
+				panic("unknown detector: " + dname)
+			}
+		}
+
+		sc := redactpkg.NewScanner(detectors...)
+		sc.Channel = tc.channel
+		emittedEvents := make([]scannerAuditEvent, 0)
+		sc.Audit = func(e redactpkg.AuditEvent) {
+			emittedEvents = append(emittedEvents, scannerAuditEvent{
+				Detector:      e.Detector,
+				Channel:       e.Channel,
+				Confidence:    e.Confidence.String(),
+				RedactedCount: e.RedactedCount,
+				Blocked:       e.Blocked,
+				CorrelationID: e.CorrelationID,
+			})
+		}
+
+		res, err := sc.Scan(tc.input, redactpkg.ScanOptions{
+			Strict:        tc.strict,
+			CorrelationID: tc.correlationID,
+		})
+		if err != nil {
+			panic(fmt.Sprintf("scanner failed unexpectedly: %v", err))
+		}
+
+		findings := make([]scannerFinding, 0, len(res.Findings))
+		for _, f := range res.Findings {
+			findings = append(findings, scannerFinding{
+				Detector:   f.Detector,
+				Confidence: f.Confidence.String(),
+				Count:      f.Count,
+			})
+		}
+
+		scanCases = append(scanCases, scannerCase{
+			Name:            tc.name,
+			Detectors:       tc.detectors,
+			Secrets:         tc.secrets,
+			Strict:          tc.strict,
+			CorrelationID:   tc.correlationID,
+			Channel:         tc.channel,
+			Input:           tc.input,
+			ExpectedText:    res.Text,
+			ExpectedBlocked: res.Blocked,
+			Findings:        findings,
+			AuditEvents:     emittedEvents,
+		})
+	}
+
+	truthyInputs := []string{
+		"1", "t", "T", "true", "TRUE", "True", "yes", "YES", "Yes", "on", "ON", "On",
+		"", "0", "false", "no", "off", "random", "TRUE ",
+	}
+	truthyCases := make([]truthyCase, 0, len(truthyInputs))
+	for _, in := range truthyInputs {
+		truthyCases = append(truthyCases, truthyCase{
+			Input:    in,
+			Expected: evaluateTruthy(in),
+		})
+	}
+
+	return redactFixture{
+		SchemaVersion: 1,
+		Oracle:        meta,
+		Constants: redactConstants{
+			Marker:                redactpkg.Marker,
+			BlockedText:           "[REDACTED: output withheld]",
+			MinExactValueLen:      4,
+			MinTokenLen:           20,
+			MinEntropyBitsPerChar: 4.85,
+		},
+		ExactValueCases: exactCases,
+		EntropyCases:    entropyCases,
+		ScannerCases:    scanCases,
+		TruthyCases:     truthyCases,
+	}
+}
+
+func evaluateTruthy(v string) bool {
+	switch v {
+	case "1", "t", "T", "true", "TRUE", "True", "yes", "YES", "Yes", "on", "ON", "On":
+		return true
+	default:
+		return false
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Main / CLI entry point
+// ---------------------------------------------------------------------------
+
+func main() {
+	output := flag.String("output", "", "legacy single fixture path")
+	errorOutput := flag.String("error-output", "", "error fixture path")
+	secretRefOutput := flag.String("secret-ref-output", "", "secret ref fixture path")
+	redactOutput := flag.String("redact-output", "", "redact fixture path")
+	kind := flag.String("kind", "all", "fixture kind to generate or check: all, error, secret_ref, redact")
+	check := flag.Bool("check", false, "fail if the fixture differs")
+	commit := flag.String("oracle-commit", "", "Go oracle commit for a new fixture")
+	release := flag.String("oracle-release", "", "Go oracle release for a new fixture")
+	flag.Parse()
+
+	if *errorOutput == "" {
+		if *output != "" && (*kind == "error" || *kind == "all") {
+			*errorOutput = *output
+		} else {
+			*errorOutput = "testdata/port/core/error-contract.json"
+		}
+	}
+	if *secretRefOutput == "" {
+		*secretRefOutput = "testdata/port/core/secret-ref-contract.json"
+	}
+	if *redactOutput == "" {
+		*redactOutput = "testdata/port/core/redact-contract.json"
+	}
+
+	meta := oracle{Commit: *commit, Release: *release}
+	if *check || meta.Commit == "" || meta.Release == "" {
+		existing, err := readHeader(*errorOutput)
+		if err == nil {
+			meta = existing.Oracle
+		}
+	}
+	if meta.Commit == "" || meta.Release == "" {
+		fatal("--oracle-commit and --oracle-release are required when generating a new fixture")
+	}
+
+	runError := *kind == "all" || *kind == "error"
+	runSecretRef := *kind == "all" || *kind == "secret_ref"
+	runRedact := *kind == "all" || *kind == "redact"
+
+	if runError {
+		processFixture(*errorOutput, *check, "error-contract", func() ([]byte, int, error) {
+			f := buildErrorFixture(meta)
+			b, err := marshalJSON(f)
+			return b, len(f.Cases), err
+		})
+	}
+
+	if runSecretRef {
+		processFixture(*secretRefOutput, *check, "secret-ref-contract", func() ([]byte, int, error) {
+			f := buildSecretRefFixture(meta)
+			b, err := marshalJSON(f)
+			return b, len(f.ParseRefCases) + len(f.ParseHandleCases), err
+		})
+	}
+
+	if runRedact {
+		processFixture(*redactOutput, *check, "redact-contract", func() ([]byte, int, error) {
+			f := buildRedactFixture(meta)
+			b, err := marshalJSON(f)
+			return b, len(f.ExactValueCases) + len(f.EntropyCases) + len(f.ScannerCases), err
+		})
+	}
+}
+
+func processFixture(path string, check bool, label string, gen func() ([]byte, int, error)) {
+	content, count, err := gen()
+	if err != nil {
+		fatal("generate %s fixture: %v", label, err)
+	}
+
+	if check {
+		existing, err := os.ReadFile(path) // #nosec G304 -- explicit operator-selected fixture path
+		if err != nil {
+			fatal("read %s fixture (%s): %v", label, path, err)
+		}
+		if !bytes.Equal(existing, content) {
+			fatal("%s fixture (%s) is stale; run make core-fixtures-generate", label, path)
+		}
+		fmt.Printf("PASS %s fixture (%d cases)\n", label, count)
+		return
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		fatal("create fixture directory for %s: %v", path, err)
+	}
+	if err := os.WriteFile(path, content, 0o600); err != nil {
+		fatal("write fixture %s: %v", path, err)
+	}
+	fmt.Printf("WROTE %s (%d cases)\n", path, count)
+}
+
+func marshalJSON(value any) ([]byte, error) {
 	content, err := json.MarshalIndent(value, "", "  ")
 	if err != nil {
 		return nil, err
@@ -258,17 +805,17 @@ func marshalFixture(value fixture) ([]byte, error) {
 	return append(content, '\n'), nil
 }
 
-func readFixture(path string) (fixture, error) {
+func readHeader(path string) (headerOnly, error) {
 	content, err := os.ReadFile(path) // #nosec G304 -- explicit operator-selected fixture path
 	if err != nil {
-		return fixture{}, err
+		return headerOnly{}, err
 	}
-	var value fixture
+	var value headerOnly
 	if err := json.Unmarshal(content, &value); err != nil {
-		return fixture{}, err
+		return headerOnly{}, err
 	}
 	if value.SchemaVersion != 1 {
-		return fixture{}, fmt.Errorf("unsupported schema_version %d", value.SchemaVersion)
+		return headerOnly{}, fmt.Errorf("unsupported schema_version %d", value.SchemaVersion)
 	}
 	return value, nil
 }

--- a/scripts/rust-port/cmd/coregen/main.go
+++ b/scripts/rust-port/cmd/coregen/main.go
@@ -1,0 +1,279 @@
+// Command coregen freezes pure Go domain contracts for the staged Rust port.
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	stderrors "errors"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	corekitexitcodes "github.com/danieljustus/symaira-corekit/exitcodes"
+
+	errorspkg "github.com/danieljustus/symaira-vault/internal/errors"
+)
+
+type fixture struct {
+	SchemaVersion   int              `json:"schema_version"`
+	Oracle          oracle           `json:"oracle"`
+	ExitCodes       []namedInt       `json:"exit_codes"`
+	ErrorKinds      []namedInt       `json:"error_kinds"`
+	Cases           []errorCase      `json:"cases"`
+	ExitResolutions []exitResolution `json:"exit_resolutions"`
+	CorekitMappings []codeMapping    `json:"corekit_mappings"`
+	CorekitReverse  []codeMapping    `json:"corekit_reverse_mappings"`
+}
+
+type oracle struct {
+	Commit  string `json:"commit"`
+	Release string `json:"release"`
+}
+
+type namedInt struct {
+	Name  string `json:"name"`
+	Value int    `json:"value"`
+}
+
+type errorCase struct {
+	Name              string `json:"name"`
+	Code              int    `json:"code"`
+	Kind              int    `json:"kind"`
+	Message           string `json:"message"`
+	CauseKind         string `json:"cause_kind,omitempty"`
+	CauseMessage      string `json:"cause_message,omitempty"`
+	Hint              string `json:"hint,omitempty"`
+	Error             string `json:"error"`
+	Formatted         string `json:"formatted"`
+	EffectiveExitCode int    `json:"effective_exit_code"`
+	IsNotFound        bool   `json:"is_not_found"`
+	IsWriteError      bool   `json:"is_write_error"`
+}
+
+type exitResolution struct {
+	Name string `json:"name"`
+	Code int    `json:"code"`
+}
+
+type codeMapping struct {
+	Vault   int `json:"vault"`
+	Corekit int `json:"corekit"`
+}
+
+func main() {
+	output := flag.String("output", "testdata/port/core/error-contract.json", "fixture path")
+	check := flag.Bool("check", false, "fail if the fixture differs")
+	commit := flag.String("oracle-commit", "", "Go oracle commit for a new fixture")
+	release := flag.String("oracle-release", "", "Go oracle release for a new fixture")
+	flag.Parse()
+
+	meta := oracle{Commit: *commit, Release: *release}
+	if *check {
+		existing, err := readFixture(*output)
+		if err != nil {
+			fatal("read existing fixture: %v", err)
+		}
+		meta = existing.Oracle
+	}
+	if meta.Commit == "" || meta.Release == "" {
+		fatal("--oracle-commit and --oracle-release are required when generating a fixture")
+	}
+
+	generated := buildFixture(meta)
+	content, err := marshalFixture(generated)
+	if err != nil {
+		fatal("encode fixture: %v", err)
+	}
+	if *check {
+		existing, err := os.ReadFile(*output) // #nosec G304 -- explicit operator-selected fixture path
+		if err != nil {
+			fatal("read fixture: %v", err)
+		}
+		if !bytes.Equal(existing, content) {
+			fatal("error-contract fixture is stale; run make core-fixtures-generate")
+		}
+		fmt.Printf("PASS error-contract fixture (%d cases)\n", len(generated.Cases))
+		return
+	}
+	if err := os.MkdirAll(filepath.Dir(*output), 0o750); err != nil {
+		fatal("create fixture directory: %v", err)
+	}
+	if err := os.WriteFile(*output, content, 0o600); err != nil {
+		fatal("write fixture: %v", err)
+	}
+	fmt.Printf("WROTE %s (%d cases)\n", *output, len(generated.Cases))
+}
+
+func buildFixture(meta oracle) fixture {
+	readCause := stderrors.New("disk read")
+	writeCause := stderrors.New("disk full")
+	cases := []namedError{
+		{"new", errorspkg.NewCLIError(errorspkg.ExitLocked, "vault locked", stderrors.New("passphrase missing"))},
+		{"not_found", errorspkg.NotFound("entry %q not found", "github")},
+		{"field_not_found", errorspkg.Wrap(errorspkg.ExitNotFound, errorspkg.ErrFieldNotFound, nil, "field %q missing", "token")},
+		{"read_failed", errorspkg.ReadFailed(readCause, "cannot read entry")},
+		{"read_failed_nil", errorspkg.ReadFailed(nil, "cannot read entry without cause")},
+		{"write_failed", errorspkg.WriteFailed(writeCause, "cannot write entry")},
+		{"write_failed_nil", errorspkg.WriteFailed(nil, "cannot write entry without cause")},
+		{"not_initialized", errorspkg.NotInitialized("vault not initialized at %s", "/vault")},
+		{"new_vault_not_initialized", errorspkg.NewVaultNotInitialized()},
+		{"locked", errorspkg.Locked("session expired")},
+		{"permission_denied", errorspkg.PermissionDenied("agent cannot write")},
+		{"invalid_input", errorspkg.InvalidInput("length must be positive")},
+		{"config_error", errorspkg.ConfigError("config value is invalid")},
+		{"internal", errorspkg.Internal("unexpected state")},
+		{"already_exists", errorspkg.AlreadyExists("entry already exists")},
+		{"custom_hint", errorspkg.NewCLIError(errorspkg.ExitGeneralError, "operation failed", nil).WithHint("Run symvault doctor")},
+		{"sentinel_priority", errorspkg.NewCLIError(errorspkg.ExitGeneralError, "locked wrapper", fmt.Errorf("outer: %w", errorspkg.ErrVaultLocked))},
+	}
+
+	resultCases := make([]errorCase, 0, len(cases))
+	for _, item := range cases {
+		resultCases = append(resultCases, describeError(item.Name, item.Error))
+	}
+
+	return fixture{
+		SchemaVersion: 1,
+		Oracle:        meta,
+		ExitCodes: []namedInt{
+			{"success", int(errorspkg.ExitSuccess)},
+			{"general", int(errorspkg.ExitGeneralError)},
+			{"not_found", int(errorspkg.ExitNotFound)},
+			{"not_initialized", int(errorspkg.ExitNotInitialized)},
+			{"locked", int(errorspkg.ExitLocked)},
+			{"permission_denied", int(errorspkg.ExitPermissionDenied)},
+			{"config", int(errorspkg.ExitConfigError)},
+			{"doctor_warn", int(errorspkg.ExitDoctorWarn)},
+			{"doctor_fail", int(errorspkg.ExitDoctorFail)},
+			{"invalid_input", int(errorspkg.ExitInvalidInput)},
+			{"usage", int(errorspkg.ExitUsage)},
+			{"update_available", int(errorspkg.ExitUpdateAvailable)},
+		},
+		ErrorKinds: []namedInt{
+			{"none", int(errorspkg.ErrKindNone)},
+			{"not_found", int(errorspkg.ErrNotFound)},
+			{"field_not_found", int(errorspkg.ErrFieldNotFound)},
+			{"read_failed", int(errorspkg.ErrReadFailed)},
+			{"write_failed", int(errorspkg.ErrWriteFailed)},
+		},
+		Cases: resultCases,
+		ExitResolutions: []exitResolution{
+			{"nil", int(errorspkg.ExitCodeFromError(nil))},
+			{"plain", int(errorspkg.ExitCodeFromError(stderrors.New("plain")))},
+			{"entry_not_found", int(errorspkg.ExitCodeFromError(fmt.Errorf("outer: %w", errorspkg.ErrEntryNotFound)))},
+			{"vault_not_initialized", int(errorspkg.ExitCodeFromError(fmt.Errorf("outer: %w", errorspkg.ErrVaultNotInitialized)))},
+			{"vault_locked", int(errorspkg.ExitCodeFromError(fmt.Errorf("outer: %w", errorspkg.ErrVaultLocked)))},
+			{"permission_denied", int(errorspkg.ExitCodeFromError(fmt.Errorf("outer: %w", errorspkg.ErrPermissionDenied)))},
+		},
+		CorekitMappings: corekitMappings(),
+		CorekitReverse:  corekitReverseMappings(),
+	}
+}
+
+type namedError struct {
+	Name  string
+	Error *errorspkg.CLIError
+}
+
+func describeError(name string, value *errorspkg.CLIError) errorCase {
+	return errorCase{
+		Name:              name,
+		Code:              int(value.Code),
+		Kind:              int(value.Kind),
+		Message:           value.Message,
+		CauseKind:         causeKind(value.Cause),
+		CauseMessage:      causeMessage(value.Cause),
+		Hint:              value.Hint,
+		Error:             value.Error(),
+		Formatted:         errorspkg.FormatCLIError(value),
+		EffectiveExitCode: int(errorspkg.ExitCodeFromError(value)),
+		IsNotFound:        errorspkg.IsNotFound(value),
+		IsWriteError:      errorspkg.IsWriteError(value),
+	}
+}
+
+func causeKind(err error) string {
+	switch {
+	case stderrors.Is(err, errorspkg.ErrEntryNotFound):
+		return "entry_not_found"
+	case stderrors.Is(err, errorspkg.ErrVaultNotInitialized):
+		return "vault_not_initialized"
+	case stderrors.Is(err, errorspkg.ErrVaultLocked):
+		return "vault_locked"
+	case stderrors.Is(err, errorspkg.ErrPermissionDenied):
+		return "permission_denied"
+	case err != nil:
+		return "other"
+	default:
+		return ""
+	}
+}
+
+func causeMessage(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}
+
+func corekitMappings() []codeMapping {
+	codes := []errorspkg.ExitCode{
+		errorspkg.ExitSuccess,
+		errorspkg.ExitGeneralError,
+		errorspkg.ExitNotFound,
+		errorspkg.ExitNotInitialized,
+		errorspkg.ExitLocked,
+		errorspkg.ExitPermissionDenied,
+		errorspkg.ExitConfigError,
+		errorspkg.ExitDoctorWarn,
+		errorspkg.ExitDoctorFail,
+		errorspkg.ExitInvalidInput,
+		errorspkg.ExitUpdateAvailable,
+	}
+	result := make([]codeMapping, 0, len(codes))
+	for _, code := range codes {
+		result = append(result, codeMapping{Vault: int(code), Corekit: int(errorspkg.ToCorekitExitCode(code))})
+	}
+	return result
+}
+
+func corekitReverseMappings() []codeMapping {
+	codes := []corekitexitcodes.ExitCode{0, 1, 2, 4, 5, 9, 42}
+	result := make([]codeMapping, 0, len(codes))
+	for _, code := range codes {
+		result = append(result, codeMapping{
+			Vault:   int(errorspkg.FromCorekitExitCode(code)),
+			Corekit: int(code),
+		})
+	}
+	return result
+}
+
+func marshalFixture(value fixture) ([]byte, error) {
+	content, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(content, '\n'), nil
+}
+
+func readFixture(path string) (fixture, error) {
+	content, err := os.ReadFile(path) // #nosec G304 -- explicit operator-selected fixture path
+	if err != nil {
+		return fixture{}, err
+	}
+	var value fixture
+	if err := json.Unmarshal(content, &value); err != nil {
+		return fixture{}, err
+	}
+	if value.SchemaVersion != 1 {
+		return fixture{}, fmt.Errorf("unsupported schema_version %d", value.SchemaVersion)
+	}
+	return value, nil
+}
+
+func fatal(format string, args ...any) {
+	_, _ = fmt.Fprintf(os.Stderr, "FAIL "+format+"\n", args...)
+	os.Exit(1)
+}

--- a/scripts/rust-port/cmd/coregen/main_test.go
+++ b/scripts/rust-port/cmd/coregen/main_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+)
+
+func TestBuildFixtureIsDeterministic(t *testing.T) {
+	meta := oracle{Commit: "test", Release: "v0.0.0"}
+	first, err := marshalFixture(buildFixture(meta))
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := marshalFixture(buildFixture(meta))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(first, second) {
+		t.Fatal("error fixture generation is not deterministic")
+	}
+}
+
+func TestBuildFixtureCoversStableTaxonomy(t *testing.T) {
+	fixture := buildFixture(oracle{Commit: "test", Release: "test"})
+	wantExitCodes := []namedInt{
+		{"success", 0}, {"general", 1}, {"not_found", 2}, {"not_initialized", 3},
+		{"locked", 4}, {"permission_denied", 5}, {"config", 6}, {"doctor_warn", 7},
+		{"doctor_fail", 8}, {"invalid_input", 9}, {"usage", 9}, {"update_available", 10},
+	}
+	if !reflect.DeepEqual(fixture.ExitCodes, wantExitCodes) {
+		t.Fatalf("exit codes = %#v, want %#v", fixture.ExitCodes, wantExitCodes)
+	}
+	wantKinds := []namedInt{{"none", 0}, {"not_found", 1}, {"field_not_found", 2}, {"read_failed", 3}, {"write_failed", 4}}
+	if !reflect.DeepEqual(fixture.ErrorKinds, wantKinds) {
+		t.Fatalf("error kinds = %#v, want %#v", fixture.ErrorKinds, wantKinds)
+	}
+	if len(fixture.CorekitReverse) != 7 {
+		t.Fatalf("corekit reverse mappings = %d, want 7", len(fixture.CorekitReverse))
+	}
+	wantCases := []string{
+		"new", "not_found", "field_not_found", "read_failed", "read_failed_nil",
+		"write_failed", "write_failed_nil", "not_initialized", "new_vault_not_initialized",
+		"locked", "permission_denied", "invalid_input", "config_error", "internal",
+		"already_exists", "custom_hint", "sentinel_priority",
+	}
+	gotCases := make([]string, len(fixture.Cases))
+	for i, item := range fixture.Cases {
+		gotCases[i] = item.Name
+	}
+	if !reflect.DeepEqual(gotCases, wantCases) {
+		t.Fatalf("error cases = %#v, want %#v", gotCases, wantCases)
+	}
+}

--- a/scripts/rust-port/cmd/coregen/main_test.go
+++ b/scripts/rust-port/cmd/coregen/main_test.go
@@ -2,17 +2,20 @@ package main
 
 import (
 	"bytes"
+	"os"
+	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 )
 
-func TestBuildFixtureIsDeterministic(t *testing.T) {
+func TestBuildErrorFixtureIsDeterministic(t *testing.T) {
 	meta := oracle{Commit: "test", Release: "v0.0.0"}
-	first, err := marshalFixture(buildFixture(meta))
+	first, err := marshalJSON(buildErrorFixture(meta))
 	if err != nil {
 		t.Fatal(err)
 	}
-	second, err := marshalFixture(buildFixture(meta))
+	second, err := marshalJSON(buildErrorFixture(meta))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -21,8 +24,38 @@ func TestBuildFixtureIsDeterministic(t *testing.T) {
 	}
 }
 
+func TestBuildSecretRefFixtureIsDeterministic(t *testing.T) {
+	meta := oracle{Commit: "test", Release: "v0.0.0"}
+	first, err := marshalJSON(buildSecretRefFixture(meta))
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := marshalJSON(buildSecretRefFixture(meta))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(first, second) {
+		t.Fatal("secret-ref fixture generation is not deterministic")
+	}
+}
+
+func TestBuildRedactFixtureIsDeterministic(t *testing.T) {
+	meta := oracle{Commit: "test", Release: "v0.0.0"}
+	first, err := marshalJSON(buildRedactFixture(meta))
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := marshalJSON(buildRedactFixture(meta))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(first, second) {
+		t.Fatal("redact fixture generation is not deterministic")
+	}
+}
+
 func TestBuildFixtureCoversStableTaxonomy(t *testing.T) {
-	fixture := buildFixture(oracle{Commit: "test", Release: "test"})
+	fixture := buildErrorFixture(oracle{Commit: "test", Release: "test"})
 	wantExitCodes := []namedInt{
 		{"success", 0}, {"general", 1}, {"not_found", 2}, {"not_initialized", 3},
 		{"locked", 4}, {"permission_denied", 5}, {"config", 6}, {"doctor_warn", 7},
@@ -50,5 +83,150 @@ func TestBuildFixtureCoversStableTaxonomy(t *testing.T) {
 	}
 	if !reflect.DeepEqual(gotCases, wantCases) {
 		t.Fatalf("error cases = %#v, want %#v", gotCases, wantCases)
+	}
+}
+
+func TestBuildSecretRefFixtureCoversGoOracle(t *testing.T) {
+	fixture := buildSecretRefFixture(oracle{Commit: "test", Release: "v0.0.0"})
+	if len(fixture.ParseRefCases) < 20 {
+		t.Fatalf("unexpectedly few ParseRef cases: %d", len(fixture.ParseRefCases))
+	}
+	if len(fixture.ParseHandleCases) < 10 {
+		t.Fatalf("unexpectedly few ParseSecretHandle cases: %d", len(fixture.ParseHandleCases))
+	}
+
+	// Verify both valid and invalid partitions exist
+	validRef, invalidRef := 0, 0
+	for _, tc := range fixture.ParseRefCases {
+		if tc.Valid {
+			validRef++
+			if tc.Path == "" && tc.Input != "op:///github" {
+				t.Fatalf("valid case %q has empty path", tc.Name)
+			}
+			if tc.Field == "" {
+				t.Fatalf("valid case %q has empty field", tc.Name)
+			}
+		} else {
+			invalidRef++
+			if tc.ErrorMessage == "" {
+				t.Fatalf("invalid case %q missing error message", tc.Name)
+			}
+		}
+	}
+	if validRef == 0 || invalidRef == 0 {
+		t.Fatalf("ParseRef partition empty: valid=%d invalid=%d", validRef, invalidRef)
+	}
+
+	validHandles, invalidHandles := 0, 0
+	for _, tc := range fixture.ParseHandleCases {
+		if tc.Valid {
+			validHandles++
+			if tc.StringRepr == "" {
+				t.Fatalf("valid handle %q missing string_repr", tc.Name)
+			}
+		} else {
+			invalidHandles++
+		}
+	}
+	if validHandles == 0 || invalidHandles == 0 {
+		t.Fatalf("ParseHandle partition empty: valid=%d invalid=%d", validHandles, invalidHandles)
+	}
+}
+
+func TestBuildRedactFixtureCoversGoOracle(t *testing.T) {
+	fixture := buildRedactFixture(oracle{Commit: "test", Release: "v0.0.0"})
+	if fixture.Constants.Marker != "[REDACTED]" {
+		t.Fatalf("unexpected marker: %q", fixture.Constants.Marker)
+	}
+	if fixture.Constants.BlockedText != "[REDACTED: output withheld]" {
+		t.Fatalf("unexpected blocked text: %q", fixture.Constants.BlockedText)
+	}
+	if fixture.Constants.MinExactValueLen != 4 {
+		t.Fatalf("unexpected min exact value len: %d", fixture.Constants.MinExactValueLen)
+	}
+	if fixture.Constants.MinTokenLen != 20 {
+		t.Fatalf("unexpected min token len: %d", fixture.Constants.MinTokenLen)
+	}
+	if fixture.Constants.MinEntropyBitsPerChar != 4.85 {
+		t.Fatalf("unexpected min entropy: %f", fixture.Constants.MinEntropyBitsPerChar)
+	}
+	if len(fixture.ExactValueCases) < 5 {
+		t.Fatalf("unexpectedly few exact value cases: %d", len(fixture.ExactValueCases))
+	}
+	if len(fixture.EntropyCases) < 7 {
+		t.Fatalf("unexpectedly few entropy cases: %d", len(fixture.EntropyCases))
+	}
+	if len(fixture.ScannerCases) < 8 {
+		t.Fatalf("unexpectedly few scanner cases: %d", len(fixture.ScannerCases))
+	}
+	if len(fixture.TruthyCases) < 15 {
+		t.Fatalf("unexpectedly few truthy cases: %d", len(fixture.TruthyCases))
+	}
+}
+
+func TestNegativeControlFixtureDriftDetection(t *testing.T) {
+	// Negative control: proving that drift detection reliably detects stale content
+	meta := oracle{Commit: "test", Release: "v0.0.0"}
+	expected, err := marshalJSON(buildSecretRefFixture(meta))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tampered := bytes.ReplaceAll(expected, []byte(`"schema_version": 1`), []byte(`"schema_version": 99`))
+	if bytes.Equal(expected, tampered) {
+		t.Fatal("tampering failed to modify fixture")
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "fixture.json")
+	if err := os.WriteFile(path, tampered, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	existing, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Equal(existing, expected) {
+		t.Fatal("negative control failed: tampered file unexpectedly matches expected")
+	}
+}
+
+func TestReadHeaderRejectsInvalidSchema(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "invalid_schema.json")
+	if err := os.WriteFile(path, []byte(`{"schema_version": 2, "oracle": {"commit":"x","release":"y"}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := readHeader(path)
+	if err == nil {
+		t.Fatal("expected rejection of schema_version 2")
+	}
+	if !strings.Contains(err.Error(), "unsupported schema_version") {
+		t.Fatalf("unexpected error message: %v", err)
+	}
+}
+
+func TestRedactFixtureAuditEventsNeverContainSecrets(t *testing.T) {
+	fixture := buildRedactFixture(oracle{Commit: "test", Release: "v0.0.0"})
+	for _, sc := range fixture.ScannerCases {
+		for _, sec := range sc.Secrets {
+			if sec == "" || len(sec) < 4 {
+				continue
+			}
+			for _, evt := range sc.AuditEvents {
+				if strings.Contains(evt.Detector, sec) || strings.Contains(evt.Channel, sec) || strings.Contains(evt.CorrelationID, sec) {
+					t.Fatalf("secret %q leaked in audit event: %+v", sec, evt)
+				}
+			}
+			for _, f := range sc.Findings {
+				if strings.Contains(f.Detector, sec) {
+					t.Fatalf("secret %q leaked in finding: %+v", sec, f)
+				}
+			}
+			if sc.ExpectedBlocked && strings.Contains(sc.ExpectedText, sec) {
+				t.Fatalf("secret %q leaked in blocked output: %q", sec, sc.ExpectedText)
+			}
+		}
 	}
 }

--- a/testdata/port/core/error-contract.json
+++ b/testdata/port/core/error-contract.json
@@ -1,0 +1,392 @@
+{
+  "schema_version": 1,
+  "oracle": {
+    "commit": "caadd5e",
+    "release": "v0.22.1"
+  },
+  "exit_codes": [
+    {
+      "name": "success",
+      "value": 0
+    },
+    {
+      "name": "general",
+      "value": 1
+    },
+    {
+      "name": "not_found",
+      "value": 2
+    },
+    {
+      "name": "not_initialized",
+      "value": 3
+    },
+    {
+      "name": "locked",
+      "value": 4
+    },
+    {
+      "name": "permission_denied",
+      "value": 5
+    },
+    {
+      "name": "config",
+      "value": 6
+    },
+    {
+      "name": "doctor_warn",
+      "value": 7
+    },
+    {
+      "name": "doctor_fail",
+      "value": 8
+    },
+    {
+      "name": "invalid_input",
+      "value": 9
+    },
+    {
+      "name": "usage",
+      "value": 9
+    },
+    {
+      "name": "update_available",
+      "value": 10
+    }
+  ],
+  "error_kinds": [
+    {
+      "name": "none",
+      "value": 0
+    },
+    {
+      "name": "not_found",
+      "value": 1
+    },
+    {
+      "name": "field_not_found",
+      "value": 2
+    },
+    {
+      "name": "read_failed",
+      "value": 3
+    },
+    {
+      "name": "write_failed",
+      "value": 4
+    }
+  ],
+  "cases": [
+    {
+      "name": "new",
+      "code": 4,
+      "kind": 0,
+      "message": "vault locked",
+      "cause_kind": "other",
+      "cause_message": "passphrase missing",
+      "error": "vault locked: passphrase missing",
+      "formatted": "vault locked: passphrase missing",
+      "effective_exit_code": 4,
+      "is_not_found": false,
+      "is_write_error": false
+    },
+    {
+      "name": "not_found",
+      "code": 2,
+      "kind": 1,
+      "message": "entry \"github\" not found",
+      "cause_kind": "entry_not_found",
+      "cause_message": "entry not found",
+      "hint": "Try: symvault list to browse entries, or symvault find \u003cterm\u003e to search by keyword.",
+      "error": "entry \"github\" not found: entry not found",
+      "formatted": "entry \"github\" not found: entry not found\nHint: Try: symvault list to browse entries, or symvault find \u003cterm\u003e to search by keyword.",
+      "effective_exit_code": 2,
+      "is_not_found": true,
+      "is_write_error": false
+    },
+    {
+      "name": "field_not_found",
+      "code": 2,
+      "kind": 2,
+      "message": "field \"token\" missing",
+      "error": "field \"token\" missing",
+      "formatted": "field \"token\" missing",
+      "effective_exit_code": 2,
+      "is_not_found": true,
+      "is_write_error": false
+    },
+    {
+      "name": "read_failed",
+      "code": 1,
+      "kind": 3,
+      "message": "cannot read entry",
+      "cause_kind": "other",
+      "cause_message": "disk read",
+      "error": "cannot read entry: disk read",
+      "formatted": "cannot read entry: disk read",
+      "effective_exit_code": 1,
+      "is_not_found": false,
+      "is_write_error": false
+    },
+    {
+      "name": "read_failed_nil",
+      "code": 1,
+      "kind": 3,
+      "message": "cannot read entry without cause",
+      "error": "cannot read entry without cause",
+      "formatted": "cannot read entry without cause",
+      "effective_exit_code": 1,
+      "is_not_found": false,
+      "is_write_error": false
+    },
+    {
+      "name": "write_failed",
+      "code": 1,
+      "kind": 4,
+      "message": "cannot write entry",
+      "cause_kind": "other",
+      "cause_message": "disk full",
+      "error": "cannot write entry: disk full",
+      "formatted": "cannot write entry: disk full",
+      "effective_exit_code": 1,
+      "is_not_found": false,
+      "is_write_error": true
+    },
+    {
+      "name": "write_failed_nil",
+      "code": 1,
+      "kind": 4,
+      "message": "cannot write entry without cause",
+      "error": "cannot write entry without cause",
+      "formatted": "cannot write entry without cause",
+      "effective_exit_code": 1,
+      "is_not_found": false,
+      "is_write_error": true
+    },
+    {
+      "name": "not_initialized",
+      "code": 3,
+      "kind": 0,
+      "message": "vault not initialized at /vault",
+      "cause_kind": "vault_not_initialized",
+      "cause_message": "vault not initialized",
+      "hint": "Run: symvault init to initialize a new vault.",
+      "error": "vault not initialized at /vault",
+      "formatted": "vault not initialized at /vault\nHint: Run: symvault init to initialize a new vault.",
+      "effective_exit_code": 3,
+      "is_not_found": false,
+      "is_write_error": false
+    },
+    {
+      "name": "new_vault_not_initialized",
+      "code": 3,
+      "kind": 0,
+      "message": "vault not initialized. Run 'symvault init' first",
+      "cause_kind": "vault_not_initialized",
+      "cause_message": "vault not initialized",
+      "error": "vault not initialized. Run 'symvault init' first",
+      "formatted": "vault not initialized. Run 'symvault init' first",
+      "effective_exit_code": 3,
+      "is_not_found": false,
+      "is_write_error": false
+    },
+    {
+      "name": "locked",
+      "code": 4,
+      "kind": 0,
+      "message": "session expired",
+      "cause_kind": "vault_locked",
+      "cause_message": "vault locked",
+      "hint": "Run: symvault unlock to unlock the vault, or set a passphrase via 'symvault auth set passphrase'.",
+      "error": "session expired: vault locked",
+      "formatted": "session expired: vault locked\nHint: Run: symvault unlock to unlock the vault, or set a passphrase via 'symvault auth set passphrase'.",
+      "effective_exit_code": 4,
+      "is_not_found": false,
+      "is_write_error": false
+    },
+    {
+      "name": "permission_denied",
+      "code": 5,
+      "kind": 0,
+      "message": "agent cannot write",
+      "cause_kind": "permission_denied",
+      "cause_message": "permission denied",
+      "error": "agent cannot write: permission denied",
+      "formatted": "agent cannot write: permission denied",
+      "effective_exit_code": 5,
+      "is_not_found": false,
+      "is_write_error": false
+    },
+    {
+      "name": "invalid_input",
+      "code": 9,
+      "kind": 0,
+      "message": "length must be positive",
+      "error": "length must be positive",
+      "formatted": "length must be positive",
+      "effective_exit_code": 9,
+      "is_not_found": false,
+      "is_write_error": false
+    },
+    {
+      "name": "config_error",
+      "code": 6,
+      "kind": 0,
+      "message": "config value is invalid",
+      "error": "config value is invalid",
+      "formatted": "config value is invalid",
+      "effective_exit_code": 6,
+      "is_not_found": false,
+      "is_write_error": false
+    },
+    {
+      "name": "internal",
+      "code": 1,
+      "kind": 0,
+      "message": "unexpected state",
+      "error": "unexpected state",
+      "formatted": "unexpected state",
+      "effective_exit_code": 1,
+      "is_not_found": false,
+      "is_write_error": false
+    },
+    {
+      "name": "already_exists",
+      "code": 1,
+      "kind": 0,
+      "message": "entry already exists",
+      "error": "entry already exists",
+      "formatted": "entry already exists",
+      "effective_exit_code": 1,
+      "is_not_found": false,
+      "is_write_error": false
+    },
+    {
+      "name": "custom_hint",
+      "code": 1,
+      "kind": 0,
+      "message": "operation failed",
+      "hint": "Run symvault doctor",
+      "error": "operation failed",
+      "formatted": "operation failed\nHint: Run symvault doctor",
+      "effective_exit_code": 1,
+      "is_not_found": false,
+      "is_write_error": false
+    },
+    {
+      "name": "sentinel_priority",
+      "code": 1,
+      "kind": 0,
+      "message": "locked wrapper",
+      "cause_kind": "vault_locked",
+      "cause_message": "outer: vault locked",
+      "error": "locked wrapper: outer: vault locked",
+      "formatted": "locked wrapper: outer: vault locked",
+      "effective_exit_code": 4,
+      "is_not_found": false,
+      "is_write_error": false
+    }
+  ],
+  "exit_resolutions": [
+    {
+      "name": "nil",
+      "code": 0
+    },
+    {
+      "name": "plain",
+      "code": 1
+    },
+    {
+      "name": "entry_not_found",
+      "code": 2
+    },
+    {
+      "name": "vault_not_initialized",
+      "code": 3
+    },
+    {
+      "name": "vault_locked",
+      "code": 4
+    },
+    {
+      "name": "permission_denied",
+      "code": 5
+    }
+  ],
+  "corekit_mappings": [
+    {
+      "vault": 0,
+      "corekit": 0
+    },
+    {
+      "vault": 1,
+      "corekit": 1
+    },
+    {
+      "vault": 2,
+      "corekit": 5
+    },
+    {
+      "vault": 3,
+      "corekit": 1
+    },
+    {
+      "vault": 4,
+      "corekit": 1
+    },
+    {
+      "vault": 5,
+      "corekit": 4
+    },
+    {
+      "vault": 6,
+      "corekit": 9
+    },
+    {
+      "vault": 7,
+      "corekit": 1
+    },
+    {
+      "vault": 8,
+      "corekit": 1
+    },
+    {
+      "vault": 9,
+      "corekit": 2
+    },
+    {
+      "vault": 10,
+      "corekit": 1
+    }
+  ],
+  "corekit_reverse_mappings": [
+    {
+      "vault": 0,
+      "corekit": 0
+    },
+    {
+      "vault": 1,
+      "corekit": 1
+    },
+    {
+      "vault": 9,
+      "corekit": 2
+    },
+    {
+      "vault": 5,
+      "corekit": 4
+    },
+    {
+      "vault": 2,
+      "corekit": 5
+    },
+    {
+      "vault": 6,
+      "corekit": 9
+    },
+    {
+      "vault": 1,
+      "corekit": 42
+    }
+  ]
+}

--- a/testdata/port/core/redact-contract.json
+++ b/testdata/port/core/redact-contract.json
@@ -1,0 +1,504 @@
+{
+  "schema_version": 1,
+  "oracle": {
+    "commit": "caadd5e",
+    "release": "v0.22.1"
+  },
+  "constants": {
+    "marker": "[REDACTED]",
+    "blocked_text": "[REDACTED: output withheld]",
+    "min_exact_value_len": 4,
+    "min_token_len": 20,
+    "min_entropy_bits_per_char": 4.85
+  },
+  "exact_value_cases": [
+    {
+      "name": "single_secret",
+      "secrets": [
+        "sup3r-s3cret-value-xyz"
+      ],
+      "input": "the password is sup3r-s3cret-value-xyz and that's it",
+      "expected_redacted": "the password is [REDACTED] and that's it",
+      "expected_count": 1
+    },
+    {
+      "name": "repeat_secret",
+      "secrets": [
+        "sup3r-s3cret-value-xyz"
+      ],
+      "input": "token=sup3r-s3cret-value-xyz and repeat sup3r-s3cret-value-xyz end",
+      "expected_redacted": "token=[REDACTED] and repeat [REDACTED] end",
+      "expected_count": 2
+    },
+    {
+      "name": "multiple_secrets",
+      "secrets": [
+        "first-secret-token",
+        "second-secret-key"
+      ],
+      "input": "first: first-secret-token, second: second-secret-key",
+      "expected_redacted": "first: [REDACTED], second: [REDACTED]",
+      "expected_count": 2
+    },
+    {
+      "name": "short_and_empty_ignored",
+      "secrets": [
+        "",
+        "a",
+        "ab",
+        "abc"
+      ],
+      "input": "ab is short and empty is nothing",
+      "expected_redacted": "ab is short and empty is nothing",
+      "expected_count": 0
+    },
+    {
+      "name": "no_match",
+      "secrets": [
+        "absent-secret-token"
+      ],
+      "input": "clean text without secrets",
+      "expected_redacted": "clean text without secrets",
+      "expected_count": 0
+    },
+    {
+      "name": "empty_input",
+      "secrets": [
+        "any-secret-token"
+      ],
+      "input": "",
+      "expected_redacted": "",
+      "expected_count": 0
+    }
+  ],
+  "entropy_cases": [
+    {
+      "name": "high_entropy_token",
+      "input": "config value: kQ7#zM2$pL9@rT4!vX8\u0026wY6^bN3*cJ1~ end",
+      "expected_redacted": "config value: [REDACTED] end",
+      "expected_count": 1
+    },
+    {
+      "name": "ordinary_prose",
+      "input": "This is a perfectly ordinary sentence about deploying the release pipeline on Friday afternoon.",
+      "expected_redacted": "This is a perfectly ordinary sentence about deploying the release pipeline on Friday afternoon.",
+      "expected_count": 0
+    },
+    {
+      "name": "short_token",
+      "input": "short=aB3$kZ9",
+      "expected_redacted": "short=aB3$kZ9",
+      "expected_count": 0
+    },
+    {
+      "name": "uuid_v4",
+      "input": "request_id=f47ac10b-58cc-4372-a567-0e02b2c3d479",
+      "expected_redacted": "request_id=f47ac10b-58cc-4372-a567-0e02b2c3d479",
+      "expected_count": 0
+    },
+    {
+      "name": "sha256_hash",
+      "input": "checksum=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "expected_redacted": "checksum=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "expected_count": 0
+    },
+    {
+      "name": "base64_payload",
+      "input": "payload=VGhpcyBpcyBqdXN0IGEgcGxhaW4gRW5nbGlzaCBzZW50ZW5jZSBlbmNvZGVkIGFzIGJhc2U2NA==",
+      "expected_redacted": "[REDACTED]",
+      "expected_count": 1
+    },
+    {
+      "name": "long_numeric_identifier",
+      "input": "order_id=12345678901234567890123456789012",
+      "expected_redacted": "order_id=12345678901234567890123456789012",
+      "expected_count": 0
+    },
+    {
+      "name": "empty_input",
+      "input": "",
+      "expected_redacted": "",
+      "expected_count": 0
+    }
+  ],
+  "scanner_cases": [
+    {
+      "name": "no_detectors",
+      "detectors": [],
+      "strict": false,
+      "input": "hello world",
+      "expected_text": "hello world",
+      "expected_blocked": false,
+      "findings": [],
+      "audit_events": []
+    },
+    {
+      "name": "exact_non_strict",
+      "detectors": [
+        "exact_value"
+      ],
+      "secrets": [
+        "redactmesoftvalue1"
+      ],
+      "strict": false,
+      "correlation_id": "corr-2",
+      "channel": "test.stdout",
+      "input": "output containing redactmesoftvalue1 here, and more text after",
+      "expected_text": "output containing [REDACTED] here, and more text after",
+      "expected_blocked": false,
+      "findings": [
+        {
+          "detector": "exact_value",
+          "confidence": "high",
+          "count": 1
+        }
+      ],
+      "audit_events": [
+        {
+          "detector": "exact_value",
+          "channel": "test.stdout",
+          "confidence": "high",
+          "redacted_count": 1,
+          "blocked": false,
+          "correlation_id": "corr-2"
+        }
+      ]
+    },
+    {
+      "name": "exact_strict",
+      "detectors": [
+        "exact_value"
+      ],
+      "secrets": [
+        "blockmehardvalue1"
+      ],
+      "strict": true,
+      "correlation_id": "corr-1",
+      "channel": "test.stdout",
+      "input": "output containing blockmehardvalue1 here",
+      "expected_text": "[REDACTED: output withheld]",
+      "expected_blocked": true,
+      "findings": [
+        {
+          "detector": "exact_value",
+          "confidence": "high",
+          "count": 1
+        }
+      ],
+      "audit_events": [
+        {
+          "detector": "exact_value",
+          "channel": "test.stdout",
+          "confidence": "high",
+          "redacted_count": 1,
+          "blocked": true,
+          "correlation_id": "corr-1"
+        }
+      ]
+    },
+    {
+      "name": "entropy_non_strict",
+      "detectors": [
+        "entropy_heuristic"
+      ],
+      "strict": false,
+      "correlation_id": "corr-3",
+      "channel": "test.channel",
+      "input": "value: kQ7#zM2$pL9@rT4!vX8\u0026wY6^bN3*cJ1~ end",
+      "expected_text": "value: [REDACTED] end",
+      "expected_blocked": false,
+      "findings": [
+        {
+          "detector": "entropy_heuristic",
+          "confidence": "low",
+          "count": 1
+        }
+      ],
+      "audit_events": [
+        {
+          "detector": "entropy_heuristic",
+          "channel": "test.channel",
+          "confidence": "low",
+          "redacted_count": 1,
+          "blocked": false,
+          "correlation_id": "corr-3"
+        }
+      ]
+    },
+    {
+      "name": "entropy_strict",
+      "detectors": [
+        "entropy_heuristic"
+      ],
+      "strict": true,
+      "correlation_id": "corr-4",
+      "channel": "test.channel",
+      "input": "value: kQ7#zM2$pL9@rT4!vX8\u0026wY6^bN3*cJ1~ end",
+      "expected_text": "value: [REDACTED] end",
+      "expected_blocked": false,
+      "findings": [
+        {
+          "detector": "entropy_heuristic",
+          "confidence": "low",
+          "count": 1
+        }
+      ],
+      "audit_events": [
+        {
+          "detector": "entropy_heuristic",
+          "channel": "test.channel",
+          "confidence": "low",
+          "redacted_count": 1,
+          "blocked": false,
+          "correlation_id": "corr-4"
+        }
+      ]
+    },
+    {
+      "name": "both_non_strict",
+      "detectors": [
+        "exact_value",
+        "entropy_heuristic"
+      ],
+      "secrets": [
+        "mysecretpassword"
+      ],
+      "strict": false,
+      "correlation_id": "corr-5",
+      "channel": "test.stdout",
+      "input": "pass: mysecretpassword, blob: kQ7#zM2$pL9@rT4!vX8\u0026wY6^bN3*cJ1~",
+      "expected_text": "pass: [REDACTED], blob: [REDACTED]",
+      "expected_blocked": false,
+      "findings": [
+        {
+          "detector": "exact_value",
+          "confidence": "high",
+          "count": 1
+        },
+        {
+          "detector": "entropy_heuristic",
+          "confidence": "low",
+          "count": 1
+        }
+      ],
+      "audit_events": [
+        {
+          "detector": "exact_value",
+          "channel": "test.stdout",
+          "confidence": "high",
+          "redacted_count": 1,
+          "blocked": false,
+          "correlation_id": "corr-5"
+        },
+        {
+          "detector": "entropy_heuristic",
+          "channel": "test.stdout",
+          "confidence": "low",
+          "redacted_count": 1,
+          "blocked": false,
+          "correlation_id": "corr-5"
+        }
+      ]
+    },
+    {
+      "name": "both_strict",
+      "detectors": [
+        "exact_value",
+        "entropy_heuristic"
+      ],
+      "secrets": [
+        "mysecretpassword"
+      ],
+      "strict": true,
+      "correlation_id": "corr-6",
+      "channel": "test.stdout",
+      "input": "pass: mysecretpassword, blob: kQ7#zM2$pL9@rT4!vX8\u0026wY6^bN3*cJ1~",
+      "expected_text": "[REDACTED: output withheld]",
+      "expected_blocked": true,
+      "findings": [
+        {
+          "detector": "exact_value",
+          "confidence": "high",
+          "count": 1
+        },
+        {
+          "detector": "entropy_heuristic",
+          "confidence": "low",
+          "count": 1
+        }
+      ],
+      "audit_events": [
+        {
+          "detector": "exact_value",
+          "channel": "test.stdout",
+          "confidence": "high",
+          "redacted_count": 1,
+          "blocked": true,
+          "correlation_id": "corr-6"
+        },
+        {
+          "detector": "entropy_heuristic",
+          "channel": "test.stdout",
+          "confidence": "low",
+          "redacted_count": 1,
+          "blocked": true,
+          "correlation_id": "corr-6"
+        }
+      ]
+    },
+    {
+      "name": "json_structure",
+      "detectors": [
+        "exact_value"
+      ],
+      "secrets": [
+        "topsecretvalue1"
+      ],
+      "strict": false,
+      "input": "{\"stdout\":\"login ok, token=topsecretvalue1\",\"exit_code\":0}",
+      "expected_text": "{\"stdout\":\"login ok, token=[REDACTED]\",\"exit_code\":0}",
+      "expected_blocked": false,
+      "findings": [
+        {
+          "detector": "exact_value",
+          "confidence": "high",
+          "count": 1
+        }
+      ],
+      "audit_events": [
+        {
+          "detector": "exact_value",
+          "channel": "",
+          "confidence": "high",
+          "redacted_count": 1,
+          "blocked": false,
+          "correlation_id": ""
+        }
+      ]
+    },
+    {
+      "name": "multiline",
+      "detectors": [
+        "exact_value"
+      ],
+      "secrets": [
+        "multilinesecretval"
+      ],
+      "strict": false,
+      "input": "line one\nline two multilinesecretval\nline three (truncat",
+      "expected_text": "line one\nline two [REDACTED]\nline three (truncat",
+      "expected_blocked": false,
+      "findings": [
+        {
+          "detector": "exact_value",
+          "confidence": "high",
+          "count": 1
+        }
+      ],
+      "audit_events": [
+        {
+          "detector": "exact_value",
+          "channel": "",
+          "confidence": "high",
+          "redacted_count": 1,
+          "blocked": false,
+          "correlation_id": ""
+        }
+      ]
+    },
+    {
+      "name": "no_matches",
+      "detectors": [
+        "exact_value",
+        "entropy_heuristic"
+      ],
+      "secrets": [
+        "absentpassword"
+      ],
+      "strict": true,
+      "input": "normal text with no secrets",
+      "expected_text": "normal text with no secrets",
+      "expected_blocked": false,
+      "findings": [],
+      "audit_events": []
+    }
+  ],
+  "truthy_cases": [
+    {
+      "input": "1",
+      "expected": true
+    },
+    {
+      "input": "t",
+      "expected": true
+    },
+    {
+      "input": "T",
+      "expected": true
+    },
+    {
+      "input": "true",
+      "expected": true
+    },
+    {
+      "input": "TRUE",
+      "expected": true
+    },
+    {
+      "input": "True",
+      "expected": true
+    },
+    {
+      "input": "yes",
+      "expected": true
+    },
+    {
+      "input": "YES",
+      "expected": true
+    },
+    {
+      "input": "Yes",
+      "expected": true
+    },
+    {
+      "input": "on",
+      "expected": true
+    },
+    {
+      "input": "ON",
+      "expected": true
+    },
+    {
+      "input": "On",
+      "expected": true
+    },
+    {
+      "input": "",
+      "expected": false
+    },
+    {
+      "input": "0",
+      "expected": false
+    },
+    {
+      "input": "false",
+      "expected": false
+    },
+    {
+      "input": "no",
+      "expected": false
+    },
+    {
+      "input": "off",
+      "expected": false
+    },
+    {
+      "input": "random",
+      "expected": false
+    },
+    {
+      "input": "TRUE ",
+      "expected": false
+    }
+  ]
+}

--- a/testdata/port/core/secret-ref-contract.json
+++ b/testdata/port/core/secret-ref-contract.json
@@ -1,0 +1,290 @@
+{
+  "schema_version": 1,
+  "oracle": {
+    "commit": "caadd5e",
+    "release": "v0.22.1"
+  },
+  "parse_ref_cases": [
+    {
+      "name": "op_full_path",
+      "input": "op://work/aws/password",
+      "valid": true,
+      "path": "work/aws",
+      "field": "password"
+    },
+    {
+      "name": "op_simple_path",
+      "input": "op://github/token",
+      "valid": true,
+      "path": "github",
+      "field": "token"
+    },
+    {
+      "name": "op_nested_path",
+      "input": "op://work/team/aws/password",
+      "valid": true,
+      "path": "work/team/aws",
+      "field": "password"
+    },
+    {
+      "name": "op_two_segments",
+      "input": "op://work/aws",
+      "valid": true,
+      "path": "work",
+      "field": "aws"
+    },
+    {
+      "name": "op_deeply_nested",
+      "input": "op://org/team/project/service/api/key",
+      "valid": true,
+      "path": "org/team/project/service/api",
+      "field": "key"
+    },
+    {
+      "name": "op_trailing_slash",
+      "input": "op://work/aws/",
+      "valid": false,
+      "path": "",
+      "field": "",
+      "error_message": "invalid secret reference: missing field in op:// reference: op://work/aws/"
+    },
+    {
+      "name": "op_single_segment",
+      "input": "op://work",
+      "valid": false,
+      "path": "",
+      "field": "",
+      "error_message": "invalid secret reference: missing field in op:// reference: op://work"
+    },
+    {
+      "name": "op_empty_rest",
+      "input": "op://",
+      "valid": false,
+      "path": "",
+      "field": "",
+      "error_message": "invalid secret reference: missing field in op:// reference: op://"
+    },
+    {
+      "name": "op_slash_only",
+      "input": "op:///",
+      "valid": false,
+      "path": "",
+      "field": "",
+      "error_message": "invalid secret reference: missing field in op:// reference: op:///"
+    },
+    {
+      "name": "op_leading_slash",
+      "input": "op:///github",
+      "valid": true,
+      "path": "",
+      "field": "github"
+    },
+    {
+      "name": "dot_notation_nested",
+      "input": "work/aws.password",
+      "valid": true,
+      "path": "work/aws",
+      "field": "password"
+    },
+    {
+      "name": "dot_notation_simple",
+      "input": "github.token",
+      "valid": true,
+      "path": "github",
+      "field": "token"
+    },
+    {
+      "name": "dot_notation_deep",
+      "input": "work/team/aws.password",
+      "valid": true,
+      "path": "work/team/aws",
+      "field": "password"
+    },
+    {
+      "name": "dot_in_field",
+      "input": "work/aws.api.key",
+      "valid": true,
+      "path": "work/aws.api",
+      "field": "key"
+    },
+    {
+      "name": "dot_minimal",
+      "input": "a.b",
+      "valid": true,
+      "path": "a",
+      "field": "b"
+    },
+    {
+      "name": "dot_missing_field",
+      "input": "work/aws",
+      "valid": false,
+      "path": "",
+      "field": "",
+      "error_message": "invalid secret reference: expected path.field or op://path/field syntax, got: work/aws"
+    },
+    {
+      "name": "dot_leading_dot",
+      "input": ".password",
+      "valid": false,
+      "path": "",
+      "field": "",
+      "error_message": "invalid secret reference: expected path.field or op://path/field syntax, got: .password"
+    },
+    {
+      "name": "dot_trailing_dot",
+      "input": "work/aws.",
+      "valid": false,
+      "path": "",
+      "field": "",
+      "error_message": "invalid secret reference: expected path.field or op://path/field syntax, got: work/aws."
+    },
+    {
+      "name": "empty",
+      "input": "",
+      "valid": false,
+      "path": "",
+      "field": "",
+      "error_message": "invalid secret reference: empty reference"
+    },
+    {
+      "name": "plain_word",
+      "input": "notavalidref",
+      "valid": false,
+      "path": "",
+      "field": "",
+      "error_message": "invalid secret reference: expected path.field or op://path/field syntax, got: notavalidref"
+    },
+    {
+      "name": "field_only",
+      "input": "password",
+      "valid": false,
+      "path": "",
+      "field": "",
+      "error_message": "invalid secret reference: expected path.field or op://path/field syntax, got: password"
+    },
+    {
+      "name": "invalid_scheme",
+      "input": "://path/field",
+      "valid": false,
+      "path": "",
+      "field": "",
+      "error_message": "invalid secret reference: expected path.field or op://path/field syntax, got: ://path/field"
+    },
+    {
+      "name": "missing_slashes",
+      "input": "op:path/field",
+      "valid": false,
+      "path": "",
+      "field": "",
+      "error_message": "invalid secret reference: expected path.field or op://path/field syntax, got: op:path/field"
+    }
+  ],
+  "parse_handle_cases": [
+    {
+      "name": "handle_full_path",
+      "input": "op://work/aws/password",
+      "valid": true,
+      "path": "work/aws",
+      "field": "password",
+      "string_repr": "op://work/aws/password"
+    },
+    {
+      "name": "handle_simple_path",
+      "input": "op://github/token",
+      "valid": true,
+      "path": "github",
+      "field": "token",
+      "string_repr": "op://github/token"
+    },
+    {
+      "name": "handle_nested_path",
+      "input": "op://work/team/aws/password",
+      "valid": true,
+      "path": "work/team/aws",
+      "field": "password",
+      "string_repr": "op://work/team/aws/password"
+    },
+    {
+      "name": "handle_two_segments",
+      "input": "op://work/aws",
+      "valid": true,
+      "path": "work",
+      "field": "aws",
+      "string_repr": "op://work/aws"
+    },
+    {
+      "name": "handle_path_only",
+      "input": "op://work",
+      "valid": true,
+      "path": "work",
+      "field": "",
+      "string_repr": "op://work/"
+    },
+    {
+      "name": "handle_personal_notes",
+      "input": "op://personal/notes",
+      "valid": true,
+      "path": "personal",
+      "field": "notes",
+      "string_repr": "op://personal/notes"
+    },
+    {
+      "name": "handle_trailing_slash",
+      "input": "op://personal/notes/",
+      "valid": true,
+      "path": "personal/notes/",
+      "field": "",
+      "string_repr": "op://personal/notes//"
+    },
+    {
+      "name": "handle_single",
+      "input": "op://single",
+      "valid": true,
+      "path": "single",
+      "field": "",
+      "string_repr": "op://single/"
+    },
+    {
+      "name": "handle_empty",
+      "input": "",
+      "valid": false,
+      "path": "",
+      "field": ""
+    },
+    {
+      "name": "handle_prefix_only",
+      "input": "op://",
+      "valid": false,
+      "path": "",
+      "field": ""
+    },
+    {
+      "name": "handle_prefix_slash",
+      "input": "op:///",
+      "valid": false,
+      "path": "",
+      "field": ""
+    },
+    {
+      "name": "handle_not_handle",
+      "input": "not-a-handle",
+      "valid": false,
+      "path": "",
+      "field": ""
+    },
+    {
+      "name": "handle_invalid_scheme",
+      "input": "://path/field",
+      "valid": false,
+      "path": "",
+      "field": ""
+    },
+    {
+      "name": "handle_dot_notation",
+      "input": "work/aws.password",
+      "valid": false,
+      "path": "",
+      "field": ""
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- freeze the Go error taxonomy, secret-reference parsing, and redaction behavior as generated language-neutral fixtures
- add safe Rust implementations in `symvault-core`
- keep `RUST-003` in progress until policy, quota, password, TOTP, and type contracts are complete

## Verification

- `make port-contract`
- `make rust-gates`
- `cargo +nightly miri test -p symvault-core` (39 tests)
- separate specification review: PASS
- separate quality/security review: APPROVED
- added-line secret-pattern scan: PASS

## Risk and rollback

Go remains the production implementation and executable oracle. The new Rust code is not wired into production paths. Reverting this PR removes only staged fixtures and Rust core implementations.
