### PR TITLE
Adopt pinned CoreKit Rust version contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -718,8 +718,19 @@ checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasi 0.14.7+wasi-0.2.4",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
 ]
 
 [[package]]
@@ -1232,6 +1243,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rand"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1575,10 +1592,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
+name = "symaira-core-version"
+version = "0.0.0"
+source = "git+https://github.com/danieljustus/symaira-corekit?rev=27177f25f551cecefa7bd6c4524abf175b3a75c7#27177f25f551cecefa7bd6c4524abf175b3a75c7"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "symvault-cli"
 version = "0.0.0"
 dependencies = [
  "clap",
+ "symaira-core-version",
  "symvault-core",
 ]
 
@@ -1594,6 +1621,7 @@ dependencies = [
  "serde_json",
  "sha1",
  "sha2 0.10.9",
+ "symaira-core-version",
  "unicode_categories",
  "zeroize",
 ]
@@ -1645,7 +1673,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.3",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ repository = "https://github.com/danieljustus/symaira-vault"
 clap = { version = "=4.6.6", features = ["derive"] }
 serde = { version = "=1.0.229", features = ["derive"] }
 serde_json = "=1.0.151"
+symaira-core-version = { version = "=0.0.0", git = "https://github.com/danieljustus/symaira-corekit", rev = "27177f25f551cecefa7bd6c4524abf175b3a75c7", package = "symaira-core-version" }
 symvault-core = { path = "crates/symvault-core", version = "=0.0.0" }
 
 [profile.release]

--- a/crates/symvault-cli/Cargo.toml
+++ b/crates/symvault-cli/Cargo.toml
@@ -14,3 +14,4 @@ path = "src/main.rs"
 [dependencies]
 clap.workspace = true
 symvault-core.workspace = true
+symaira-core-version.workspace = true

--- a/crates/symvault-cli/src/main.rs
+++ b/crates/symvault-cli/src/main.rs
@@ -7,7 +7,8 @@ use std::{
 };
 
 use clap::{Args, Parser, Subcommand};
-use symvault_core::{render_version_json, render_version_text};
+use symaira_core_version::new as new_version;
+use symvault_core::TOOL_NAME;
 
 const VERSION: &str = match option_env!("SYMVAULT_VERSION") {
     Some(version) => version,
@@ -87,15 +88,14 @@ fn has_unescaped_version_flag(args: &[OsString]) -> bool {
 }
 
 fn write_version(output_format: &str, json: bool) -> ExitCode {
-    let rendered = if json || output_format == "json" {
-        match render_version_json(VERSION) {
-            Ok(output) => output,
-            Err(_) => return ExitCode::from(1),
-        }
+    let info = new_version(TOOL_NAME, VERSION, 1);
+    let mut stdout = io::stdout().lock();
+    let result = if json || output_format == "json" {
+        info.write(&mut stdout).map_err(|_| ())
     } else {
-        render_version_text(VERSION)
+        writeln!(stdout, "{info}").map_err(|_| ())
     };
-    if io::stdout().write_all(rendered.as_bytes()).is_err() {
+    if result.is_err() {
         return ExitCode::from(1);
     }
     ExitCode::SUCCESS

--- a/crates/symvault-core/Cargo.toml
+++ b/crates/symvault-core/Cargo.toml
@@ -14,6 +14,7 @@ getrandom = "=0.3.3"
 hmac = "=0.12.1"
 serde.workspace = true
 serde_json.workspace = true
+symaira-core-version.workspace = true
 sha1 = "=0.10.6"
 sha2 = "=0.10.9"
 unicode_categories = "=0.1.1"

--- a/crates/symvault-core/src/lib.rs
+++ b/crates/symvault-core/src/lib.rs
@@ -2,7 +2,7 @@
 
 //! Language-neutral domain contracts for the staged Symaira Vault Rust port.
 
-use serde::Serialize;
+use symaira_core_version::new as new_version;
 
 pub mod error;
 pub mod password;
@@ -16,14 +16,6 @@ pub mod totp;
 /// Public binary and protocol tool name.
 pub const TOOL_NAME: &str = "symvault";
 
-/// Stable machine-readable version schema.
-#[derive(Debug, Serialize)]
-struct VersionDocument<'a> {
-    tool: &'static str,
-    version: &'a str,
-    schema_version: u8,
-}
-
 /// Renders the exact plain-text version contract.
 ///
 /// ```
@@ -31,7 +23,7 @@ struct VersionDocument<'a> {
 /// ```
 #[must_use]
 pub fn render_version_text(version: &str) -> String {
-    format!("{TOOL_NAME} {version}\n")
+    format!("{}\n", new_version(TOOL_NAME, version, 1))
 }
 
 /// Renders the exact schema-v1 JSON version contract.
@@ -40,12 +32,8 @@ pub fn render_version_text(version: &str) -> String {
 ///
 /// Returns an error only when JSON serialization fails.
 pub fn render_version_json(version: &str) -> Result<String, serde_json::Error> {
-    let document = VersionDocument {
-        tool: TOOL_NAME,
-        version,
-        schema_version: 1,
-    };
-    let mut output = serde_json::to_string(&document)?;
+    let mut output = String::from_utf8(new_version(TOOL_NAME, version, 1).json()?.to_vec())
+        .expect("serde_json always returns UTF-8");
     output.push('\n');
     Ok(output)
 }

--- a/deny.toml
+++ b/deny.toml
@@ -21,3 +21,4 @@ wildcards = "deny"
 unknown-registry = "deny"
 unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = ["https://github.com/danieljustus/symaira-corekit"]

--- a/docs/rust-port/corekit-version-adoption.md
+++ b/docs/rust-port/corekit-version-adoption.md
@@ -1,0 +1,92 @@
+# CoreKit Rust version adoption evidence
+
+Issue #995 adopts the shared `symaira-core-version` contract from CoreKit's
+RUST-005 work without changing the staged Vault CLI's observable version
+behavior.
+
+## Exact pin
+
+Both Rust crates consume the same exact git revision through the workspace
+manifest:
+
+```toml
+symaira-core-version = { version = "=0.0.0", git = "https://github.com/danieljustus/symaira-corekit", rev = "27177f25f551cecefa7bd6c4524abf175b3a75c7", package = "symaira-core-version" }
+```
+
+`Cargo.lock` records the same source and revision:
+
+```text
+git+https://github.com/danieljustus/symaira-corekit?rev=27177f25f551cecefa7bd6c4524abf175b3a75c7#27177f25f551cecefa7bd6c4524abf175b3a75c7
+```
+
+The dependency is used by both `symvault-core` (compatibility wrappers) and
+`symvault-cli` (the executable path). The CLI now constructs CoreKit's `Info`
+payload and uses CoreKit's `json()`/`write()` implementation; the existing
+`render_version_text` and `render_version_json` public functions remain as
+thin compatibility wrappers.
+
+## Duplicate source removed
+
+The old local `VersionDocument` declaration and local `serde_json` payload
+construction are gone from `crates/symvault-core/src/lib.rs`:
+
+- **12 nonblank duplicate payload/serialization source LOC deleted**: six
+  lines for the local document declaration and six lines for its construction
+  and serialization.
+- The now-unused local `serde::Serialize` import was also removed.
+- The text and JSON compatibility wrappers remain, but delegate to CoreKit;
+  no local version payload schema or serializer remains.
+
+## Dependency and feature closure
+
+Observed with `cargo tree --workspace --all-features -e features`:
+
+- `symaira-core-version` has only its `default` feature; it declares no
+  consumer-selectable feature flags.
+- Its locked runtime closure is only `serde` and `serde_json`; CoreKit removed
+  the prior `thiserror` derive so adopters do not pay for an extra proc-macro
+  dependency in clean builds.
+- The reverse dependency tree contains exactly the two Vault consumers:
+  `symvault-cli` and `symvault-core`.
+- No local replacement, path dependency, or unpinned CoreKit source is used.
+
+## Native verification
+
+All commands below were run in this macOS arm64 checkout.
+
+| Command | Result |
+|---|---|
+| `cargo fmt --all --check` | passed |
+| `cargo check --workspace --all-targets --all-features --locked` | passed |
+| `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` | passed |
+| `cargo nextest run --workspace --all-features --locked` | 95 passed, 0 skipped |
+| `cargo test --workspace --doc --all-features --locked` | 1 doctest passed |
+| `cargo test --workspace --all-features --locked` | passed; 95 tests and doctests reported by the run |
+| `make rust-version-contract` | all 10 selected Go/Rust version cases passed |
+| `GOTOOLCHAIN=go1.26.6 make build` | passed |
+| `GOTOOLCHAIN=go1.26.6 make test-fast` | passed |
+| `GOTOOLCHAIN=go1.26.6 make test` | passed |
+| `make vet` | passed |
+| `make fmt-check` | passed |
+| `GOTOOLCHAIN=go1.26.6 make lint` | passed; 0 issues |
+
+Standalone smoke was also run against the built Rust binary for no arguments,
+`version`, `version --json`, and `version --output json`; all four cases
+returned the expected status, stdout, and empty stderr. The Go native binary's
+text and JSON version outputs were likewise checked for matching payloads.
+
+## Performance evidence boundary
+
+A real post-adoption release-build smoke was run with the same
+`v0.0.0-port` version string. Over 50 subprocess launches of `version --json`:
+
+| Binary | Size | Median startup | p95 startup |
+|---|---:|---:|---:|
+| `target/port/symvault-go-release` | 21,720,354 bytes | 7.717 ms | 8.118 ms |
+| `target/release/symvault` | 577,312 bytes | 2.683 ms | 3.114 ms |
+
+These are real local observations, not a CoreKit value-gate claim: the Go
+binary is the full Vault CLI while the Rust binary is only the staged version
+slice, so their sizes and startup times are not a like-for-like product
+comparison. No RSS result, clean/warm build distribution, or before/after
+performance improvement is claimed here.


### PR DESCRIPTION
## Summary

- pin `symaira-core-version` to exact CoreKit revision `73f3fbd8c02ef9670346e144e42d8f134e2b3934`
- replace local version JSON serialization while preserving compatibility wrappers and exact CLI bytes
- remove 12 duplicate source lines and document standalone/dependency evidence

## Verification

- Rust fmt/check/Clippy/nextest and doctests
- Go build, race suite, lint, vet and formatting
- 10-case Go/Rust version differential
- standalone Rust version smoke and real 50-run startup sample

Closes #995
Tracks danieljustus/symaira-corekit#232