### PR TITLE
test(vault): add Go-Rust store reopen contract

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build install test test-fast test-coverage test-verbose test-race test-ci cover clean lint lint-fix fmt fmt-check vet passlint completions manpages port-fixtures-generate port-fixtures-check core-fixtures-generate core-fixtures-check quota-fixtures-generate quota-fixtures-check policy-fixtures-generate policy-fixtures-check differential-go-selftest crypto-differential crypto-fuzz-smoke port-contract store-differential rust-build rust-check rust-lint rust-test rust-miri rust-features rust-coverage rust-security rust-version-contract rust-fuzz-lock rust-fuzz-smoke rust-fuzz rust-gates help docs-check
+.PHONY: all build install test test-fast test-coverage test-verbose test-race test-ci cover clean lint lint-fix fmt fmt-check vet passlint completions manpages port-fixtures-generate port-fixtures-check core-fixtures-generate core-fixtures-check quota-fixtures-generate quota-fixtures-check policy-fixtures-generate policy-fixtures-check differential-go-selftest crypto-differential crypto-fuzz-smoke port-contract store-reopen-fixture store-differential rust-build rust-check rust-lint rust-test rust-miri rust-features rust-coverage rust-security rust-version-contract rust-fuzz-lock rust-fuzz-smoke rust-fuzz rust-gates help docs-check
 
 # Variables
 BINARY_NAME := symvault
@@ -318,7 +318,13 @@ rust-version-contract:
 		--left ./$(PORT_GO_BINARY) --right ./$(RUST_BINARY) \
 		--cases $(PORT_CLI_CASES) --stage version
 
+store-reopen-fixture:
+	GOTOOLCHAIN=$(GO_TOOLCHAIN) $(GO) run ./scripts/rust-port/cmd/storereopen --generate --fixture testdata/port/store/reopen.json
+
 store-differential:
+	GOTOOLCHAIN=$(GO_TOOLCHAIN) $(GO) run ./scripts/rust-port/cmd/storereopen --fixture testdata/port/store/reopen.json
+	$(CARGO) build -p symvault-store --example store-reopen --locked
+	GOTOOLCHAIN=$(GO_TOOLCHAIN) $(GO) run ./scripts/rust-port/cmd/storereopen --run --fixture testdata/port/store/reopen.json --rust-binary target/debug/examples/store-reopen
 	GOTOOLCHAIN=$(GO_TOOLCHAIN) $(GO) run ./scripts/rust-port/cmd/storegen --check --output testdata/port/store/store.json
 	$(CARGO) test -p symvault-store --locked
 
@@ -376,7 +382,8 @@ help:
 	@echo "  differential-go-selftest - Compare the Go oracle with itself in isolated sandboxes"
 	@echo "  crypto-differential - Verify Go↔Rust age and KDF cross-decryption"
 	@echo "  crypto-fuzz-smoke - Run the bounded Argon2id parser fuzz smoke"
-	@echo "  store-differential - Verify Go-generated read-only vault fixtures against Rust"
+	@echo "  store-reopen-fixture  - Generate the deterministic Go↔Rust reopen fixture"
+	@echo "  store-differential - Verify Go↔Rust storage reopen and read-only fixtures"
 	@echo "  rust-fuzz-smoke   - Run the deterministic bounded Rust age/KDF fuzz smoke"
 	@echo "  rust-fuzz         - Run the bounded main/scheduled Rust age/KDF fuzz pass"
 	@echo "  port-contract      - Run all Rust-port contract preparation gates"

--- a/crates/symvault-store/examples/store-reopen.rs
+++ b/crates/symvault-store/examples/store-reopen.rs
@@ -1,0 +1,57 @@
+#![deny(unsafe_code)]
+
+use std::{env, fs, path::PathBuf, process};
+
+use symvault_crypto::parse_identity;
+use symvault_store::{Entry, Store};
+
+const IDENTITY: &str = "AGE-SECRET-KEY-1HS3YTK69EJH0ZYM8ANNNDWQMPT7ZMLPYGTMC47F5T4EDJ5N7EYMQ4L5CDL";
+
+fn argument(args: &[String], name: &str) -> Result<String, String> {
+    let index = args
+        .iter()
+        .position(|arg| arg == name)
+        .ok_or_else(|| format!("missing {name}"))?;
+    args.get(index + 1)
+        .cloned()
+        .ok_or_else(|| format!("missing value for {name}"))
+}
+
+fn run() -> Result<(), String> {
+    let args: Vec<_> = env::args().collect();
+    let action = argument(&args, "--action")?;
+    let root = PathBuf::from(argument(&args, "--root")?);
+    let path = argument(&args, "--path")?;
+    let identity = parse_identity(IDENTITY).map_err(|error| error.to_string())?;
+    let store = Store::open(&root, &identity).map_err(|error| error.to_string())?;
+
+    match action.as_str() {
+        "read" => {
+            let entry = store
+                .get(&path, &identity)
+                .map_err(|error| error.to_string())?;
+            serde_json::to_writer(std::io::stdout(), &entry).map_err(|error| error.to_string())?;
+            println!();
+        }
+        "write" => {
+            let entry_file = PathBuf::from(argument(&args, "--entry-file")?);
+            let bytes = fs::read(entry_file).map_err(|error| error.to_string())?;
+            let entry: Entry = serde_json::from_slice(&bytes).map_err(|error| error.to_string())?;
+            store
+                .write_new_entry(&path, &entry, &identity)
+                .map_err(|error| error.to_string())?;
+            let result = serde_json::json!({"path": path, "written": true});
+            serde_json::to_writer(std::io::stdout(), &result).map_err(|error| error.to_string())?;
+            println!();
+        }
+        other => return Err(format!("unsupported action {other}")),
+    }
+    Ok(())
+}
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("store-reopen: {error}");
+        process::exit(1);
+    }
+}

--- a/crates/symvault-store/src/lib.rs
+++ b/crates/symvault-store/src/lib.rs
@@ -237,11 +237,15 @@ where
     Ok(Option::<bool>::deserialize(deserializer)?.unwrap_or_default())
 }
 
-#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+fn go_zero_time() -> String {
+    "0001-01-01T00:00:00Z".into()
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct EntryMetadata {
-    #[serde(default)]
+    #[serde(default = "go_zero_time")]
     pub created: String,
-    #[serde(default)]
+    #[serde(default = "go_zero_time")]
     pub updated: String,
     #[serde(default)]
     pub version: i64,
@@ -249,6 +253,18 @@ pub struct EntryMetadata {
     pub tags: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub write_history: Vec<WriteRecord>,
+}
+
+impl Default for EntryMetadata {
+    fn default() -> Self {
+        Self {
+            created: "0001-01-01T00:00:00Z".into(),
+            updated: "0001-01-01T00:00:00Z".into(),
+            version: 0,
+            tags: Vec::new(),
+            write_history: Vec::new(),
+        }
+    }
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]

--- a/crates/symvault-store/tests/entry_defaults.rs
+++ b/crates/symvault-store/tests/entry_defaults.rs
@@ -1,0 +1,17 @@
+use symvault_store::Entry;
+
+#[test]
+fn missing_entry_times_use_go_zero_time_on_wire() {
+    let serialized = serde_json::to_value(Entry::default()).unwrap();
+    assert_eq!(serialized["meta"]["created"], "0001-01-01T00:00:00Z");
+    assert_eq!(serialized["meta"]["updated"], "0001-01-01T00:00:00Z");
+
+    let decoded: Entry = serde_json::from_value(serde_json::json!({
+        "data": {},
+        "meta": {},
+        "secret_meta": {}
+    }))
+    .unwrap();
+    assert_eq!(decoded.metadata.created, "0001-01-01T00:00:00Z");
+    assert_eq!(decoded.metadata.updated, "0001-01-01T00:00:00Z");
+}

--- a/scripts/rust-port/cmd/storereopen/main.go
+++ b/scripts/rust-port/cmd/storereopen/main.go
@@ -1,0 +1,275 @@
+// Command storereopen runs the executable Go↔Rust storage reopen contract.
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"sort"
+
+	"filippo.io/age"
+
+	vaultconfig "github.com/danieljustus/symaira-vault/internal/config"
+	vaultpkg "github.com/danieljustus/symaira-vault/internal/vault"
+)
+
+const (
+	oracleCommit  = "caadd5e"
+	oracleRelease = "v0.22.1"
+	identityText  = "AGE-SECRET-KEY-1HS3YTK69EJH0ZYM8ANNNDWQMPT7ZMLPYGTMC47F5T4EDJ5N7EYMQ4L5CDL"
+)
+
+type fixture struct {
+	SchemaVersion int     `json:"schema_version"`
+	Oracle        oracle  `json:"oracle"`
+	Cases         []caseV `json:"cases"`
+}
+
+type oracle struct {
+	Commit  string `json:"commit"`
+	Release string `json:"release"`
+}
+
+type caseV struct {
+	Name          string          `json:"name"`
+	Path          string          `json:"path"`
+	Entry         json.RawMessage `json:"entry,omitempty"`
+	StoragePath   string          `json:"storage_path"`
+	ReadDirection string          `json:"read_direction"`
+}
+
+type projection struct {
+	Path           string         `json:"path"`
+	Data           map[string]any `json:"data"`
+	Classification int            `json:"classification"`
+	Canary         bool           `json:"canary"`
+}
+
+func defaultFixture() fixture {
+	return fixture{
+		SchemaVersion: 1,
+		Oracle:        oracle{Commit: oracleCommit, Release: oracleRelease},
+		Cases: []caseV{
+			{
+				Name:          "go_to_rust_read",
+				Path:          "go-created",
+				StoragePath:   "entries/go-created.age",
+				ReadDirection: "go_write_rust_read",
+			},
+			{
+				Name:          "rust_to_go_read",
+				Path:          "rust-created",
+				Entry:         json.RawMessage(`{"path":"rust-created","data":{"token":"rust-fixture-token","enabled":true},"meta":{},"secret_meta":{}}`),
+				StoragePath:   "entries/rust-created.age",
+				ReadDirection: "rust_write_go_read",
+			},
+		},
+	}
+}
+
+func validateFixture(value fixture) error {
+	if value.SchemaVersion != 1 || value.Oracle.Commit != oracleCommit || value.Oracle.Release != oracleRelease {
+		return errors.New("reopen fixture provenance changed")
+	}
+	if len(value.Cases) != 2 {
+		return fmt.Errorf("reopen case cardinality %d, want 2", len(value.Cases))
+	}
+	wantNames := []string{"go_to_rust_read", "rust_to_go_read"}
+	wantPaths := []string{"go-created", "rust-created"}
+	wantStorage := []string{"entries/go-created.age", "entries/rust-created.age"}
+	for i, item := range value.Cases {
+		if item.Name != wantNames[i] || item.Path != wantPaths[i] || item.StoragePath != wantStorage[i] || item.ReadDirection == "" {
+			return fmt.Errorf("reopen case %d changed", i)
+		}
+	}
+	if len(value.Cases[1].Entry) == 0 {
+		return errors.New("rust write case has no entry input")
+	}
+	var entry vaultpkg.Entry
+	if err := json.Unmarshal(value.Cases[1].Entry, &entry); err != nil {
+		return fmt.Errorf("rust write entry: %w", err)
+	}
+	if entry.Path != value.Cases[1].Path || len(entry.Data) != 2 {
+		return errors.New("rust write entry shape changed")
+	}
+	return nil
+}
+
+func writeFixture(path string) error {
+	value := defaultFixture()
+	if err := validateFixture(value); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o600)
+}
+
+func readFixture(path string) (fixture, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fixture{}, err
+	}
+	var value fixture
+	if err := json.Unmarshal(data, &value); err != nil {
+		return fixture{}, err
+	}
+	if err := validateFixture(value); err != nil {
+		return fixture{}, err
+	}
+	return value, nil
+}
+
+func fixedIdentity() (*age.X25519Identity, error) {
+	return age.ParseX25519Identity(identityText)
+}
+
+func runRust(binary, root string, args ...string) ([]byte, error) {
+	cmd := exec.Command(binary, args...)
+	cmd.Dir = root
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	output, err := cmd.Output()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return nil, fmt.Errorf("rust %v: %w: %s", args, err, exitErr.Stderr)
+		}
+		return nil, fmt.Errorf("rust %v: %w", args, err)
+	}
+	if stderr.Len() != 0 {
+		return nil, fmt.Errorf("rust %v wrote unexpected stderr", args)
+	}
+	return output, nil
+}
+
+func project(entry *vaultpkg.Entry) projection {
+	return projection{Path: entry.Path, Data: entry.Data, Classification: int(entry.Classification), Canary: entry.Canary}
+}
+
+func sortedKeys(values map[string]any) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func runDifferential(binary string, value fixture) error {
+	absoluteBinary, err := filepath.Abs(binary)
+	if err != nil {
+		return err
+	}
+	binary = absoluteBinary
+	identity, err := fixedIdentity()
+	if err != nil {
+		return err
+	}
+	root, err := os.MkdirTemp("", "symvault-store-reopen-")
+	if err != nil {
+		return err
+	}
+	defer func() { _ = os.RemoveAll(root) }()
+	legacy := false
+	cfg := vaultconfig.Default()
+	cfg.VaultDir = root
+	cfg.Vault = &vaultconfig.VaultConfig{FormatVersion: 2, LegacyMode: &legacy, SearchIndex: false}
+	if initErr := vaultpkg.Init(root, identity, cfg); initErr != nil {
+		return fmt.Errorf("go init: %w", initErr)
+	}
+	if writeErr := os.WriteFile(filepath.Join(root, "recipients.txt"), []byte(identity.Recipient().String()+"\n"), 0o600); writeErr != nil {
+		return writeErr
+	}
+	goEntry := &vaultpkg.Entry{Path: value.Cases[0].Path, Data: map[string]any{
+		"username": "go-fixture-user",
+		"token":    "go-fixture-token",
+	}}
+	if writeErr := vaultpkg.WriteEntry(root, goEntry.Path, goEntry, identity); writeErr != nil {
+		return fmt.Errorf("go write: %w", writeErr)
+	}
+	goWritten, err := vaultpkg.ReadEntry(root, goEntry.Path, identity)
+	if err != nil {
+		return fmt.Errorf("go reopen: %w", err)
+	}
+	readOutput, err := runRust(binary, root, "--action", "read", "--root", root, "--path", value.Cases[0].Path)
+	if err != nil {
+		return err
+	}
+	var rustRead vaultpkg.Entry
+	if decodeErr := json.Unmarshal(readOutput, &rustRead); decodeErr != nil {
+		return fmt.Errorf("decode rust read: %w", decodeErr)
+	}
+	if !reflect.DeepEqual(project(&rustRead), project(goWritten)) {
+		return fmt.Errorf("Go→Rust reopen projection mismatch: path=%q/%q keys=%v/%v classification=%d/%d canary=%t/%t", rustRead.Path, goWritten.Path, sortedKeys(rustRead.Data), sortedKeys(goWritten.Data), rustRead.Classification, goWritten.Classification, rustRead.Canary, goWritten.Canary)
+	}
+
+	entryFile := filepath.Join(root, "rust-entry.json")
+	if writeErr := os.WriteFile(entryFile, value.Cases[1].Entry, 0o600); writeErr != nil {
+		return writeErr
+	}
+	if _, runErr := runRust(binary, root, "--action", "write", "--root", root, "--path", value.Cases[1].Path, "--entry-file", entryFile); runErr != nil {
+		return runErr
+	}
+	goRead, err := vaultpkg.ReadEntry(root, value.Cases[1].Path, identity)
+	if err != nil {
+		return fmt.Errorf("go read: %w", err)
+	}
+	var expected vaultpkg.Entry
+	if err := json.Unmarshal(value.Cases[1].Entry, &expected); err != nil {
+		return err
+	}
+	if !reflect.DeepEqual(project(goRead), project(&expected)) {
+		return fmt.Errorf("Rust→Go reopen projection mismatch")
+	}
+	if _, err := os.Stat(filepath.Join(root, value.Cases[1].StoragePath)); err != nil {
+		return fmt.Errorf("rust storage path: %w", err)
+	}
+	return nil
+}
+
+func main() {
+	fixturePath := flag.String("fixture", "testdata/port/store/reopen.json", "reopen fixture path")
+	generate := flag.Bool("generate", false, "write the deterministic contract fixture")
+	run := flag.Bool("run", false, "run the Go↔Rust differential")
+	rustBinary := flag.String("rust-binary", "", "path to the Rust store-reopen example")
+	flag.Parse()
+	if *generate {
+		if err := writeFixture(*fixturePath); err != nil {
+			fmt.Fprintln(os.Stderr, "FAIL generate reopen fixture:", err)
+			os.Exit(1)
+		}
+		fmt.Println("WROTE", *fixturePath)
+		return
+	}
+	value, err := readFixture(*fixturePath)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "FAIL reopen fixture:", err)
+		os.Exit(1)
+	}
+	if !*run {
+		fmt.Println("PASS reopen fixture (2 cases)")
+		return
+	}
+	if *rustBinary == "" {
+		fmt.Fprintln(os.Stderr, "FAIL differential: --rust-binary is required")
+		os.Exit(2)
+	}
+	if err := runDifferential(*rustBinary, value); err != nil {
+		fmt.Fprintln(os.Stderr, "FAIL Go↔Rust reopen:", err)
+		os.Exit(1)
+	}
+	fmt.Println("PASS Go↔Rust reopen (2 cases)")
+}

--- a/scripts/rust-port/cmd/storereopen/main.go
+++ b/scripts/rust-port/cmd/storereopen/main.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"sort"
+	"strings"
 
 	"filippo.io/age"
 
@@ -101,24 +102,56 @@ func validateFixture(value fixture) error {
 	return nil
 }
 
+func confinedFixturePath(path string) (string, error) {
+	clean := filepath.Clean(path)
+	if filepath.IsAbs(clean) {
+		return "", errors.New("fixture path must be relative")
+	}
+	root, err := filepath.Abs("testdata/port/store")
+	if err != nil {
+		return "", err
+	}
+	absolute, err := filepath.Abs(clean)
+	if err != nil {
+		return "", err
+	}
+	relative, err := filepath.Rel(root, absolute)
+	if err != nil {
+		return "", err
+	}
+	if relative == "." || relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+		return "", errors.New("fixture path escapes testdata/port/store")
+	}
+	return absolute, nil
+}
+
 func writeFixture(path string) error {
-	value := defaultFixture()
-	if err := validateFixture(value); err != nil {
+	safePath, err := confinedFixturePath(path)
+	if err != nil {
 		return err
+	}
+	value := defaultFixture()
+	if validateErr := validateFixture(value); validateErr != nil {
+		return validateErr
 	}
 	data, err := json.MarshalIndent(value, "", "  ")
 	if err != nil {
 		return err
 	}
 	data = append(data, '\n')
-	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+	if err := os.MkdirAll(filepath.Dir(safePath), 0o750); err != nil {
 		return err
 	}
-	return os.WriteFile(path, data, 0o600)
+	return os.WriteFile(safePath, data, 0o600)
 }
 
 func readFixture(path string) (fixture, error) {
-	data, err := os.ReadFile(path)
+	safePath, err := confinedFixturePath(path)
+	if err != nil {
+		return fixture{}, err
+	}
+	// #nosec G304 -- confinedFixturePath restricts reads to the contract fixture tree.
+	data, err := os.ReadFile(safePath)
 	if err != nil {
 		return fixture{}, err
 	}

--- a/scripts/rust-port/cmd/storereopen/main_test.go
+++ b/scripts/rust-port/cmd/storereopen/main_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestConfinedFixturePath(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{name: "contract fixture", path: filepath.Join("testdata", "port", "store", "reopen.json"), want: true},
+		{name: "absolute path", path: filepath.Join(string(filepath.Separator), "tmp", "fixture.json")},
+		{name: "parent escape", path: filepath.Join("testdata", "port", "store", "..", "..", "outside.json")},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := confinedFixturePath(test.path)
+			if (err == nil) != test.want {
+				t.Fatalf("confinedFixturePath(%q) error=%v, want allowed=%t", test.path, err, test.want)
+			}
+		})
+	}
+}

--- a/testdata/port/store/reopen.json
+++ b/testdata/port/store/reopen.json
@@ -1,0 +1,30 @@
+{
+  "schema_version": 1,
+  "oracle": {
+    "commit": "caadd5e",
+    "release": "v0.22.1"
+  },
+  "cases": [
+    {
+      "name": "go_to_rust_read",
+      "path": "go-created",
+      "storage_path": "entries/go-created.age",
+      "read_direction": "go_write_rust_read"
+    },
+    {
+      "name": "rust_to_go_read",
+      "path": "rust-created",
+      "entry": {
+        "path": "rust-created",
+        "data": {
+          "token": "rust-fixture-token",
+          "enabled": true
+        },
+        "meta": {},
+        "secret_meta": {}
+      },
+      "storage_path": "entries/rust-created.age",
+      "read_direction": "rust_write_go_read"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a deterministic two-way Go↔Rust storage reopen contract for RUST-005
- exercise Go-written data read by Rust and Rust-written data read by Go in an isolated temporary vault
- align Rust missing metadata timestamps with Go JSON zero-time and add a regression test
- keep the existing read-only store fixture gate in the composite target

## Verification
- `make store-differential`
- `GOTOOLCHAIN=go1.26.6 make test-fast`
- `GOTOOLCHAIN=go1.26.6 make lint`
- `make rust-gates`

All listed gates passed locally. This PR advances the storage slice only; replacement/delete, pseudonymized storage, manifests, encrypted search, native CI and release/cutover gates remain open.

Closes #1005