### PR TITLE
fix(rust-port): make policy fixtures portable on Windows

### DIFF
--- a/scripts/rust-port/cmd/policygen/main.go
+++ b/scripts/rust-port/cmd/policygen/main.go
@@ -634,9 +634,9 @@ func toGoPolicy(input fixturePolicy) *policypkg.Policy {
 	for _, rule := range input.Rules {
 		conditions := policypkg.Conditions{
 			AgentID:      rule.Conditions.AgentID,
-			Path:         rule.Conditions.Path,
+			Path:         filepath.FromSlash(rule.Conditions.Path),
 			Tags:         append([]string(nil), rule.Conditions.Tags...),
-			WorkingDir:   rule.Conditions.WorkingDir,
+			WorkingDir:   filepath.FromSlash(rule.Conditions.WorkingDir),
 			EnvVars:      cloneMap(rule.Conditions.EnvVars),
 			ActionType:   rule.Conditions.ActionType,
 			AllowedTools: append([]string(nil), rule.Conditions.AllowedTools...),
@@ -662,9 +662,9 @@ func toGoContext(input fixtureContext) policypkg.EvalContext {
 	}
 	return policypkg.EvalContext{
 		AgentID:         input.AgentID,
-		Path:            input.Path,
+		Path:            filepath.FromSlash(input.Path),
 		Tags:            append([]string(nil), input.Tags...),
-		WorkingDir:      input.WorkingDir,
+		WorkingDir:      filepath.FromSlash(input.WorkingDir),
 		EnvVars:         cloneMap(input.EnvVars),
 		ActionType:      input.ActionType,
 		ToolName:        input.ToolName,

--- a/testdata/port/core/policy-contract.json
+++ b/testdata/port/core/policy-contract.json
@@ -10,7 +10,7 @@
       "internal/policy/types.go"
     ],
     "source_digest": "c285d8da0d20535e465fb6922e4ce87dabe581133c642d1a1a66e2dc37f4858b",
-    "generator_digest": "c7598c412f5e0cddbb485c832a405cf72d3f1ffe50c541fc4cfb37abe68fc478"
+    "generator_digest": "4f9bfd6d4ab7ee4673d621b7f04ddfcc7ca870d8d2b72f73af873fc0dc3f1f90"
   },
   "validation_cases": [
     {


### PR DESCRIPTION
## Summary
- Convert slash-separated fixture paths at the Go oracle boundary before native policy evaluation.
- Keep the committed language-neutral fixture bytes stable across operating systems.

## Verification
- `go test -v -timeout=30m -skip 'TestFlow|TestBinaryE2E|Integration' ./...`
- `make lint`
- `make rust-gates`
- `make port-contract test-fast docs-check`

Fixes #994
