### PR TITLE
fix(ci): restore Rust migration gates on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,10 +261,7 @@ jobs:
         run: rustup toolchain install nightly-2026-09-03 --profile minimal --component rust-src
 
       - name: Install pinned cargo-fuzz
-        uses: taiki-e/install-action@7b8d4719ee4aaa279bdf55df38dacb9ebfe12a6c # v2.87.6
-        with:
-          tool: cargo-fuzz@0.13.2
-          fallback: none
+        run: cargo install cargo-fuzz --version 0.13.2 --locked
 
       - name: Run bounded main/scheduled Rust fuzz pass
         run: make rust-fuzz
@@ -540,6 +537,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+          fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0

--- a/internal/policy/engine_test.go
+++ b/internal/policy/engine_test.go
@@ -588,8 +588,8 @@ func TestMatchPath(t *testing.T) {
 		{"~/dev/*", filepath.Join(home, "dev", "project", "sub"), false},
 		{"~/dev/**", filepath.Join(home, "dev", "project", "sub"), true},
 		{"~/exact/path", filepath.Join(home, "exact", "path"), true},
-		{"prefix/", filepath.Join("prefix", "sub"), true},
-		{"prefix/*", filepath.Join("prefix", "sub"), true},
+		{filepath.Join("prefix", "") + string(filepath.Separator), filepath.Join("prefix", "sub"), true},
+		{filepath.Join("prefix", "*"), filepath.Join("prefix", "sub"), true},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- Fetch the pinned Go oracle history in the main test matrix so crypto provenance tests can resolve `caadd5e`.
- Install the pinned `cargo-fuzz` release through Cargo because the pinned install action rejects version `0.13.2`.
- Build policy matcher test patterns with the native path separator on Windows.

## Verification
- `go test ./internal/policy`
- `go test ./scripts/rust-port/cmd/cryptogen`
- YAML parse via Ruby Psych
- `git diff --check`

Fixes #998
Refs #999