### PR TITLE
fix(rust-port): use Windows job objects for process trees

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -297,6 +297,31 @@ jobs:
         run: |
           go test -v -timeout=15m -skip 'TestFlow|TestBinaryE2E|Integration' ./...
 
+  windows-process-tree:
+    name: Process tree (Windows) — PR
+    if: github.event_name == 'pull_request'
+    runs-on: windows-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: '1.26.6'
+          cache: true
+
+      - name: Install dependencies
+        run: go mod download
+
+      - name: Run Windows process-tree regression
+        run: >-
+          go test -v -timeout=5m
+          -run "TestCommandTimedOutRequiresEffectiveTreeCancellation|TestRunNaturalNonzeroExitIsNotTimedOut|TestRunDeadlineWithoutEffectiveTreeCancellationPreservesNaturalExit|TestRunPreservesWaitDelayWhenTreeIsAlreadyGone|TestRunAssignmentFailureCleansUpSynchronously|TestRunAssignmentFailureKillsUnassignedSuspendedProcess|TestWindowsClassifyAlreadyGoneWaitDelayEINVAL|TestRunTimeoutKillsDescendantJobObject|TestRunTimeoutWaitsForInheritedPipeCleanup|TestWindowsProcessTreeLifecycleAndErrors|TestWindowsProcessTreeKillReportsActiveJob|TestWindowsProcessTreeKillReportsEmptyJob"
+          ./scripts/rust-port/internal/diff
+
   build-pr:
     name: Build (linux-amd64) — PR
     if: github.event_name == 'pull_request'
@@ -708,8 +733,8 @@ jobs:
   #
   # Uses if: always() so that skipped main-only jobs (fuzz, integration-test,
   # smoke-test, the full test/build matrices) don't block the PR gate.
-  # On PR: test-pr + build-pr must pass. On main: test + build + fuzz +
-  # integration-test + smoke-test must pass.
+  # On PR: test-pr + windows-process-tree + build-pr must pass. On main:
+  # test + build + fuzz + integration-test + smoke-test must pass.
 
   ci-gate:
     name: CI Success
@@ -720,6 +745,7 @@ jobs:
       - dependency-scan
       - lint
       - test-pr
+      - windows-process-tree
       - test
       - fuzz
       - build-pr
@@ -743,6 +769,7 @@ jobs:
           RES_RUST: ${{ needs.rust.result }}
           RES_RUST_NATIVE: ${{ needs.rust-native.result }}
           RES_TEST_PR: ${{ needs.test-pr.result }}
+          RES_WINDOWS_PROCESS_TREE: ${{ needs.windows-process-tree.result }}
           RES_BUILD_PR: ${{ needs.build-pr.result }}
           RES_TEST: ${{ needs.test.result }}
           RES_FUZZ: ${{ needs.fuzz.result }}
@@ -774,6 +801,7 @@ jobs:
 
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             check "$RES_TEST_PR"   test-pr
+            check "$RES_WINDOWS_PROCESS_TREE" windows-process-tree
             check "$RES_BUILD_PR"  build-pr
             # Main-only jobs: must be ok (skipped/success), must not have failed
             check "$RES_TEST"             test

--- a/scripts/rust-port/internal/diff/diff_test.go
+++ b/scripts/rust-port/internal/diff/diff_test.go
@@ -1,11 +1,14 @@
 package diff
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"reflect"
+	"strconv"
 	"testing"
 	"time"
 )
@@ -58,6 +61,339 @@ func TestRunTimesOutAndTerminatesProcess(t *testing.T) {
 	}
 	if !result.TimedOut {
 		t.Fatal("expected process timeout")
+	}
+}
+
+func TestCommandTimedOutRequiresEffectiveTreeCancellation(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Nanosecond)
+	defer cancel()
+	<-ctx.Done()
+
+	for _, test := range []struct {
+		name      string
+		effective bool
+		want      bool
+	}{
+		{name: "natural success", effective: false, want: false},
+		{name: "natural nonzero exit", effective: false, want: false},
+		{name: "effective kill", effective: true, want: true},
+		{name: "active lingering descendant", effective: true, want: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := commandTimedOut(ctx, test.effective); got != test.want {
+				t.Fatalf("commandTimedOut(effective=%t) = %t, want %t", test.effective, got, test.want)
+			}
+		})
+	}
+}
+
+func TestClassifyWaitErrorPreservesWaitDelayWithoutTimeout(t *testing.T) {
+	err := classifyWaitError(exec.ErrWaitDelay, false, false, false, false, false)
+	if err == nil {
+		t.Fatal("non-timeout ErrWaitDelay was suppressed")
+	}
+	if !errors.Is(err, exec.ErrWaitDelay) {
+		t.Fatalf("error = %v, want ErrWaitDelay", err)
+	}
+}
+
+func TestRunNormalExit(t *testing.T) {
+	result, err := Run(os.Args[0], Case{
+		ID:        "normal-exit",
+		Args:      []string{"-test.run=TestRunAndCompareIdenticalHelper"},
+		Env:       map[string]string{"SYMVAULT_PORT_HELPER": "1", "PORT_OUTPUT": "${WORKSPACE}/out.txt"},
+		TimeoutMS: 5000,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.TimedOut {
+		t.Fatal("normal process was marked timed out")
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("exit code = %d, want 0", result.ExitCode)
+	}
+	if got := string(result.Stdout); got != "ok\nPASS\n" {
+		t.Fatalf("stdout = %q, want helper output", got)
+	}
+}
+
+func TestRunNaturalNonzeroExitIsNotTimedOut(t *testing.T) {
+	result, err := Run(os.Args[0], Case{
+		ID:        "natural-nonzero-exit",
+		Args:      []string{"-test.run=TestRunAndCompareIdenticalHelper"},
+		Env:       map[string]string{"SYMVAULT_PORT_HELPER": "1", "PORT_HELPER_MODE": "exit-nonzero"},
+		TimeoutMS: 5000,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.TimedOut {
+		t.Fatal("natural nonzero exit was marked timed out")
+	}
+	if result.ExitCode != 7 {
+		t.Fatalf("exit code = %d, want 7", result.ExitCode)
+	}
+}
+
+func TestRunDeadlineWithoutEffectiveTreeCancellationPreservesNaturalExit(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		mode     string
+		exitCode int
+	}{
+		{name: "success", mode: "delayed-success", exitCode: 0},
+		{name: "nonzero", mode: "delayed-nonzero", exitCode: 7},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			originalFactory := processTreeFactory
+			var fakeTree *timeoutTestProcessTree
+			processTreeFactory = func(cmd *exec.Cmd) (processTree, error) {
+				fakeTree = &timeoutTestProcessTree{cmd: cmd}
+				return fakeTree, nil
+			}
+			t.Cleanup(func() { processTreeFactory = originalFactory })
+
+			result, err := Run(os.Args[0], Case{
+				ID:        "deadline-natural-" + test.name,
+				Args:      []string{"-test.run=TestRunAndCompareIdenticalHelper"},
+				Env:       map[string]string{"SYMVAULT_PORT_HELPER": "1", "PORT_HELPER_MODE": test.mode},
+				TimeoutMS: 50,
+			})
+			if err != nil {
+				t.Fatalf("Run: %v", err)
+			}
+			if result.TimedOut {
+				t.Fatal("natural exit after ineffective cancellation was marked timed out")
+			}
+			if result.ExitCode != test.exitCode {
+				t.Fatalf("exit code = %d, want %d", result.ExitCode, test.exitCode)
+			}
+			if fakeTree == nil || fakeTree.killCalls != 1 {
+				t.Fatalf("tree.Kill calls = %d, want 1", fakeTree.killCalls)
+			}
+		})
+	}
+}
+
+func TestRunTimeoutWaitsForInheritedPipeCleanup(t *testing.T) {
+	pidPath := filepath.Join(t.TempDir(), "child.pid")
+	stopPath := filepath.Join(t.TempDir(), "stop")
+	donePath := filepath.Join(t.TempDir(), "done")
+	originalFactory := processTreeFactory
+	var fakeTree *timeoutTestProcessTree
+	processTreeFactory = func(cmd *exec.Cmd) (processTree, error) {
+		// Leave the controlled descendant alive so this test exercises
+		// os/exec's pipe-copy timeout rather than process-tree termination.
+		fakeTree = &timeoutTestProcessTree{cmd: cmd, killEffective: true}
+		return fakeTree, nil
+	}
+	stopDescendant := func() {
+		_ = os.WriteFile(stopPath, []byte("stop\n"), 0o600)
+		deadline := time.Now().Add(2 * time.Second)
+		for time.Now().Before(deadline) {
+			if _, err := os.Stat(donePath); err == nil {
+				return
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+		if pidBytes, err := os.ReadFile(pidPath); err == nil {
+			if pid, parseErr := strconv.Atoi(string(pidBytes)); parseErr == nil {
+				if process, findErr := os.FindProcess(pid); findErr == nil {
+					_ = process.Kill()
+				}
+			}
+		}
+		t.Errorf("controlled descendant did not acknowledge cleanup")
+	}
+	t.Cleanup(func() {
+		stopDescendant()
+		processTreeFactory = originalFactory
+	})
+
+	started := time.Now()
+	result, err := Run(os.Args[0], Case{
+		ID:   "timeout-inherited-pipes",
+		Args: []string{"-test.run=TestRunAndCompareIdenticalHelper"},
+		Env: map[string]string{
+			"SYMVAULT_PORT_HELPER": "1",
+			"PORT_HELPER_MODE":     "pipe-leak",
+			"PORT_CHILD_PID":       pidPath,
+			"PORT_CHILD_STOP":      stopPath,
+			"PORT_CHILD_DONE":      donePath,
+		},
+		TimeoutMS: 100,
+	})
+	if elapsed := time.Since(started); elapsed > processWaitDelay+time.Second {
+		t.Fatalf("Run exceeded timeout+WaitDelay bound: %s", elapsed)
+	}
+	if err != nil {
+		t.Fatalf("bounded inherited-pipe cleanup: %v", err)
+	}
+	if !result.TimedOut {
+		t.Fatal("expected process timeout")
+	}
+	if fakeTree == nil {
+		t.Fatal("process-tree factory was not called")
+	}
+	if fakeTree.killCalls != 1 {
+		t.Fatalf("process-tree cleanup calls = %d, want 1", fakeTree.killCalls)
+	}
+	pidBytes, readErr := os.ReadFile(pidPath)
+	if readErr != nil {
+		t.Fatalf("read controlled descendant PID: %v", readErr)
+	}
+	if _, parseErr := strconv.Atoi(string(pidBytes)); parseErr != nil {
+		t.Fatalf("parse controlled descendant PID %q: %v", string(pidBytes), parseErr)
+	}
+	stopDescendant()
+}
+
+func TestRunPreservesWaitDelayWhenTreeIsAlreadyGone(t *testing.T) {
+	pidPath := filepath.Join(t.TempDir(), "child.pid")
+	stopPath := filepath.Join(t.TempDir(), "stop")
+	donePath := filepath.Join(t.TempDir(), "done")
+	originalFactory := processTreeFactory
+	var fakeTree *timeoutTestProcessTree
+	processTreeFactory = func(cmd *exec.Cmd) (processTree, error) {
+		fakeTree = &timeoutTestProcessTree{cmd: cmd}
+		return fakeTree, nil
+	}
+	stopDescendant := func() {
+		_ = os.WriteFile(stopPath, []byte("stop\n"), 0o600)
+		deadline := time.Now().Add(2 * time.Second)
+		for time.Now().Before(deadline) {
+			if _, err := os.Stat(donePath); err == nil {
+				return
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+		if pidBytes, err := os.ReadFile(pidPath); err == nil {
+			if pid, parseErr := strconv.Atoi(string(pidBytes)); parseErr == nil {
+				if process, findErr := os.FindProcess(pid); findErr == nil {
+					_ = process.Kill()
+				}
+			}
+		}
+		t.Errorf("controlled descendant did not acknowledge cleanup")
+	}
+	t.Cleanup(func() {
+		stopDescendant()
+		processTreeFactory = originalFactory
+	})
+
+	started := time.Now()
+	_, err := Run(os.Args[0], Case{
+		ID:   "natural-exit-inherited-pipes",
+		Args: []string{"-test.run=TestRunAndCompareIdenticalHelper"},
+		Env: map[string]string{
+			"SYMVAULT_PORT_HELPER": "1",
+			"PORT_HELPER_MODE":     "pipe-leak-natural",
+			"PORT_CHILD_PID":       pidPath,
+			"PORT_CHILD_STOP":      stopPath,
+			"PORT_CHILD_DONE":      donePath,
+		},
+		TimeoutMS: 100,
+	})
+	if elapsed := time.Since(started); elapsed > processWaitDelay+time.Second {
+		t.Fatalf("Run exceeded timeout+WaitDelay bound: %s", elapsed)
+	}
+	if err == nil || !errors.Is(err, exec.ErrWaitDelay) {
+		t.Fatalf("wait-delay error = %v, want ErrWaitDelay", err)
+	}
+	if fakeTree == nil {
+		t.Fatal("process-tree factory was not called")
+	}
+	if fakeTree.killCalls > 1 {
+		t.Fatalf("process-tree cleanup calls = %d, want at most 1", fakeTree.killCalls)
+	}
+	stopDescendant()
+}
+
+func TestRunTimeoutPreservesTreeAndCloseErrorsAfterWaitDelay(t *testing.T) {
+	treeErr := errors.New("job termination failed")
+	closeErr := errors.New("job close failed")
+	originalFactory := processTreeFactory
+	var fakeTree *timeoutTestProcessTree
+	processTreeFactory = func(cmd *exec.Cmd) (processTree, error) {
+		// Return an error without terminating the process. CommandContext's
+		// WaitDelay fallback must still kill it and let the synchronous Wait end.
+		fakeTree = &timeoutTestProcessTree{cmd: cmd, killEffective: true, killErr: treeErr, closeErr: closeErr}
+		return fakeTree, nil
+	}
+	t.Cleanup(func() { processTreeFactory = originalFactory })
+
+	started := time.Now()
+	_, err := Run(os.Args[0], Case{
+		ID:        "timeout-cleanup-errors",
+		Args:      []string{"-test.run=TestRunAndCompareIdenticalHelper"},
+		Env:       map[string]string{"SYMVAULT_PORT_HELPER": "1", "PORT_HELPER_MODE": "hang"},
+		TimeoutMS: 20,
+	})
+	if elapsed := time.Since(started); elapsed > processWaitDelay+time.Second {
+		t.Fatalf("WaitDelay fallback exceeded bound: %s", elapsed)
+	}
+	if err == nil {
+		t.Fatal("expected timeout cleanup errors")
+	}
+	if !errors.Is(err, treeErr) {
+		t.Fatalf("timeout error did not preserve tree termination error: %v", err)
+	}
+	if !errors.Is(err, closeErr) {
+		t.Fatalf("timeout error did not preserve tree close error: %v", err)
+	}
+	if fakeTree.killCalls != 1 {
+		t.Fatalf("tree.Kill calls = %d, want 1", fakeTree.killCalls)
+	}
+}
+
+type timeoutTestProcessTree struct {
+	cmd           *exec.Cmd
+	assignErr     error
+	killErr       error
+	closeErr      error
+	killEffective bool
+	killProcess   bool
+	killCalls     int
+}
+
+func (t *timeoutTestProcessTree) Assign() error { return t.assignErr }
+func (t *timeoutTestProcessTree) Kill() (bool, error) {
+	t.killCalls++
+	if t.killProcess {
+		return true, t.cmd.Process.Kill()
+	}
+	return t.killEffective, t.killErr
+}
+func (t *timeoutTestProcessTree) Close() error { return t.closeErr }
+
+func TestRunAssignmentFailureCleansUpSynchronously(t *testing.T) {
+	assignErr := errors.New("job assignment failed")
+	originalFactory := processTreeFactory
+	var fakeTree *timeoutTestProcessTree
+	processTreeFactory = func(cmd *exec.Cmd) (processTree, error) {
+		// Simulate a tree operation that cannot see the unassigned process;
+		// Run must fall back to command.Process.Kill immediately.
+		fakeTree = &timeoutTestProcessTree{cmd: cmd, assignErr: assignErr}
+		return fakeTree, nil
+	}
+	t.Cleanup(func() { processTreeFactory = originalFactory })
+
+	started := time.Now()
+	_, err := Run(os.Args[0], Case{
+		ID:        "assignment-failure",
+		Args:      []string{"-test.run=TestRunAndCompareIdenticalHelper"},
+		Env:       map[string]string{"SYMVAULT_PORT_HELPER": "1", "PORT_HELPER_MODE": "hang"},
+		TimeoutMS: 5 * 1000,
+	})
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("assignment cleanup did not directly kill the suspended child: %s", elapsed)
+	}
+	if err == nil || !errors.Is(err, assignErr) {
+		t.Fatalf("assignment failure = %v, want %v", err, assignErr)
+	}
+	if fakeTree == nil || fakeTree.killCalls != 1 {
+		t.Fatalf("tree.Kill calls = %d, want 1", fakeTree.killCalls)
 	}
 }
 
@@ -140,8 +476,51 @@ func helperProcess() {
 	case "hang":
 		time.Sleep(30 * time.Second)
 		return
+	case "exit-nonzero":
+		os.Exit(7)
+	case "delayed-success":
+		time.Sleep(200 * time.Millisecond)
+		return
+	case "delayed-nonzero":
+		time.Sleep(200 * time.Millisecond)
+		os.Exit(7)
+	case "pipe-leak":
+		child := exec.Command(os.Args[0], "-test.run=TestRunAndCompareIdenticalHelper")
+		child.Env = append(os.Environ(), "SYMVAULT_PORT_HELPER=1", "PORT_HELPER_MODE=hold-pipes")
+		child.Stdout = os.Stdout
+		child.Stderr = os.Stderr
+		if err := child.Start(); err != nil {
+			os.Exit(2)
+		}
+		if err := os.WriteFile(os.Getenv("PORT_CHILD_PID"), []byte(strconv.Itoa(child.Process.Pid)), 0o600); err != nil {
+			os.Exit(3)
+		}
+		for {
+			time.Sleep(5 * time.Millisecond)
+		}
+	case "pipe-leak-natural":
+		child := exec.Command(os.Args[0], "-test.run=TestRunAndCompareIdenticalHelper")
+		child.Env = append(os.Environ(), "SYMVAULT_PORT_HELPER=1", "PORT_HELPER_MODE=hold-pipes")
+		child.Stdout = os.Stdout
+		child.Stderr = os.Stderr
+		if err := child.Start(); err != nil {
+			os.Exit(2)
+		}
+		if err := os.WriteFile(os.Getenv("PORT_CHILD_PID"), []byte(strconv.Itoa(child.Process.Pid)), 0o600); err != nil {
+			os.Exit(3)
+		}
+		return
+	case "hold-pipes":
+		for {
+			if _, err := os.Stat(os.Getenv("PORT_CHILD_STOP")); err == nil {
+				_ = os.WriteFile(os.Getenv("PORT_CHILD_DONE"), []byte("done\n"), 0o600)
+				return
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
 	case "child":
-		child := exec.Command("sleep", "30")
+		child := exec.Command(os.Args[0], "-test.run=TestRunAndCompareIdenticalHelper")
+		child.Env = append(os.Environ(), "SYMVAULT_PORT_HELPER=1", "PORT_HELPER_MODE=hang")
 		if err := child.Start(); err != nil {
 			os.Exit(2)
 		}

--- a/scripts/rust-port/internal/diff/exec.go
+++ b/scripts/rust-port/internal/diff/exec.go
@@ -1,6 +1,7 @@
 package diff
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -9,6 +10,7 @@ import (
 	"runtime"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -23,8 +25,10 @@ type Result struct {
 	SandboxRoot string
 }
 
+const processWaitDelay = 2 * time.Second
+
 // Run executes binary in a fresh HOME/XDG/workspace sandbox.
-func Run(binary string, testCase Case) (Result, error) {
+func Run(binary string, testCase Case) (result Result, err error) {
 	absoluteBinary, err := filepath.Abs(binary)
 	if err != nil {
 		return Result{}, fmt.Errorf("resolve binary: %w", err)
@@ -69,8 +73,9 @@ func Run(binary string, testCase Case) (Result, error) {
 		"${TMPDIR}":    tmp,
 	}
 	args := replaceAll(testCase.Args, replacements)
-	command := exec.Command(absoluteBinary, args...) // #nosec G204 -- explicit harness operand, never derived from fixture output
-	configureProcessTree(command)
+	ctx, cancel := context.WithTimeout(context.Background(), testCase.timeout())
+	defer cancel()
+	command := exec.CommandContext(ctx, absoluteBinary, args...) // #nosec G204 -- explicit harness operand, never derived from fixture output
 	command.Dir = workspace
 	if testCase.WorkingDir != "" {
 		command.Dir, err = safeWorkspacePath(workspace, replace(testCase.WorkingDir, replacements))
@@ -87,49 +92,105 @@ func Run(binary string, testCase Case) (Result, error) {
 	stderr := newLimitedBuffer()
 	command.Stdout = stdout
 	command.Stderr = stderr
+	// WaitDelay bounds os/exec's internal pipe-copy wait when a descendant
+	// retains an inherited stdout or stderr handle after this process exits.
+	command.WaitDelay = processWaitDelay
+
+	tree, treeErr := processTreeFactory(command)
+	if treeErr != nil {
+		return Result{}, fmt.Errorf("create process tree: %w", treeErr)
+	}
+
+	var cancelMu sync.Mutex
+	var cancelOnce sync.Once
+	var treeCancelAttempted bool
+	var treeCancelEffective bool
+	var treeCancelErr error
+	command.Cancel = func() error {
+		cancelOnce.Do(func() {
+			effective, killErr := tree.Kill()
+			cancelMu.Lock()
+			treeCancelAttempted = true
+			treeCancelEffective = effective
+			treeCancelErr = killErr
+			cancelMu.Unlock()
+		})
+		cancelMu.Lock()
+		defer cancelMu.Unlock()
+		if treeCancelErr != nil {
+			return treeCancelErr
+		}
+		if !treeCancelEffective {
+			// Tell os/exec that the process tree was already gone. This
+			// prevents a late context deadline from becoming a spurious
+			// process error while still allowing WaitDelay to surface
+			// inherited-pipe cleanup honestly.
+			return os.ErrProcessDone
+		}
+		return nil
+	}
+	defer func() {
+		if closeErr := tree.Close(); closeErr != nil {
+			err = errors.Join(err, fmt.Errorf("close process tree: %w", closeErr))
+		}
+	}()
 
 	if startErr := command.Start(); startErr != nil {
 		return Result{}, fmt.Errorf("start %s: %w", absoluteBinary, startErr)
 	}
-	waitDone := make(chan error, 1)
-	go func() { waitDone <- command.Wait() }()
-
-	var waitErr error
-	timedOut := false
-	timer := time.NewTimer(testCase.timeout())
-	select {
-	case waitErr = <-waitDone:
-		timer.Stop()
-	case <-timer.C:
-		timedOut = true
-		killErr := killProcessTree(command)
-		select {
-		case waitErr = <-waitDone:
-		case <-time.After(2 * time.Second):
-			_ = command.Process.Kill()
-			return Result{}, fmt.Errorf("process did not exit within 2s after timeout")
-		}
-		if killErr != nil {
-			return Result{}, fmt.Errorf("terminate timed-out process tree: %w", killErr)
-		}
+	// The Windows process tree starts this command suspended. Assign resumes
+	// its primary thread only after job membership is established.
+	if assignErr := tree.Assign(); assignErr != nil {
+		// Assignment can fail while the Windows process is still suspended and
+		// outside the job. Do not rely on CommandContext's WaitDelay fallback
+		// for this lifecycle failure.
+		cleanupErr := cleanupAssignmentFailure(command, cancel, command.Cancel, func() (bool, error) {
+			cancelMu.Lock()
+			defer cancelMu.Unlock()
+			return treeCancelEffective, treeCancelErr
+		})
+		return Result{}, errors.Join(fmt.Errorf("assign process to tree: %w", assignErr), cleanupErr)
 	}
 
+	// CommandContext owns the cancellation watcher. Wait must remain
+	// synchronous so os/exec can apply WaitDelay and finish all I/O cleanup
+	// before Run returns.
+	waitErr := command.Wait()
+	cancelMu.Lock()
+	treeCancellationAttempted := treeCancelAttempted
+	treeCancellationEffective := treeCancelEffective
+	treeCancellationErr := treeCancelErr
+	cancelMu.Unlock()
+	deadlineExceeded := errors.Is(ctx.Err(), context.DeadlineExceeded)
+	timedOut := commandTimedOut(ctx, treeCancellationEffective)
+	treeCancellationIneffective := treeCancellationAttempted &&
+		!treeCancellationEffective &&
+		treeCancellationErr == nil
+	waitCleanupErr := classifyWaitError(
+		waitErr,
+		timedOut,
+		command.ProcessState != nil && command.ProcessState.Success(),
+		deadlineExceeded,
+		treeCancellationIneffective,
+		command.ProcessState != nil && command.ProcessState.Exited(),
+	)
+	if waitCleanupErr != nil {
+		return Result{}, errors.Join(waitCleanupErr, wrapTreeCancellationError("terminate process tree", treeCancellationErr))
+	}
 	exitCode := 0
 	if waitErr != nil {
 		var exitErr *exec.ExitError
 		if errors.As(waitErr, &exitErr) {
 			exitCode = exitErr.ExitCode()
-		} else {
-			return Result{}, fmt.Errorf("wait for process: %w", waitErr)
 		}
 	}
 	if stdout.Truncated() || stderr.Truncated() {
 		return Result{}, fmt.Errorf("captured process output exceeded %d bytes per stream", maxCapturedStreamBytes)
 	}
 	signal := terminationSignal(command.ProcessState)
-	files, err := buildManifest(root)
-	if err != nil {
-		return Result{}, fmt.Errorf("manifest sandbox: %w", err)
+	files, manifestErr := buildManifest(root)
+	if manifestErr != nil {
+		return Result{}, fmt.Errorf("manifest sandbox: %w", manifestErr)
 	}
 	return Result{
 		ExitCode:    exitCode,
@@ -139,7 +200,71 @@ func Run(binary string, testCase Case) (Result, error) {
 		Stderr:      append([]byte(nil), stderr.Bytes()...),
 		Files:       files,
 		SandboxRoot: root,
-	}, nil
+	}, wrapTreeCancellationError("terminate process tree", treeCancellationErr)
+}
+
+func commandTimedOut(ctx context.Context, effective bool) bool {
+	return effective && errors.Is(ctx.Err(), context.DeadlineExceeded)
+}
+
+func cleanupAssignmentFailure(command *exec.Cmd, cancel context.CancelFunc, cancelCommand func() error, cancellationState func() (effective bool, treeErr error)) error {
+	// Kill the tree first, then explicitly kill the direct process when the
+	// tree operation was ineffective. This handles an unassigned suspended
+	// Windows child without waiting for os/exec's WaitDelay fallback.
+	_ = cancelCommand()
+	treeCancellationEffective, treeCancellationErr := cancellationState()
+
+	var directKillErr error
+	if !treeCancellationEffective {
+		if command.Process == nil {
+			directKillErr = errors.New("directly kill process after tree cancellation: process is nil")
+		} else if killErr := command.Process.Kill(); killErr != nil && !errors.Is(killErr, os.ErrProcessDone) {
+			directKillErr = fmt.Errorf("directly kill process after ineffective tree cancellation: %w", killErr)
+		}
+	}
+	cancel()
+	waitErr := command.Wait()
+	var waitCleanupErr error
+	if waitErr != nil {
+		waitCleanupErr = fmt.Errorf("wait for process after assignment failure: %w", waitErr)
+	}
+	return errors.Join(
+		wrapTreeCancellationError("terminate process tree after assignment failure", treeCancellationErr),
+		directKillErr,
+		waitCleanupErr,
+	)
+}
+
+func wrapTreeCancellationError(prefix string, err error) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("%s: %w", prefix, err)
+}
+
+func classifyWaitError(waitErr error, timedOut, naturalExit, deadlineExceeded, treeCancellationIneffective, processExited bool) error {
+	if waitErr == nil {
+		return nil
+	}
+	var exitErr *exec.ExitError
+	if errors.As(waitErr, &exitErr) {
+		return nil
+	}
+	if isAlreadyGoneWaitDelayError(waitErr, deadlineExceeded, treeCancellationIneffective, processExited) {
+		waitErr = exec.ErrWaitDelay
+	}
+	if timedOut &&
+		(errors.Is(waitErr, context.Canceled) ||
+			errors.Is(waitErr, context.DeadlineExceeded) ||
+			errors.Is(waitErr, exec.ErrWaitDelay)) {
+		return nil
+	}
+	if naturalExit &&
+		(errors.Is(waitErr, context.Canceled) ||
+			errors.Is(waitErr, context.DeadlineExceeded)) {
+		return nil
+	}
+	return fmt.Errorf("wait for process: %w", waitErr)
 }
 
 func isolatedEnv(home, tmp, runtimeDir, state string, extra map[string]string, replacements map[string]string) ([]string, error) {

--- a/scripts/rust-port/internal/diff/process.go
+++ b/scripts/rust-port/internal/diff/process.go
@@ -1,0 +1,9 @@
+package diff
+
+type processTree interface {
+	Assign() error
+	Kill() (effective bool, err error)
+	Close() error
+}
+
+var processTreeFactory = newProcessTree

--- a/scripts/rust-port/internal/diff/process_unix.go
+++ b/scripts/rust-port/internal/diff/process_unix.go
@@ -8,17 +8,33 @@ import (
 	"syscall"
 )
 
-func configureProcessTree(cmd *exec.Cmd) {
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+type unixProcessTree struct {
+	cmd *exec.Cmd
 }
 
-func killProcessTree(cmd *exec.Cmd) error {
-	if cmd.Process == nil {
-		return nil
+func newProcessTree(cmd *exec.Cmd) (processTree, error) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	return &unixProcessTree{cmd: cmd}, nil
+}
+
+func (t *unixProcessTree) Assign() error {
+	return nil
+}
+
+func (t *unixProcessTree) Kill() (bool, error) {
+	if t.cmd.Process == nil {
+		return false, nil
 	}
-	err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	err := syscall.Kill(-t.cmd.Process.Pid, syscall.SIGKILL)
 	if errors.Is(err, syscall.ESRCH) {
-		return nil
+		return false, nil
 	}
-	return err
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func (t *unixProcessTree) Close() error {
+	return nil
 }

--- a/scripts/rust-port/internal/diff/process_unix_test.go
+++ b/scripts/rust-port/internal/diff/process_unix_test.go
@@ -5,6 +5,7 @@ package diff
 import (
 	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -65,5 +66,66 @@ func TestRunTimeoutKillsDescendantProcessGroup(t *testing.T) {
 			t.Fatalf("descendant process %d survived group termination: %v", pid, err)
 		}
 		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestUnixProcessTreeLifecycle(t *testing.T) {
+	cmd := exec.Command("true")
+	tree, err := newProcessTree(cmd)
+	if err != nil {
+		t.Fatalf("newProcessTree: %v", err)
+	}
+	if err := tree.Assign(); err != nil {
+		t.Fatalf("tree.Assign: %v", err)
+	}
+	if err := tree.Close(); err != nil {
+		t.Fatalf("tree.Close: %v", err)
+	}
+}
+
+func TestUnixProcessTreeKillReportsEffectiveAndAlreadyGone(t *testing.T) {
+	activeCmd := exec.Command("sleep", "30")
+	activeTree, err := newProcessTree(activeCmd)
+	if err != nil {
+		t.Fatalf("newProcessTree active: %v", err)
+	}
+	if err := activeCmd.Start(); err != nil {
+		t.Fatalf("activeCmd.Start: %v", err)
+	}
+	if err := activeTree.Assign(); err != nil {
+		t.Fatalf("activeTree.Assign: %v", err)
+	}
+	effective, err := activeTree.Kill()
+	if err != nil {
+		t.Fatalf("activeTree.Kill: %v", err)
+	}
+	if !effective {
+		t.Fatal("activeTree.Kill reported no effective termination")
+	}
+	_ = activeCmd.Wait()
+	if err := activeTree.Close(); err != nil {
+		t.Fatalf("activeTree.Close: %v", err)
+	}
+
+	goneCmd := exec.Command("true")
+	goneTree, err := newProcessTree(goneCmd)
+	if err != nil {
+		t.Fatalf("newProcessTree gone: %v", err)
+	}
+	if err := goneCmd.Start(); err != nil {
+		t.Fatalf("goneCmd.Start: %v", err)
+	}
+	if err := goneTree.Assign(); err != nil {
+		t.Fatalf("goneTree.Assign: %v", err)
+	}
+	if err := goneCmd.Wait(); err != nil {
+		t.Fatalf("goneCmd.Wait: %v", err)
+	}
+	effective, err = goneTree.Kill()
+	if err != nil {
+		t.Fatalf("goneTree.Kill: %v", err)
+	}
+	if effective {
+		t.Fatal("goneTree.Kill reported effective termination after natural exit")
 	}
 }

--- a/scripts/rust-port/internal/diff/process_windows.go
+++ b/scripts/rust-port/internal/diff/process_windows.go
@@ -3,20 +3,219 @@
 package diff
 
 import (
+	"errors"
 	"fmt"
 	"os/exec"
+	"sync"
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
 )
 
-func configureProcessTree(_ *exec.Cmd) {}
+type windowsProcessTreeState uint8
 
-func killProcessTree(cmd *exec.Cmd) error {
-	if cmd.Process == nil {
+const (
+	windowsProcessTreeReady windowsProcessTreeState = iota
+	windowsProcessTreeAssigned
+	windowsProcessTreeResumed
+	windowsProcessTreeClosed
+)
+
+type windowsProcessTree struct {
+	cmd   *exec.Cmd
+	job   windows.Handle
+	state windowsProcessTreeState
+	mu    sync.Mutex
+}
+
+func newProcessTree(cmd *exec.Cmd) (processTree, error) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.CreationFlags |= windows.CREATE_SUSPENDED
+
+	job, err := windows.CreateJobObject(nil, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create job object: %w", err)
+	}
+
+	info := windows.JOBOBJECT_EXTENDED_LIMIT_INFORMATION{
+		BasicLimitInformation: windows.JOBOBJECT_BASIC_LIMIT_INFORMATION{
+			LimitFlags: windows.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+		},
+	}
+	_, err = windows.SetInformationJobObject(
+		job,
+		windows.JobObjectExtendedLimitInformation,
+		uintptr(unsafe.Pointer(&info)),
+		uint32(unsafe.Sizeof(info)),
+	)
+	if err != nil {
+		closeErr := windows.CloseHandle(job)
+		if closeErr != nil {
+			return nil, errors.Join(
+				fmt.Errorf("configure job object kill on close: %w", err),
+				fmt.Errorf("close job object after configuration failure: %w", closeErr),
+			)
+		}
+		return nil, fmt.Errorf("configure job object kill on close: %w", err)
+	}
+
+	return &windowsProcessTree{cmd: cmd, job: job}, nil
+}
+
+// Assign admits the suspended process to the job, then resumes its primary
+// thread. Keeping both operations in this lifecycle step prevents descendants
+// from running before they inherit the job membership.
+func (t *windowsProcessTree) Assign() error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	switch t.state {
+	case windowsProcessTreeAssigned, windowsProcessTreeResumed:
+		return errors.New("process tree already assigned")
+	case windowsProcessTreeClosed:
+		return errors.New("process tree is closed")
+	}
+	if t.cmd.Process == nil {
+		return errors.New("cannot assign nil process to job object")
+	}
+
+	var assignErr error
+	withErr := t.cmd.Process.WithHandle(func(handle uintptr) {
+		assignErr = windows.AssignProcessToJobObject(t.job, windows.Handle(handle))
+	})
+	if withErr != nil {
+		return fmt.Errorf("retrieve process handle for job assignment: %w", withErr)
+	}
+	if assignErr != nil {
+		return fmt.Errorf("assign process to job object: %w", assignErr)
+	}
+	t.state = windowsProcessTreeAssigned
+
+	if err := resumePrimaryThread(uint32(t.cmd.Process.Pid)); err != nil {
+		return fmt.Errorf("resume primary process thread: %w", err)
+	}
+	t.state = windowsProcessTreeResumed
+	return nil
+}
+
+func resumePrimaryThread(pid uint32) error {
+	snapshot, err := windows.CreateToolhelp32Snapshot(windows.TH32CS_SNAPTHREAD, 0)
+	if err != nil {
+		return fmt.Errorf("create thread snapshot: %w", err)
+	}
+
+	closeSnapshot := func() error {
+		if closeErr := windows.CloseHandle(snapshot); closeErr != nil {
+			return fmt.Errorf("close thread snapshot: %w", closeErr)
+		}
 		return nil
 	}
-	// taskkill /T terminates descendants as well as the direct process. Keep a
-	// direct Kill fallback for minimal Windows environments without taskkill.
-	if err := exec.Command("taskkill", "/T", "/F", "/PID", fmt.Sprint(cmd.Process.Pid)).Run(); err == nil {
+
+	var entry windows.ThreadEntry32
+	entry.Size = uint32(unsafe.Sizeof(entry))
+	if err := windows.Thread32First(snapshot, &entry); err != nil {
+		return errors.Join(fmt.Errorf("enumerate process threads: %w", err), closeSnapshot())
+	}
+
+	for {
+		if entry.OwnerProcessID == pid {
+			thread, openErr := windows.OpenThread(windows.THREAD_SUSPEND_RESUME, false, entry.ThreadID)
+			if openErr != nil {
+				return errors.Join(
+					fmt.Errorf("open primary process thread: %w", openErr),
+					closeSnapshot(),
+				)
+			}
+
+			previousSuspendCount, resumeErr := windows.ResumeThread(thread)
+			closeThreadErr := windows.CloseHandle(thread)
+			closeSnapshotErr := closeSnapshot()
+			var errs []error
+			if resumeErr != nil {
+				errs = append(errs, fmt.Errorf("resume primary process thread: %w", resumeErr))
+			} else if previousSuspendCount == 0 {
+				errs = append(errs, errors.New("primary process thread was not suspended"))
+			}
+			if closeThreadErr != nil {
+				errs = append(errs, fmt.Errorf("close primary process thread: %w", closeThreadErr))
+			}
+			if closeSnapshotErr != nil {
+				errs = append(errs, closeSnapshotErr)
+			}
+			return errors.Join(errs...)
+		}
+
+		if err := windows.Thread32Next(snapshot, &entry); err != nil {
+			return errors.Join(fmt.Errorf("enumerate process threads: %w", err), closeSnapshot())
+		}
+	}
+}
+
+type windowsJobObjectBasicAccountingInformation struct {
+	TotalUserTime             int64
+	TotalKernelTime           int64
+	ThisPeriodTotalUserTime   int64
+	ThisPeriodTotalKernelTime int64
+	TotalPageFaultCount       uint32
+	TotalProcesses            uint32
+	ActiveProcesses           uint32
+	TotalTerminatedProcesses  uint32
+}
+
+func (t *windowsProcessTree) activeProcessesLocked() (uint32, error) {
+	var info windowsJobObjectBasicAccountingInformation
+	if err := windows.QueryInformationJobObject(
+		t.job,
+		windows.JobObjectBasicAccountingInformation,
+		uintptr(unsafe.Pointer(&info)),
+		uint32(unsafe.Sizeof(info)),
+		nil,
+	); err != nil {
+		return 0, fmt.Errorf("query job object accounting: %w", err)
+	}
+	return info.ActiveProcesses, nil
+}
+
+func (t *windowsProcessTree) Kill() (bool, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.state == windowsProcessTreeClosed {
+		return false, nil
+	}
+
+	activeProcesses, queryErr := t.activeProcessesLocked()
+	var errs []error
+	if queryErr != nil {
+		errs = append(errs, queryErr)
+	} else if activeProcesses > 0 {
+		if err := windows.TerminateJobObject(t.job, 1); err != nil {
+			errs = append(errs, fmt.Errorf("terminate job object: %w", err))
+		}
+	}
+	if err := t.closeLocked(); err != nil {
+		errs = append(errs, fmt.Errorf("close job object on kill: %w", err))
+	}
+	return queryErr == nil && activeProcesses > 0, errors.Join(errs...)
+}
+
+func (t *windowsProcessTree) Close() error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.closeLocked()
+}
+
+func (t *windowsProcessTree) closeLocked() error {
+	if t.state == windowsProcessTreeClosed {
 		return nil
 	}
-	return cmd.Process.Kill()
+	if err := windows.CloseHandle(t.job); err != nil {
+		return fmt.Errorf("close job object: %w", err)
+	}
+	t.job = 0
+	t.state = windowsProcessTreeClosed
+	return nil
 }

--- a/scripts/rust-port/internal/diff/process_windows_test.go
+++ b/scripts/rust-port/internal/diff/process_windows_test.go
@@ -1,0 +1,246 @@
+//go:build windows
+
+package diff
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/windows"
+)
+
+func TestRunTimeoutKillsDescendantJobObject(t *testing.T) {
+	caseSpec := Case{
+		ID:   "timeout-child-windows",
+		Args: []string{"-test.run=TestRunAndCompareIdenticalHelper"},
+		Env: map[string]string{
+			"SYMVAULT_PORT_HELPER": "1",
+			"PORT_HELPER_MODE":     "child",
+		},
+		TimeoutMS: 500,
+	}
+	result, err := Run(os.Args[0], caseSpec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.TimedOut {
+		t.Fatal("expected process timeout")
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(result.Stdout)))
+	if err != nil {
+		t.Fatalf("parse helper child PID from %q: %v", string(result.Stdout), err)
+	}
+
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		hProc, openErr := windows.OpenProcess(
+			windows.PROCESS_QUERY_LIMITED_INFORMATION|windows.SYNCHRONIZE,
+			false,
+			uint32(pid),
+		)
+		if openErr != nil {
+			// Process handle cannot be opened; process has exited and terminated.
+			return
+		}
+		event, waitErr := windows.WaitForSingleObject(hProc, 0)
+		_ = windows.CloseHandle(hProc)
+		if waitErr == nil && event == windows.WAIT_OBJECT_0 {
+			// Process has terminated.
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("descendant process %d survived job object termination", pid)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+func TestRunAssignmentFailureKillsUnassignedSuspendedProcess(t *testing.T) {
+	originalFactory := processTreeFactory
+	processTreeFactory = func(cmd *exec.Cmd) (processTree, error) {
+		tree, err := newProcessTree(cmd)
+		if err != nil {
+			return nil, err
+		}
+		nativeTree := tree.(*windowsProcessTree)
+		if err := windows.CloseHandle(nativeTree.job); err != nil {
+			return nil, fmt.Errorf("close test job handle: %w", err)
+		}
+		nativeTree.job = 0
+		return nativeTree, nil
+	}
+	t.Cleanup(func() { processTreeFactory = originalFactory })
+
+	started := time.Now()
+	_, err := Run(os.Args[0], Case{
+		ID:        "assignment-failure-windows-native",
+		Args:      []string{"-test.run=TestRunAndCompareIdenticalHelper"},
+		Env:       map[string]string{"SYMVAULT_PORT_HELPER": "1", "PORT_HELPER_MODE": "hang"},
+		TimeoutMS: 5000,
+	})
+	if elapsed := time.Since(started); elapsed > processWaitDelay+time.Second {
+		t.Fatalf("native assignment cleanup exceeded WaitDelay bound: %s; error: %v", elapsed, err)
+	}
+	if err == nil || !strings.Contains(err.Error(), "assign process to tree") {
+		t.Fatalf("assignment failure = %v, want native assignment error", err)
+	}
+}
+
+func TestWindowsProcessTreeLifecycleAndErrors(t *testing.T) {
+	cmd := exec.Command("cmd.exe", "/c", "exit", "0")
+	existingSysProcAttr := &syscall.SysProcAttr{CreationFlags: windows.CREATE_NEW_PROCESS_GROUP}
+	cmd.SysProcAttr = existingSysProcAttr
+	tree, err := newProcessTree(cmd)
+	if err != nil {
+		t.Fatalf("newProcessTree: %v", err)
+	}
+	started := false
+	t.Cleanup(func() {
+		if started {
+			_, _ = tree.Kill()
+			_ = cmd.Wait()
+		}
+		if closeErr := tree.Close(); closeErr != nil {
+			t.Errorf("tree.Close cleanup: %v", closeErr)
+		}
+	})
+
+	if cmd.SysProcAttr != existingSysProcAttr {
+		t.Fatal("newProcessTree replaced the existing SysProcAttr")
+	}
+	if cmd.SysProcAttr.CreationFlags&windows.CREATE_NEW_PROCESS_GROUP == 0 {
+		t.Fatal("newProcessTree dropped the existing creation flags")
+	}
+	if cmd.SysProcAttr.CreationFlags&windows.CREATE_SUSPENDED == 0 {
+		t.Fatal("newProcessTree did not request suspended process creation")
+	}
+
+	// Assigning before Start (when cmd.Process == nil) must fail.
+	if err := tree.Assign(); err == nil {
+		t.Fatal("expected error assigning nil process")
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("cmd.Start: %v", err)
+	}
+	started = true
+
+	if err := tree.Assign(); err != nil {
+		t.Fatalf("tree.Assign: %v", err)
+	}
+	if err := tree.Assign(); err == nil {
+		t.Fatal("expected error assigning an already-assigned process tree")
+	}
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("cmd.Wait: %v", err)
+	}
+	started = false
+
+	if err := tree.Close(); err != nil {
+		t.Fatalf("tree.Close: %v", err)
+	}
+	if err := tree.Close(); err != nil {
+		t.Fatalf("second tree.Close: %v", err)
+	}
+	if err := tree.Assign(); err == nil {
+		t.Fatal("expected error assigning after close")
+	}
+}
+
+func TestWindowsProcessTreeKillReportsActiveJob(t *testing.T) {
+	cmd := exec.Command("cmd.exe", "/c", "ping 127.0.0.1 -n 30 >NUL")
+	tree, err := newProcessTree(cmd)
+	if err != nil {
+		t.Fatalf("newProcessTree: %v", err)
+	}
+	started := false
+	t.Cleanup(func() {
+		if started {
+			_, _ = tree.Kill()
+			_ = cmd.Wait()
+		}
+		_ = tree.Close()
+	})
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("cmd.Start: %v", err)
+	}
+	started = true
+	if err := tree.Assign(); err != nil {
+		t.Fatalf("tree.Assign: %v", err)
+	}
+
+	effective, err := tree.Kill()
+	if err != nil {
+		t.Fatalf("tree.Kill: %v", err)
+	}
+	if !effective {
+		t.Fatal("tree.Kill reported no effective termination for active job")
+	}
+	_ = cmd.Wait()
+	started = false
+}
+
+func TestWindowsProcessTreeKillReportsEmptyJob(t *testing.T) {
+	cmd := exec.Command("cmd.exe", "/c", "exit", "0")
+	tree, err := newProcessTree(cmd)
+	if err != nil {
+		t.Fatalf("newProcessTree: %v", err)
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("cmd.Start: %v", err)
+	}
+	if err := tree.Assign(); err != nil {
+		t.Fatalf("tree.Assign: %v", err)
+	}
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("cmd.Wait: %v", err)
+	}
+
+	effective, err := tree.Kill()
+	if err != nil {
+		t.Fatalf("tree.Kill: %v", err)
+	}
+	if effective {
+		t.Fatal("tree.Kill reported effective termination for an empty job")
+	}
+}
+
+func TestWindowsClassifyAlreadyGoneWaitDelayEINVAL(t *testing.T) {
+	waitErr := fmt.Errorf("exec: killing Cmd: %w", syscall.EINVAL)
+	err := classifyWaitError(waitErr, false, true, true, true, true)
+	if !errors.Is(err, exec.ErrWaitDelay) {
+		t.Fatalf("already-gone wait error = %v, want ErrWaitDelay", err)
+	}
+	if errors.Is(err, syscall.EINVAL) {
+		t.Fatalf("already-gone wait error retained EINVAL: %v", err)
+	}
+
+	for _, test := range []struct {
+		name                        string
+		deadlineExceeded            bool
+		treeCancellationIneffective bool
+		processExited               bool
+		waitErr                     error
+	}{
+		{name: "no deadline", deadlineExceeded: false, treeCancellationIneffective: true, processExited: true, waitErr: waitErr},
+		{name: "effective tree cancellation", deadlineExceeded: true, treeCancellationIneffective: false, processExited: true, waitErr: waitErr},
+		{name: "live process", deadlineExceeded: true, treeCancellationIneffective: true, processExited: false, waitErr: waitErr},
+		{name: "different EINVAL source", deadlineExceeded: true, treeCancellationIneffective: true, processExited: true, waitErr: fmt.Errorf("wait for process: %w", syscall.EINVAL)},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			err := classifyWaitError(test.waitErr, false, test.processExited, test.deadlineExceeded, test.treeCancellationIneffective, test.processExited)
+			if err == nil || !errors.Is(err, syscall.EINVAL) {
+				t.Fatalf("error = %v, want preserved EINVAL", err)
+			}
+			if errors.Is(err, exec.ErrWaitDelay) {
+				t.Fatalf("error = %v, unexpectedly classified as ErrWaitDelay", err)
+			}
+		})
+	}
+}

--- a/scripts/rust-port/internal/diff/wait_error_unix.go
+++ b/scripts/rust-port/internal/diff/wait_error_unix.go
@@ -1,0 +1,7 @@
+//go:build !windows
+
+package diff
+
+func isAlreadyGoneWaitDelayError(waitErr error, deadlineExceeded, treeCancellationIneffective, processExited bool) bool {
+	return false
+}

--- a/scripts/rust-port/internal/diff/wait_error_windows.go
+++ b/scripts/rust-port/internal/diff/wait_error_windows.go
@@ -1,0 +1,17 @@
+//go:build windows
+
+package diff
+
+import (
+	"errors"
+	"strings"
+	"syscall"
+)
+
+func isAlreadyGoneWaitDelayError(waitErr error, deadlineExceeded, treeCancellationIneffective, processExited bool) bool {
+	return deadlineExceeded &&
+		treeCancellationIneffective &&
+		processExited &&
+		strings.HasPrefix(waitErr.Error(), "exec: killing Cmd: ") &&
+		errors.Is(waitErr, syscall.EINVAL)
+}


### PR DESCRIPTION
## Summary
- replace taskkill-based timeout cleanup with native Windows Job Objects
- launch suspended, assign before resume, and handle ineffective assignment/termination paths synchronously
- cover normal-exit/deadline races and inherited-pipe cleanup in the native Windows CI lane

## Verification
- `make port-contract`
- `make rust-gates`
- `make test-fast`
- pinned golangci-lint v2.11.4 / Go 1.26.6
- `go test -race -count=3 ./scripts/rust-port/internal/diff`
- Windows amd64 test cross-compile
- final spec review: PASS
- final quality/security review: PASS

Native Windows execution is delegated to the existing `windows-latest` CI job.

Closes #980