### PR TITLE
fix(rust-index): match Go search index wire schema

### DIFF
--- a/crates/symvault-crypto/src/lib.rs
+++ b/crates/symvault-crypto/src/lib.rs
@@ -574,8 +574,8 @@ pub fn decrypt_index(
 }
 
 fn derive_index_key(identity: &Identity, salt: &[u8]) -> Vec<u8> {
-    let identity_bytes = recipient_string(identity);
-    let identity_bytes = identity_bytes.as_bytes();
+    let identity_string = identity.0.to_string();
+    let identity_bytes = identity_string.expose_secret().as_bytes();
     if salt.is_empty() {
         return Sha256::digest(identity_bytes).to_vec();
     }

--- a/crates/symvault-store/Cargo.toml
+++ b/crates/symvault-store/Cargo.toml
@@ -8,6 +8,7 @@ repository.workspace = true
 publish = false
 
 [dependencies]
+base64 = "=0.22.1"
 serde.workspace = true
 serde_json.workspace = true
 serde_yaml_ng = "=0.10.0"

--- a/crates/symvault-store/examples/search-index-adapter.rs
+++ b/crates/symvault-store/examples/search-index-adapter.rs
@@ -1,0 +1,65 @@
+#![deny(unsafe_code)]
+
+use std::{env, fs, path::PathBuf, process};
+
+use symvault_crypto::parse_identity;
+use symvault_store::{Entry, SearchIndex, Store};
+
+fn arg(args: &[String], name: &str) -> Result<String, String> {
+    let index = args
+        .iter()
+        .position(|value| value == name)
+        .ok_or_else(|| format!("missing {name}"))?;
+    args.get(index + 1)
+        .cloned()
+        .ok_or_else(|| format!("missing value for {name}"))
+}
+
+fn run() -> Result<(), String> {
+    let args: Vec<_> = env::args().collect();
+    let action = arg(&args, "--action")?;
+    let root = PathBuf::from(arg(&args, "--root")?);
+    let identity = parse_identity(&arg(&args, "--identity")?).map_err(|error| error.to_string())?;
+    let store = Store::open(&root, &identity).map_err(|error| error.to_string())?;
+
+    match action.as_str() {
+        "build" => {
+            SearchIndex::build(&store, &identity).map_err(|error| error.to_string())?;
+            println!("{{\"case_id\":\"rust_build_index\"}}");
+        }
+        "load-search" => {
+            let mut index = SearchIndex::load(&store, &identity)
+                .map_err(|error| error.to_string())?
+                .ok_or_else(|| "search index missing or rejected".to_owned())?;
+            let candidates = store.list(&identity).map_err(|error| error.to_string())?;
+            let matches = index
+                .search(&candidates, &arg(&args, "--query")?)
+                .map_err(|error| error.to_string())?;
+            let result = serde_json::json!({
+                "case_id": "rust_load_go_index_search",
+                "matches": matches,
+            });
+            serde_json::to_writer(std::io::stdout(), &result).map_err(|error| error.to_string())?;
+            println!();
+        }
+        "write-build" => {
+            let bytes = fs::read(arg(&args, "--entry-file")?).map_err(|error| error.to_string())?;
+            let entry: Entry = serde_json::from_slice(&bytes).map_err(|error| error.to_string())?;
+            let path = arg(&args, "--path")?;
+            store
+                .write_new_entry(&path, &entry, &identity)
+                .map_err(|error| error.to_string())?;
+            SearchIndex::build(&store, &identity).map_err(|error| error.to_string())?;
+            println!("{{\"case_id\":\"rust_build_index_for_go_load\"}}");
+        }
+        other => return Err(format!("unsupported action {other}")),
+    }
+    Ok(())
+}
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("search-index-adapter: {error}");
+        process::exit(1);
+    }
+}

--- a/crates/symvault-store/examples/search-index-adapter.rs
+++ b/crates/symvault-store/examples/search-index-adapter.rs
@@ -19,6 +19,11 @@ fn run() -> Result<(), String> {
     let args: Vec<_> = env::args().collect();
     let action = arg(&args, "--action")?;
     let root = PathBuf::from(arg(&args, "--root")?);
+    let case_id = args
+        .windows(2)
+        .find(|pair| pair[0] == "--case-id")
+        .map(|pair| pair[1].as_str())
+        .unwrap_or("adapter");
     let identity = parse_identity(&arg(&args, "--identity")?).map_err(|error| error.to_string())?;
     let store = Store::open(&root, &identity).map_err(|error| error.to_string())?;
 
@@ -30,7 +35,7 @@ fn run() -> Result<(), String> {
         "load-search" => {
             let mut index = SearchIndex::load(&store, &identity)
                 .map_err(|error| error.to_string())?
-                .ok_or_else(|| "search index missing or rejected".to_owned())?;
+                .ok_or_else(|| format!("{case_id}: search index missing or rejected"))?;
             let candidates = store.list(&identity).map_err(|error| error.to_string())?;
             let matches = index
                 .search(&candidates, &arg(&args, "--query")?)

--- a/crates/symvault-store/src/audit.rs
+++ b/crates/symvault-store/src/audit.rs
@@ -437,12 +437,14 @@ fn write_private(path: &Path, bytes: &[u8]) -> io::Result<()> {
     set_private_mode(&file)
 }
 
+#[cfg(unix)]
 fn set_private_mode(file: &File) -> io::Result<()> {
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        file.set_permissions(fs::Permissions::from_mode(0o600))?;
-    }
+    use std::os::unix::fs::PermissionsExt;
+    file.set_permissions(fs::Permissions::from_mode(0o600))
+}
+
+#[cfg(not(unix))]
+fn set_private_mode(_file: &File) -> io::Result<()> {
     Ok(())
 }
 

--- a/crates/symvault-store/src/lib.rs
+++ b/crates/symvault-store/src/lib.rs
@@ -1637,14 +1637,94 @@ struct EmptyIndexValue {}
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 struct IndexDocument {
-    #[serde(rename = "v")]
+    #[serde(rename = "v", default, deserialize_with = "deserialize_null_generic")]
     values: BTreeMap<String, Vec<String>>,
-    #[serde(rename = "c")]
+    #[serde(
+        rename = "ti",
+        default,
+        deserialize_with = "deserialize_null_generic",
+        skip_serializing_if = "BTreeMap::is_empty"
+    )]
+    token_index: BTreeMap<String, BTreeMap<String, EmptyIndexValue>>,
+    #[serde(
+        rename = "pt",
+        default,
+        deserialize_with = "deserialize_null_generic",
+        skip_serializing_if = "BTreeMap::is_empty"
+    )]
+    path_tokens: BTreeMap<String, Vec<String>>,
+    #[serde(
+        rename = "hi",
+        default,
+        deserialize_with = "deserialize_null_generic",
+        skip_serializing_if = "BTreeMap::is_empty"
+    )]
+    host_index: BTreeMap<String, BTreeMap<String, EmptyIndexValue>>,
+    #[serde(
+        rename = "ph",
+        default,
+        deserialize_with = "deserialize_null_generic",
+        skip_serializing_if = "BTreeMap::is_empty"
+    )]
+    path_hosts: BTreeMap<String, Vec<String>>,
+    #[serde(
+        rename = "c",
+        default,
+        deserialize_with = "deserialize_null_generic",
+        skip_serializing_if = "is_zero"
+    )]
     entry_count: usize,
-    #[serde(rename = "p", default)]
+    #[serde(
+        rename = "p",
+        default,
+        deserialize_with = "deserialize_null_generic",
+        skip_serializing_if = "BTreeMap::is_empty"
+    )]
     paths: BTreeMap<String, EmptyIndexValue>,
-    #[serde(rename = "s", default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(
+        rename = "s",
+        default,
+        deserialize_with = "deserialize_index_salt",
+        serialize_with = "serialize_index_salt",
+        skip_serializing_if = "Vec::is_empty"
+    )]
     salt: Vec<u8>,
+}
+
+fn is_zero(value: &usize) -> bool {
+    *value == 0
+}
+
+fn deserialize_null_generic<'de, D, T>(deserializer: D) -> Result<T, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: Deserialize<'de> + Default,
+{
+    Ok(Option::<T>::deserialize(deserializer)?.unwrap_or_default())
+}
+
+fn deserialize_index_salt<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let encoded = Option::<String>::deserialize(deserializer)?;
+    encoded
+        .map(|value| {
+            use base64::Engine;
+            base64::engine::general_purpose::STANDARD
+                .decode(value)
+                .map_err(serde::de::Error::custom)
+        })
+        .transpose()
+        .map(|value| value.unwrap_or_default())
+}
+
+fn serialize_index_salt<S>(salt: &[u8], serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    use base64::Engine;
+    serializer.serialize_str(&base64::engine::general_purpose::STANDARD.encode(salt))
 }
 
 impl SearchIndex {

--- a/internal/vault/search_index_crosslang_test.go
+++ b/internal/vault/search_index_crosslang_test.go
@@ -1,0 +1,160 @@
+package vault
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"sync"
+	"testing"
+
+	vaultconfig "github.com/danieljustus/symaira-vault/internal/config"
+	"github.com/danieljustus/symaira-vault/internal/testutil"
+)
+
+var searchIndexAdapterBuild struct {
+	sync.Once
+	path string
+	err  error
+}
+
+func searchIndexAdapter(t testing.TB) string {
+	t.Helper()
+	searchIndexAdapterBuild.Do(func() {
+		_, file, _, ok := runtime.Caller(0)
+		if !ok {
+			searchIndexAdapterBuild.err = fmt.Errorf("runtime.Caller failed")
+			return
+		}
+		repo := filepath.Clean(filepath.Join(filepath.Dir(file), "../.."))
+		target := filepath.Join(repo, ".worktrees", "rust-integration", "target")
+		if err := os.MkdirAll(target, 0o700); err != nil {
+			searchIndexAdapterBuild.err = err
+			return
+		}
+		cmd := exec.Command("cargo", "build", "-p", "symvault-store", "--example", "search-index-adapter")
+		cmd.Dir = repo
+		cmd.Env = append(os.Environ(), "CARGO_TARGET_DIR="+target)
+		var stderr bytes.Buffer
+		cmd.Stderr = &stderr
+		if output, err := cmd.Output(); err != nil {
+			searchIndexAdapterBuild.err = fmt.Errorf("cargo build: %w: %s\n%s", err, stderr.Bytes(), output)
+			return
+		}
+		searchIndexAdapterBuild.path = filepath.Join(target, "debug", "examples", "search-index-adapter")
+	})
+	if searchIndexAdapterBuild.err != nil {
+		t.Fatalf("build search-index adapter: %v", searchIndexAdapterBuild.err)
+	}
+	return searchIndexAdapterBuild.path
+}
+
+func runSearchIndexAdapter(t testing.TB, binary, root, identity, action string, extra ...string) map[string]any {
+	t.Helper()
+	args := []string{"--action", action, "--root", root, "--identity", identity}
+	args = append(args, extra...)
+	cmd := exec.Command(binary, args...)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	output, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("adapter %s: %v\nstderr=%s", action, err, stderr.String())
+	}
+	var result map[string]any
+	if err := json.Unmarshal(output, &result); err != nil {
+		t.Fatalf("adapter %s output %q: %v", action, output, err)
+	}
+	return result
+}
+
+func TestEncryptedIndexGoRustLiveAcceptance(t *testing.T) {
+	searchIndexStore.invalidateAll()
+	t.Cleanup(searchIndexStore.invalidateAll)
+	adapter := searchIndexAdapter(t)
+
+	// Case go_index_rust_load_search: the Go production builder writes the
+	// current salted wire format; Rust must load it, not fall back to entries.
+	goRoot := t.TempDir()
+	goIdentity := testutil.TempIdentity(t)
+	cfg := vaultconfig.Default()
+	cfg.VaultDir = goRoot
+	if err := Init(goRoot, goIdentity, cfg); err != nil {
+		t.Fatalf("Init Go vault: %v", err)
+	}
+	mustWriteEntry(t, goRoot, goIdentity, "go-doc", map[string]interface{}{
+		"title": "Go interoperability marker",
+		"token": "go-rust-accepted",
+	})
+	goIndex := &EncryptedIndex{}
+	if err := goIndex.Build(goRoot, goIdentity); err != nil {
+		t.Fatalf("Go Build: %v", err)
+	}
+	loaded := runSearchIndexAdapter(t, adapter, goRoot, goIdentity.String(), "load-search", "--query", "go-rust-accepted")
+	if loaded["case_id"] != "rust_load_go_index_search" {
+		t.Fatalf("executed case_id = %v", loaded["case_id"])
+	}
+	matches, ok := loaded["matches"].([]any)
+	if !ok || len(matches) != 1 || matches[0] != "go-doc" {
+		t.Fatalf("Rust matches = %v, want [go-doc]", loaded["matches"])
+	}
+
+	// Case rust_index_go_load_search: Rust writes a real current index and Go
+	// explicitly exercises its unexported loadFromDisk path.
+	rustRoot := t.TempDir()
+	trustIdentity := testutil.TempIdentity(t)
+	cfg = vaultconfig.Default()
+	cfg.VaultDir = rustRoot
+	if err := Init(rustRoot, trustIdentity, cfg); err != nil {
+		t.Fatalf("Init Rust vault: %v", err)
+	}
+	entryFile := filepath.Join(t.TempDir(), "entry.json")
+	entry := map[string]any{"path": "rust-doc", "data": map[string]any{
+		"title": "Rust interoperability marker", "token": "rust-go-accepted",
+	}, "meta": map[string]any{}, "secret_meta": map[string]any{}}
+	entryBytes, _ := json.Marshal(entry)
+	if err := os.WriteFile(entryFile, entryBytes, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	built := runSearchIndexAdapter(t, adapter, rustRoot, trustIdentity.String(), "write-build", "--path", "rust-doc", "--entry-file", entryFile)
+	if built["case_id"] != "rust_build_index_for_go_load" {
+		t.Fatalf("executed case_id = %v", built["case_id"])
+	}
+	goLoaded := &EncryptedIndex{}
+	if err := goLoaded.loadFromDisk(rustRoot, trustIdentity); err != nil {
+		t.Fatalf("Go loadFromDisk Rust index: %v", err)
+	}
+	goMatches, err := goLoaded.MatchEntries(rustRoot, trustIdentity, []string{"rust-doc"}, "rust-go-accepted")
+	if err != nil {
+		t.Fatalf("Go search Rust index: %v", err)
+	}
+	if !reflect.DeepEqual(goMatches, map[string]struct{}{"rust-doc": {}}) {
+		t.Fatalf("Go matches = %v, want rust-doc", goMatches)
+	}
+
+	// Case wrong_identity_rejected: a valid index must not be accepted by a
+	// different identity, even though the vault layout is otherwise valid.
+	wrong := testutil.TempIdentity(t)
+	wrongLoaded := &EncryptedIndex{}
+	if err := wrongLoaded.loadFromDisk(rustRoot, wrong); err == nil {
+		t.Fatal("wrong identity unexpectedly loaded encrypted index")
+	}
+
+	// Case tampered_ciphertext_rejected: authenticated corruption must fail the
+	// explicit loader rather than becoming an empty successful search.
+	raw, err := os.ReadFile(indexFilePath(goRoot))
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw[len(raw)-1] ^= 1
+	if err := os.WriteFile(indexFilePath(goRoot), raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	tampered := &EncryptedIndex{}
+	if err := tampered.loadFromDisk(goRoot, goIdentity); err == nil {
+		t.Fatal("tampered ciphertext unexpectedly loaded")
+	}
+}

--- a/internal/vault/search_index_crosslang_test.go
+++ b/internal/vault/search_index_crosslang_test.go
@@ -37,7 +37,7 @@ func searchIndexAdapter(t testing.TB) string {
 			return
 		}
 		repo := filepath.Clean(filepath.Join(filepath.Dir(file), "../.."))
-		target := filepath.Join(repo, ".worktrees", "rust-integration", "target")
+		target := filepath.Join(repo, "target", "search-index-adapter")
 		if err := os.MkdirAll(target, 0o700); err != nil {
 			searchIndexAdapterBuild.err = err
 			return

--- a/internal/vault/search_index_crosslang_test.go
+++ b/internal/vault/search_index_crosslang_test.go
@@ -1,30 +1,36 @@
 package vault
 
 import (
-	"bytes"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"strings"
 	"sync"
 	"testing"
+
+	"filippo.io/age"
+	"golang.org/x/crypto/chacha20poly1305"
+	"golang.org/x/crypto/hkdf"
 
 	vaultconfig "github.com/danieljustus/symaira-vault/internal/config"
 	"github.com/danieljustus/symaira-vault/internal/testutil"
 )
 
 var searchIndexAdapterBuild struct {
-	sync.Once
 	path string
 	err  error
 }
 
 func searchIndexAdapter(t testing.TB) string {
 	t.Helper()
-	searchIndexAdapterBuild.Do(func() {
+	searchIndexAdapterBuildOnce.Do(func() {
 		_, file, _, ok := runtime.Caller(0)
 		if !ok {
 			searchIndexAdapterBuild.err = fmt.Errorf("runtime.Caller failed")
@@ -36,13 +42,9 @@ func searchIndexAdapter(t testing.TB) string {
 			searchIndexAdapterBuild.err = err
 			return
 		}
-		cmd := exec.Command("cargo", "build", "-p", "symvault-store", "--example", "search-index-adapter")
-		cmd.Dir = repo
-		cmd.Env = append(os.Environ(), "CARGO_TARGET_DIR="+target)
-		var stderr bytes.Buffer
-		cmd.Stderr = &stderr
-		if output, err := cmd.Output(); err != nil {
-			searchIndexAdapterBuild.err = fmt.Errorf("cargo build: %w: %s\n%s", err, stderr.Bytes(), output)
+		output, err := runSearchIndexCommand(repo, target, "cargo", "build", "-p", "symvault-store", "--example", "search-index-adapter")
+		if err != nil {
+			searchIndexAdapterBuild.err = fmt.Errorf("cargo build: %w: %s", err, output)
 			return
 		}
 		searchIndexAdapterBuild.path = filepath.Join(target, "debug", "examples", "search-index-adapter")
@@ -53,22 +55,53 @@ func searchIndexAdapter(t testing.TB) string {
 	return searchIndexAdapterBuild.path
 }
 
+var searchIndexAdapterBuildOnce = new(sync.Once)
+
+func runSearchIndexAdapterExpectError(t testing.TB, binary, root, identity, action, caseID string, extra ...string) {
+	t.Helper()
+	output, err := runSearchIndexCommand(root, "", binary, append([]string{"--action", action, "--root", root, "--identity", identity, "--case-id", caseID}, extra...)...)
+	if err == nil {
+		t.Fatalf("adapter %s unexpectedly succeeded", caseID)
+	}
+	if strings.Contains(err.Error(), "deadline exceeded") || strings.Contains(err.Error(), "WaitDelay") {
+		t.Fatalf("adapter %s was not a bounded loader rejection: %v", caseID, err)
+	}
+	if !strings.Contains(output, caseID+": search index missing or rejected") {
+		t.Fatalf("adapter %s error = %q, want explicit rejection diagnostic", caseID, output)
+	}
+}
+
 func runSearchIndexAdapter(t testing.TB, binary, root, identity, action string, extra ...string) map[string]any {
 	t.Helper()
-	args := []string{"--action", action, "--root", root, "--identity", identity}
-	args = append(args, extra...)
-	cmd := exec.Command(binary, args...)
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
-	output, err := cmd.Output()
+	result, err := runSearchIndexCommand(root, "", binary, append([]string{"--action", action, "--root", root, "--identity", identity}, extra...)...)
 	if err != nil {
-		t.Fatalf("adapter %s: %v\nstderr=%s", action, err, stderr.String())
+		t.Fatalf("adapter %s: %v\nstderr=%s", action, err, result)
 	}
-	var result map[string]any
-	if err := json.Unmarshal(output, &result); err != nil {
-		t.Fatalf("adapter %s output %q: %v", action, output, err)
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(result), &parsed); err != nil {
+		t.Fatalf("adapter %s output %q: %v", action, result, err)
 	}
-	return result
+	return parsed
+}
+
+func publicKeyDerivedIndexCiphertext(t testing.TB, identity *age.X25519Identity, salt []byte) []byte {
+	t.Helper()
+	key := make([]byte, chacha20poly1305.KeySize)
+	kdf := hkdf.New(sha256.New, []byte(identity.Recipient().String()), salt, []byte("symvault-search-index-v1"))
+	if _, err := io.ReadFull(kdf, key); err != nil {
+		t.Fatal(err)
+	}
+	cipher, err := chacha20poly1305.New(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	nonce := make([]byte, cipher.NonceSize())
+	if _, err := rand.Read(nonce); err != nil {
+		t.Fatal(err)
+	}
+	plaintext := []byte(`{"v":{"go-doc":["go-rust-accepted"]},"c":1,"s":"` + base64.StdEncoding.EncodeToString(salt) + `"}`)
+	encrypted := cipher.Seal(nil, nonce, plaintext, nil)
+	return append(append(append([]byte{1}, salt...), nonce...), encrypted...)
 }
 
 func TestEncryptedIndexGoRustLiveAcceptance(t *testing.T) {
@@ -135,26 +168,50 @@ func TestEncryptedIndexGoRustLiveAcceptance(t *testing.T) {
 		t.Fatalf("Go matches = %v, want rust-doc", goMatches)
 	}
 
-	// Case wrong_identity_rejected: a valid index must not be accepted by a
-	// different identity, even though the vault layout is otherwise valid.
+	// Keep both the Go and Rust loader negatives. Recreate the fixture after
+	// each rejection because both implementations fail closed by deleting it.
 	wrong := testutil.TempIdentity(t)
-	wrongLoaded := &EncryptedIndex{}
-	if err := wrongLoaded.loadFromDisk(rustRoot, wrong); err == nil {
-		t.Fatal("wrong identity unexpectedly loaded encrypted index")
-	}
-
-	// Case tampered_ciphertext_rejected: authenticated corruption must fail the
-	// explicit loader rather than becoming an empty successful search.
 	raw, err := os.ReadFile(indexFilePath(goRoot))
 	if err != nil {
 		t.Fatal(err)
 	}
-	raw[len(raw)-1] ^= 1
+	if err := (&EncryptedIndex{}).loadFromDisk(goRoot, wrong); err == nil {
+		t.Fatal("go_wrong_identity_rejected: Go loader unexpectedly accepted")
+	}
 	if err := os.WriteFile(indexFilePath(goRoot), raw, 0o600); err != nil {
 		t.Fatal(err)
 	}
-	tampered := &EncryptedIndex{}
-	if err := tampered.loadFromDisk(goRoot, goIdentity); err == nil {
-		t.Fatal("tampered ciphertext unexpectedly loaded")
+	runSearchIndexAdapterExpectError(t, adapter, goRoot, wrong.String(), "load-search", "rust_wrong_identity_rejected", "--query", "go-rust-accepted")
+	if err := os.WriteFile(indexFilePath(goRoot), raw, 0o600); err != nil {
+		t.Fatal(err)
 	}
+
+	tamperedRaw := append([]byte(nil), raw...)
+	tamperedRaw[len(tamperedRaw)-1] ^= 1
+	if err := os.WriteFile(indexFilePath(goRoot), tamperedRaw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := (&EncryptedIndex{}).loadFromDisk(goRoot, goIdentity); err == nil {
+		t.Fatal("go_tampered_ciphertext_rejected: Go loader unexpectedly accepted")
+	}
+	if err := os.WriteFile(indexFilePath(goRoot), tamperedRaw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runSearchIndexAdapterExpectError(t, adapter, goRoot, goIdentity.String(), "load-search", "rust_tampered_ciphertext_rejected", "--query", "go-rust-accepted")
+
+	// Case public_key_derived_ciphertext_rejected: a malicious fixture made
+	// with the recipient public bytes (rather than the private identity) must
+	// fail both loaders even when its decrypted JSON shape is otherwise valid.
+	publicSalt := []byte("public-derived-16")
+	publicDerived := publicKeyDerivedIndexCiphertext(t, goIdentity, publicSalt)
+	if err := os.WriteFile(indexFilePath(goRoot), publicDerived, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := (&EncryptedIndex{}).loadFromDisk(goRoot, goIdentity); err == nil {
+		t.Fatal("go_public_key_derived_ciphertext_rejected: Go loader unexpectedly accepted")
+	}
+	if err := os.WriteFile(indexFilePath(goRoot), publicDerived, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runSearchIndexAdapterExpectError(t, adapter, goRoot, goIdentity.String(), "load-search", "rust_public_key_derived_ciphertext_rejected", "--query", "go-rust-accepted")
 }

--- a/internal/vault/search_index_crosslang_test.go
+++ b/internal/vault/search_index_crosslang_test.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"filippo.io/age"
 	"golang.org/x/crypto/chacha20poly1305"
@@ -42,7 +43,11 @@ func searchIndexAdapter(t testing.TB) string {
 			searchIndexAdapterBuild.err = err
 			return
 		}
-		output, err := runSearchIndexCommand(repo, target, "cargo", "build", "-p", "symvault-store", "--example", "search-index-adapter")
+		// A cold Cargo build is intentionally allowed more time than the adapter
+		// operations themselves. The latter use runSearchIndexCommand's bounded
+		// two-minute timeout; applying it to dependency compilation makes the
+		// differential test depend on a warm cache rather than adapter behavior.
+		output, err := runSearchIndexCommandWithTimeout(5*time.Minute, repo, target, "cargo", "build", "-p", "symvault-store", "--example", "search-index-adapter")
 		if err != nil {
 			searchIndexAdapterBuild.err = fmt.Errorf("cargo build: %w: %s", err, output)
 			return

--- a/internal/vault/search_index_process_unix_test.go
+++ b/internal/vault/search_index_process_unix_test.go
@@ -1,0 +1,55 @@
+//go:build !windows
+
+package vault
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func runSearchIndexCommand(dir, target, binary string, args ...string) (string, error) {
+	return runSearchIndexCommandWithTimeout(2*time.Minute, dir, target, binary, args...)
+}
+
+func runSearchIndexCommandWithTimeout(timeout time.Duration, dir, target, binary string, args ...string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, binary, args...)
+	cmd.Dir = dir
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return os.ErrProcessDone
+		}
+		err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		if err == syscall.ESRCH {
+			return os.ErrProcessDone
+		}
+		return err
+	}
+	cmd.WaitDelay = 2 * time.Second
+	if target != "" {
+		cmd.Env = append(os.Environ(), "CARGO_TARGET_DIR="+target)
+	}
+	output, err := cmd.CombinedOutput()
+	if ctx.Err() != nil {
+		return string(output), ctx.Err()
+	}
+	return string(output), err
+}
+
+func TestSearchIndexCommandTimeoutIsBounded(t *testing.T) {
+	started := time.Now()
+	_, err := runSearchIndexCommandWithTimeout(50*time.Millisecond, t.TempDir(), "", "sh", "-c", "sleep 10")
+	if err == nil || !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("timeout error = %v, want deadline exceeded", err)
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("timeout command exceeded deterministic bound: %s", elapsed)
+	}
+}

--- a/internal/vault/search_index_process_windows_test.go
+++ b/internal/vault/search_index_process_windows_test.go
@@ -1,0 +1,30 @@
+//go:build windows
+
+package vault
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"time"
+)
+
+func runSearchIndexCommand(dir, target, binary string, args ...string) (string, error) {
+	return runSearchIndexCommandWithTimeout(2*time.Minute, dir, target, binary, args...)
+}
+
+func runSearchIndexCommandWithTimeout(timeout time.Duration, dir, target, binary string, args ...string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, binary, args...)
+	cmd.Dir = dir
+	cmd.WaitDelay = 2 * time.Second
+	if target != "" {
+		cmd.Env = append(os.Environ(), "CARGO_TARGET_DIR="+target)
+	}
+	output, err := cmd.CombinedOutput()
+	if ctx.Err() != nil {
+		return string(output), ctx.Err()
+	}
+	return string(output), err
+}


### PR DESCRIPTION
## Scope
- corrective `RUST-005` / `STORE-005` search-index wire-compatibility patch; it does not advance the Rust cutover or move any product, repository, or module
- Rust storage boundary: `crates/symvault-store`; Go oracle and direct consumer: `internal/vault/search_index.go`, which persists `.search-index` in each vault directory
- public executable entry used solely for the differential harness: `search-index-adapter`; no CLI, MCP, HTTP, platform-helper, permission, packaging, or data migration behavior is introduced

## Changes
- decode Go-compatible `ti`, `pt`, `hi`, `ph`, nullable maps, zero counts, and the Base64 salt field `s`
- derive the search-index key from private age-identity material; a public-recipient-derived ciphertext is rejected by both implementations
- exercise actual Go-written/Rust-read and Rust-written/Go-read indexes, wrong-identity and tamper failures, plus a bounded process-tree timeout harness

## Verification
- macOS (Apple Silicon): `cargo fmt --all --check`
- macOS: `cargo test -p symvault-store --locked` — 24 tests passed
- macOS: `cargo clippy -p symvault-store --all-targets --all-features --locked -- -D warnings`
- macOS: `GOTOOLCHAIN=go1.26.6 GOWORK=off go test ./internal/vault -run 'Test(EncryptedIndexGoRustLiveAcceptance|SearchIndexCommandTimeoutIsBounded)' -count=1`
- macOS: `GOTOOLCHAIN=go1.26.6 GOWORK=off go test ./internal/vault -count=1`
- macOS: `make store-differential` — reopen fixture, Go↔Rust reopen, store fixture and Rust store suite passed
- macOS: `cargo audit` and `cargo deny check` — passed (existing deny duplicate/license warnings only)
- GitHub: Rust, contract, lint, Go tests, Windows process-tree, and native audit differential on Ubuntu/macOS/Windows passed

## Handoff and rollback
- Candidate HEAD: `bb36ff28d43b49b1eeb0cf1402176cd32ca89537`; base: `81210de2720ee000fa26adda4da4080daae01677`.
- The Go reference remains intact. Rollback is a normal revert of this PR; Go retains the authoritative `.search-index` reader/writer.
- Not a full migration conclusion: `RUST-006` and `RUST-008` remain in progress; `RUST-007` and `RUST-009` through `RUST-015` remain blocked or incomplete in the existing ledger.
- This PR cannot merge yet because protected `CI Success` is red on the base dependency CVE: `google.golang.org/grpc@v1.83.1` (`CVE-2026-84445`). The current conflicting PR #1020 already carries the related grpc upgrade; this PR deliberately does not duplicate or overwrite that parallel work.
