### PR TITLE
Add deterministic audit-chain fixtures and Rust HMAC core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1691,6 +1691,7 @@ name = "symvault-store"
 version = "0.0.0"
 dependencies = [
  "base64",
+ "hmac",
  "rustix",
  "serde",
  "serde_json",

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build install test test-fast test-coverage test-verbose test-race test-ci cover clean lint lint-fix fmt fmt-check vet passlint completions manpages port-fixtures-generate port-fixtures-check core-fixtures-generate core-fixtures-check quota-fixtures-generate quota-fixtures-check policy-fixtures-generate policy-fixtures-check differential-go-selftest crypto-differential crypto-fuzz-smoke port-contract store-reopen-fixture store-differential rust-build rust-check rust-lint rust-test rust-miri rust-features rust-coverage rust-security rust-version-contract rust-fuzz-lock rust-fuzz-smoke rust-fuzz rust-gates help docs-check
+.PHONY: all build install test test-fast test-coverage test-verbose test-race test-ci cover clean lint lint-fix fmt fmt-check vet passlint completions manpages port-fixtures-generate port-fixtures-check core-fixtures-generate core-fixtures-check quota-fixtures-generate quota-fixtures-check policy-fixtures-generate policy-fixtures-check audit-fixtures-generate audit-fixtures-check differential-go-selftest crypto-differential crypto-fuzz-smoke port-contract store-reopen-fixture store-differential rust-build rust-check rust-lint rust-test rust-miri rust-features rust-coverage rust-security rust-version-contract rust-fuzz-lock rust-fuzz-smoke rust-fuzz rust-gates help docs-check
 
 # Variables
 BINARY_NAME := symvault
@@ -226,6 +226,16 @@ policy-fixtures-check:
 	GOTOOLCHAIN=$(GO_TOOLCHAIN) $(GO) run ./scripts/rust-port/cmd/policygen \
 		--check --output $(PORT_POLICY_FIXTURE)
 
+audit-fixtures-generate:
+	SYMVAULT_TEST_KEYRING=memory GOTOOLCHAIN=$(GO_TOOLCHAIN) $(GO) run ./scripts/rust-port/cmd/auditgen \
+		--output testdata/port/audit/chain.json \
+		--oracle-commit $(PORT_ORACLE_COMMIT) \
+		--oracle-release $(PORT_ORACLE_RELEASE)
+
+audit-fixtures-check:
+	SYMVAULT_TEST_KEYRING=memory GOTOOLCHAIN=$(GO_TOOLCHAIN) $(GO) run ./scripts/rust-port/cmd/auditgen \
+		--check --output testdata/port/audit/chain.json
+
 differential-go-selftest:
 	GOTOOLCHAIN=$(GO_TOOLCHAIN) $(MAKE) build
 	GOTOOLCHAIN=$(GO_TOOLCHAIN) $(GO) run ./scripts/rust-port/cmd/diffharness \
@@ -379,6 +389,8 @@ help:
 	@echo "  quota-fixtures-check    - Verify pure quota transition vectors have not drifted"
 	@echo "  policy-fixtures-generate - Regenerate frozen Go-oracle policy/tier fixtures"
 	@echo "  policy-fixtures-check    - Verify Go-oracle policy/tier fixtures have not drifted"
+	@echo "  audit-fixtures-generate  - Regenerate frozen Go-oracle audit-chain fixtures"
+	@echo "  audit-fixtures-check     - Verify Go-oracle audit-chain fixtures have not drifted"
 	@echo "  differential-go-selftest - Compare the Go oracle with itself in isolated sandboxes"
 	@echo "  crypto-differential - Verify Go↔Rust age and KDF cross-decryption"
 	@echo "  crypto-fuzz-smoke - Run the bounded Argon2id parser fuzz smoke"

--- a/crates/symvault-store/Cargo.toml
+++ b/crates/symvault-store/Cargo.toml
@@ -8,6 +8,7 @@ repository.workspace = true
 publish = false
 
 [dependencies]
+hmac = "=0.12.1"
 serde.workspace = true
 serde_json.workspace = true
 serde_yaml_ng = "=0.10.0"

--- a/crates/symvault-store/src/audit/mod.rs
+++ b/crates/symvault-store/src/audit/mod.rs
@@ -1,0 +1,542 @@
+//! Pure keyed audit-chain primitives shared by future storage and adapters.
+//!
+//! The Go audit logger writes one `LogEntry` JSON object per line. When an HMAC
+//! key is available, the `kid` field identifies the key generation and the
+//! `hmac` field authenticates the previous raw HMAC bytes followed by the
+//! compact JSON object with `hmac` omitted. This module deliberately operates
+//! on caller-owned bytes and entries only; key persistence, file rotation, and
+//! CLI/MCP integration remain outside this slice.
+
+use std::{collections::BTreeMap, fmt};
+
+use hmac::{Hmac, Mac};
+use serde::{Deserialize, Deserializer, Serialize};
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+use zeroize::Zeroize;
+
+type HmacSha256 = Hmac<Sha256>;
+
+const HEX: &[u8; 16] = b"0123456789abcdef";
+
+/// Errors produced by the pure audit-chain operations.
+#[derive(Debug, Error)]
+pub enum AuditError {
+    #[error("hmac key is empty")]
+    EmptyKey,
+    #[error("no hmac keys provided")]
+    NoKeys,
+    #[error("failed to serialize audit entry: {0}")]
+    Serialize(#[from] serde_json::Error),
+}
+
+/// A JSONL audit record with the same field names, order, and omission rules
+/// as Go's `internal/audit.LogEntry`.
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct LogEntry {
+    #[serde(rename = "ts", default, deserialize_with = "deserialize_null_default")]
+    pub timestamp: String,
+    #[serde(default, deserialize_with = "deserialize_null_default")]
+    pub agent: String,
+    #[serde(default, deserialize_with = "deserialize_null_default")]
+    pub action: String,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_null_default",
+        skip_serializing_if = "String::is_empty"
+    )]
+    pub path: String,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_null_default",
+        skip_serializing_if = "String::is_empty"
+    )]
+    pub field: String,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_null_default",
+        skip_serializing_if = "String::is_empty"
+    )]
+    pub transport: String,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_null_default",
+        skip_serializing_if = "String::is_empty"
+    )]
+    pub reason: String,
+    #[serde(
+        rename = "share_id",
+        default,
+        deserialize_with = "deserialize_null_default",
+        skip_serializing_if = "String::is_empty"
+    )]
+    pub share_id: String,
+    #[serde(
+        rename = "from_agent",
+        default,
+        deserialize_with = "deserialize_null_default",
+        skip_serializing_if = "String::is_empty"
+    )]
+    pub from_agent: String,
+    #[serde(
+        rename = "to_agent",
+        default,
+        deserialize_with = "deserialize_null_default",
+        skip_serializing_if = "String::is_empty"
+    )]
+    pub to_agent: String,
+    #[serde(
+        rename = "share_action",
+        default,
+        deserialize_with = "deserialize_null_default",
+        skip_serializing_if = "String::is_empty"
+    )]
+    pub share_action: String,
+    #[serde(
+        rename = "dur_ms",
+        default,
+        deserialize_with = "deserialize_null_default",
+        skip_serializing_if = "is_zero"
+    )]
+    pub dur_ms: i64,
+    #[serde(
+        rename = "token_id",
+        default,
+        deserialize_with = "deserialize_null_default",
+        skip_serializing_if = "String::is_empty"
+    )]
+    pub token_id: String,
+    #[serde(
+        rename = "req_id",
+        default,
+        deserialize_with = "deserialize_null_default",
+        skip_serializing_if = "String::is_empty"
+    )]
+    pub request_id: String,
+    #[serde(
+        rename = "sess_id",
+        default,
+        deserialize_with = "deserialize_null_default",
+        skip_serializing_if = "String::is_empty"
+    )]
+    pub session_id: String,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_null_default",
+        skip_serializing_if = "String::is_empty"
+    )]
+    pub kid: String,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_null_default",
+        skip_serializing_if = "String::is_empty"
+    )]
+    pub hmac: String,
+    #[serde(
+        rename = "argv_hash",
+        default,
+        deserialize_with = "deserialize_null_default",
+        skip_serializing_if = "String::is_empty"
+    )]
+    pub argv_hash: String,
+    #[serde(default, deserialize_with = "deserialize_null_default")]
+    pub ok: bool,
+}
+
+/// Alias that makes the audit purpose explicit at call sites.
+pub type AuditLogEntry = LogEntry;
+
+fn deserialize_null_default<'de, D, T>(deserializer: D) -> Result<T, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Deserialize<'de> + Default,
+{
+    Ok(Option::<T>::deserialize(deserializer)?.unwrap_or_default())
+}
+
+fn is_zero(value: &i64) -> bool {
+    *value == 0
+}
+
+/// The result counters returned by Go's `VerifyLogAgainstKeys` equivalent.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct VerifyResult {
+    pub valid: bool,
+    pub total: usize,
+    pub verified: usize,
+    pub legacy: usize,
+    pub tampered: usize,
+    pub unverifiable: usize,
+    /// Zero-based index of the first tampered entry, or `-1` when none exists.
+    pub first_bad_idx: i64,
+}
+
+/// Computes the Go `KeyFingerprint`: the first four SHA-256 bytes as lowercase
+/// hexadecimal, used as the audit entry's key-generation ID (`kid`).
+#[must_use]
+pub fn key_fingerprint(key: &[u8]) -> String {
+    let digest = Sha256::digest(key);
+    encode_hex(&digest[..4])
+}
+
+/// Serializes an entry exactly as the Go logger does before HMAC computation.
+/// The `hmac` field is cleared and therefore omitted by its `omitempty` rule.
+pub fn canonical_json(entry: &LogEntry) -> Result<Vec<u8>, AuditError> {
+    let mut unsigned = entry.clone();
+    unsigned.hmac.clear();
+    serialize_go_json(&unsigned).map_err(AuditError::from)
+}
+
+/// Computes the lowercase hexadecimal HMAC-SHA256 for one chain entry.
+/// `previous_hmac` is the raw decoded HMAC bytes from the preceding record;
+/// an empty slice represents the first record or a legacy prefix reset.
+pub fn compute_hmac(
+    key: &[u8],
+    previous_hmac: &[u8],
+    entry: &LogEntry,
+) -> Result<String, AuditError> {
+    Ok(encode_hex(&compute_hmac_bytes(key, previous_hmac, entry)?))
+}
+
+fn compute_hmac_bytes(
+    key: &[u8],
+    previous_hmac: &[u8],
+    entry: &LogEntry,
+) -> Result<[u8; 32], AuditError> {
+    let canonical = canonical_json(entry)?;
+    let mut mac =
+        <HmacSha256 as Mac>::new_from_slice(key).expect("HMAC-SHA256 accepts every key length");
+    mac.update(previous_hmac);
+    mac.update(&canonical);
+    let digest = mac.finalize().into_bytes();
+    let mut result = [0; 32];
+    result.copy_from_slice(&digest);
+    Ok(result)
+}
+
+/// A deterministic in-memory signer for one JSONL audit chain.
+pub struct AuditChain {
+    key: Vec<u8>,
+    kid: String,
+    previous_hmac: Vec<u8>,
+}
+
+impl fmt::Debug for AuditChain {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("AuditChain")
+            .field("kid", &self.kid)
+            .field("has_previous_hmac", &(!self.previous_hmac.is_empty()))
+            .finish_non_exhaustive()
+    }
+}
+
+impl AuditChain {
+    /// Starts a new chain and computes its `kid` from `key`.
+    pub fn new(key: &[u8]) -> Result<Self, AuditError> {
+        Self::with_previous_hmac(key, &[])
+    }
+
+    /// Starts a chain whose next record links to `previous_hmac`, as needed by
+    /// a caller reopening an existing log. No filesystem or parsing is done.
+    pub fn with_previous_hmac(key: &[u8], previous_hmac: &[u8]) -> Result<Self, AuditError> {
+        if key.is_empty() {
+            return Err(AuditError::EmptyKey);
+        }
+        Ok(Self {
+            key: key.to_vec(),
+            kid: key_fingerprint(key),
+            previous_hmac: previous_hmac.to_vec(),
+        })
+    }
+
+    /// Returns the key-generation ID written into signed records.
+    #[must_use]
+    pub fn key_id(&self) -> &str {
+        &self.kid
+    }
+
+    /// Returns the raw HMAC bytes used as the next record's predecessor.
+    #[must_use]
+    pub fn previous_hmac(&self) -> Option<&[u8]> {
+        (!self.previous_hmac.is_empty()).then_some(self.previous_hmac.as_slice())
+    }
+
+    /// Signs an entry, replacing any caller-supplied `kid` and `hmac` exactly
+    /// as the Go logger does before writing it.
+    pub fn sign_entry(&mut self, mut entry: LogEntry) -> Result<LogEntry, AuditError> {
+        entry.kid.clone_from(&self.kid);
+        let digest = compute_hmac_bytes(&self.key, &self.previous_hmac, &entry)?;
+        entry.hmac = encode_hex(&digest);
+        self.previous_hmac = digest.to_vec();
+        Ok(entry)
+    }
+
+    /// Signs an entry and returns one complete JSONL record, including its
+    /// terminating newline.
+    pub fn append(&mut self, entry: LogEntry) -> Result<Vec<u8>, AuditError> {
+        let signed = self.sign_entry(entry)?;
+        let mut line = serialize_go_json(&signed).map_err(AuditError::from)?;
+        line.push(b'\n');
+        Ok(line)
+    }
+}
+
+impl Drop for AuditChain {
+    fn drop(&mut self) {
+        self.key.zeroize();
+        self.previous_hmac.zeroize();
+    }
+}
+
+/// Verifies JSONL bytes against one HMAC key.
+pub fn verify_jsonl(data: &[u8], key: &[u8]) -> Result<VerifyResult, AuditError> {
+    if key.is_empty() {
+        return Err(AuditError::EmptyKey);
+    }
+    let kid = key_fingerprint(key);
+    let mut keys = BTreeMap::new();
+    keys.insert(kid.clone(), key.to_vec());
+    verify_jsonl_against_keys(data, &keys, &kid)
+}
+
+/// Verifies JSONL bytes against known key generations.
+///
+/// Records with a `kid` use that key directly. Records without a `kid` try
+/// `current_kid` first and then the remaining IDs in lexical order, matching
+/// the Go verifier's deterministic fallback. A missing key is unverifiable,
+/// not tampered. A legacy record before the first HMAC is accepted; a missing
+/// HMAC after the chain starts is a tamper/reset signal.
+pub fn verify_jsonl_against_keys(
+    data: &[u8],
+    keys: &BTreeMap<String, Vec<u8>>,
+    current_kid: &str,
+) -> Result<VerifyResult, AuditError> {
+    if keys.is_empty() {
+        return Err(AuditError::NoKeys);
+    }
+
+    let entries = parse_entries(data);
+    let trial_kids = trial_kid_order(keys, current_kid);
+    let mut result = VerifyResult {
+        valid: true,
+        total: entries.len(),
+        verified: 0,
+        legacy: 0,
+        tampered: 0,
+        unverifiable: 0,
+        first_bad_idx: -1,
+    };
+    let mut previous_hmac = Vec::new();
+    let mut chain_started = false;
+
+    for (index, entry) in entries.iter().enumerate() {
+        if entry.hmac.is_empty() {
+            if chain_started {
+                mark_tampered(&mut result, index);
+            } else {
+                result.legacy += 1;
+                previous_hmac.clear();
+            }
+            continue;
+        }
+
+        let Some(entry_hmac) = decode_hex(&entry.hmac) else {
+            mark_tampered(&mut result, index);
+            continue;
+        };
+
+        let (matched, known) = if !entry.kid.is_empty() {
+            match keys.get(&entry.kid) {
+                Some(key) => (
+                    constant_time_equal(
+                        &compute_hmac_bytes(key, &previous_hmac, entry)?,
+                        &entry_hmac,
+                    ),
+                    true,
+                ),
+                None => (false, false),
+            }
+        } else {
+            let mut matched = false;
+            let mut known = false;
+            for kid in &trial_kids {
+                let expected = compute_hmac_bytes(
+                    keys.get(kid).expect("trial key ID came from the key map"),
+                    &previous_hmac,
+                    entry,
+                )?;
+                if constant_time_equal(&expected, &entry_hmac) {
+                    matched = true;
+                    known = true;
+                    break;
+                }
+            }
+            (matched, known)
+        };
+
+        match (matched, known) {
+            (true, _) => result.verified += 1,
+            (false, true) => mark_tampered(&mut result, index),
+            (false, false) => result.unverifiable += 1,
+        }
+
+        // Match Go's forward-link behavior: later records use the literal
+        // stored HMAC even when this record was tampered or unverifiable.
+        previous_hmac = entry_hmac;
+        chain_started = true;
+    }
+
+    Ok(result)
+}
+
+fn mark_tampered(result: &mut VerifyResult, index: usize) {
+    result.tampered += 1;
+    result.valid = false;
+    if result.first_bad_idx < 0 {
+        result.first_bad_idx = i64::try_from(index).expect("audit index fits in i64");
+    }
+}
+
+fn trial_kid_order(keys: &BTreeMap<String, Vec<u8>>, current_kid: &str) -> Vec<String> {
+    let mut order = Vec::with_capacity(keys.len());
+    if keys.contains_key(current_kid) {
+        order.push(current_kid.to_owned());
+    }
+    order.extend(
+        keys.keys()
+            .filter(|kid| kid.as_str() != current_kid)
+            .cloned(),
+    );
+    order
+}
+
+fn parse_entries(data: &[u8]) -> Vec<LogEntry> {
+    data.split(|byte| *byte == b'\n')
+        .filter_map(|line| {
+            let line = String::from_utf8_lossy(line);
+            let line = line.trim();
+            if line.is_empty() {
+                return None;
+            }
+            // Go's json.Unmarshal("null", &entry) leaves a zero LogEntry and
+            // reports success; Option preserves that small compatibility edge.
+            serde_json::from_str::<Option<LogEntry>>(line)
+                .ok()
+                .map(|entry| entry.unwrap_or_default())
+        })
+        .collect()
+}
+
+fn serialize_go_json<T: Serialize>(value: &T) -> Result<Vec<u8>, serde_json::Error> {
+    let raw = serde_json::to_vec(value)?;
+    Ok(escape_go_json_html(&raw))
+}
+
+// encoding/json escapes these characters even inside otherwise ordinary JSON
+// strings. serde_json intentionally does not, so apply the Go-compatible
+// escaping after compact serialization while leaving JSON syntax untouched.
+fn escape_go_json_html(raw: &[u8]) -> Vec<u8> {
+    let mut escaped = Vec::with_capacity(raw.len());
+    let mut in_string = false;
+    let mut escaped_character = false;
+    let mut index = 0;
+    while index < raw.len() {
+        let byte = raw[index];
+        if !in_string {
+            escaped.push(byte);
+            if byte == b'"' {
+                in_string = true;
+            }
+            index += 1;
+            continue;
+        }
+
+        if escaped_character {
+            escaped.push(byte);
+            escaped_character = false;
+            index += 1;
+            continue;
+        }
+
+        match byte {
+            b'\\' => {
+                escaped.push(byte);
+                escaped_character = true;
+                index += 1;
+            }
+            b'"' => {
+                escaped.push(byte);
+                in_string = false;
+                index += 1;
+            }
+            b'<' => {
+                escaped.extend_from_slice(b"\\u003c");
+                index += 1;
+            }
+            b'>' => {
+                escaped.extend_from_slice(b"\\u003e");
+                index += 1;
+            }
+            b'&' => {
+                escaped.extend_from_slice(b"\\u0026");
+                index += 1;
+            }
+            0xe2 if index + 2 < raw.len() && raw[index + 1] == 0x80 && raw[index + 2] == 0xa8 => {
+                escaped.extend_from_slice(b"\\u2028");
+                index += 3;
+            }
+            0xe2 if index + 2 < raw.len() && raw[index + 1] == 0x80 && raw[index + 2] == 0xa9 => {
+                escaped.extend_from_slice(b"\\u2029");
+                index += 3;
+            }
+            _ => {
+                escaped.push(byte);
+                index += 1;
+            }
+        }
+    }
+    escaped
+}
+
+fn encode_hex(bytes: &[u8]) -> String {
+    let mut result = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        result.push(HEX[(byte >> 4) as usize] as char);
+        result.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    result
+}
+
+fn decode_hex(value: &str) -> Option<Vec<u8>> {
+    let bytes = value.as_bytes();
+    if !bytes.len().is_multiple_of(2) {
+        return None;
+    }
+    let (pairs, remainder) = bytes.as_chunks::<2>();
+    debug_assert!(remainder.is_empty());
+    pairs
+        .iter()
+        .map(|pair| Some((hex_nibble(pair[0])? << 4) | hex_nibble(pair[1])?))
+        .collect()
+}
+
+fn hex_nibble(value: u8) -> Option<u8> {
+    match value {
+        b'0'..=b'9' => Some(value - b'0'),
+        b'a'..=b'f' => Some(value - b'a' + 10),
+        b'A'..=b'F' => Some(value - b'A' + 10),
+        _ => None,
+    }
+}
+
+fn constant_time_equal(left: &[u8], right: &[u8]) -> bool {
+    if left.len() != right.len() {
+        return false;
+    }
+    let mut difference = 0u8;
+    for (left, right) in left.iter().zip(right) {
+        difference |= left ^ right;
+    }
+    difference == 0
+}

--- a/crates/symvault-store/src/lib.rs
+++ b/crates/symvault-store/src/lib.rs
@@ -22,6 +22,8 @@ use thiserror::Error;
 use walkdir::WalkDir;
 use zeroize::Zeroize;
 
+pub mod audit;
+
 const ENTRIES_DIR: &str = "entries";
 const CONFIG_FILE: &str = "config.yaml";
 const IDENTITY_FILE: &str = "identity.age";

--- a/crates/symvault-store/tests/audit_chain.rs
+++ b/crates/symvault-store/tests/audit_chain.rs
@@ -24,7 +24,9 @@ struct Oracle {
     commit: String,
     release: String,
     source_files: Vec<String>,
-    generator: String,
+    source_digest: String,
+    generator_files: Vec<String>,
+    generator_digest: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -67,13 +69,19 @@ fn pinned_go_fixture_covers_canonical_bytes_and_deterministic_append() {
         fixture.oracle.source_files,
         [
             "internal/audit/audit.go",
-            "internal/audit/audit_hmac_test.go"
+            "internal/audit/audit_hmac_test.go",
+            "internal/audit/keystore.go"
         ]
     );
     assert_eq!(
-        fixture.oracle.generator,
-        "Go internal/audit canonicalJSON and computeHMAC"
+        fixture.oracle.generator_files,
+        [
+            "scripts/rust-port/cmd/auditgen/main.go",
+            "scripts/rust-port/cmd/auditgen/main_test.go"
+        ]
     );
+    assert_eq!(fixture.oracle.source_digest.len(), 64);
+    assert_eq!(fixture.oracle.generator_digest.len(), 64);
 
     let key = key_from_hex(&fixture.key_hex);
     assert_eq!(key.len(), 32);

--- a/crates/symvault-store/tests/audit_chain.rs
+++ b/crates/symvault-store/tests/audit_chain.rs
@@ -1,0 +1,227 @@
+#![deny(unsafe_code)]
+
+use std::collections::BTreeMap;
+
+use serde::Deserialize;
+use serde_json::Value;
+use symvault_store::audit::{
+    AuditChain, AuditLogEntry, LogEntry, canonical_json, compute_hmac, key_fingerprint,
+    verify_jsonl, verify_jsonl_against_keys,
+};
+
+const FIXTURE: &[u8] = include_bytes!("../../../testdata/port/audit/chain.json");
+
+#[derive(Debug, Deserialize)]
+struct Fixture {
+    schema_version: u8,
+    oracle: Oracle,
+    key_hex: String,
+    entries: Vec<EntryVector>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Oracle {
+    commit: String,
+    release: String,
+    source_files: Vec<String>,
+    generator: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct EntryVector {
+    entry: AuditLogEntry,
+    canonical_json: String,
+    hmac: String,
+    line: String,
+}
+
+fn fixture() -> Fixture {
+    serde_json::from_slice(FIXTURE).expect("decode Go-generated audit fixture")
+}
+
+fn key_from_hex(value: &str) -> Vec<u8> {
+    assert!(value.len().is_multiple_of(2));
+    let (pairs, remainder) = value.as_bytes().as_chunks::<2>();
+    assert!(remainder.is_empty());
+    pairs
+        .iter()
+        .map(|pair| {
+            let high = (pair[0] as char).to_digit(16).expect("hex high nibble");
+            let low = (pair[1] as char).to_digit(16).expect("hex low nibble");
+            ((high << 4) | low) as u8
+        })
+        .collect()
+}
+
+fn hmac_bytes(value: &str) -> Vec<u8> {
+    key_from_hex(value)
+}
+
+#[test]
+fn pinned_go_fixture_covers_canonical_bytes_and_deterministic_append() {
+    let fixture = fixture();
+    assert_eq!(fixture.schema_version, 1);
+    assert_eq!(fixture.oracle.commit, "caadd5e");
+    assert_eq!(fixture.oracle.release, "v0.22.1");
+    assert_eq!(
+        fixture.oracle.source_files,
+        [
+            "internal/audit/audit.go",
+            "internal/audit/audit_hmac_test.go"
+        ]
+    );
+    assert_eq!(
+        fixture.oracle.generator,
+        "Go internal/audit canonicalJSON and computeHMAC"
+    );
+
+    let key = key_from_hex(&fixture.key_hex);
+    assert_eq!(key.len(), 32);
+    assert_eq!(key_fingerprint(&key), "630dcd29");
+
+    let mut chain = AuditChain::new(&key).expect("non-empty fixture key");
+    let mut previous = Vec::new();
+    let mut jsonl = Vec::new();
+    for vector in &fixture.entries {
+        assert_eq!(
+            canonical_json(&vector.entry).expect("canonical JSON"),
+            vector.canonical_json.as_bytes()
+        );
+        assert_eq!(
+            compute_hmac(&key, &previous, &vector.entry).expect("HMAC"),
+            vector.hmac
+        );
+        assert!(
+            vector
+                .hmac
+                .chars()
+                .all(|character| character.is_ascii_hexdigit())
+        );
+        assert_eq!(vector.hmac, vector.hmac.to_ascii_lowercase());
+        assert_eq!(vector.hmac.len(), 64);
+
+        let line = chain.append(vector.entry.clone()).expect("append entry");
+        assert_eq!(line, format!("{}\n", vector.line).as_bytes());
+        jsonl.extend_from_slice(&line);
+        previous = hmac_bytes(&vector.hmac);
+    }
+
+    let result = verify_jsonl(&jsonl, &key).expect("verify fixture chain");
+    assert!(result.valid);
+    assert_eq!(result.total, fixture.entries.len());
+    assert_eq!(result.verified, fixture.entries.len());
+    assert_eq!(result.legacy, 0);
+    assert_eq!(result.tampered, 0);
+    assert_eq!(result.unverifiable, 0);
+    assert_eq!(result.first_bad_idx, -1);
+}
+
+#[test]
+fn tampering_a_canonical_field_is_detected_at_its_original_index() {
+    let fixture = fixture();
+    let key = key_from_hex(&fixture.key_hex);
+    let mut lines: Vec<String> = fixture
+        .entries
+        .iter()
+        .map(|vector| vector.line.clone())
+        .collect();
+    let mut tampered: Value = serde_json::from_str(&lines[1]).expect("fixture JSON");
+    tampered["action"] = Value::String("tampered-action".into());
+    lines[1] = serde_json::to_string(&tampered).expect("serialize tampered JSON");
+    let data = format!("{}\n", lines.join("\n"));
+
+    let result = verify_jsonl(data.as_bytes(), &key).expect("verify tampered chain");
+    assert!(!result.valid);
+    assert_eq!(result.total, 3);
+    assert_eq!(result.verified, 2);
+    assert_eq!(result.tampered, 1);
+    assert_eq!(result.first_bad_idx, 1);
+    assert_eq!(result.legacy, 0);
+}
+
+#[test]
+fn legacy_prefix_is_accepted_but_missing_hmac_after_chain_is_a_reset() {
+    let fixture = fixture();
+    let key = key_from_hex(&fixture.key_hex);
+    let legacy =
+        br#"{"ts":"2024-01-15T10:29:59Z","agent":"fixture-agent","action":"legacy","ok":true}"#;
+
+    let prefix_data = format!(
+        "{}\n{}\n",
+        String::from_utf8_lossy(legacy),
+        fixture.entries[0].line
+    );
+    let prefix_result = verify_jsonl(prefix_data.as_bytes(), &key).expect("verify legacy prefix");
+    assert!(prefix_result.valid);
+    assert_eq!(prefix_result.total, 2);
+    assert_eq!(prefix_result.legacy, 1);
+    assert_eq!(prefix_result.verified, 1);
+    assert_eq!(prefix_result.tampered, 0);
+    assert_eq!(prefix_result.first_bad_idx, -1);
+
+    let reset_data = format!(
+        "{}\n{}\n{}\n{}\n",
+        fixture.entries[0].line,
+        String::from_utf8_lossy(legacy),
+        fixture.entries[1].line,
+        fixture.entries[2].line
+    );
+    let reset_result = verify_jsonl(reset_data.as_bytes(), &key).expect("verify reset attempt");
+    assert!(!reset_result.valid);
+    assert_eq!(reset_result.total, 4);
+    assert_eq!(reset_result.legacy, 0);
+    assert_eq!(reset_result.verified, 3);
+    assert_eq!(reset_result.tampered, 1);
+    assert_eq!(reset_result.first_bad_idx, 1);
+}
+
+#[test]
+fn kid_selects_a_known_generation_and_unknown_generation_is_unverifiable() {
+    let fixture = fixture();
+    let key = key_from_hex(&fixture.key_hex);
+    let current_kid = key_fingerprint(&key);
+    let mut keys = BTreeMap::new();
+    keys.insert(current_kid.clone(), key.clone());
+
+    let result = verify_jsonl_against_keys(
+        format!("{}\n", fixture.entries[0].line).as_bytes(),
+        &keys,
+        &current_kid,
+    )
+    .expect("verify known kid");
+    assert!(result.valid);
+    assert_eq!(result.verified, 1);
+    assert_eq!(result.unverifiable, 0);
+
+    let mut unknown: Value = serde_json::from_str(&fixture.entries[0].line).expect("fixture JSON");
+    unknown["kid"] = Value::String("deadbeef".into());
+    let unknown_data = format!(
+        "{}\n",
+        serde_json::to_string(&unknown).expect("serialize unknown kid")
+    );
+    let result = verify_jsonl_against_keys(unknown_data.as_bytes(), &keys, &current_kid)
+        .expect("verify unknown kid");
+    assert!(result.valid);
+    assert_eq!(result.verified, 0);
+    assert_eq!(result.unverifiable, 1);
+    assert_eq!(result.tampered, 0);
+}
+
+#[test]
+fn canonical_json_uses_go_html_escaping_and_omits_hmac() {
+    let entry = LogEntry {
+        timestamp: "2024-01-15T10:30:00Z".into(),
+        agent: "a<&>\u{2028}\u{2029}".into(),
+        action: "get".into(),
+        hmac: "should-not-be-canonicalized".into(),
+        ok: true,
+        ..LogEntry::default()
+    };
+    let canonical =
+        String::from_utf8(canonical_json(&entry).expect("canonical JSON")).expect("UTF-8 JSON");
+    assert_eq!(
+        canonical,
+        "{\"ts\":\"2024-01-15T10:30:00Z\",\"agent\":\"a\\u003c\\u0026\\u003e\\u2028\\u2029\",\"action\":\"get\",\"ok\":true}"
+    );
+    assert!(!canonical.contains("hmac"));
+}

--- a/scripts/rust-port/cmd/auditgen/main.go
+++ b/scripts/rust-port/cmd/auditgen/main.go
@@ -173,7 +173,7 @@ func fixedEntries() []auditpkg.LogEntry {
 	}
 }
 
-func buildFixture(root string) (fixture, error) {
+func buildFixture(root string) (built fixture, retErr error) {
 	meta, err := authoritativeOracle(root)
 	if err != nil {
 		return fixture{}, err
@@ -187,9 +187,13 @@ func buildFixture(root string) (fixture, error) {
 	if err != nil {
 		return fixture{}, fmt.Errorf("create isolated audit directory: %w", err)
 	}
-	defer os.RemoveAll(dir) // #nosec G304 -- dir is the generator's private temporary directory.
+	defer func() { // #nosec G304 -- dir is the generator's private temporary directory.
+		if removeErr := os.RemoveAll(dir); removeErr != nil && retErr == nil {
+			retErr = fmt.Errorf("remove isolated audit directory: %w", removeErr)
+		}
+	}()
 
-	if err := os.WriteFile(filepath.Join(dir, "audit-hmac-key"), key, 0o600); err != nil {
+	if err = os.WriteFile(filepath.Join(dir, "audit-hmac-key"), key, 0o600); err != nil {
 		return fixture{}, fmt.Errorf("seed fixture HMAC key: %w", err)
 	}
 
@@ -200,25 +204,25 @@ func buildFixture(root string) (fixture, error) {
 		return fixture{}, fmt.Errorf("open production audit logger: %w", err)
 	}
 	for _, entry := range fixedEntries() {
-		if err := logger.LogEntry(entry); err != nil {
+		if err = logger.LogEntry(entry); err != nil {
 			_ = logger.Close()
 			restoreConfig()
 			return fixture{}, fmt.Errorf("write production audit entry: %w", err)
 		}
 	}
-	if err := logger.Close(); err != nil {
+	if err = logger.Close(); err != nil {
 		restoreConfig()
 		return fixture{}, fmt.Errorf("close production audit logger: %w", err)
 	}
 	restoreConfig()
 
 	logPath := filepath.Join(dir, "audit-"+fixtureAgent+".log")
-	result, err := auditpkg.VerifyLog(logPath, key)
+	verification, err := auditpkg.VerifyLog(logPath, key)
 	if err != nil {
 		return fixture{}, fmt.Errorf("verify generated audit chain: %w", err)
 	}
-	if !result.Valid || result.Total != len(fixedEntries()) || result.Verified != len(fixedEntries()) || result.Tampered != 0 || result.Legacy != 0 || result.FirstBadIdx != -1 {
-		return fixture{}, fmt.Errorf("generated audit chain did not verify: %+v", result)
+	if !verification.Valid || verification.Total != len(fixedEntries()) || verification.Verified != len(fixedEntries()) || verification.Tampered != 0 || verification.Legacy != 0 || verification.FirstBadIdx != -1 {
+		return fixture{}, fmt.Errorf("generated audit chain did not verify: %+v", verification)
 	}
 
 	data, err := os.ReadFile(logPath) // #nosec G304 -- logPath is inside the generator's private temp directory.
@@ -232,14 +236,14 @@ func buildFixture(root string) (fixture, error) {
 			continue
 		}
 		var entry auditpkg.LogEntry
-		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+		if err = json.Unmarshal([]byte(line), &entry); err != nil {
 			return fixture{}, fmt.Errorf("decode generated entry %d: %w", i, err)
 		}
 		storedHMAC := entry.HMAC
 		entry.HMAC = ""
-		canonical, err := json.Marshal(entry)
-		if err != nil {
-			return fixture{}, fmt.Errorf("marshal canonical entry %d: %w", i, err)
+		canonical, marshalErr := json.Marshal(entry)
+		if marshalErr != nil {
+			return fixture{}, fmt.Errorf("marshal canonical entry %d: %w", i, marshalErr)
 		}
 		entries = append(entries, entryVector{
 			Entry:         entry,
@@ -330,10 +334,10 @@ func checkFixture(root, path string) error {
 		return fmt.Errorf("read audit fixture: %w", err)
 	}
 	var actual fixture
-	if err := json.Unmarshal(data, &actual); err != nil {
+	if err = json.Unmarshal(data, &actual); err != nil {
 		return fmt.Errorf("decode audit fixture: %w", err)
 	}
-	if err := validateFixture(actual, expected.Oracle); err != nil {
+	if err = validateFixture(actual, expected.Oracle); err != nil {
 		return err
 	}
 	expectedBytes, err := marshalFixture(expected)

--- a/scripts/rust-port/cmd/auditgen/main.go
+++ b/scripts/rust-port/cmd/auditgen/main.go
@@ -1,0 +1,420 @@
+// Command auditgen freezes deterministic keyed audit-chain vectors for the
+// staged Rust store port.
+package main
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+
+	auditpkg "github.com/danieljustus/symaira-vault/internal/audit"
+)
+
+const (
+	pinnedOracleCommit  = "caadd5e"
+	pinnedOracleRelease = "v0.22.1"
+	fixtureKeyHex       = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+	fixtureAgent        = "fixture-agent"
+	keyringEnv          = "SYMVAULT_TEST_KEYRING"
+)
+
+var oracleSourceFiles = []string{
+	"internal/audit/audit.go",
+	"internal/audit/audit_hmac_test.go",
+	"internal/audit/keystore.go",
+}
+
+var generatorFiles = []string{
+	"scripts/rust-port/cmd/auditgen/main.go",
+	"scripts/rust-port/cmd/auditgen/main_test.go",
+}
+
+type oracle struct {
+	Commit          string   `json:"commit"`
+	Release         string   `json:"release"`
+	SourceFiles     []string `json:"source_files"`
+	SourceDigest    string   `json:"source_digest"`
+	GeneratorFiles  []string `json:"generator_files"`
+	GeneratorDigest string   `json:"generator_digest"`
+}
+
+type fixture struct {
+	SchemaVersion int           `json:"schema_version"`
+	Oracle        oracle        `json:"oracle"`
+	KeyHex        string        `json:"key_hex"`
+	Entries       []entryVector `json:"entries"`
+}
+
+type entryVector struct {
+	Entry         auditpkg.LogEntry `json:"entry"`
+	CanonicalJSON string            `json:"canonical_json"`
+	HMAC          string            `json:"hmac"`
+	Line          string            `json:"line"`
+}
+
+func rootDir() string {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		panic("locate auditgen")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", "..", "..", ".."))
+}
+
+func digestFiles(root string, names []string, pinned bool) (string, error) {
+	sorted := append([]string(nil), names...)
+	sort.Strings(sorted)
+	hash := sha256.New()
+	for _, name := range sorted {
+		var (
+			data []byte
+			err  error
+		)
+		if pinned {
+			data, err = exec.Command("git", "-C", root, "show", pinnedOracleCommit+":"+name).Output() // #nosec G204 -- executable and revision are fixed; name comes from a compile-time list.
+		} else {
+			data, err = os.ReadFile(filepath.Join(root, name)) // #nosec G304 -- names come from a compile-time list.
+		}
+		if err != nil {
+			return "", fmt.Errorf("digest %s: %w", name, err)
+		}
+		_, _ = hash.Write([]byte(name))
+		_, _ = hash.Write([]byte{0})
+		_, _ = hash.Write(data)
+		_, _ = hash.Write([]byte{0})
+	}
+	return hex.EncodeToString(hash.Sum(nil)), nil
+}
+
+func authoritativeOracle(root string) (oracle, error) {
+	pinnedDigest, err := digestFiles(root, oracleSourceFiles, true)
+	if err != nil {
+		return oracle{}, fmt.Errorf("hash pinned audit oracle: %w", err)
+	}
+	currentDigest, err := digestFiles(root, oracleSourceFiles, false)
+	if err != nil {
+		return oracle{}, fmt.Errorf("hash current audit oracle: %w", err)
+	}
+	if currentDigest != pinnedDigest {
+		return oracle{}, fmt.Errorf("current audit oracle differs from pinned commit %s; advance the oracle before regenerating", pinnedOracleCommit)
+	}
+	generatorDigest, err := digestFiles(root, generatorFiles, false)
+	if err != nil {
+		return oracle{}, fmt.Errorf("hash audit generator: %w", err)
+	}
+	return oracle{
+		Commit:          pinnedOracleCommit,
+		Release:         pinnedOracleRelease,
+		SourceFiles:     append([]string(nil), oracleSourceFiles...),
+		SourceDigest:    pinnedDigest,
+		GeneratorFiles:  append([]string(nil), generatorFiles...),
+		GeneratorDigest: generatorDigest,
+	}, nil
+}
+
+func resolveOracle(check bool, commit, release string) error {
+	if commit != "" && commit != pinnedOracleCommit {
+		return fmt.Errorf("oracle commit %q is not the pinned commit %q", commit, pinnedOracleCommit)
+	}
+	if release != "" && release != pinnedOracleRelease {
+		return fmt.Errorf("oracle release %q is not the pinned release %q", release, pinnedOracleRelease)
+	}
+	if !check && (commit == "" || release == "") {
+		return errors.New("--oracle-commit and --oracle-release are required when generating a new fixture")
+	}
+	return nil
+}
+
+func fixedEntries() []auditpkg.LogEntry {
+	return []auditpkg.LogEntry{
+		{
+			Timestamp: "2024-01-15T10:30:00Z",
+			Agent:     fixtureAgent,
+			Action:    "get",
+			Path:      "secret/api-key",
+			Field:     "password",
+			Transport: "stdio",
+			DurMs:     17,
+			OK:        true,
+		},
+		{
+			Timestamp:   "2024-01-15T10:30:01Z",
+			Agent:       fixtureAgent,
+			Action:      "set",
+			Path:        "secret/api-key",
+			Field:       "password",
+			Transport:   "http",
+			Reason:      "write_denied",
+			ShareID:     "share-1",
+			FromAgent:   fixtureAgent,
+			ToAgent:     "other-agent",
+			ShareAction: "share_request",
+			TokenID:     "tok_1",
+			RequestID:   "req_1",
+			SessionID:   "sess_1",
+			OK:          false,
+		},
+		{
+			Timestamp: "2024-01-15T10:30:02Z",
+			Agent:     fixtureAgent,
+			Action:    "list",
+			ArgvHash:  "argv-hash",
+			OK:        true,
+		},
+	}
+}
+
+func buildFixture(root string) (fixture, error) {
+	meta, err := authoritativeOracle(root)
+	if err != nil {
+		return fixture{}, err
+	}
+	key, err := hex.DecodeString(fixtureKeyHex)
+	if err != nil {
+		return fixture{}, fmt.Errorf("decode fixture key: %w", err)
+	}
+
+	dir, err := os.MkdirTemp("", "symvault-auditgen-")
+	if err != nil {
+		return fixture{}, fmt.Errorf("create isolated audit directory: %w", err)
+	}
+	defer os.RemoveAll(dir) // #nosec G304 -- dir is the generator's private temporary directory.
+
+	if err := os.WriteFile(filepath.Join(dir, "audit-hmac-key"), key, 0o600); err != nil {
+		return fixture{}, fmt.Errorf("seed fixture HMAC key: %w", err)
+	}
+
+	restoreConfig := configureDeterministicAudit()
+	logger, err := auditpkg.New(fixtureAgent, dir, nil)
+	if err != nil {
+		restoreConfig()
+		return fixture{}, fmt.Errorf("open production audit logger: %w", err)
+	}
+	for _, entry := range fixedEntries() {
+		if err := logger.LogEntry(entry); err != nil {
+			_ = logger.Close()
+			restoreConfig()
+			return fixture{}, fmt.Errorf("write production audit entry: %w", err)
+		}
+	}
+	if err := logger.Close(); err != nil {
+		restoreConfig()
+		return fixture{}, fmt.Errorf("close production audit logger: %w", err)
+	}
+	restoreConfig()
+
+	logPath := filepath.Join(dir, "audit-"+fixtureAgent+".log")
+	result, err := auditpkg.VerifyLog(logPath, key)
+	if err != nil {
+		return fixture{}, fmt.Errorf("verify generated audit chain: %w", err)
+	}
+	if !result.Valid || result.Total != len(fixedEntries()) || result.Verified != len(fixedEntries()) || result.Tampered != 0 || result.Legacy != 0 || result.FirstBadIdx != -1 {
+		return fixture{}, fmt.Errorf("generated audit chain did not verify: %+v", result)
+	}
+
+	data, err := os.ReadFile(logPath) // #nosec G304 -- logPath is inside the generator's private temp directory.
+	if err != nil {
+		return fixture{}, fmt.Errorf("read generated audit log: %w", err)
+	}
+	lines := strings.Split(strings.TrimSuffix(string(data), "\n"), "\n")
+	entries := make([]entryVector, 0, len(lines))
+	for i, line := range lines {
+		if line == "" {
+			continue
+		}
+		var entry auditpkg.LogEntry
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			return fixture{}, fmt.Errorf("decode generated entry %d: %w", i, err)
+		}
+		storedHMAC := entry.HMAC
+		entry.HMAC = ""
+		canonical, err := json.Marshal(entry)
+		if err != nil {
+			return fixture{}, fmt.Errorf("marshal canonical entry %d: %w", i, err)
+		}
+		entries = append(entries, entryVector{
+			Entry:         entry,
+			CanonicalJSON: string(canonical),
+			HMAC:          storedHMAC,
+			Line:          line,
+		})
+	}
+	return fixture{SchemaVersion: 1, Oracle: meta, KeyHex: fixtureKeyHex, Entries: entries}, nil
+}
+
+func configureDeterministicAudit() func() {
+	const (
+		maxSizeEnv = "SYMVAULT_AUDIT_MAX_SIZE_MB"
+		maxBackups = "SYMVAULT_AUDIT_MAX_BACKUPS"
+		maxAgeDays = "SYMVAULT_AUDIT_MAX_AGE_DAYS"
+	)
+	type environmentValue struct {
+		value string
+		set   bool
+	}
+	previous := make(map[string]environmentValue, 3)
+	for _, name := range []string{maxSizeEnv, maxBackups, maxAgeDays} {
+		value, set := os.LookupEnv(name)
+		previous[name] = environmentValue{value: value, set: set}
+		_ = os.Unsetenv(name)
+	}
+	auditpkg.SetConfig(&auditpkg.Config{MaxFileSize: 1 << 30, MaxBackups: 5, MaxAgeDays: 36500})
+	return func() {
+		for name, previousValue := range previous {
+			if previousValue.set {
+				_ = os.Setenv(name, previousValue.value)
+			} else {
+				_ = os.Unsetenv(name)
+			}
+		}
+		auditpkg.ReloadConfig()
+	}
+}
+
+func marshalFixture(value fixture) ([]byte, error) {
+	content, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(content, '\n'), nil
+}
+
+func sameStrings(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func validateFixture(value fixture, expected oracle) error {
+	if value.SchemaVersion != 1 {
+		return fmt.Errorf("unsupported schema_version %d", value.SchemaVersion)
+	}
+	if value.Oracle.Commit != expected.Commit || value.Oracle.Release != expected.Release ||
+		value.Oracle.SourceDigest != expected.SourceDigest || value.Oracle.GeneratorDigest != expected.GeneratorDigest ||
+		!sameStrings(value.Oracle.SourceFiles, expected.SourceFiles) || !sameStrings(value.Oracle.GeneratorFiles, expected.GeneratorFiles) {
+		return errors.New("audit fixture provenance changed; regenerate from the pinned Go oracle")
+	}
+	if value.KeyHex != fixtureKeyHex || len(value.Entries) != len(fixedEntries()) {
+		return errors.New("audit fixture key or entry cardinality changed")
+	}
+	for i, entry := range value.Entries {
+		if entry.Entry.Agent != fixtureAgent || entry.HMAC == "" || entry.Line == "" || entry.CanonicalJSON == "" {
+			return fmt.Errorf("audit fixture entry %d is incomplete", i)
+		}
+	}
+	return nil
+}
+
+func checkFixture(root, path string) error {
+	expected, err := buildFixture(root)
+	if err != nil {
+		return err
+	}
+	data, err := os.ReadFile(path) // #nosec G304 -- path is the explicit fixture selected by the caller.
+	if err != nil {
+		return fmt.Errorf("read audit fixture: %w", err)
+	}
+	var actual fixture
+	if err := json.Unmarshal(data, &actual); err != nil {
+		return fmt.Errorf("decode audit fixture: %w", err)
+	}
+	if err := validateFixture(actual, expected.Oracle); err != nil {
+		return err
+	}
+	expectedBytes, err := marshalFixture(expected)
+	if err != nil {
+		return fmt.Errorf("marshal expected audit fixture: %w", err)
+	}
+	if !bytes.Equal(data, expectedBytes) {
+		return errors.New("audit fixture is stale; run make audit-fixtures-generate")
+	}
+	return nil
+}
+
+func reexecWithMemoryKeyring() error {
+	env := make([]string, 0, len(os.Environ())+1)
+	prefix := keyringEnv + "="
+	for _, value := range os.Environ() {
+		if !strings.HasPrefix(value, prefix) {
+			env = append(env, value)
+		}
+	}
+	env = append(env, prefix+"memory")
+	command := exec.Command(os.Args[0], os.Args[1:]...) // #nosec G204 -- re-executes this fixed generator binary.
+	command.Env = env
+	command.Stdout = os.Stdout
+	command.Stderr = os.Stderr
+	if err := command.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			os.Exit(exitErr.ExitCode())
+		}
+		return err
+	}
+	return nil
+}
+
+func run() {
+	output := flag.String("output", "testdata/port/audit/chain.json", "audit fixture path")
+	check := flag.Bool("check", false, "fail if the fixture differs")
+	commit := flag.String("oracle-commit", "", "Go oracle commit")
+	release := flag.String("oracle-release", "", "Go oracle release")
+	flag.Parse()
+
+	if err := resolveOracle(*check, *commit, *release); err != nil {
+		fatal("resolve oracle metadata: %v", err)
+	}
+	root := rootDir()
+	if *check {
+		if err := checkFixture(root, *output); err != nil {
+			fatal("%v", err)
+		}
+		fmt.Println("PASS audit fixture (3 entries)")
+		return
+	}
+	value, err := buildFixture(root)
+	if err != nil {
+		fatal("generate audit fixture: %v", err)
+	}
+	content, err := marshalFixture(value)
+	if err != nil {
+		fatal("marshal audit fixture: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(*output), 0o750); err != nil {
+		fatal("create audit fixture directory: %v", err)
+	}
+	if err := os.WriteFile(*output, content, 0o600); err != nil {
+		fatal("write audit fixture: %v", err)
+	}
+	fmt.Printf("WROTE %s (%d entries)\n", *output, len(value.Entries))
+}
+
+func main() {
+	if os.Getenv(keyringEnv) != "memory" {
+		if err := reexecWithMemoryKeyring(); err != nil {
+			fatal("start isolated generator: %v", err)
+		}
+		return
+	}
+	run()
+}
+
+func fatal(format string, args ...any) {
+	_, _ = fmt.Fprintf(os.Stderr, "FAIL "+format+"\n", args...)
+	os.Exit(1)
+}

--- a/scripts/rust-port/cmd/auditgen/main_test.go
+++ b/scripts/rust-port/cmd/auditgen/main_test.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeFixture(t *testing.T, value fixture) string {
+	t.Helper()
+	content, err := marshalFixture(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "chain.json")
+	if err := os.WriteFile(path, content, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestResolveOracleRejectsTamperedMetadata(t *testing.T) {
+	if err := resolveOracle(true, "tampered", pinnedOracleRelease); err == nil {
+		t.Fatal("expected tampered commit rejection")
+	}
+	if err := resolveOracle(true, pinnedOracleCommit, "v0.0.0"); err == nil {
+		t.Fatal("expected tampered release rejection")
+	}
+	if err := resolveOracle(false, "", pinnedOracleRelease); err == nil {
+		t.Fatal("expected missing generation commit rejection")
+	}
+	if err := resolveOracle(true, "", ""); err != nil {
+		t.Fatalf("check mode should use pinned metadata: %v", err)
+	}
+}
+
+func TestBuildFixtureIsDeterministicAndProductionVerified(t *testing.T) {
+	root := rootDir()
+	first, err := buildFixture(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := buildFixture(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstJSON, err := marshalFixture(first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondJSON, err := marshalFixture(second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(firstJSON, secondJSON) {
+		t.Fatal("audit fixture generation is not deterministic")
+	}
+	if first.SchemaVersion != 1 || first.KeyHex != fixtureKeyHex || len(first.Entries) != 3 {
+		t.Fatalf("fixture shape = schema %d, key %q, entries %d", first.SchemaVersion, first.KeyHex, len(first.Entries))
+	}
+	if len(first.Oracle.SourceDigest) != 64 || len(first.Oracle.GeneratorDigest) != 64 {
+		t.Fatalf("incomplete provenance: %#v", first.Oracle)
+	}
+	for i, entry := range first.Entries {
+		if entry.Entry.Kid != "630dcd29" {
+			t.Fatalf("entry %d kid = %q, want production fingerprint", i, entry.Entry.Kid)
+		}
+		if len(entry.HMAC) != 64 || entry.HMAC != strings.ToLower(entry.HMAC) {
+			t.Fatalf("entry %d HMAC = %q", i, entry.HMAC)
+		}
+	}
+}
+
+func TestCheckRejectsProvenanceAndFixtureDrift(t *testing.T) {
+	root := rootDir()
+	value, err := buildFixture(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := value.Oracle
+	if err := validateFixture(value, expected); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*fixture)
+	}{
+		{"source_digest", func(v *fixture) { v.Oracle.SourceDigest = strings.Repeat("0", 64) }},
+		{"generator_digest", func(v *fixture) { v.Oracle.GeneratorDigest = strings.Repeat("0", 64) }},
+		{"entry", func(v *fixture) { v.Entries[1].Entry.Action = "tampered-action" }},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mutated := value
+			mutated.Entries = append([]entryVector(nil), value.Entries...)
+			tc.mutate(&mutated)
+			path := writeFixture(t, mutated)
+			if err := checkFixture(root, path); err == nil {
+				t.Fatal("check accepted tampered fixture")
+			}
+		})
+	}
+}
+
+func TestFixtureJSONRoundTripPreservesEntryVectors(t *testing.T) {
+	value, err := buildFixture(rootDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	content, err := marshalFixture(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded fixture
+	if err := json.Unmarshal(content, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(content, mustMarshalFixture(t, decoded)) {
+		t.Fatal("fixture JSON round trip changed bytes")
+	}
+}
+
+func mustMarshalFixture(t *testing.T, value fixture) []byte {
+	t.Helper()
+	content, err := marshalFixture(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return content
+}

--- a/testdata/port/audit/chain.json
+++ b/testdata/port/audit/chain.json
@@ -5,9 +5,15 @@
     "release": "v0.22.1",
     "source_files": [
       "internal/audit/audit.go",
-      "internal/audit/audit_hmac_test.go"
+      "internal/audit/audit_hmac_test.go",
+      "internal/audit/keystore.go"
     ],
-    "generator": "Go internal/audit canonicalJSON and computeHMAC"
+    "source_digest": "f1bac365a1a1ddc445530ea28794dd7a7331923a3eb463c7e299faf77e3af557",
+    "generator_files": [
+      "scripts/rust-port/cmd/auditgen/main.go",
+      "scripts/rust-port/cmd/auditgen/main_test.go"
+    ],
+    "generator_digest": "660d273325a57422b7a45d9f8a1c577f8e15cf882712d39130710606b8d9ee77"
   },
   "key_hex": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
   "entries": [

--- a/testdata/port/audit/chain.json
+++ b/testdata/port/audit/chain.json
@@ -13,7 +13,7 @@
       "scripts/rust-port/cmd/auditgen/main.go",
       "scripts/rust-port/cmd/auditgen/main_test.go"
     ],
-    "generator_digest": "660d273325a57422b7a45d9f8a1c577f8e15cf882712d39130710606b8d9ee77"
+    "generator_digest": "53e9f6695b5672b6222c741489ea038b0ddca0f9658cdf602633ee341cff2908"
   },
   "key_hex": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
   "entries": [

--- a/testdata/port/audit/chain.json
+++ b/testdata/port/audit/chain.json
@@ -1,0 +1,67 @@
+{
+  "schema_version": 1,
+  "oracle": {
+    "commit": "caadd5e",
+    "release": "v0.22.1",
+    "source_files": [
+      "internal/audit/audit.go",
+      "internal/audit/audit_hmac_test.go"
+    ],
+    "generator": "Go internal/audit canonicalJSON and computeHMAC"
+  },
+  "key_hex": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+  "entries": [
+    {
+      "entry": {
+        "ts": "2024-01-15T10:30:00Z",
+        "agent": "fixture-agent",
+        "action": "get",
+        "path": "secret/api-key",
+        "field": "password",
+        "transport": "stdio",
+        "dur_ms": 17,
+        "kid": "630dcd29",
+        "ok": true
+      },
+      "canonical_json": "{\"ts\":\"2024-01-15T10:30:00Z\",\"agent\":\"fixture-agent\",\"action\":\"get\",\"path\":\"secret/api-key\",\"field\":\"password\",\"transport\":\"stdio\",\"dur_ms\":17,\"kid\":\"630dcd29\",\"ok\":true}",
+      "hmac": "a11dfff65e057ded5b934170889a8ce15fbd6b0d3c9c18d84496750fae0eead8",
+      "line": "{\"ts\":\"2024-01-15T10:30:00Z\",\"agent\":\"fixture-agent\",\"action\":\"get\",\"path\":\"secret/api-key\",\"field\":\"password\",\"transport\":\"stdio\",\"dur_ms\":17,\"kid\":\"630dcd29\",\"hmac\":\"a11dfff65e057ded5b934170889a8ce15fbd6b0d3c9c18d84496750fae0eead8\",\"ok\":true}"
+    },
+    {
+      "entry": {
+        "ts": "2024-01-15T10:30:01Z",
+        "agent": "fixture-agent",
+        "action": "set",
+        "path": "secret/api-key",
+        "field": "password",
+        "transport": "http",
+        "reason": "write_denied",
+        "share_id": "share-1",
+        "from_agent": "fixture-agent",
+        "to_agent": "other-agent",
+        "share_action": "share_request",
+        "token_id": "tok_1",
+        "req_id": "req_1",
+        "sess_id": "sess_1",
+        "kid": "630dcd29",
+        "ok": false
+      },
+      "canonical_json": "{\"ts\":\"2024-01-15T10:30:01Z\",\"agent\":\"fixture-agent\",\"action\":\"set\",\"path\":\"secret/api-key\",\"field\":\"password\",\"transport\":\"http\",\"reason\":\"write_denied\",\"share_id\":\"share-1\",\"from_agent\":\"fixture-agent\",\"to_agent\":\"other-agent\",\"share_action\":\"share_request\",\"token_id\":\"tok_1\",\"req_id\":\"req_1\",\"sess_id\":\"sess_1\",\"kid\":\"630dcd29\",\"ok\":false}",
+      "hmac": "40dcac220e13c866c458af8ed96987574cf52a3ed726f5850d45c573186a514a",
+      "line": "{\"ts\":\"2024-01-15T10:30:01Z\",\"agent\":\"fixture-agent\",\"action\":\"set\",\"path\":\"secret/api-key\",\"field\":\"password\",\"transport\":\"http\",\"reason\":\"write_denied\",\"share_id\":\"share-1\",\"from_agent\":\"fixture-agent\",\"to_agent\":\"other-agent\",\"share_action\":\"share_request\",\"token_id\":\"tok_1\",\"req_id\":\"req_1\",\"sess_id\":\"sess_1\",\"kid\":\"630dcd29\",\"hmac\":\"40dcac220e13c866c458af8ed96987574cf52a3ed726f5850d45c573186a514a\",\"ok\":false}"
+    },
+    {
+      "entry": {
+        "ts": "2024-01-15T10:30:02Z",
+        "agent": "fixture-agent",
+        "action": "list",
+        "kid": "630dcd29",
+        "argv_hash": "argv-hash",
+        "ok": true
+      },
+      "canonical_json": "{\"ts\":\"2024-01-15T10:30:02Z\",\"agent\":\"fixture-agent\",\"action\":\"list\",\"kid\":\"630dcd29\",\"argv_hash\":\"argv-hash\",\"ok\":true}",
+      "hmac": "3409b71d5a49c3ff6a989a9575d943aec39728180627166dd7c56615dccc8327",
+      "line": "{\"ts\":\"2024-01-15T10:30:02Z\",\"agent\":\"fixture-agent\",\"action\":\"list\",\"kid\":\"630dcd29\",\"hmac\":\"3409b71d5a49c3ff6a989a9575d943aec39728180627166dd7c56615dccc8327\",\"argv_hash\":\"argv-hash\",\"ok\":true}"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add the Rust `symvault-store` keyed HMAC-SHA256 audit-chain core with Go-compatible canonical JSON, key IDs, previous-HMAC linking, legacy/reset handling, and lowercase hex output
- add a Go-pinned `auditgen` command that generates and checks the language-neutral audit fixture using source and generator provenance digests
- add focused Rust and generator tests plus Makefile targets for reproducible fixture drift checks

## Verification
- `make audit-fixtures-check`
- `GOTOOLCHAIN=go1.26.6 go test ./scripts/rust-port/cmd/auditgen`
- `GOTOOLCHAIN=go1.26.6 go test ./internal/audit`
- `cargo fmt --all --check`
- `cargo clippy -p symvault-store --all-targets -- -D warnings`
- `cargo test -p symvault-store --all-targets`

## Scope and rollback
This keeps the Go implementation as the oracle and does not change the production cutover or remove the Go fallback. The changes are isolated to the Rust store audit core and its deterministic fixture tooling; reverting this PR restores the previous fixture workflow.

Closes #1015
