### PR TITLE
fix(redaction): handle overlapping exact values safely

### DIFF
--- a/cmd/file/use.go
+++ b/cmd/file/use.go
@@ -1,6 +1,7 @@
 package file
 
 import (
+	"encoding/base64"
 	"fmt"
 	"os"
 	"strings"
@@ -68,10 +69,12 @@ func runFileUse(cmd *cobra.Command, args []string) error {
 			name = strings.ToUpper(resolvedField)
 		}
 
+		files := map[string]string{name: string(content)}
 		result, runErr := secrets.RunCommand(secrets.RunOptions{
-			Command: command,
-			Files:   map[string]string{name: string(content)},
-			Timeout: UseTimeout,
+			Command:      command,
+			Files:        files,
+			Timeout:      UseTimeout,
+			KnownSecrets: attachmentKnownSecrets(name, content),
 		})
 		if runErr != nil {
 			return runErr
@@ -88,4 +91,11 @@ func runFileUse(cmd *cobra.Command, args []string) error {
 		}
 		return nil
 	})
+}
+
+func attachmentKnownSecrets(name string, content []byte) map[string]string {
+	return map[string]string{
+		name + ":content": string(content),
+		name + ":base64":  base64.StdEncoding.EncodeToString(content),
+	}
 }

--- a/cmd/file/use_test.go
+++ b/cmd/file/use_test.go
@@ -2,6 +2,8 @@ package file
 
 import (
 	"encoding/base64"
+	"io"
+	"os"
 	"runtime"
 	"strings"
 	"testing"
@@ -9,6 +11,30 @@ import (
 
 	vaultpkg "github.com/danieljustus/symaira-vault/internal/vault"
 )
+
+func captureUseStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	original := os.Stdout
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stdout = writer
+	defer func() { os.Stdout = original }()
+
+	fn()
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close stdout writer: %v", err)
+	}
+	output, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("read stdout: %v", err)
+	}
+	if err := reader.Close(); err != nil {
+		t.Fatalf("close stdout reader: %v", err)
+	}
+	return string(output)
+}
 
 func resetUseFlags(t *testing.T) {
 	t.Helper()
@@ -32,8 +58,13 @@ func TestRunFileUse_MaterializesAttachmentForCommand(t *testing.T) {
 	UseTimeout = 5 * time.Second
 
 	args := []string{"elster/cert#cert_p12", "sh", "-c", `cat "$SYMVAULT_FILE_CERT_P12"`}
-	if err := runFileUse(nil, args); err != nil {
-		t.Fatalf("runFileUse: %v", err)
+	output := captureUseStdout(t, func() {
+		if err := runFileUse(nil, args); err != nil {
+			t.Fatalf("runFileUse: %v", err)
+		}
+	})
+	if strings.Contains(output, string(content)) || !strings.Contains(output, "***") {
+		t.Fatalf("stdout = %q, want attachment content redacted", output)
 	}
 }
 
@@ -98,6 +129,17 @@ func TestRunFileUse_EntryNotFound(t *testing.T) {
 	args := []string{"does/not-exist#field", "true"}
 	if err := runFileUse(nil, args); err == nil {
 		t.Fatal("expected error for missing entry, got nil")
+	}
+}
+
+func TestAttachmentKnownSecretsIncludesContentAndCanonicalBase64(t *testing.T) {
+	content := []byte("binary attachment content")
+	got := attachmentKnownSecrets("CERT", content)
+	if got["CERT:content"] != string(content) {
+		t.Fatal("known secrets omit decoded attachment content")
+	}
+	if got["CERT:base64"] != base64.StdEncoding.EncodeToString(content) {
+		t.Fatal("known secrets omit canonical base64 attachment content")
 	}
 }
 

--- a/cmd/file_test.go
+++ b/cmd/file_test.go
@@ -132,8 +132,8 @@ func TestCmdFile_UseInvokesCommandWithMaterializedPath(t *testing.T) {
 
 	out := execWithStdout("--vault", vaultDir, "file", "use", "elster/cert", "--",
 		"sh", "-c", "cat \"$SYMVAULT_FILE_CERT_P12\"")
-	if !strings.Contains(out, string(content)) {
-		t.Errorf("expected materialized file content %q in stdout, got: %q", content, out)
+	if strings.Contains(out, string(content)) || !strings.Contains(out, "***") {
+		t.Errorf("stdout = %q, want materialized file content redacted", out)
 	}
 }
 
@@ -151,8 +151,8 @@ func TestCmdFile_UseCustomAsName(t *testing.T) {
 
 	out := execWithStdout("--vault", vaultDir, "file", "use", "elster/cert", "--as", "MYCERT", "--",
 		"sh", "-c", "cat \"$SYMVAULT_FILE_MYCERT\"")
-	if !strings.Contains(out, string(content)) {
-		t.Errorf("expected materialized file content %q in stdout, got: %q", content, out)
+	if strings.Contains(out, string(content)) || !strings.Contains(out, "***") {
+		t.Errorf("stdout = %q, want materialized file content redacted", out)
 	}
 }
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -56,6 +56,7 @@ With --broker the child's outbound traffic is routed through an in-process egres
 			return cli.WithVault(func(v *vaultpkg.Vault, vs *cli.VaultService) error {
 				// Parse --env flags: each is "ENV_NAME=path.field"
 				envMap := make(map[string]string)
+				knownSecrets := make(map[string]string)
 				for _, envFlag := range runEnvFlags {
 					parts := strings.SplitN(envFlag, "=", 2)
 					if len(parts) != 2 {
@@ -69,6 +70,7 @@ With --broker the child's outbound traffic is routed through an in-process egres
 						return resolveErr
 					}
 					envMap[envName] = value
+					knownSecrets[envName] = value
 				}
 
 				// Parse --env-file flags: each file contains "ENV_NAME=path.field" lines
@@ -86,6 +88,7 @@ With --broker the child's outbound traffic is routed through an in-process egres
 							return resolveErr
 						}
 						envMap[envName] = value
+						knownSecrets[envName] = value
 					}
 				}
 
@@ -106,11 +109,12 @@ With --broker the child's outbound traffic is routed through an in-process egres
 				}
 
 				result, err := secrets.RunCommand(secrets.RunOptions{
-					Command:     args,
-					Env:         envMap,
-					Passthrough: runPassthrough,
-					WorkingDir:  runWorkingDir,
-					Timeout:     runTimeout,
+					Command:      args,
+					Env:          envMap,
+					Passthrough:  runPassthrough,
+					WorkingDir:   runWorkingDir,
+					Timeout:      runTimeout,
+					KnownSecrets: knownSecrets,
 				})
 				if brokerCleanup != nil {
 					brokerCleanup()

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -10,6 +10,18 @@ import (
 	vaultpkg "github.com/danieljustus/symaira-vault/internal/vault"
 )
 
+func assertRunOutputRedacted(t *testing.T, output string, secrets ...string) {
+	t.Helper()
+	for _, secret := range secrets {
+		if strings.Contains(output, secret) {
+			t.Fatalf("stdout leaked known secret %q: %q", secret, output)
+		}
+	}
+	if !strings.Contains(output, "***") {
+		t.Fatalf("stdout = %q, want redaction marker", output)
+	}
+}
+
 func TestCmdRun_Basic(t *testing.T) {
 	vaultDir, passphrase := initVault(t)
 	setPassEnv(t, string(passphrase))
@@ -30,9 +42,7 @@ func TestCmdRun_SecretInjection(t *testing.T) {
 	defer setupVaultFlag(t, vaultDir)()
 
 	out := execWithStdout("--vault", vaultDir, "run", "--env", "API_KEY=github.api_key", "--", "sh", "-c", "echo $API_KEY")
-	if !strings.Contains(out, "secret123") {
-		t.Errorf("expected 'secret123' in stdout, got: %q", out)
-	}
+	assertRunOutputRedacted(t, out, "secret123")
 }
 
 func TestCmdRun_MissingSecretRef(t *testing.T) {
@@ -113,12 +123,7 @@ func TestCmdRun_MultipleEnvFlags(t *testing.T) {
 		"--env", "TOKEN=svc1.token",
 		"--env", "SECRET=svc2.secret",
 		"--", "sh", "-c", "echo TOKEN=$TOKEN SECRET=$SECRET")
-	if !strings.Contains(out, "TOKEN=tok1") {
-		t.Errorf("expected TOKEN=tok1 in stdout, got: %q", out)
-	}
-	if !strings.Contains(out, "SECRET=sec1") {
-		t.Errorf("expected SECRET=sec1 in stdout, got: %q", out)
-	}
+	assertRunOutputRedacted(t, out, "tok1", "sec1")
 }
 
 func TestCmdRun_NonZeroExit(t *testing.T) {
@@ -198,9 +203,7 @@ func TestCmdRun_EnvWithBareRef(t *testing.T) {
 	defer setupVaultFlag(t, vaultDir)()
 
 	out := execWithStdout("--vault", vaultDir, "run", "--env", "DB_PASSWORD=db.password", "--", "sh", "-c", "echo $DB_PASSWORD")
-	if !strings.Contains(out, "thepass") {
-		t.Errorf("expected 'thepass' in stdout, got: %q", out)
-	}
+	assertRunOutputRedacted(t, out, "thepass")
 }
 
 func TestCmdRun_StdoutStderrPassthrough(t *testing.T) {
@@ -276,9 +279,7 @@ func TestCmdRun_EnvFile(t *testing.T) {
 	}
 
 	out := execWithStdout("--vault", vaultDir, "run", "--env-file", envFile, "--", "sh", "-c", "echo $DB_PASS")
-	if !strings.Contains(out, "filesecret") {
-		t.Errorf("expected 'filesecret' in stdout, got: %q", out)
-	}
+	assertRunOutputRedacted(t, out, "filesecret")
 }
 
 func TestCmdRun_EnvFileMultiple(t *testing.T) {
@@ -299,12 +300,7 @@ func TestCmdRun_EnvFileMultiple(t *testing.T) {
 
 	out := execWithStdout("--vault", vaultDir, "run", "--env-file", envFile, "--",
 		"sh", "-c", "echo TOKEN=$TOKEN SECRET=$SECRET")
-	if !strings.Contains(out, "TOKEN=tok_from_file") {
-		t.Errorf("expected TOKEN=tok_from_file in stdout, got: %q", out)
-	}
-	if !strings.Contains(out, "SECRET=sec_from_file") {
-		t.Errorf("expected SECRET=sec_from_file in stdout, got: %q", out)
-	}
+	assertRunOutputRedacted(t, out, "tok_from_file", "sec_from_file")
 }
 
 func TestCmdRun_EnvFileWithComments(t *testing.T) {
@@ -322,9 +318,7 @@ func TestCmdRun_EnvFileWithComments(t *testing.T) {
 	}
 
 	out := execWithStdout("--vault", vaultDir, "run", "--env-file", envFile, "--", "sh", "-c", "echo $DB_PASS")
-	if !strings.Contains(out, "comment_test") {
-		t.Errorf("expected 'comment_test' in stdout, got: %q", out)
-	}
+	assertRunOutputRedacted(t, out, "comment_test")
 }
 
 func TestCmdRun_EnvFileNotFound(t *testing.T) {
@@ -418,9 +412,7 @@ func TestCmdRun_EnvFileEmptyLines(t *testing.T) {
 	}
 
 	out := execWithStdout("--vault", vaultDir, "run", "--env-file", envFile, "--", "sh", "-c", "echo $DB_PASS")
-	if !strings.Contains(out, "empty_lines_test") {
-		t.Errorf("expected 'empty_lines_test' in stdout, got: %q", out)
-	}
+	assertRunOutputRedacted(t, out, "empty_lines_test")
 }
 
 func TestParseEnvFile(t *testing.T) {

--- a/crates/symvault-core/src/redact.rs
+++ b/crates/symvault-core/src/redact.rs
@@ -2,7 +2,9 @@
 
 //! Secret redaction core: detectors, Shannon entropy heuristic, and fail-closed scanner.
 
-use core::fmt;
+use core::{cmp::Reverse, fmt};
+use std::collections::HashSet;
+
 use serde::{Deserialize, Serialize};
 
 /// Marker substituted for detected secret values.
@@ -16,6 +18,17 @@ pub const ENV_STRICT_MODE: &str = "SYMVAULT_REDACT_STRICT_MODE";
 
 /// Minimum length for a literal exact-value detector match.
 pub const MIN_EXACT_VALUE_LEN: usize = 4;
+
+/// Maximum number of distinct exact values retained by one detector.
+pub const MAX_EXACT_VALUE_COUNT: usize = 1024;
+
+/// Maximum number of exact match spans retained by one detector.
+pub const MAX_EXACT_MATCH_SPANS: usize = 4096;
+
+/// Maximum number of exact-value byte comparisons per detector invocation.
+/// The 64 MiB budget supports normal 16 MiB outputs with a small number of
+/// values while bounding CPU for large outputs and many non-matching values.
+pub const MAX_EXACT_SCAN_WORK: usize = 64 * 1024 * 1024;
 
 /// Minimum token length for the entropy heuristic detector.
 pub const MIN_TOKEN_LEN: usize = 20;
@@ -83,28 +96,45 @@ pub trait Detector: Send + Sync {
 /// Detector matching literal occurrences of known secrets.
 pub struct ExactValueDetector {
     values: Vec<String>,
+    overflowed: bool,
 }
 
 impl ExactValueDetector {
     /// Creates a new `ExactValueDetector`, filtering out secrets shorter than `MIN_EXACT_VALUE_LEN`.
+    /// Values are stably deduplicated and processed longest-first so overlapping
+    /// secrets cannot expose a suffix of the longer value.
     #[must_use]
     pub fn new<I, S>(values: I) -> Self
     where
         I: IntoIterator<Item = S>,
         S: AsRef<str>,
     {
-        let filtered = values
-            .into_iter()
-            .filter_map(|s| {
-                let s = s.as_ref();
-                if s.len() >= MIN_EXACT_VALUE_LEN {
-                    Some(s.to_string())
-                } else {
-                    None
-                }
-            })
-            .collect();
-        Self { values: filtered }
+        let mut seen = HashSet::new();
+        let mut filtered = Vec::new();
+        let mut overflowed = false;
+        for value in values {
+            let value = value.as_ref();
+            if value.len() < MIN_EXACT_VALUE_LEN {
+                continue;
+            }
+            if seen.contains(value) {
+                continue;
+            }
+            if filtered.len() >= MAX_EXACT_VALUE_COUNT {
+                overflowed = true;
+                break;
+            }
+            let owned = value.to_string();
+            seen.insert(owned.clone());
+            filtered.push(owned);
+        }
+        // Stable sorting preserves caller order for equal-length values,
+        // making the tie-break deterministic.
+        filtered.sort_by_key(|value| Reverse(value.len()));
+        Self {
+            values: filtered,
+            overflowed,
+        }
     }
 }
 
@@ -128,26 +158,100 @@ impl Detector for ExactValueDetector {
     }
 
     fn redact(&self, text: &str) -> Result<(String, usize), RedactError> {
-        let mut current = text.to_string();
-        let mut total = 0;
-        for v in &self.values {
-            let (next, count) = replace_all_value(&current, v);
-            current = next;
-            total += count;
+        if self.overflowed && !text.is_empty() {
+            return Ok((MARKER.to_string(), 1));
         }
-        Ok((current, total))
+        match redact_exact_values(text, &self.values, MAX_EXACT_SCAN_WORK) {
+            Some(result) => Ok(result),
+            None => Ok((MARKER.to_string(), 1)),
+        }
     }
 }
 
-fn replace_all_value(text: &str, value: &str) -> (String, usize) {
-    if value.is_empty() {
-        return (text.to_string(), 0);
+fn redact_exact_values(
+    text: &str,
+    values: &[String],
+    mut scan_work: usize,
+) -> Option<(String, usize)> {
+    if text.is_empty() {
+        return Some((text.to_string(), 0));
     }
-    let count = text.matches(value).count();
-    if count == 0 {
-        return (text.to_string(), 0);
+
+    // Find matches against the original text before replacing anything. Each
+    // value uses left-to-right, non-overlapping occurrence discovery. Thus
+    // self-overlapping occurrences such as "abab" in "ababab" select the
+    // first occurrence and then resume after its end.
+    let mut ranges = Vec::new();
+    for value in values {
+        let Some(max_start) = text.len().checked_sub(value.len()) else {
+            continue;
+        };
+        let mut search_start = 0;
+        while search_start <= max_start {
+            let mut matched = true;
+            for offset in 0..value.len() {
+                if scan_work == 0 {
+                    return None;
+                }
+                scan_work -= 1;
+                let index = search_start.checked_add(offset)?;
+                if text.as_bytes()[index] != value.as_bytes()[offset] {
+                    matched = false;
+                    break;
+                }
+            }
+            if matched {
+                let end = search_start.checked_add(value.len())?;
+                if ranges.len() >= MAX_EXACT_MATCH_SPANS {
+                    return None;
+                }
+                ranges.push(ExactMatchRange {
+                    start: search_start,
+                    end,
+                });
+                search_start = end;
+            } else {
+                search_start = search_start.checked_add(1)?;
+            }
+        }
     }
-    (text.replace(value, MARKER), count)
+    if ranges.is_empty() {
+        return Some((text.to_string(), 0));
+    }
+
+    // Merge overlaps, but keep merely adjacent spans separate. Sorting by
+    // byte offsets preserves UTF-8 boundaries because every match came from a
+    // valid string search and is therefore aligned to the original text.
+    ranges.sort_by_key(|range| (range.start, range.end));
+    let mut merged = Vec::with_capacity(ranges.len());
+    for candidate in ranges {
+        if merged
+            .last()
+            .is_none_or(|previous: &ExactMatchRange| candidate.start >= previous.end)
+        {
+            merged.push(candidate);
+        } else if let Some(previous) = merged.last_mut() {
+            previous.end = previous.end.max(candidate.end);
+        }
+    }
+
+    // Do not calculate an expanded capacity: marker replacement can overflow
+    // that arithmetic for attacker-controlled sizes. String grows safely.
+    let mut out = String::with_capacity(text.len());
+    let mut last_end = 0;
+    for span in &merged {
+        out.push_str(&text[last_end..span.start]);
+        out.push_str(MARKER);
+        last_end = span.end;
+    }
+    out.push_str(&text[last_end..]);
+    Some((out, merged.len()))
+}
+
+#[derive(Clone, Copy)]
+struct ExactMatchRange {
+    start: usize,
+    end: usize,
 }
 
 /// Conservative Shannon entropy heuristic detector for random secret tokens.
@@ -474,6 +578,170 @@ mod tests {
         let (out, count) = d.redact("abc is short").expect("redact");
         assert_eq!(count, 0);
         assert_eq!(out, "abc is short");
+    }
+
+    #[test]
+    fn exact_value_detector_prefers_longest_overlap_independent_of_order() {
+        let short = "short";
+        let long = "short-with-sensitive-suffix";
+        let input = format!("overlap={long} standalone={short}");
+        let want = format!("overlap={MARKER} standalone={MARKER}");
+
+        for values in [[short, long], [long, short]] {
+            let d = ExactValueDetector::new(values);
+            let (out, count) = d.redact(&input).expect("redact");
+            assert_eq!(count, 2);
+            assert_eq!(out, want);
+        }
+    }
+
+    #[test]
+    fn exact_value_detector_deduplicates_replacement_counts() {
+        let d = ExactValueDetector::new(["short", "short", "short-with-sensitive-suffix"]);
+        let (out, count) = d
+            .redact("short-with-sensitive-suffix short")
+            .expect("redact");
+        assert_eq!(count, 2);
+        assert_eq!(out, format!("{MARKER} {MARKER}"));
+    }
+
+    #[test]
+    fn exact_value_detector_overlap_semantics() {
+        let cases = [
+            (
+                "equal_partial_short_first",
+                ["abcd", "bcde"],
+                "abcde",
+                MARKER,
+                1,
+            ),
+            (
+                "equal_partial_long_first",
+                ["bcde", "abcd"],
+                "abcde",
+                MARKER,
+                1,
+            ),
+            (
+                "unequal_partial",
+                ["abcdef", "defgh"],
+                "abcdefgh",
+                MARKER,
+                1,
+            ),
+            (
+                "containment",
+                ["secret-value", "cret-val"],
+                "prefix secret-value suffix",
+                "prefix [REDACTED] suffix",
+                1,
+            ),
+            (
+                "adjacent_nonoverlap",
+                ["abcd", "efgh"],
+                "abcdefgh",
+                "[REDACTED][REDACTED]",
+                2,
+            ),
+            (
+                "repeated_occurrences",
+                ["abcd", "efgh"],
+                "abcd--abcd",
+                "[REDACTED]--[REDACTED]",
+                2,
+            ),
+            (
+                "duplicates",
+                ["abcd", "abcd"],
+                "abcd abcd",
+                "[REDACTED] [REDACTED]",
+                2,
+            ),
+            (
+                "utf8_surrounding_text",
+                ["sëcret", "ëcret"],
+                "🔐sëcret🚀",
+                "🔐[REDACTED]🚀",
+                1,
+            ),
+            (
+                "self_overlap",
+                ["abab", "zzzz"],
+                "ababab",
+                "[REDACTED]ab",
+                1,
+            ),
+        ];
+
+        for (name, values, input, expected, expected_count) in cases {
+            let (out, count) = ExactValueDetector::new(values)
+                .redact(input)
+                .expect("redact");
+            assert_eq!(out, expected, "case {name}");
+            assert_eq!(count, expected_count, "case {name}");
+        }
+    }
+
+    #[test]
+    fn exact_value_detector_value_overflow_fails_closed() {
+        let values: Vec<String> = (0..=MAX_EXACT_VALUE_COUNT)
+            .map(|i| format!("secret-{i:04}"))
+            .collect();
+        let (out, count) = ExactValueDetector::new(values)
+            .redact("ordinary output")
+            .expect("redact");
+        assert_eq!(out, MARKER);
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn exact_value_detector_span_overflow_fails_closed() {
+        let input = "abcd ".repeat(MAX_EXACT_MATCH_SPANS + 1);
+        let (out, count) = ExactValueDetector::new(["abcd"])
+            .redact(&input)
+            .expect("redact");
+        assert_eq!(out, MARKER);
+        assert_eq!(count, 1);
+        assert!(!out.contains("abcd"));
+    }
+
+    #[test]
+    fn exact_value_scan_work_boundary_is_deterministic() {
+        let values = vec!["z".to_string()];
+        let (out, count) = redact_exact_values("aaaa", &values, 4).expect("near-bound scan");
+        assert_eq!(out, "aaaa");
+        assert_eq!(count, 0);
+        assert!(redact_exact_values("aaaa", &values, 3).is_none());
+    }
+
+    #[cfg_attr(
+        miri,
+        ignore = "64 MiB CPU-bound stress scan exceeds the Miri execution budget"
+    )]
+    #[test]
+    fn exact_value_scan_work_huge_text_many_values_fails_closed() {
+        let input = "x".repeat(1 << 20);
+        let values: Vec<String> = (0..MAX_EXACT_VALUE_COUNT)
+            .map(|i| format!("not-present-{i:04}"))
+            .collect();
+        let (out, count) = ExactValueDetector::new(values)
+            .redact(&input)
+            .expect("redact");
+        assert_eq!(out, MARKER);
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn exact_value_scan_work_arithmetic_is_safe() {
+        let values = vec!["z".to_string()];
+        let (out, count) = redact_exact_values("aaaa", &values, usize::MAX).expect("max budget");
+        assert_eq!(out, "aaaa");
+        assert_eq!(count, 0);
+        let long_value = vec!["zzzzz".to_string()];
+        let (out, count) =
+            redact_exact_values("aaaa", &long_value, usize::MAX).expect("long value");
+        assert_eq!(out, "aaaa");
+        assert_eq!(count, 0);
     }
 
     #[test]

--- a/crates/symvault-core/tests/redact_contract.rs
+++ b/crates/symvault-core/tests/redact_contract.rs
@@ -5,8 +5,8 @@ use std::sync::{Arc, Mutex};
 use serde::Deserialize;
 use symvault_core::redact::{
     AuditEvent, BLOCKED_TEXT, Detector, EntropyDetector, ExactValueDetector, MARKER,
-    MIN_ENTROPY_BITS_PER_CHAR, MIN_EXACT_VALUE_LEN, MIN_TOKEN_LEN, ScanOptions, Scanner, is_truthy,
-    shannon_entropy,
+    MAX_EXACT_MATCH_SPANS, MAX_EXACT_SCAN_WORK, MAX_EXACT_VALUE_COUNT, MIN_ENTROPY_BITS_PER_CHAR,
+    MIN_EXACT_VALUE_LEN, MIN_TOKEN_LEN, ScanOptions, Scanner, is_truthy, shannon_entropy,
 };
 
 #[derive(Debug, Deserialize)]
@@ -24,6 +24,9 @@ struct Constants {
     marker: String,
     blocked_text: String,
     min_exact_value_len: usize,
+    max_exact_value_count: usize,
+    max_exact_match_spans: usize,
+    max_exact_scan_work: usize,
     min_token_len: usize,
     min_entropy_bits_per_char: f64,
 }
@@ -99,6 +102,9 @@ fn constants_match_go_oracle() {
     assert_eq!(fix.constants.marker, MARKER);
     assert_eq!(fix.constants.blocked_text, BLOCKED_TEXT);
     assert_eq!(fix.constants.min_exact_value_len, MIN_EXACT_VALUE_LEN);
+    assert_eq!(fix.constants.max_exact_value_count, MAX_EXACT_VALUE_COUNT);
+    assert_eq!(fix.constants.max_exact_match_spans, MAX_EXACT_MATCH_SPANS);
+    assert_eq!(fix.constants.max_exact_scan_work, MAX_EXACT_SCAN_WORK);
     assert_eq!(fix.constants.min_token_len, MIN_TOKEN_LEN);
     assert!((fix.constants.min_entropy_bits_per_char - MIN_ENTROPY_BITS_PER_CHAR).abs() < 1e-9);
 }
@@ -233,6 +239,22 @@ fn scanner_cases_match_go_oracle() {
                 tc.name
             );
         }
+    }
+}
+
+#[test]
+fn property_exact_value_overlap_order_independence() {
+    let short = "short";
+    let long = "short-with-sensitive-suffix";
+    let input = format!("overlap={long} standalone={short}");
+    let expected = format!("overlap={MARKER} standalone={MARKER}");
+
+    for secrets in [[short, long], [long, short]] {
+        let detector = ExactValueDetector::new(secrets);
+        let (redacted, count) = detector.redact(&input).expect("redact");
+        assert_eq!(redacted, expected);
+        assert_eq!(count, 2);
+        assert!(!redacted.contains("sensitive-suffix"));
     }
 }
 

--- a/docs/leak-detection.md
+++ b/docs/leak-detection.md
@@ -33,6 +33,14 @@ affected output is withheld entirely (replaced with a fixed
 scanner bug can cause you to see less output than expected; it cannot cause
 an unscanned value to slip through.
 
+Exact-value redaction also has explicit memory and CPU bounds: one operation
+retains at most 1,024 distinct values and 4,096 match spans, and performs at
+most 64 MiB of byte comparisons. Values are deduplicated before scanning, and
+exact values remain matchable even when they are only one byte long. If any
+bound would be exceeded, the entire output is replaced by the fixed redaction
+marker. In that fail-closed case the reported count is `1`, meaning one
+withheld output rather than a count of individual spans.
+
 ## What this explicitly does not protect against
 
 This is a **process-boundary output filter**, not a general secrets-leak
@@ -66,6 +74,17 @@ prevention system. In particular, it does **not**:
 By default, a detection is **redacted**: the matched text is replaced with
 `[REDACTED]` in place, and the rest of the output (with the match removed)
 is still delivered. This is the "detect and warn" behavior.
+
+For exact-value detections, configured values are stably de-duplicated, then
+all non-overlapping occurrences of each value are found in the original text.
+The resulting byte ranges are sorted and overlapping ranges are merged into one
+redacted span; merely adjacent ranges remain separate. A value contained in a
+longer match is therefore not counted separately, while a shorter value outside
+the longer match is still redacted. Replacement count is the number of merged
+spans, so partial overlaps are counted once regardless of caller order. For a
+value that overlaps with itself, occurrence discovery is left-to-right and
+resumes at the end of the selected occurrence (for example, `abab` in `ababab`
+selects the first `abab`); the same range merge rules then apply across values.
 
 An opt-in **strict mode** changes this for high-confidence detections only:
 when a **high-confidence** match (exact-value or pattern-match tier) fires

--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"net"
@@ -21,6 +22,7 @@ import (
 
 	"github.com/danieljustus/symaira-vault/internal/audit"
 	configpkg "github.com/danieljustus/symaira-vault/internal/config"
+	"github.com/danieljustus/symaira-vault/internal/mcp/apitemplates"
 	"github.com/danieljustus/symaira-vault/internal/vault"
 )
 
@@ -361,9 +363,34 @@ allow_private: true
 	}
 }
 
+func TestRedactKnownValues_OverlapOrderIndependent(t *testing.T) {
+	cases := []struct {
+		name  string
+		data  map[string]any
+		input string
+		want  string
+	}{
+		{name: "containment", data: map[string]any{"a": "secret-value", "b": "cret-val"}, input: "prefix secret-value suffix", want: "prefix *** suffix"},
+		{name: "containment_reverse", data: map[string]any{"a": "cret-val", "b": "secret-value"}, input: "prefix secret-value suffix", want: "prefix *** suffix"},
+		{name: "equal_partial", data: map[string]any{"a": "abcd", "b": "bcde"}, input: "abcde", want: "***"},
+		{name: "equal_partial_reverse", data: map[string]any{"a": "bcde", "b": "abcd"}, input: "abcde", want: "***"},
+		{name: "unequal_partial", data: map[string]any{"a": "abcdef", "b": "defgh"}, input: "abcdefgh", want: "***"},
+		{name: "unequal_partial_reverse", data: map[string]any{"a": "defgh", "b": "abcdef"}, input: "abcdefgh", want: "***"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			values := apitemplates.CollectRedactionValues(apitemplates.AuthNone, tc.data)
+			if got := redactKnownValues(tc.input, values); got != tc.want {
+				t.Fatalf("redactKnownValues() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestProxy_ResponseSanitized(t *testing.T) {
 	const token = "known-secret-value-77"
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Credential-Echo", token)
 		_, _ = io.WriteString(w, `{"echo": "`+token+`"}`)
 	}))
 	defer upstream.Close()
@@ -388,6 +415,123 @@ func TestProxy_ResponseSanitized(t *testing.T) {
 	}
 	if !strings.Contains(string(body), "***") {
 		t.Errorf("response body = %q, want redacted marker", body)
+	}
+	if got := resp.Header.Get("X-Credential-Echo"); strings.Contains(got, token) || !strings.Contains(got, "***") {
+		t.Fatalf("response header was not redacted: %q", got)
+	}
+}
+
+func TestRedactKnownValues_WireFormats(t *testing.T) {
+	basicWire := base64.StdEncoding.EncodeToString([]byte("api-user:password with spaces"))
+	basicValues := apitemplates.CollectAuthRedactionValues(apitemplates.AuthBasic, map[string]any{
+		"username": "api-user",
+		"password": "password with spaces",
+	})
+	if got := redactKnownValues("echo="+basicWire, basicValues); strings.Contains(got, basicWire) {
+		t.Fatalf("Basic wire value leaked: %q", got)
+	}
+
+	const queryValue = "secret with / and ?"
+	queryWire := url.QueryEscape(queryValue)
+	queryValues := apitemplates.CollectAuthRedactionValues(apitemplates.AuthQueryParam, map[string]any{
+		"param_value": queryValue,
+	})
+	if got := redactKnownValues("echo="+queryWire, queryValues); strings.Contains(got, queryWire) {
+		t.Fatalf("query wire value leaked: %q", got)
+	}
+}
+
+func TestProxy_ResponseSanitized_OverlappingKnownValues(t *testing.T) {
+	const longValue = "abcdef"
+	const overlappingValue = "defgh"
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, "response="+longValue+overlappingValue)
+	}))
+	defer upstream.Close()
+
+	vaultDir, identity := setupVault(t, "testapi", map[string]any{
+		"credential": longValue,
+		"secondary":  overlappingValue,
+	}, "testapi", bearerTemplate(upstream.URL))
+	proxyURL, stop := startProxy(t, Config{
+		VaultDir:     vaultDir,
+		Identity:     identity,
+		AgentName:    "broker-test",
+		AllowPrivate: true,
+	})
+	defer stop()
+
+	resp, err := newProxyClient(proxyURL).Get(upstream.URL + "/overlap")
+	if err != nil {
+		t.Fatalf("GET through proxy: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	got := string(body)
+	for _, value := range []string{longValue, overlappingValue, longValue + overlappingValue} {
+		if strings.Contains(got, value) {
+			t.Fatalf("response body leaks overlapping credential %q: %q", value, got)
+		}
+	}
+	if !strings.Contains(got, "***") {
+		t.Fatalf("response body = %q, want redacted marker", got)
+	}
+}
+
+func TestProxy_ErrorRedactsOverlappingSubstitutionValues(t *testing.T) {
+	const firstValue = "abcdef"
+	const secondValue = "defgh"
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("closed upstream must not receive the request")
+	}))
+	upstreamURL := upstream.URL
+	upstream.Close()
+
+	templateBody := fmt.Sprintf(`base_url: %s
+auth_type: none
+entry_ref: errorapi
+substitutions:
+  - placeholder: __ONE__
+    field: first
+    in: [path]
+  - placeholder: __TWO__
+    field: second
+    in: [path]
+allowed_endpoints:
+  - /*
+allowed_methods:
+  - GET
+allow_private: true
+`, upstreamURL)
+	vaultDir, identity := setupVault(t, "errorapi", map[string]any{
+		"first":  firstValue,
+		"second": secondValue,
+	}, "errorapi", templateBody)
+	proxyURL, stop := startProxy(t, Config{
+		VaultDir:     vaultDir,
+		Identity:     identity,
+		AgentName:    "broker-test",
+		AllowPrivate: true,
+	})
+	defer stop()
+
+	resp, err := newProxyClient(proxyURL).Get(upstreamURL + "/__ONE____TWO__")
+	if err != nil {
+		t.Fatalf("GET through proxy: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	got := string(body)
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Fatalf("status = %d, want %d; body = %q", resp.StatusCode, http.StatusBadGateway, got)
+	}
+	for _, value := range []string{firstValue, secondValue, firstValue + secondValue} {
+		if strings.Contains(got, value) {
+			t.Fatalf("error body leaks substituted credential %q: %q", value, got)
+		}
+	}
+	if !strings.Contains(got, "***") {
+		t.Fatalf("error body = %q, want redacted marker", got)
 	}
 }
 
@@ -936,4 +1080,94 @@ func connectAndGetStatus(t *testing.T, proxyURL, targetURL, path string) (int, s
 	body, _ := io.ReadAll(gresp.Body)
 	_ = gresp.Body.Close()
 	return gresp.StatusCode, string(body)
+}
+
+func TestProxy_ResponseMasksKnownPatternPrefixAndSuffix(t *testing.T) {
+	secret := "fixture@example.invalid|nonsecret-tail"
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, "prefix="+secret+" suffix")
+	}))
+	defer upstream.Close()
+
+	vaultDir, identity := setupVault(t, "testapi", map[string]any{"credential": secret}, "testapi", bearerTemplate(upstream.URL))
+	proxyURL, stop := startProxy(t, Config{
+		VaultDir:     vaultDir,
+		Identity:     identity,
+		AgentName:    "broker-test",
+		AllowPrivate: true,
+	})
+	defer stop()
+
+	resp, err := newProxyClient(proxyURL).Get(upstream.URL + "/prefix")
+	if err != nil {
+		t.Fatalf("GET through proxy: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	got := string(body)
+	if strings.Contains(got, "fixture@example.invalid") || strings.Contains(got, "nonsecret-tail") {
+		t.Fatalf("response leaks known secret or suffix: %q", got)
+	}
+	if !strings.Contains(got, "***") {
+		t.Fatalf("response body = %q, want redaction marker", got)
+	}
+}
+
+type queryAuthErrorTransport struct{}
+
+func (queryAuthErrorTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return nil, fmt.Errorf("synthetic upstream error for %s", req.URL.String())
+}
+
+func TestProxy_ErrorRedactsQueryAuthValueAndSuffix(t *testing.T) {
+	authValue := "fixture@example.invalid|broker-query-auth-suffix"
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("closed upstream must not receive the request")
+	}))
+	upstreamURL := upstream.URL
+	upstream.Close()
+
+	templateBody := fmt.Sprintf(`base_url: %s
+auth_type: query_param
+entry_ref: queryerror
+allowed_endpoints:
+  - /*
+allowed_methods:
+  - GET
+allow_private: true
+`, upstreamURL)
+	vaultDir, identity := setupVault(t, "queryerror", map[string]any{
+		"param_name":  "access_token",
+		"param_value": authValue,
+	}, "queryerror", templateBody)
+	p, err := New(Config{
+		VaultDir:     vaultDir,
+		Identity:     identity,
+		AgentName:    "broker-test",
+		AllowPrivate: true,
+	})
+	if err != nil {
+		t.Fatalf("broker.New: %v", err)
+	}
+	p.client.Transport = queryAuthErrorTransport{}
+	proxy := httptest.NewServer(p.Handler())
+	defer proxy.Close()
+	proxyURL := proxy.URL
+
+	resp, err := newProxyClient(proxyURL).Get(upstreamURL + "/ping")
+	if err != nil {
+		t.Fatalf("GET through proxy: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	got := string(body)
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Fatalf("status = %d, want %d; body = %q", resp.StatusCode, http.StatusBadGateway, got)
+	}
+	if strings.Contains(got, authValue) || strings.Contains(got, "broker-query-auth-suffix") {
+		t.Fatalf("broker error leaks query auth value or suffix: %q", got)
+	}
+	if !strings.Contains(got, "***") {
+		t.Fatalf("broker error body = %q, want redacted marker", got)
+	}
 }

--- a/internal/broker/proxy.go
+++ b/internal/broker/proxy.go
@@ -320,15 +320,21 @@ func (p *Proxy) forward(w http.ResponseWriter, r *http.Request, target string, t
 	}()
 
 	var body io.Reader
-	var redactVals []string
+	authType := apitemplates.AuthNone
+	if tmpl != nil {
+		authType = tmpl.AuthType
+	}
+	redactVals := apitemplates.CollectRedactionValues(authType, entryData)
 	var values map[string]string
 	if tmpl != nil && len(tmpl.Substitutions) > 0 {
 		var subErr error
-		values, redactVals, subErr = apitemplates.ResolveSubstitutionValues(tmpl, entryData)
+		var substitutionRedactVals []string
+		values, substitutionRedactVals, subErr = apitemplates.ResolveSubstitutionValues(tmpl, entryData)
 		if subErr != nil {
 			http.Error(w, "cannot resolve substitutions for host", http.StatusInternalServerError)
 			return
 		}
+		redactVals = apitemplates.CollectRedactionValues(authType, entryData, substitutionRedactVals)
 		target = apitemplates.ApplyURLSubstitutions(target, tmpl.Substitutions, values)
 		raw, readErr := io.ReadAll(io.LimitReader(r.Body, maxBrokerResponseBytes+1))
 		if readErr != nil {
@@ -381,14 +387,14 @@ func (p *Proxy) forward(w http.ResponseWriter, r *http.Request, target string, t
 	}
 	bodyText := string(raw)
 
-	// Sanitize: pattern-based detection plus known credential values.
+	// Redact known credential values on the original response before generic
+	// pattern masking. A generic pattern can match only a provider-shaped
+	// prefix of a longer known value, leaving its suffix exposed.
+	bodyText = redactKnownValues(bodyText, redactVals)
 	sanitizer := masking.NewSanitizer()
 	bodyText = sanitizer.Sanitize(bodyText, masking.MaskOptions{CustomMask: "***"})
-	if entryData != nil {
-		bodyText = redactKnownValues(bodyText, entryData)
-	}
 
-	copyHeaders(w.Header(), resp.Header)
+	copySanitizedResponseHeaders(w.Header(), resp.Header, redactVals)
 	w.Header().Del("Content-Length")
 	w.WriteHeader(status)
 	_, _ = io.WriteString(w, bodyText)
@@ -459,13 +465,24 @@ func copyHeaders(dst, src http.Header) {
 	}
 }
 
-func redactKnownValues(text string, entryData map[string]any) string {
-	for _, v := range entryData {
-		if vStr, ok := v.(string); ok && vStr != "" {
-			text = strings.ReplaceAll(text, vStr, "***")
+func copySanitizedResponseHeaders(dst, src http.Header, redactVals []string) {
+	sanitizer := masking.NewSanitizer()
+	for key, values := range src {
+		switch strings.ToLower(key) {
+		case "connection", "proxy-connection", "keep-alive", "transfer-encoding", "upgrade", "te":
+			continue
+		}
+		for _, value := range values {
+			value = apitemplates.RedactValues(value, redactVals)
+			value = sanitizer.Sanitize(value, masking.MaskOptions{CustomMask: "***"})
+			dst.Add(key, value)
 		}
 	}
-	return text
+}
+
+func redactKnownValues(text string, values []string) string {
+	redacted, _ := masking.RedactKnownSecrets(text, values, "***")
+	return redacted
 }
 
 // loadTemplates resolves the full catalog: embedded built-ins (with vault-local

--- a/internal/mcp/apitemplates/auth.go
+++ b/internal/mcp/apitemplates/auth.go
@@ -5,7 +5,11 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"reflect"
+	"sort"
 	"strings"
+
+	"github.com/danieljustus/symaira-vault/internal/mcp/masking"
 )
 
 // ResolveField returns the first non-empty string value from the entry data
@@ -75,6 +79,135 @@ func InjectAuth(httpReq *http.Request, tmpl *APITemplate, entryData map[string]a
 	}
 
 	return nil
+}
+
+// CollectAuthRedactionValues returns the string values that InjectAuth can
+// place in a request. Field order is fixed and duplicates are removed, so the
+// result is deterministic and safe to use for exact-first error redaction.
+// Additional values are typically substitution values already resolved for the
+// same request; they are included in stable input order and deduplicated too.
+func CollectAuthRedactionValues(authType AuthType, entryData map[string]any, additional ...[]string) []string {
+	fields := []string{"credential", "token", "password", "username", "header_value", "param_value"}
+	values := make([]string, 0, len(fields))
+	seen := make(map[string]struct{}, len(fields))
+	appendValue := func(value string) {
+		if value == "" {
+			return
+		}
+		if _, ok := seen[value]; ok {
+			return
+		}
+		seen[value] = struct{}{}
+		values = append(values, value)
+	}
+	for _, field := range fields {
+		if value, ok := entryData[field].(string); ok {
+			appendValue(value)
+		}
+	}
+	if authType == AuthBasic {
+		username := ResolveField(entryData, "username")
+		password := ResolveField(entryData, "credential", "password")
+		if username != "" && password != "" {
+			appendValue(base64.StdEncoding.EncodeToString([]byte(username + ":" + password)))
+		}
+	}
+	if authType == AuthQueryParam {
+		appendValue(url.QueryEscape(ResolveField(entryData, "param_value", "credential", "token", "password")))
+	}
+	for _, extraValues := range additional {
+		for _, value := range extraValues {
+			appendValue(value)
+			appendValue(url.QueryEscape(value))
+			appendValue(url.PathEscape(value))
+			appendValue((&url.URL{Path: value}).EscapedPath())
+		}
+	}
+	return values
+}
+
+// CollectRedactionValues returns auth wire values plus every string stored in
+// the resolved entry. Responses and transport errors can echo fields beyond
+// the credential used for injection.
+func CollectRedactionValues(authType AuthType, entryData map[string]any, additional ...[]string) []string {
+	values := CollectAuthRedactionValues(authType, entryData, additional...)
+	seen := make(map[string]struct{}, len(values)+len(entryData))
+	for _, value := range values {
+		seen[value] = struct{}{}
+	}
+
+	appendValue := func(value string) {
+		if value == "" {
+			return
+		}
+		if _, exists := seen[value]; exists {
+			return
+		}
+		seen[value] = struct{}{}
+		values = append(values, value)
+	}
+	type visit struct {
+		kind reflect.Kind
+		ptr  uintptr
+	}
+	visited := make(map[visit]struct{})
+	var walk func(reflect.Value)
+	walk = func(value reflect.Value) {
+		if !value.IsValid() {
+			return
+		}
+		for value.Kind() == reflect.Interface || value.Kind() == reflect.Pointer {
+			if value.IsNil() {
+				return
+			}
+			if value.Kind() == reflect.Pointer {
+				key := visit{kind: value.Kind(), ptr: value.Pointer()}
+				if _, exists := visited[key]; exists {
+					return
+				}
+				visited[key] = struct{}{}
+			}
+			value = value.Elem()
+		}
+		switch value.Kind() {
+		case reflect.String:
+			appendValue(value.String())
+		case reflect.Map:
+			if value.IsNil() || value.Type().Key().Kind() != reflect.String {
+				return
+			}
+			key := visit{kind: value.Kind(), ptr: value.Pointer()}
+			if _, exists := visited[key]; exists {
+				return
+			}
+			visited[key] = struct{}{}
+			keys := value.MapKeys()
+			sort.Slice(keys, func(i, j int) bool { return keys[i].String() < keys[j].String() })
+			for _, mapKey := range keys {
+				walk(value.MapIndex(mapKey))
+			}
+		case reflect.Slice:
+			if value.IsNil() {
+				return
+			}
+			key := visit{kind: value.Kind(), ptr: value.Pointer()}
+			if _, exists := visited[key]; exists {
+				return
+			}
+			visited[key] = struct{}{}
+			for i := 0; i < value.Len(); i++ {
+				walk(value.Index(i))
+			}
+		case reflect.Array:
+			for i := 0; i < value.Len(); i++ {
+				walk(value.Index(i))
+			}
+		default:
+			return
+		}
+	}
+	walk(reflect.ValueOf(entryData))
+	return values
 }
 
 // ResolveSubstitutionValues resolves every declared substitution placeholder
@@ -214,11 +347,6 @@ func EntryRefPath(entryRef string) (string, error) {
 // RedactValues replaces every occurrence of the given secret values in msg
 // with "***" so substituted credentials never reach error messages.
 func RedactValues(msg string, values []string) string {
-	for _, v := range values {
-		if v == "" {
-			continue
-		}
-		msg = strings.ReplaceAll(msg, v, "***")
-	}
-	return msg
+	redacted, _ := masking.RedactKnownSecrets(msg, values, "***")
+	return redacted
 }

--- a/internal/mcp/apitemplates/auth_test.go
+++ b/internal/mcp/apitemplates/auth_test.go
@@ -1,7 +1,11 @@
 package apitemplates
 
 import (
+	"encoding/base64"
 	"net/http"
+	"net/url"
+	"reflect"
+	"slices"
 	"testing"
 )
 
@@ -162,5 +166,63 @@ func TestInjectAuth_Unsupported(t *testing.T) {
 	err := InjectAuth(req, tmpl, nil)
 	if err == nil {
 		t.Fatal("InjectAuth() expected error for unsupported auth type, got nil")
+	}
+}
+
+func TestCollectAuthRedactionValues_IsStableAndDeduplicated(t *testing.T) {
+	got := CollectAuthRedactionValues(AuthHeader, map[string]any{
+		"param_value":  "same",
+		"header_value": "header-secret",
+		"username":     "same",
+		"password":     "password-secret",
+		"token":        "token-secret",
+		"credential":   "same",
+	}, []string{"password-secret", "substitution-secret", "substitution-secret"})
+	want := []string{"same", "token-secret", "password-secret", "header-secret", "substitution-secret"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("CollectAuthRedactionValues() = %v, want %v", got, want)
+	}
+}
+
+func TestCollectAuthRedactionValues_IncludesBasicWireValue(t *testing.T) {
+	values := CollectAuthRedactionValues(AuthBasic, map[string]any{
+		"username": "api-user",
+		"password": "password with spaces",
+	})
+	wireValue := base64.StdEncoding.EncodeToString([]byte("api-user:password with spaces"))
+	if !slices.Contains(values, wireValue) {
+		t.Fatal("redaction values omit Basic wire value")
+	}
+}
+
+func TestCollectAuthRedactionValues_IncludesEncodedURLValues(t *testing.T) {
+	const value = "secret with / and ?"
+	values := CollectAuthRedactionValues(AuthQueryParam, map[string]any{"param_value": value}, []string{value})
+	for _, wireValue := range []string{url.QueryEscape(value), url.PathEscape(value), (&url.URL{Path: value}).EscapedPath()} {
+		if !slices.Contains(values, wireValue) {
+			t.Fatalf("redaction values omit encoded wire value %q", wireValue)
+		}
+	}
+}
+
+func TestCollectRedactionValues_RecursesDeterministically(t *testing.T) {
+	pointerSecret := "pointer-secret"
+	cycle := map[string]any{"value": "cycle-secret"}
+	cycle["self"] = cycle
+	entryData := map[string]any{
+		"nested": map[string]any{
+			"z": []any{"slice-secret", map[string]string{"key": "map-secret"}},
+			"a": "first-secret",
+		},
+		"strings": []string{"second-secret"},
+		"typed":   []map[string]any{{"value": "typed-secret"}},
+		"array":   [1]string{"array-secret"},
+		"pointer": &pointerSecret,
+		"cycle":   cycle,
+	}
+	got := CollectRedactionValues(AuthNone, entryData)
+	want := []string{"array-secret", "cycle-secret", "first-secret", "slice-secret", "map-secret", "pointer-secret", "second-secret", "typed-secret"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("CollectRedactionValues() = %v, want %v", got, want)
 	}
 }

--- a/internal/mcp/apitemplates/substitution_test.go
+++ b/internal/mcp/apitemplates/substitution_test.go
@@ -333,6 +333,29 @@ func TestRedactValues(t *testing.T) {
 	}
 }
 
+func TestRedactValues_OverlapOrderIndependent(t *testing.T) {
+	cases := []struct {
+		name   string
+		values []string
+		input  string
+		want   string
+	}{
+		{name: "containment", values: []string{"secret-value", "cret-val"}, input: "prefix secret-value suffix", want: "prefix *** suffix"},
+		{name: "containment_reverse", values: []string{"cret-val", "secret-value"}, input: "prefix secret-value suffix", want: "prefix *** suffix"},
+		{name: "equal_partial", values: []string{"abcd", "bcde"}, input: "abcde", want: "***"},
+		{name: "equal_partial_reverse", values: []string{"bcde", "abcd"}, input: "abcde", want: "***"},
+		{name: "unequal_partial", values: []string{"abcdef", "defgh"}, input: "abcdefgh", want: "***"},
+		{name: "unequal_partial_reverse", values: []string{"defgh", "abcdef"}, input: "abcdefgh", want: "***"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := RedactValues(tc.input, tc.values); got != tc.want {
+				t.Fatalf("RedactValues() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestRedactValues_EmptyValueSkip(t *testing.T) {
 	msg := "token=sekret msg unchanged"
 	got := RedactValues(msg, []string{"", "", "sekret"})

--- a/internal/mcp/masking/sanitizer.go
+++ b/internal/mcp/masking/sanitizer.go
@@ -5,6 +5,7 @@ package masking
 import (
 	"fmt"
 	"regexp"
+	"sort"
 	"strings"
 	"sync"
 )
@@ -327,18 +328,155 @@ func (s *Sanitizer) Sanitize(text string, opts MaskOptions) string {
 	return b.String()
 }
 
-// SanitizeWithKnownSecrets replaces known secret values in text with masks.
-// This is used when you already know the secret values (e.g., from resolved env vars).
-func SanitizeWithKnownSecrets(text string, secrets map[string]string, mask string) string {
+// MaxKnownSecretValues bounds the number of distinct values retained for
+// one exact-redaction operation. Overflow is fail-closed.
+const MaxKnownSecretValues = 1024
+
+// MaxKnownSecretSpans bounds the number of match spans retained for one
+// exact-redaction operation. Overflow is fail-closed.
+const MaxKnownSecretSpans = 4096
+
+// MaxKnownSecretScanWork bounds exact matching by the number of byte
+// comparisons performed for one operation. The 64 MiB budget keeps a normal
+// 16 MiB output with a small number of values usable while preventing a large
+// output multiplied by many non-matching values from consuming unbounded CPU.
+const MaxKnownSecretScanWork int64 = 64 * 1024 * 1024
+
+// knownSecretSpan is a byte range in the original input text.
+type knownSecretSpan struct {
+	start int
+	end   int
+}
+
+// RedactKnownSecrets scans the original text for all non-empty literal values
+// and replaces their merged spans with mask. Values are stably deduplicated
+// and matched longest-first before replacement, so replacement order cannot
+// expose an overlapping suffix.
+//
+// The returned count is the number of merged redacted spans. If the distinct
+// value, retained-span, or byte-comparison budget is exceeded, the entire
+// output is replaced by mask and the count is 1, denoting one withheld output
+// rather than a span count. The bounds avoid retaining or allocating unbounded
+// match state or spending unbounded CPU while preserving exact matches as
+// short as one byte.
+func RedactKnownSecrets(text string, values []string, mask string) (string, int) {
+	return redactKnownSecretsWithBudget(text, values, mask, MaxKnownSecretScanWork)
+}
+
+func redactKnownSecretsWithBudget(text string, values []string, mask string, scanWork int64) (string, int) {
 	if mask == "" {
 		mask = "***"
 	}
-	result := text
-	for _, value := range secrets {
+	if text == "" {
+		return text, 0
+	}
+	if scanWork < 0 {
+		return mask, 1
+	}
+
+	seen := make(map[string]struct{}, minInt(len(values), MaxKnownSecretValues))
+	unique := make([]string, 0, minInt(len(values), MaxKnownSecretValues))
+	for _, value := range values {
 		if value == "" {
 			continue
 		}
-		result = strings.ReplaceAll(result, value, mask)
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		if len(unique) >= MaxKnownSecretValues {
+			return mask, 1
+		}
+		seen[value] = struct{}{}
+		unique = append(unique, value)
 	}
+	// Match longer values first so Go and Rust consume the same deterministic
+	// scan budget when overlapping values are supplied in different orders.
+	sort.SliceStable(unique, func(i, j int) bool {
+		return len(unique[i]) > len(unique[j])
+	})
+
+	spans := make([]knownSecretSpan, 0, minInt(len(unique), MaxKnownSecretSpans))
+	for _, value := range unique {
+		if len(value) > len(text) {
+			continue
+		}
+		maxStart := len(text) - len(value)
+		for searchStart := 0; searchStart <= maxStart; {
+			matched := true
+			for offset := 0; offset < len(value); offset++ {
+				if scanWork <= 0 {
+					return mask, 1
+				}
+				scanWork--
+				if text[searchStart+offset] != value[offset] {
+					matched = false
+					break
+				}
+			}
+			if matched {
+				end := searchStart + len(value)
+				if len(spans) >= MaxKnownSecretSpans {
+					return mask, 1
+				}
+				spans = append(spans, knownSecretSpan{start: searchStart, end: end})
+				searchStart = end
+			} else {
+				searchStart++
+			}
+		}
+	}
+	if len(spans) == 0 {
+		return text, 0
+	}
+
+	sort.Slice(spans, func(i, j int) bool {
+		if spans[i].start != spans[j].start {
+			return spans[i].start < spans[j].start
+		}
+		return spans[i].end < spans[j].end
+	})
+	merged := make([]knownSecretSpan, 0, len(spans))
+	for _, candidate := range spans {
+		if len(merged) == 0 || candidate.start >= merged[len(merged)-1].end {
+			merged = append(merged, candidate)
+			continue
+		}
+		if candidate.end > merged[len(merged)-1].end {
+			merged[len(merged)-1].end = candidate.end
+		}
+	}
+
+	var out strings.Builder
+	lastEnd := 0
+	for _, span := range merged {
+		out.WriteString(text[lastEnd:span.start])
+		out.WriteString(mask)
+		lastEnd = span.end
+	}
+	out.WriteString(text[lastEnd:])
+	return out.String(), len(merged)
+}
+
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+// SanitizeWithKnownSecrets replaces known secret values in text with masks.
+// This is used when you already know the secret values (e.g., from resolved env vars).
+func SanitizeWithKnownSecrets(text string, secrets map[string]string, mask string) string {
+	keys := make([]string, 0, len(secrets))
+	for key := range secrets {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	values := make([]string, 0, len(keys))
+	for _, key := range keys {
+		values = append(values, secrets[key])
+	}
+	result, _ := RedactKnownSecrets(text, values, mask)
 	return result
 }

--- a/internal/mcp/masking/sanitizer_test.go
+++ b/internal/mcp/masking/sanitizer_test.go
@@ -1,6 +1,7 @@
 package masking
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -278,6 +279,44 @@ func TestSanitizeWithKnownSecrets(t *testing.T) {
 	}
 }
 
+func TestRedactKnownSecrets_OverlapOrderIndependent(t *testing.T) {
+	cases := []struct {
+		name   string
+		values []string
+		input  string
+		want   string
+		count  int
+	}{
+		{name: "containment", values: []string{"secret-value", "cret-val"}, input: "prefix secret-value suffix", want: "prefix *** suffix", count: 1},
+		{name: "containment_reverse", values: []string{"cret-val", "secret-value"}, input: "prefix secret-value suffix", want: "prefix *** suffix", count: 1},
+		{name: "equal_partial", values: []string{"abcd", "bcde"}, input: "abcde", want: "***", count: 1},
+		{name: "equal_partial_reverse", values: []string{"bcde", "abcd"}, input: "abcde", want: "***", count: 1},
+		{name: "unequal_partial", values: []string{"abcdef", "defgh"}, input: "abcdefgh", want: "***", count: 1},
+		{name: "unequal_partial_reverse", values: []string{"defgh", "abcdef"}, input: "abcdefgh", want: "***", count: 1},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, count := RedactKnownSecrets(tc.input, tc.values, "***")
+			if got != tc.want || count != tc.count {
+				t.Fatalf("RedactKnownSecrets() = (%q, %d), want (%q, %d)", got, count, tc.want, tc.count)
+			}
+			for _, value := range tc.values {
+				if strings.Contains(got, value) {
+					t.Fatalf("overlapping secret %q leaked in %q", value, got)
+				}
+			}
+		})
+	}
+}
+
+func TestSanitizeWithKnownSecrets_PreservesShortKnownValues(t *testing.T) {
+	got := SanitizeWithKnownSecrets("x a y", map[string]string{"SHORT": "a"}, "***")
+	if got != "x *** y" {
+		t.Fatalf("SanitizeWithKnownSecrets() = %q, want %q", got, "x *** y")
+	}
+}
+
 func TestSanitizePerformance(t *testing.T) {
 	sanitizer := NewSanitizer()
 	var text strings.Builder
@@ -528,5 +567,75 @@ func TestValidatorIntegration(t *testing.T) {
 		if m.PatternName == "iban" {
 			t.Errorf("expected no IBAN match for invalid country code, got %q", m.Value)
 		}
+	}
+}
+
+func TestRedactKnownSecrets_DuplicateHeavyValuesAreBounded(t *testing.T) {
+	values := make([]string, 100_000)
+	for i := range values {
+		values[i] = "q"
+	}
+
+	got, count := RedactKnownSecrets("prefix q suffix", values, "***")
+	if got != "prefix *** suffix" || count != 1 {
+		t.Fatalf("RedactKnownSecrets() = (%q, %d), want (%q, 1)", got, count, "prefix *** suffix")
+	}
+}
+
+func TestRedactKnownSecrets_SpanOverflowFailsClosed(t *testing.T) {
+	input := strings.Repeat("x", MaxKnownSecretSpans+1)
+	got, count := RedactKnownSecrets(input, []string{"x"}, "***")
+	if got != "***" || count != 1 {
+		t.Fatalf("overflow result = (%q, %d), want (***, 1)", got, count)
+	}
+	if strings.Contains(got, "x") {
+		t.Fatalf("overflow result leaked exact value: %q", got)
+	}
+}
+
+func TestRedactKnownSecrets_16MiBOneByteSecretFailsClosed(t *testing.T) {
+	input := strings.Repeat("z", 16<<20)
+	got, count := RedactKnownSecrets(input, []string{"z"}, "***")
+	if got != "***" || count != 1 {
+		t.Fatalf("16 MiB result = (%q, %d), want (***, 1)", got, count)
+	}
+}
+
+func TestRedactKnownSecrets_ScanWorkBoundary(t *testing.T) {
+	input := strings.Repeat("a", 32)
+
+	got, count := redactKnownSecretsWithBudget(input, []string{"z"}, "***", int64(len(input)))
+	if got != input || count != 0 {
+		t.Fatalf("near-bound result = (%q, %d), want unchanged input and zero matches", got, count)
+	}
+
+	got, count = redactKnownSecretsWithBudget(input, []string{"z"}, "***", int64(len(input)-1))
+	if got != "***" || count != 1 {
+		t.Fatalf("over-bound result = (%q, %d), want (***, 1)", got, count)
+	}
+}
+
+func TestRedactKnownSecrets_HugeTextManyValuesFailsClosed(t *testing.T) {
+	input := strings.Repeat("x", 16<<20)
+	values := make([]string, MaxKnownSecretValues)
+	for i := range values {
+		values[i] = fmt.Sprintf("not-present-%04d", i)
+	}
+
+	got, count := RedactKnownSecrets(input, values, "***")
+	if got != "***" || count != 1 {
+		t.Fatalf("huge scan result = (%q, %d), want (***, 1)", got, count)
+	}
+}
+
+func TestRedactKnownSecrets_ScanWorkArithmeticIsSafe(t *testing.T) {
+	got, count := redactKnownSecretsWithBudget("aaaa", []string{"z"}, "***", int64(1<<63-1))
+	if got != "aaaa" || count != 0 {
+		t.Fatalf("max-budget result = (%q, %d), want unchanged input and zero matches", got, count)
+	}
+
+	got, count = redactKnownSecretsWithBudget("aaaa", []string{"zzzzz"}, "***", int64(1<<63-1))
+	if got != "aaaa" || count != 0 {
+		t.Fatalf("long-value result = (%q, %d), want unchanged input and zero matches", got, count)
 	}
 }

--- a/internal/mcp/server/tools_execute_api_request.go
+++ b/internal/mcp/server/tools_execute_api_request.go
@@ -128,7 +128,7 @@ func (s *Server) handleExecuteAPIRequest(ctx context.Context, req mcp.CallToolRe
 	// entry. Values never enter logs or audit entries; any error message that
 	// could carry a substituted value is redacted below.
 	var substitutionValues map[string]string
-	var redactVals []string
+	redactVals := apitemplates.CollectRedactionValues(tmpl.AuthType, entry.Data)
 	if len(tmpl.Substitutions) > 0 {
 		values, redactList, subErr := apitemplates.ResolveSubstitutionValues(tmpl, entry.Data)
 		if subErr != nil {
@@ -136,7 +136,7 @@ func (s *Server) handleExecuteAPIRequest(ctx context.Context, req mcp.CallToolRe
 			return mcp.NewToolResultError(fmt.Sprintf("cannot resolve substitutions for %q: %v", tmpl.Name, subErr)), nil
 		}
 		substitutionValues = values
-		redactVals = redactList
+		redactVals = apitemplates.CollectRedactionValues(tmpl.AuthType, entry.Data, redactList)
 		requestURL = apitemplates.ApplyURLSubstitutions(requestURL, tmpl.Substitutions, values)
 		bodyStr = apitemplates.ApplyBodySubstitutions(bodyStr, tmpl.Substitutions, values)
 	}
@@ -213,24 +213,17 @@ func (s *Server) handleExecuteAPIRequest(ctx context.Context, req mcp.CallToolRe
 	// Sanitize response body: pattern-based detection + known-value masking
 	respText := string(respBody)
 
-	// Step 1: Pattern-based sanitization (detects ghp_xxx, sk-xxx, AKIAxxx, etc.)
+	// Step 1: Known-value sanitization on the original response. This must
+	// happen before generic pattern masking: a pattern may match only a
+	// provider-shaped prefix of a longer known secret, leaving its suffix
+	// exposed and making the exact value unmatchable.
 	sanitizer := masking.NewSanitizer()
-	patternSanitized := sanitizer.Sanitize(respText, masking.MaskOptions{CustomMask: "***"})
-
-	// Step 2: Known-value sanitization (vault entry data as known secrets)
-	resolvedSecrets := make(map[string]string)
-	for k, v := range entry.Data {
-		if vStr, ok := v.(string); ok {
-			resolvedSecrets[k] = vStr
-		}
+	sanitizeResponseValue := func(value string) string {
+		knownSanitized := apitemplates.RedactValues(value, redactVals)
+		return sanitizer.Sanitize(knownSanitized, masking.MaskOptions{CustomMask: "***"})
 	}
-	sanitizedBody := s.sanitizeKnownSecretValues(patternSanitized, resolvedSecrets)
-
-	// Audit log if any secrets were stripped
-	if sanitizedBody != respText {
-		s.logAudit(ctx, "execute_api_request", fmt.Sprintf("template=%s, endpoint=%s, method=%s, status=%d, sanitized=true",
-			tmpl.Name, normalizedEndpoint, method, resp.StatusCode), true)
-	}
+	sanitizedBody := sanitizeResponseValue(respText)
+	responseSanitized := sanitizedBody != respText
 
 	// Collect response headers (safe subset)
 	safeHeaders := make(map[string]string)
@@ -241,11 +234,19 @@ func (s *Server) handleExecuteAPIRequest(ctx context.Context, req mcp.CallToolRe
 			lower == "proxy-authenticate" || lower == "proxy-authorization" {
 			continue
 		}
-		safeHeaders[k] = resp.Header.Get(k)
+		rawValue := resp.Header.Get(k)
+		safeHeaders[k] = sanitizeResponseValue(rawValue)
+		responseSanitized = responseSanitized || safeHeaders[k] != rawValue
+	}
+
+	// Audit log if any secrets were stripped from the response body or headers.
+	if responseSanitized {
+		s.logAudit(ctx, "execute_api_request", fmt.Sprintf("template=%s, endpoint=%s, method=%s, status=%d, sanitized=true",
+			tmpl.Name, normalizedEndpoint, method, resp.StatusCode), true)
 	}
 
 	// Determine content type
-	contentType := resp.Header.Get("Content-Type")
+	contentType := sanitizeResponseValue(resp.Header.Get("Content-Type"))
 
 	// Audit log: template + endpoint + method + status code only
 	auditMsg := fmt.Sprintf("template=%s, endpoint=%s, method=%s, status=%d",

--- a/internal/mcp/server/tools_execute_api_request_test.go
+++ b/internal/mcp/server/tools_execute_api_request_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -221,6 +222,67 @@ allow_private: true
 	ct, _ := output["content_type"].(string)
 	if ct != "application/json" {
 		t.Errorf("content_type = %q, want application/json", ct)
+	}
+}
+
+func TestHandleExecuteAPIRequest_ErrorRedactsOverlappingSubstitutionValues(t *testing.T) {
+	const firstValue = "abcdef"
+	const secondValue = "defgh"
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("closed upstream must not receive the request")
+	}))
+	upstreamURL := upstream.URL
+	upstream.Close()
+
+	vaultDir, identity := mockVaultWithEntry(t, "errorapi", map[string]any{
+		"first":  firstValue,
+		"second": secondValue,
+	})
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:           "test",
+		AllowedPaths:   []string{"*"},
+		CanRunCommands: config.BoolPtr(true),
+		ApprovalMode:   config.StrPtr("none"),
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+
+	writeTemplateOverride(t, vaultDir, "errorapi", fmt.Sprintf(`base_url: %s
+auth_type: none
+entry_ref: errorapi
+substitutions:
+  - placeholder: __ONE__
+    field: first
+    in: [path]
+  - placeholder: __TWO__
+    field: second
+    in: [path]
+allowed_endpoints:
+  - /*
+allowed_methods:
+  - GET
+allow_private: true
+`, upstreamURL))
+
+	result, err := srv.handleExecuteAPIRequest(context.Background(), mcp.CallToolRequest{
+		Arguments: map[string]any{
+			"template": "errorapi",
+			"endpoint": "/__ONE____TWO__",
+			"method":   "GET",
+		},
+	})
+	if err != nil {
+		t.Fatalf("handleExecuteAPIRequest() error = %v", err)
+	}
+	if !result.IsError {
+		t.Fatalf("handleExecuteAPIRequest() expected error result, got %s", result.Text)
+	}
+	for _, value := range []string{firstValue, secondValue, firstValue + secondValue} {
+		if strings.Contains(result.Text, value) {
+			t.Fatalf("error result leaks substituted credential %q: %q", value, result.Text)
+		}
+	}
+	if !strings.Contains(result.Text, "***") {
+		t.Fatalf("error result = %q, want redacted marker", result.Text)
 	}
 }
 
@@ -548,6 +610,51 @@ allow_private: true
 				}
 			}
 		})
+	}
+}
+
+func TestHandleExecuteAPIRequest_ResponseRedactsBasicWireValue(t *testing.T) {
+	const username = "api-user"
+	const password = "password with spaces"
+	wireValue := base64.StdEncoding.EncodeToString([]byte(username + ":" + password))
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("X-Credential-Echo", wireValue)
+		w.Header().Set("Content-Type", wireValue)
+		_, _ = io.WriteString(w, wireValue)
+	}))
+	defer upstream.Close()
+
+	vaultDir, identity := mockVaultWithEntry(t, "basic-response-test", map[string]any{
+		"username": username,
+		"password": password,
+	})
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:           "test",
+		AllowedPaths:   []string{"*"},
+		CanRunCommands: config.BoolPtr(true),
+		ApprovalMode:   config.StrPtr("none"),
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+	writeTemplateOverride(t, vaultDir, "basic-response-test", fmt.Sprintf(`base_url: %s
+auth_type: basic
+entry_ref: basic-response-test
+allowed_endpoints:
+  - /*
+allowed_methods:
+  - GET
+allow_private: true
+`, upstream.URL))
+
+	result, err := srv.handleExecuteAPIRequest(context.Background(), mcp.CallToolRequest{Arguments: map[string]any{
+		"template": "basic-response-test",
+		"endpoint": "/test",
+		"method":   "GET",
+	}})
+	if err != nil || result.IsError {
+		t.Fatalf("handleExecuteAPIRequest() error = %v, result = %+v", err, result)
+	}
+	if strings.Contains(result.Text, wireValue) || !strings.Contains(result.Text, "***") {
+		t.Fatalf("response body was not wire-redacted: %q", result.Text)
 	}
 }
 
@@ -1071,5 +1178,99 @@ allow_private: true
 	}
 	if !strings.Contains(result.Text, "no value for placeholder") {
 		t.Errorf("result text = %q, want 'no value for placeholder'", result.Text)
+	}
+}
+
+func TestHandleExecuteAPIRequest_ResponseMasksKnownPatternPrefixAndSuffix(t *testing.T) {
+	secret := "fixture@example.invalid|nonsecret-tail"
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, "prefix="+secret+" suffix")
+	}))
+	defer upstream.Close()
+
+	vaultDir, identity := mockVaultWithEntry(t, "prefixapi", map[string]any{"credential": secret})
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:           "test",
+		AllowedPaths:   []string{"*"},
+		CanRunCommands: config.BoolPtr(true),
+		ApprovalMode:   config.StrPtr("none"),
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+	writeTemplateOverride(t, vaultDir, "prefixapi", fmt.Sprintf(`base_url: %s
+auth_type: bearer
+entry_ref: prefixapi
+allowed_endpoints:
+  - /*
+allowed_methods:
+  - GET
+allow_private: true
+`, upstream.URL))
+
+	result, err := srv.handleExecuteAPIRequest(context.Background(), mcp.CallToolRequest{Arguments: map[string]any{
+		"template": "prefixapi",
+		"endpoint": "/response",
+		"method":   "GET",
+	}})
+	if err != nil {
+		t.Fatalf("handleExecuteAPIRequest() error = %v", err)
+	}
+	var output map[string]any
+	if err := json.Unmarshal([]byte(result.Text), &output); err != nil {
+		t.Fatalf("parse result: %v", err)
+	}
+	body, _ := output["body"].(string)
+	if strings.Contains(body, "fixture@example.invalid") || strings.Contains(body, "nonsecret-tail") {
+		t.Fatalf("response leaks known secret or suffix: %q", body)
+	}
+	if !strings.Contains(body, "***") {
+		t.Fatalf("body = %q, want redaction marker", body)
+	}
+}
+
+func TestHandleExecuteAPIRequest_ErrorRedactsQueryAuthValueAndSuffix(t *testing.T) {
+	authValue := "fixture@example.invalid|query-auth-suffix"
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("closed upstream must not receive the request")
+	}))
+	closedURL := upstream.URL
+	upstream.Close()
+
+	vaultDir, identity := mockVaultWithEntry(t, "queryerror", map[string]any{
+		"param_name":  "access_token",
+		"param_value": authValue,
+	})
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:           "test",
+		AllowedPaths:   []string{"*"},
+		CanRunCommands: config.BoolPtr(true),
+		ApprovalMode:   config.StrPtr("none"),
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+	writeTemplateOverride(t, vaultDir, "queryerror", fmt.Sprintf(`base_url: %s
+auth_type: query_param
+entry_ref: queryerror
+allowed_endpoints:
+  - /*
+allowed_methods:
+  - GET
+allow_private: true
+`, closedURL))
+
+	result, err := srv.handleExecuteAPIRequest(context.Background(), mcp.CallToolRequest{Arguments: map[string]any{
+		"template": "queryerror",
+		"endpoint": "/ping",
+		"method":   "GET",
+	}})
+	if err != nil {
+		t.Fatalf("handleExecuteAPIRequest() error = %v", err)
+	}
+	if !result.IsError {
+		t.Fatal("handleExecuteAPIRequest() expected request error result")
+	}
+	if strings.Contains(result.Text, authValue) || strings.Contains(result.Text, "query-auth-suffix") {
+		t.Fatalf("request error leaks query auth value or suffix: %q", result.Text)
+	}
+	if !strings.Contains(result.Text, "request failed") {
+		t.Fatalf("error text = %q, want request failed", result.Text)
 	}
 }

--- a/internal/mcp/server/tools_execute_with_secret.go
+++ b/internal/mcp/server/tools_execute_with_secret.go
@@ -11,6 +11,7 @@ import (
 
 	mcp "github.com/danieljustus/symaira-vault/internal/mcp"
 	"github.com/danieljustus/symaira-vault/internal/mcp/apitemplates"
+	"github.com/danieljustus/symaira-vault/internal/mcp/masking"
 	"github.com/danieljustus/symaira-vault/internal/metrics"
 	"github.com/danieljustus/symaira-vault/internal/secrets"
 )
@@ -157,10 +158,11 @@ func (s *Server) handleExecuteWithSecret(ctx context.Context, req mcp.CallToolRe
 	workingDir := req.GetString("working_dir", "")
 
 	result, runErr := secrets.RunCommand(secrets.RunOptions{
-		Command:    command,
-		Env:        resolvedEnv,
-		WorkingDir: workingDir,
-		Timeout:    time.Duration(timeoutSeconds) * time.Second,
+		Command:      command,
+		Env:          resolvedEnv,
+		WorkingDir:   workingDir,
+		Timeout:      time.Duration(timeoutSeconds) * time.Second,
+		KnownSecrets: secretEnv,
 	})
 
 	exitCode := 0
@@ -253,15 +255,29 @@ func mapKeys(m map[string]string) []string {
 }
 
 func redactSecrets(command []string, secretEnv map[string]string) []string {
+	keys := make([]string, 0, len(secretEnv))
+	for key := range secretEnv {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	values := make([]string, 0, len(keys))
+	seen := make(map[string]struct{}, len(keys))
+	for _, key := range keys {
+		value := secretEnv[key]
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		values = append(values, value)
+	}
+
 	redacted := make([]string, len(command))
 	for i, arg := range command {
-		redacted[i] = arg
-		for _, secret := range secretEnv {
-			if arg == secret {
-				redacted[i] = "[REDACTED]"
-				break
-			}
-		}
+		redacted[i], _ = masking.RedactKnownSecrets(arg, values, "[REDACTED]")
 	}
 	return redacted
 }

--- a/internal/mcp/server/tools_execute_with_secret_test.go
+++ b/internal/mcp/server/tools_execute_with_secret_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/danieljustus/symaira-vault/internal/config"
 	mcp "github.com/danieljustus/symaira-vault/internal/mcp"
 	"github.com/danieljustus/symaira-vault/internal/mcp/apitemplates"
+	"github.com/danieljustus/symaira-vault/internal/mcp/masking"
 )
 
 func TestHandleExecuteWithSecret_BasicRun(t *testing.T) {
@@ -1203,5 +1204,52 @@ func TestHandleExecuteWithSecret_ExecutableAllowlist_PathQualified_Allowed(t *te
 	}
 	if result.IsError {
 		t.Fatalf("handleExecuteWithSecret() returned error: %s", result.Text)
+	}
+}
+
+func TestRedactSecrets_RedactsFullArgument(t *testing.T) {
+	const secret = "full-argument-secret"
+	got := redactSecrets([]string{"echo", "plain", secret}, map[string]string{"TOKEN": secret})
+	want := []string{"echo", "plain", "[REDACTED]"}
+	if fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("redactSecrets() = %v, want %v", got, want)
+	}
+}
+
+func TestRedactSecrets_RedactsEmbeddedSecret(t *testing.T) {
+	const secret = "embedded-secret"
+	got := redactSecrets([]string{"echo", "prefix-" + secret + "-suffix", "unchanged"}, map[string]string{"TOKEN": secret})
+	want := []string{"echo", "prefix-[REDACTED]-suffix", "unchanged"}
+	if fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("redactSecrets() = %v, want %v", got, want)
+	}
+}
+
+func TestRedactSecrets_OverlappingValuesAreOrderIndependent(t *testing.T) {
+	first := make(map[string]string)
+	first["short"] = "abc"
+	first["long"] = "bcdef"
+	second := make(map[string]string)
+	second["long"] = "bcdef"
+	second["short"] = "abc"
+
+	command := []string{"echo", "prefix-abcdef-suffix"}
+	want := []string{"echo", "prefix-[REDACTED]-suffix"}
+	for name, secrets := range map[string]map[string]string{"first insertion order": first, "second insertion order": second} {
+		t.Run(name, func(t *testing.T) {
+			got := redactSecrets(command, secrets)
+			if fmt.Sprint(got) != fmt.Sprint(want) {
+				t.Fatalf("redactSecrets() = %v, want %v", got, want)
+			}
+		})
+	}
+}
+
+func TestRedactSecrets_OverflowMasksWholeArgument(t *testing.T) {
+	command := []string{"echo", strings.Repeat("x", masking.MaxKnownSecretSpans+1), "tail"}
+	got := redactSecrets(command, map[string]string{"TOKEN": "x"})
+	want := []string{"echo", "[REDACTED]", "tail"}
+	if fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("redactSecrets() = %v, want %v", got, want)
 	}
 }

--- a/internal/mcp/server/tools_run.go
+++ b/internal/mcp/server/tools_run.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	mcp "github.com/danieljustus/symaira-vault/internal/mcp"
+	"github.com/danieljustus/symaira-vault/internal/mcp/masking"
 	"github.com/danieljustus/symaira-vault/internal/metrics"
 	secrets "github.com/danieljustus/symaira-vault/internal/secrets"
 )
@@ -84,7 +85,7 @@ func (s *Server) handleRunCommand(ctx context.Context, req mcp.CallToolRequest) 
 		return mcp.NewToolResultError(fmt.Sprintf("env contains denied keys: %s", strings.Join(denied, ", "))), nil
 	}
 
-	resolvedFiles, fileAudit, filesToolErr, filesErr := s.resolveRunCommandFiles(ctx, req.Arguments["files"])
+	resolvedFiles, fileKnownSecrets, fileAudit, filesToolErr, filesErr := s.resolveRunCommandFiles(ctx, req.Arguments["files"])
 	if filesErr != nil {
 		return nil, filesErr
 	}
@@ -100,31 +101,25 @@ func (s *Server) handleRunCommand(ctx context.Context, req mcp.CallToolRequest) 
 
 	workingDir := req.GetString("working_dir", "")
 
-	auditPath := strings.Join(command, " ")
-	if len(envNames) > 0 {
-		auditPath += ", env=[" + strings.Join(envNames, ", ") + "]"
-	}
-	if len(fileAudit) > 0 {
-		auditPath += ", files=[" + strings.Join(fileAudit, ", ") + "]"
-	}
-
 	// knownSecrets is the union of resolved env and file values, used only to
 	// redact known secret content out of command output/errors — RunOptions.Env
 	// and RunOptions.Files stay separate so files are never set as env vars.
-	knownSecrets := make(map[string]string, len(resolvedEnv)+len(resolvedFiles))
+	knownSecrets := make(map[string]string, len(resolvedEnv)+len(fileKnownSecrets))
 	for k, v := range resolvedEnv {
 		knownSecrets[k] = v
 	}
-	for k, v := range resolvedFiles {
+	for k, v := range fileKnownSecrets {
 		knownSecrets[k] = v
 	}
+	auditPath := buildRunCommandAuditPath(command, envNames, fileAudit, knownSecrets)
 
 	result, err := secrets.RunCommand(secrets.RunOptions{
-		Command:    command,
-		Env:        resolvedEnv,
-		Files:      resolvedFiles,
-		WorkingDir: workingDir,
-		Timeout:    time.Duration(timeoutSeconds) * time.Second,
+		Command:      command,
+		Env:          resolvedEnv,
+		Files:        resolvedFiles,
+		WorkingDir:   workingDir,
+		Timeout:      time.Duration(timeoutSeconds) * time.Second,
+		KnownSecrets: knownSecrets,
 	})
 
 	if err != nil {
@@ -154,6 +149,17 @@ func (s *Server) handleRunCommand(ctx context.Context, req mcp.CallToolRequest) 
 	return mcp.NewToolResultText(string(resultJSON)), nil
 }
 
+func buildRunCommandAuditPath(command, envNames, fileAudit []string, knownSecrets map[string]string) string {
+	auditPath := masking.SanitizeWithKnownSecrets(strings.Join(command, " "), knownSecrets, "***")
+	if len(envNames) > 0 {
+		auditPath += ", env=[" + strings.Join(envNames, ", ") + "]"
+	}
+	if len(fileAudit) > 0 {
+		auditPath += ", files=[" + strings.Join(fileAudit, ", ") + "]"
+	}
+	return auditPath
+}
+
 // resolveRunCommandFiles parses and resolves handleRunCommand's "files"
 // argument into plaintext content ready for ephemeral materialization,
 // mirroring the "env" map's per-ref scope check and resolution. resolvedFiles
@@ -168,51 +174,54 @@ func (s *Server) handleRunCommand(ctx context.Context, req mcp.CallToolRequest) 
 // unresolvable ref) the caller should return as-is; err is a hard access
 // denial the caller should propagate as a JSON-RPC error, matching how the
 // rest of handleRunCommand distinguishes the two.
-func (s *Server) resolveRunCommandFiles(ctx context.Context, filesRaw any) (resolvedFiles map[string]string, fileAudit []string, toolErr *mcp.CallToolResult, err error) {
+func (s *Server) resolveRunCommandFiles(ctx context.Context, filesRaw any) (resolvedFiles, knownSecrets map[string]string, fileAudit []string, toolErr *mcp.CallToolResult, err error) {
 	resolvedFiles = make(map[string]string)
+	knownSecrets = make(map[string]string)
 	if filesRaw == nil {
-		return resolvedFiles, nil, nil, nil
+		return resolvedFiles, knownSecrets, nil, nil, nil
 	}
 
 	filesMap, ok := filesRaw.(map[string]any)
 	if !ok {
 		s.logAudit(ctx, "run_command", "<invalid>", false)
-		return nil, nil, mcp.NewToolResultError("argument \"files\" must be an object"), nil
+		return nil, nil, nil, mcp.NewToolResultError("argument \"files\" must be an object"), nil
 	}
 
 	for name, specRaw := range filesMap {
 		ref, encoding, specErr := parseFileSpec(specRaw)
 		if specErr != nil {
-			return nil, nil, mcp.NewToolResultError(fmt.Sprintf("files.%s: %v", name, specErr)), nil
+			return nil, nil, nil, mcp.NewToolResultError(fmt.Sprintf("files.%s: %v", name, specErr)), nil
 		}
 
 		path := extractPathFromRef(ref)
 		if !s.checkScope(path) {
 			s.logAudit(ctx, "run_command", path, false)
 			metrics.RecordAuthDenial("scope_denied", s.agent.Name)
-			return nil, nil, nil, fmt.Errorf("access denied: secret ref path %q outside allowed scope", path)
+			return nil, nil, nil, nil, fmt.Errorf("access denied: secret ref path %q outside allowed scope", path)
 		}
 
 		value, resolveErr := secrets.ResolveSecretRef(s.vault, ref)
 		if resolveErr != nil {
-			return nil, nil, mcp.NewToolResultError(fmt.Sprintf("cannot resolve secret ref %q: %v", ref, resolveErr)), nil
+			return nil, nil, nil, mcp.NewToolResultError(fmt.Sprintf("cannot resolve secret ref %q: %v", ref, resolveErr)), nil
 		}
+		knownSecrets[name+":source"] = value
 
 		content := value
 		if encoding == "base64" {
 			decoded, decErr := base64.StdEncoding.DecodeString(value)
 			if decErr != nil {
-				return nil, nil, mcp.NewToolResultError(fmt.Sprintf("files.%s: cannot base64-decode resolved value", name)), nil
+				return nil, nil, nil, mcp.NewToolResultError(fmt.Sprintf("files.%s: cannot base64-decode resolved value", name)), nil
 			}
 			content = string(decoded)
 		}
 
 		resolvedFiles[name] = content
+		knownSecrets[name+":content"] = content
 		fileAudit = append(fileAudit, name+":"+ref)
 	}
 	sort.Strings(fileAudit)
 
-	return resolvedFiles, fileAudit, nil, nil
+	return resolvedFiles, knownSecrets, fileAudit, nil, nil
 }
 
 // extractPathFromRef returns the entry path portion of a secret reference.

--- a/internal/mcp/server/tools_run_test.go
+++ b/internal/mcp/server/tools_run_test.go
@@ -870,6 +870,30 @@ func TestHandleRunCommand_FileInjection_Base64Encoding(t *testing.T) {
 	}
 }
 
+func TestResolveRunCommandFiles_Base64KeepsSourceAndContentForRedaction(t *testing.T) {
+	binaryContent := []byte{0x50, 0x4b, 0x03, 0x04, 0x00, 0xff, 0x10}
+	encoded := base64.StdEncoding.EncodeToString(binaryContent)
+	vaultDir, identity := mockVaultWithEntry(t, "elster/org-zertifikat", map[string]any{"pfx": encoded})
+	srv := newTestServerWithVault(t, config.AgentProfile{
+		Name:         "test",
+		AllowedPaths: []string{"*"},
+	}, "stdio", vaultDir)
+	srv.vault.Identity = identity
+
+	resolved, known, _, toolErr, err := srv.resolveRunCommandFiles(context.Background(), map[string]any{
+		"CERT": map[string]any{"ref": "elster/org-zertifikat.pfx", "encoding": "base64"},
+	})
+	if err != nil || toolErr != nil {
+		t.Fatalf("resolveRunCommandFiles() error = %v, toolErr = %v", err, toolErr)
+	}
+	if resolved["CERT"] != string(binaryContent) {
+		t.Fatal("resolved file content does not match decoded bytes")
+	}
+	if known["CERT:source"] != encoded || known["CERT:content"] != string(binaryContent) {
+		t.Fatal("known secrets must retain both encoded source and decoded content")
+	}
+}
+
 func TestHandleRunCommand_FileInjection_BadBase64(t *testing.T) {
 	vaultDir, identity := mockVaultWithEntry(t, "elster/org-zertifikat", map[string]any{
 		"pfx": "not-valid-base64!!!",
@@ -1036,6 +1060,22 @@ func TestHandleRunCommand_FileInjection_ExecutableDenied(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "not in agent allowlist") {
 		t.Fatalf("error = %v, want 'not in agent allowlist'", err)
+	}
+}
+
+func TestBuildRunCommandAuditPathRedactsKnownSecrets(t *testing.T) {
+	const secret = "audit-command-secret"
+	got := buildRunCommandAuditPath(
+		[]string{"echo", secret},
+		[]string{"TOKEN"},
+		[]string{"CERT:op://vault/cert/value"},
+		map[string]string{"TOKEN": secret},
+	)
+	if strings.Contains(got, secret) {
+		t.Fatalf("audit path leaks known secret: %q", got)
+	}
+	if !strings.Contains(got, "echo ***, env=[TOKEN], files=[CERT:op://vault/cert/value]") {
+		t.Fatalf("audit path = %q, want redacted command with metadata", got)
 	}
 }
 

--- a/internal/mcp/server/tools_sanitize_test.go
+++ b/internal/mcp/server/tools_sanitize_test.go
@@ -116,6 +116,65 @@ func TestSanitizeRunOutput(t *testing.T) {
 	}
 }
 
+func TestSanitizeRunOutput_KnownSecretOverlapsAreFullyRedacted(t *testing.T) {
+	server := setupTestServer(t)
+	short := "short"
+	long := "short-with-sensitive-suffix"
+	inputs := []struct {
+		name   string
+		values []string
+	}{
+		{name: "short_first", values: []string{short, long}},
+		{name: "long_first", values: []string{long, short}},
+	}
+
+	for _, tc := range inputs {
+		t.Run(tc.name, func(t *testing.T) {
+			resolvedEnv := map[string]string{
+				"FIRST":  tc.values[0],
+				"SECOND": tc.values[1],
+			}
+			stdout := "prefix=" + long + " suffix=" + short
+			got, _ := server.sanitizeRunOutput(context.Background(), stdout, "", resolvedEnv)
+			if got != "prefix=*** suffix=***" {
+				t.Fatalf("sanitizeRunOutput() = %q, want %q", got, "prefix=*** suffix=***")
+			}
+			if strings.Contains(got, "sensitive-suffix") || strings.Contains(got, long) || strings.Contains(got, short) {
+				t.Fatalf("overlapping secret leaked: %q", got)
+			}
+		})
+	}
+}
+
+func TestSanitizeRunOutput_KnownSecretPartialOverlapsAreFullyRedacted(t *testing.T) {
+	server := setupTestServer(t)
+	cases := []struct {
+		name   string
+		values []string
+		input  string
+	}{
+		{name: "equal_first", values: []string{"abcd", "bcde"}, input: "abcde"},
+		{name: "equal_second", values: []string{"bcde", "abcd"}, input: "abcde"},
+		{name: "unequal_first", values: []string{"abcdef", "defgh"}, input: "abcdefgh"},
+		{name: "unequal_second", values: []string{"defgh", "abcdef"}, input: "abcdefgh"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resolvedEnv := map[string]string{"FIRST": tc.values[0], "SECOND": tc.values[1]}
+			got, _ := server.sanitizeRunOutput(context.Background(), "value="+tc.input, "", resolvedEnv)
+			if got != "value=***" {
+				t.Fatalf("sanitizeRunOutput() = %q, want %q", got, "value=***")
+			}
+			for _, value := range tc.values {
+				if strings.Contains(got, value) {
+					t.Fatalf("overlapping secret %q leaked: %q", value, got)
+				}
+			}
+		})
+	}
+}
+
 func TestSanitizeRunOutputNoSecrets(t *testing.T) {
 	server := setupTestServer(t)
 

--- a/internal/redact/detectors.go
+++ b/internal/redact/detectors.go
@@ -10,11 +10,24 @@ import (
 // carry little value as a secret in the first place.
 const minExactValueLen = 4
 
+// MinExactValueLen is the public contract value for exact detector filtering.
+const MinExactValueLen = minExactValueLen
+
+// MaxExactValueCount is the maximum number of distinct exact values retained.
+const MaxExactValueCount = masking.MaxKnownSecretValues
+
+// MaxExactMatchSpans is the maximum number of exact match spans retained.
+const MaxExactMatchSpans = masking.MaxKnownSecretSpans
+
+// MaxExactScanWork is the maximum number of exact-value byte comparisons.
+const MaxExactScanWork = masking.MaxKnownSecretScanWork
+
 // exactValueDetector matches literal occurrences of a fixed set of known
 // values (e.g. currently-unlocked vault secret values) and replaces them
 // with Marker. It never logs or returns the values themselves.
 type exactValueDetector struct {
-	values []string
+	values     []string
+	overflowed bool
 }
 
 // NewExactValueDetector returns a ConfidenceHigh Detector that redacts every
@@ -22,26 +35,45 @@ type exactValueDetector struct {
 // shorter than minExactValueLen are ignored (never treated as matchable)
 // to avoid mass false positives.
 func NewExactValueDetector(values []string) Detector {
-	filtered := make([]string, 0, len(values))
+	filtered := make([]string, 0, minInt(len(values), MaxExactValueCount))
+	seen := make(map[string]struct{}, minInt(len(values), MaxExactValueCount))
+	overflowed := false
 	for _, v := range values {
-		if len(v) >= minExactValueLen {
-			filtered = append(filtered, v)
+		if len(v) < minExactValueLen {
+			continue
 		}
+		if _, ok := seen[v]; ok {
+			continue
+		}
+		if len(filtered) >= MaxExactValueCount {
+			overflowed = true
+			break
+		}
+		seen[v] = struct{}{}
+		filtered = append(filtered, v)
 	}
-	return &exactValueDetector{values: filtered}
+	return &exactValueDetector{values: filtered, overflowed: overflowed}
 }
 
 func (d *exactValueDetector) Name() string           { return "exact_value" }
 func (d *exactValueDetector) Confidence() Confidence { return ConfidenceHigh }
 
+// Redact replaces every merged overlapping span selected from the original
+// text. The canonical span algorithm lives in masking so production known
+// secret sanitization and this detector cannot diverge.
 func (d *exactValueDetector) Redact(text string) (string, int, error) {
-	total := 0
-	for _, v := range d.values {
-		var n int
-		text, n = replaceAllValue(text, v)
-		total += n
+	if d.overflowed && text != "" {
+		return Marker, 1, nil
 	}
-	return text, total, nil
+	redacted, count := masking.RedactKnownSecrets(text, d.values, Marker)
+	return redacted, count, nil
+}
+
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
 }
 
 // patternDetector matches explicit credential-shaped patterns (API key

--- a/internal/redact/entropy.go
+++ b/internal/redact/entropy.go
@@ -37,6 +37,13 @@ const (
 	minEntropyBitsPerChar = 4.85
 )
 
+// MinTokenLen and MinEntropyBitsPerChar are the public contract values used
+// by the Go↔Rust redaction fixture generator.
+const (
+	MinTokenLen           = minTokenLen
+	MinEntropyBitsPerChar = minEntropyBitsPerChar
+)
+
 // entropyTokenChars is the set of characters treated as part of a
 // candidate token. It intentionally excludes common separators — space,
 // hyphen, colon, comma, and '/' — so that, e.g., a hyphen-delimited UUID

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -17,10 +17,7 @@
 //     display.
 package redact
 
-import (
-	"fmt"
-	"strings"
-)
+import "fmt"
 
 // Marker is the stable, non-reversible string substituted for every
 // detected secret. It intentionally carries no information about the
@@ -203,19 +200,4 @@ func (s *Scanner) emitAudit(e AuditEvent) {
 	if s.Audit != nil {
 		s.Audit(e)
 	}
-}
-
-// replaceAllValue replaces every non-overlapping occurrence of value in text
-// with Marker and returns the result plus the number of replacements. It is
-// a thin wrapper over strings.Count/Replace kept here so every detector in
-// this package redacts consistently.
-func replaceAllValue(text, value string) (string, int) {
-	if value == "" {
-		return text, 0
-	}
-	n := strings.Count(text, value)
-	if n == 0 {
-		return text, 0
-	}
-	return strings.ReplaceAll(text, value, Marker), n
 }

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -2,6 +2,7 @@ package redact
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -47,6 +48,38 @@ func TestExactValueDetector_IgnoresEmptyAndShortValues(t *testing.T) {
 	}
 	if got != "ab is short and empty is nothing" {
 		t.Fatalf("text should be unchanged, got %q", got)
+	}
+}
+
+func TestExactValueDetector_OverlapSemantics(t *testing.T) {
+	cases := []struct {
+		name   string
+		values []string
+		input  string
+		want   string
+		count  int
+	}{
+		{name: "equal_partial_short_first", values: []string{"abcd", "bcde"}, input: "abcde", want: Marker, count: 1},
+		{name: "equal_partial_long_first", values: []string{"bcde", "abcd"}, input: "abcde", want: Marker, count: 1},
+		{name: "unequal_partial", values: []string{"abcdef", "defgh"}, input: "abcdefgh", want: Marker, count: 1},
+		{name: "containment", values: []string{"secret-value", "cret-val"}, input: "prefix secret-value suffix", want: "prefix " + Marker + " suffix", count: 1},
+		{name: "adjacent_nonoverlap", values: []string{"abcd", "efgh"}, input: "abcdefgh", want: Marker + Marker, count: 2},
+		{name: "repeated_occurrences", values: []string{"abcd"}, input: "abcd--abcd", want: Marker + "--" + Marker, count: 2},
+		{name: "duplicates", values: []string{"abcd", "abcd", "bcde"}, input: "abcde abcd", want: Marker + " " + Marker, count: 2},
+		{name: "utf8_surrounding_text", values: []string{"sëcret", "ëcret"}, input: "🔐sëcret🚀", want: "🔐" + Marker + "🚀", count: 1},
+		{name: "self_overlap", values: []string{"abab"}, input: "ababab", want: Marker + "ab", count: 1},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, count, err := NewExactValueDetector(tc.values).Redact(tc.input)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want || count != tc.count {
+				t.Fatalf("got (%q, %d), want (%q, %d)", got, count, tc.want, tc.count)
+			}
+		})
 	}
 }
 
@@ -113,6 +146,43 @@ func TestScanner_MultilineAndTruncatedOutput(t *testing.T) {
 	}
 }
 
+func TestExactValueDetector_OverlappingValuesPreferLongest(t *testing.T) {
+	short := "short"
+	long := "short-with-sensitive-suffix"
+	input := "overlap=" + long + " standalone=" + short
+	want := "overlap=" + Marker + " standalone=" + Marker
+
+	for _, values := range [][]string{{short, long}, {long, short}} {
+		d := NewExactValueDetector(values)
+		got, n, err := d.Redact(input)
+		if err != nil {
+			t.Fatalf("values %v: unexpected error: %v", values, err)
+		}
+		if n != 2 {
+			t.Fatalf("values %v: want 2 replacements, got %d", values, n)
+		}
+		if got != want {
+			t.Fatalf("values %v: got %q, want %q", values, got, want)
+		}
+	}
+}
+
+// Replacement counts are non-overlapping matches after stable de-duplication;
+// duplicate configured values do not increase the count.
+func TestExactValueDetector_DeduplicatesReplacementCounts(t *testing.T) {
+	d := NewExactValueDetector([]string{"short", "short", "short-with-sensitive-suffix"})
+	got, n, err := d.Redact("short-with-sensitive-suffix short")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("want 2 replacements, got %d", n)
+	}
+	if got != Marker+" "+Marker {
+		t.Fatalf("got %q, want %q", got, Marker+" "+Marker)
+	}
+}
+
 type erroringDetector struct{}
 
 func (erroringDetector) Name() string           { return "erroring" }
@@ -146,5 +216,23 @@ func TestScanner_NoDetectors_ReturnsTextUnchanged(t *testing.T) {
 	}
 	if res.Blocked {
 		t.Fatalf("should not be blocked")
+	}
+}
+
+func TestExactValueDetector_ValueOverflowFailsClosed(t *testing.T) {
+	values := make([]string, MaxExactValueCount+1)
+	for i := range values {
+		values[i] = fmt.Sprintf("secret-%04d", i)
+	}
+
+	got, count, err := NewExactValueDetector(values).Redact("ordinary output")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != Marker || count != 1 {
+		t.Fatalf("overflow result = (%q, %d), want (%q, 1)", got, count, Marker)
+	}
+	if strings.Contains(got, "secret-") {
+		t.Fatalf("overflow result leaked a retained value: %q", got)
 	}
 }

--- a/internal/secrets/runner.go
+++ b/internal/secrets/runner.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"time"
 
+	"github.com/danieljustus/symaira-vault/internal/mcp/masking"
 	"github.com/danieljustus/symaira-vault/internal/redact"
 )
 
@@ -51,6 +52,10 @@ type RunOptions struct {
 	// timeout kill. Keys must be safe identifiers ([A-Za-z0-9_]+): they become
 	// both an env var suffix and a filename.
 	Files map[string]string
+	// KnownSecrets contains resolved secret values that must be redacted from
+	// captured output before generic credential-pattern masking. It is optional
+	// for callers that do not have known secret context.
+	KnownSecrets map[string]string
 }
 
 // boundedBuffer captures up to max bytes of written data while still reporting
@@ -169,19 +174,11 @@ func RunCommand(opts RunOptions) (*RunResult, error) {
 		RejectedEnvVars: rejected,
 	}
 
-	// Redact explicit credential-shaped patterns out of the captured
-	// output before it can leave the process boundary — this is the
-	// output-scanning redaction core (#695), pattern-detection layer.
-	// RunCommand is a general-purpose executor (opts.Env is arbitrary
-	// caller-supplied values, not necessarily secret material — see the
-	// TestRunCommand_EnvOverlay-style callers), so it does not have
-	// enough context to safely exact-match opts.Env as "known secrets";
-	// that exact-value redaction happens one layer up, in
-	// internal/mcp/server (sanitizeKnownSecretValues /
-	// sanitizeRunOutput), where the caller knows which resolved values
-	// are actual vault secrets. This pattern-only pass is defense in
-	// depth that composes with, not replaces, that layer.
-	redactResult(result)
+	// Redact known values before credential-shaped patterns. A generic pattern
+	// can match only a provider-shaped prefix of a longer known value, leaving
+	// the suffix exposed before the outer MCP sanitizer can exact-match it.
+	// The pattern-only behavior remains available when KnownSecrets is empty.
+	redactResult(result, opts.KnownSecrets)
 
 	if runErr != nil {
 		var exitErr *exec.ExitError
@@ -199,22 +196,36 @@ func RunCommand(opts RunOptions) (*RunResult, error) {
 	return result, nil
 }
 
-// redactResult scans result.Stdout and result.Stderr for explicit
-// credential-shaped patterns (see internal/redact), replacing any match
-// with the stable redact.Marker in place. It fails closed: if scanning
-// itself errors, the affected field is replaced with a fixed "withheld"
-// marker rather than left unredacted.
-func redactResult(result *RunResult) {
-	scanner := redact.NewScanner(redact.NewPatternDetector())
+// redactResult scans result.Stdout and result.Stderr for known values and
+// explicit credential-shaped patterns (see internal/redact), replacing any
+// match with the stable redact.Marker in place. Known values are deliberately
+// the first pass so generic patterns cannot destroy the original span.
+// It fails closed: if scanning itself errors, the affected field is replaced
+// with a fixed "withheld" marker rather than left unredacted.
+func redactResult(result *RunResult, knownSecrets map[string]string) {
+	keys := make([]string, 0, len(knownSecrets))
+	for key := range knownSecrets {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	values := make([]string, 0, len(keys))
+	for _, key := range keys {
+		values = append(values, knownSecrets[key])
+	}
+	redactOutput := func(text string) string {
+		// Preserve the runner's existing "***" marker for known values while
+		// ensuring generic patterns see the original only after exact masking.
+		knownSanitized, _ := masking.RedactKnownSecrets(text, values, "***")
+		patternScanner := redact.NewScanner(redact.NewPatternDetector())
+		result, _ := patternScanner.Scan(knownSanitized, redact.ScanOptions{})
+		return result.Text
+	}
 
 	// Result.Text is always safe to use regardless of the returned error —
 	// on a detector failure it is a fixed "withheld" marker, never the raw
 	// text (fail-closed).
-	stdoutRes, _ := scanner.Scan(result.Stdout, redact.ScanOptions{})
-	result.Stdout = stdoutRes.Text
-
-	stderrRes, _ := scanner.Scan(result.Stderr, redact.ScanOptions{})
-	result.Stderr = stderrRes.Text
+	result.Stdout = redactOutput(result.Stdout)
+	result.Stderr = redactOutput(result.Stderr)
 }
 
 // isSafeFileName reports whether name is safe to use both as an environment

--- a/internal/secrets/runner_test.go
+++ b/internal/secrets/runner_test.go
@@ -567,3 +567,26 @@ func TestRunCommand_RedactsCredentialShapedPatternFromOutput(t *testing.T) {
 		t.Fatalf("pattern-shaped secret leaked into Stdout: %q", result.Stdout)
 	}
 }
+
+func TestRunCommand_KnownSecretMasksPatternPrefixAndSuffix(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows: relies on sh")
+	}
+	secret := "fixture@example.invalid|nonsecret-tail"
+	result, err := RunCommand(RunOptions{
+		Command: []string{"sh", "-c", `printf '%s' "$KNOWN"`},
+		Env: map[string]string{
+			"KNOWN": secret,
+		},
+		KnownSecrets: map[string]string{"KNOWN": secret},
+	})
+	if err != nil {
+		t.Fatalf("RunCommand() unexpected error: %v", err)
+	}
+	if strings.Contains(result.Stdout, "fixture@example.invalid") || strings.Contains(result.Stdout, "nonsecret-tail") {
+		t.Fatalf("known secret or suffix leaked: %q", result.Stdout)
+	}
+	if !strings.Contains(result.Stdout, "***") {
+		t.Fatalf("stdout = %q, want redaction marker", result.Stdout)
+	}
+}

--- a/scripts/rust-port/cmd/coregen/main.go
+++ b/scripts/rust-port/cmd/coregen/main.go
@@ -13,6 +13,7 @@ import (
 	corekitexitcodes "github.com/danieljustus/symaira-corekit/exitcodes"
 
 	errorspkg "github.com/danieljustus/symaira-vault/internal/errors"
+	maskingpkg "github.com/danieljustus/symaira-vault/internal/mcp/masking"
 	redactpkg "github.com/danieljustus/symaira-vault/internal/redact"
 	templatepkg "github.com/danieljustus/symaira-vault/internal/template"
 	taintpkg "github.com/danieljustus/symaira-vault/internal/vault/taint"
@@ -356,6 +357,9 @@ type redactConstants struct {
 	Marker                string  `json:"marker"`
 	BlockedText           string  `json:"blocked_text"`
 	MinExactValueLen      int     `json:"min_exact_value_len"`
+	MaxExactValueCount    int     `json:"max_exact_value_count"`
+	MaxExactMatchSpans    int     `json:"max_exact_match_spans"`
+	MaxExactScanWork      int64   `json:"max_exact_scan_work"`
 	MinTokenLen           int     `json:"min_token_len"`
 	MinEntropyBitsPerChar float64 `json:"min_entropy_bits_per_char"`
 }
@@ -431,6 +435,71 @@ func buildRedactFixture(meta oracle) redactFixture {
 			input:   "first: first-secret-token, second: second-secret-key",
 		},
 		{
+			name:    "overlap_short_first",
+			secrets: []string{"short", "short-with-sensitive-suffix"},
+			input:   "overlap=short-with-sensitive-suffix standalone=short",
+		},
+		{
+			name:    "overlap_long_first",
+			secrets: []string{"short-with-sensitive-suffix", "short"},
+			input:   "overlap=short-with-sensitive-suffix standalone=short",
+		},
+		{
+			name:    "equal_partial_short_first",
+			secrets: []string{"abcd", "bcde"},
+			input:   "abcde",
+		},
+		{
+			name:    "equal_partial_long_first",
+			secrets: []string{"bcde", "abcd"},
+			input:   "abcde",
+		},
+		{
+			name:    "unequal_partial",
+			secrets: []string{"abcdef", "defgh"},
+			input:   "abcdefgh",
+		},
+		{
+			name:    "unequal_partial_reverse",
+			secrets: []string{"defgh", "abcdef"},
+			input:   "abcdefgh",
+		},
+		{
+			name:    "containment",
+			secrets: []string{"secret-value", "cret-val"},
+			input:   "prefix secret-value suffix",
+		},
+		{
+			name:    "containment_reverse",
+			secrets: []string{"cret-val", "secret-value"},
+			input:   "prefix secret-value suffix",
+		},
+		{
+			name:    "adjacent_nonoverlap",
+			secrets: []string{"abcd", "efgh"},
+			input:   "abcdefgh",
+		},
+		{
+			name:    "repeated_occurrences",
+			secrets: []string{"abcd"},
+			input:   "abcd--abcd",
+		},
+		{
+			name:    "duplicates",
+			secrets: []string{"abcd", "abcd", "bcde"},
+			input:   "abcde abcd",
+		},
+		{
+			name:    "utf8_surrounding_text",
+			secrets: []string{"sëcret", "ëcret"},
+			input:   "🔐sëcret🚀",
+		},
+		{
+			name:    "self_overlap",
+			secrets: []string{"abab"},
+			input:   "ababab",
+		},
+		{
 			name:    "short_and_empty_ignored",
 			secrets: []string{"", "a", "ab", "abc"},
 			input:   "ab is short and empty is nothing",
@@ -449,11 +518,13 @@ func buildRedactFixture(meta oracle) redactFixture {
 
 	exactCases := make([]exactValueCase, 0, len(exactInputs))
 	for _, tc := range exactInputs {
-		d := redactpkg.NewExactValueDetector(tc.secrets)
-		redacted, count, err := d.Redact(tc.input)
-		if err != nil {
-			panic(fmt.Sprintf("exact value detector failed unexpectedly: %v", err))
+		values := make([]string, 0, len(tc.secrets))
+		for _, value := range tc.secrets {
+			if len(value) >= 4 {
+				values = append(values, value)
+			}
 		}
+		redacted, count := maskingpkg.RedactKnownSecrets(tc.input, values, redactpkg.Marker)
 		exactCases = append(exactCases, exactValueCase{
 			Name:             tc.name,
 			Secrets:          tc.secrets,
@@ -681,9 +752,12 @@ func buildRedactFixture(meta oracle) redactFixture {
 		Constants: redactConstants{
 			Marker:                redactpkg.Marker,
 			BlockedText:           "[REDACTED: output withheld]",
-			MinExactValueLen:      4,
-			MinTokenLen:           20,
-			MinEntropyBitsPerChar: 4.85,
+			MinExactValueLen:      redactpkg.MinExactValueLen,
+			MaxExactValueCount:    redactpkg.MaxExactValueCount,
+			MaxExactMatchSpans:    redactpkg.MaxExactMatchSpans,
+			MaxExactScanWork:      redactpkg.MaxExactScanWork,
+			MinTokenLen:           redactpkg.MinTokenLen,
+			MinEntropyBitsPerChar: redactpkg.MinEntropyBitsPerChar,
 		},
 		ExactValueCases: exactCases,
 		EntropyCases:    entropyCases,

--- a/testdata/port/core/redact-contract.json
+++ b/testdata/port/core/redact-contract.json
@@ -8,6 +8,9 @@
     "marker": "[REDACTED]",
     "blocked_text": "[REDACTED: output withheld]",
     "min_exact_value_len": 4,
+    "max_exact_value_count": 1024,
+    "max_exact_match_spans": 4096,
+    "max_exact_scan_work": 67108864,
     "min_token_len": 20,
     "min_entropy_bits_per_char": 4.85
   },
@@ -39,6 +42,135 @@
       "input": "first: first-secret-token, second: second-secret-key",
       "expected_redacted": "first: [REDACTED], second: [REDACTED]",
       "expected_count": 2
+    },
+    {
+      "name": "overlap_short_first",
+      "secrets": [
+        "short",
+        "short-with-sensitive-suffix"
+      ],
+      "input": "overlap=short-with-sensitive-suffix standalone=short",
+      "expected_redacted": "overlap=[REDACTED] standalone=[REDACTED]",
+      "expected_count": 2
+    },
+    {
+      "name": "overlap_long_first",
+      "secrets": [
+        "short-with-sensitive-suffix",
+        "short"
+      ],
+      "input": "overlap=short-with-sensitive-suffix standalone=short",
+      "expected_redacted": "overlap=[REDACTED] standalone=[REDACTED]",
+      "expected_count": 2
+    },
+    {
+      "name": "equal_partial_short_first",
+      "secrets": [
+        "abcd",
+        "bcde"
+      ],
+      "input": "abcde",
+      "expected_redacted": "[REDACTED]",
+      "expected_count": 1
+    },
+    {
+      "name": "equal_partial_long_first",
+      "secrets": [
+        "bcde",
+        "abcd"
+      ],
+      "input": "abcde",
+      "expected_redacted": "[REDACTED]",
+      "expected_count": 1
+    },
+    {
+      "name": "unequal_partial",
+      "secrets": [
+        "abcdef",
+        "defgh"
+      ],
+      "input": "abcdefgh",
+      "expected_redacted": "[REDACTED]",
+      "expected_count": 1
+    },
+    {
+      "name": "unequal_partial_reverse",
+      "secrets": [
+        "defgh",
+        "abcdef"
+      ],
+      "input": "abcdefgh",
+      "expected_redacted": "[REDACTED]",
+      "expected_count": 1
+    },
+    {
+      "name": "containment",
+      "secrets": [
+        "secret-value",
+        "cret-val"
+      ],
+      "input": "prefix secret-value suffix",
+      "expected_redacted": "prefix [REDACTED] suffix",
+      "expected_count": 1
+    },
+    {
+      "name": "containment_reverse",
+      "secrets": [
+        "cret-val",
+        "secret-value"
+      ],
+      "input": "prefix secret-value suffix",
+      "expected_redacted": "prefix [REDACTED] suffix",
+      "expected_count": 1
+    },
+    {
+      "name": "adjacent_nonoverlap",
+      "secrets": [
+        "abcd",
+        "efgh"
+      ],
+      "input": "abcdefgh",
+      "expected_redacted": "[REDACTED][REDACTED]",
+      "expected_count": 2
+    },
+    {
+      "name": "repeated_occurrences",
+      "secrets": [
+        "abcd"
+      ],
+      "input": "abcd--abcd",
+      "expected_redacted": "[REDACTED]--[REDACTED]",
+      "expected_count": 2
+    },
+    {
+      "name": "duplicates",
+      "secrets": [
+        "abcd",
+        "abcd",
+        "bcde"
+      ],
+      "input": "abcde abcd",
+      "expected_redacted": "[REDACTED] [REDACTED]",
+      "expected_count": 2
+    },
+    {
+      "name": "utf8_surrounding_text",
+      "secrets": [
+        "sëcret",
+        "ëcret"
+      ],
+      "input": "🔐sëcret🚀",
+      "expected_redacted": "🔐[REDACTED]🚀",
+      "expected_count": 1
+    },
+    {
+      "name": "self_overlap",
+      "secrets": [
+        "abab"
+      ],
+      "input": "ababab",
+      "expected_redacted": "[REDACTED]ab",
+      "expected_count": 1
     },
     {
       "name": "short_and_empty_ignored",


### PR DESCRIPTION
## Summary
- make exact known-secret redaction overlap-safe, deterministic, bounded, and Go/Rust parity-tested
- apply exact-before-pattern sanitization across CLI, MCP, broker, audit, response bodies, headers, and content metadata
- cover encoded auth/file wire forms, nested entry values, timeout/output bounds, and Miri-compatible Rust behavior

## Verification
- `make test-fast`
- pinned golangci-lint v2.11.4 / Go 1.26.6
- `make rust-gates`
- full `cargo +nightly miri test --manifest-path crates/symvault-core/Cargo.toml`
- focused MCP/broker/CLI/security regressions
- added-line credential-shape scan
- final full review plus delta review: PASS

Closes #982