### PR TITLE
Bump google.golang.org/grpc v1.83.1 -> v1.83.2

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -27,7 +27,7 @@
           doCheck = false;
 
           # Resolved via `go mod vendor; nix hash path --sri vendor/`
-          vendorHash = "sha256-/cTuiackYtJZlnN68ZmlrYbQzXy+XE45bwslO2wN8dM=";
+          vendorHash = "sha256-kByQ1nmW/CVkgwcK8ka/I38yvCEIvS7mQK3Sm5mN1hY=";
 
           # Disable CGO for Linux — reduces distributability and is not needed
           # (keyring integration requires CGO only on darwin).

--- a/go.mod
+++ b/go.mod
@@ -142,7 +142,7 @@ require (
 	golang.org/x/sync v0.22.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260819154853-08b0e4226688 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260819154853-08b0e4226688 // indirect
-	google.golang.org/grpc v1.83.1 // indirect
+	google.golang.org/grpc v1.83.2 // indirect
 	google.golang.org/protobuf v1.36.12 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -293,8 +293,8 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260819154853-08b0e4226688 h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20260819154853-08b0e4226688/go.mod h1:1RJ9BQGyNdZwkGc1eTqkErfRZ6RJyYPHZo73BZ1vQqI=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260819154853-08b0e4226688 h1:cYNAzI2sUwhmCcoj9TxvihSrqsxt6uIkj3rDRhSDmW4=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260819154853-08b0e4226688/go.mod h1:DjtHYE8FKJLivXcBEjGwndXfIC23G0VpXiXKqG179uA=
-google.golang.org/grpc v1.83.1 h1:HIO0+BEtBP6soyqvqC8sNUjZ7bTs+0hFQuFF+RAy++Y=
-google.golang.org/grpc v1.83.1/go.mod h1:kDyl6SKsiHKt0uylY5gtn5cEjkrIOhQOGDgIc4JGwzQ=
+google.golang.org/grpc v1.83.2 h1:EManeRomTObA0BU7I8vXgg/78uE5MJ9M8B39EX2WscU=
+google.golang.org/grpc v1.83.2/go.mod h1:YPI1hK3kDked6iHvgX3tR0y+nX/qpMFKhPgFsokw1S8=
 google.golang.org/protobuf v1.36.12 h1:pJOKDDOyeXErUroCihFAd5LQuwXBSpVnKGrj5o/fwxc=
 google.golang.org/protobuf v1.36.12/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
Closes the following security alert:

### Dependency Scan (OSV)
- CVE-2026-84445 / [GHSA-2v4p-qf9q-27wj](https://github.com/grpc/grpc-go/security/advisories/GHSA-2v4p-qf9q-27wj) — `google.golang.org/grpc` 1.83.1 → 1.83.2

## Background

The "Dependency Scan" job (part of the required "CI Success" check) has been failing on `main` for CVE-2026-84445: a DoS in gRPC-Go xDS servers where a crafted request missing both the `:authority` and `Host` headers triggers an index-out-of-bounds panic. Affected: <1.82.2, 1.83.0–1.83.1. Patched: 1.82.2, 1.83.2.

`grpc` is an indirect dependency here (`internal/metrics` → `go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp` → `google.golang.org/grpc`), but OSV Scanner flags it repo-wide regardless of call depth, and this predates any specific PR — it was simply first surfaced by PR #1028 (docs-only), which was blocked by this pre-existing, unrelated CI gate on `main`.

## Change

Minimal version bump only: `go get google.golang.org/grpc@v1.83.2 && go mod tidy`. No other dependency moved.

## Verification (local)

- `go build ./...` — clean
- `go test ./...` — full suite green (all packages)
- `make fmt-check`, `make vet` — clean
- `make lint` (golangci-lint pinned v2.11.4) — same pre-existing findings as on `main` before this change (unrelated goconst/govet/unparam notes + a local Go-toolchain/golangci-lint export-data version mismatch reproduced identically on `main`); nothing new
- `gosec` (pinned v2.22.0 equivalent) — same pre-existing G204 findings as on `main`; nothing new
- `osv-scanner --lockfile=go.mod --config=osv-scanner.toml --no-call-analysis=go` — **No issues found** (CVE-2026-84445 no longer reported)

## Note on PR #1028

This should let PR #1028 (`docs/product-boundaries-20260909`) go green on its next required-check run once this merges — that PR made no dependency changes.

**However**, the latest `main` CI run (commit `81210de2`) also shows two *separate, pre-existing* failures unrelated to this fix, introduced by #1018 ("feat(rust): advance audit, platform, and sync parity"):
- `Rust native (windows-latest)`: `error: unused variable: file` in `crates/symvault-store/src/audit.rs:440` (`-D warnings` on Windows)
- `Test (windows-latest)`: `TestPinnedSyncOracleIsRepeatable` in `scripts/rust-port/cmd/syncgen` fails with `panic: archive contains unsafe path: entries\item.age` (looks like a Windows path-separator issue in the archive-path-safety check)

Both feed into the same `ci-gate` ("CI Success") job via `needs: [..., rust-native, test, ...]`, so `CI Success` will likely stay red on `main`/#1028 even after this PR merges, until those two are fixed separately. Flagging so it isn't mistaken for a regression from this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)