### PR TITLE
fix(ci): keep diff helper stdout byte-exact

### DIFF
--- a/scripts/rust-port/internal/diff/diff_test.go
+++ b/scripts/rust-port/internal/diff/diff_test.go
@@ -113,7 +113,7 @@ func TestRunNormalExit(t *testing.T) {
 	if result.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", result.ExitCode)
 	}
-	if got := string(result.Stdout); got != "ok\nPASS\n" {
+	if got := string(result.Stdout); got != "ok\n" {
 		t.Fatalf("stdout = %q, want helper output", got)
 	}
 }
@@ -531,6 +531,7 @@ func helperProcess() {
 	path := os.Getenv("PORT_OUTPUT")
 	_ = os.WriteFile(path, []byte("deterministic\n"), 0o600)
 	_, _ = os.Stdout.WriteString("ok\n")
+	os.Exit(0)
 }
 
 func contains(value, needle string) bool {


### PR DESCRIPTION
## Summary
- exit the nested diff helper immediately after writing its deterministic payload
- assert only the helper payload, not Go test harness footer output
- keep byte-exact behavior stable under coverage-enabled test binaries

## Verification
- `go test -v -race -timeout=5m -coverprofile=/tmp/issue-987-coverage.out ./scripts/rust-port/internal/diff`
- `git diff --check`

Closes #987