### PR TITLE
fix(rust): keep store native Windows CI warning-free

### DIFF
--- a/crates/symvault-store/src/lib.rs
+++ b/crates/symvault-store/src/lib.rs
@@ -771,11 +771,11 @@ fn can_use_legacy_path(path: &str) -> bool {
     path != "identity" && path != ENTRIES_DIR && !path.starts_with("entries/")
 }
 
-fn set_private_permissions(file: &fs::File) -> io::Result<()> {
+fn set_private_permissions(_file: &fs::File) -> io::Result<()> {
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        file.set_permissions(fs::Permissions::from_mode(0o600))?;
+        _file.set_permissions(fs::Permissions::from_mode(0o600))?;
     }
     Ok(())
 }

--- a/crates/symvault-store/src/tests.rs
+++ b/crates/symvault-store/src/tests.rs
@@ -544,7 +544,7 @@ fn path_validation_and_symlink_reads_fail_closed() {
         assert!(validate_entry_path(path).is_err(), "accepted {path:?}");
     }
     let (_, value) = fixture();
-    let identity = parse_identity(IDENTITY).unwrap();
+    let _identity = parse_identity(IDENTITY).unwrap();
     let temp = tempfile::tempdir().unwrap();
     let root = temp.path().to_path_buf();
     materialize(&root, &value.vaults[0]);
@@ -556,7 +556,7 @@ fn path_validation_and_symlink_reads_fail_closed() {
         )
         .unwrap();
         assert!(matches!(
-            Store::open(&root, &identity),
+            Store::open(&root, &_identity),
             Err(StoreError::Symlink(_))
         ));
     }


### PR DESCRIPTION
## Summary
- avoid Windows-only unused-variable failures in `symvault-store`
- preserve Unix private-permission behavior and symlink test behavior

## Verification
- `cargo fmt --all --check`
- `cargo test -p symvault-store --locked`
- `cargo clippy -p symvault-store --all-targets --all-features -- -D warnings`
- `cargo check -p symvault-store --target x86_64-pc-windows-gnu --all-targets --all-features`

Closes #1011