### PR TITLE
fix(config): make legacy-to-XDG migration recoverable

### DIFF
--- a/cmd/admin/migrate.go
+++ b/cmd/admin/migrate.go
@@ -38,6 +38,7 @@ func newMigrateCmd() *cobra.Command {
 	MigrateCmd.AddCommand(newMigrateKDFCmd())
 	MigrateCmd.AddCommand(newMigrateV4Cmd())
 	MigrateCmd.AddCommand(newMigrateSessionCmd())
+	MigrateCmd.AddCommand(newMigratePathsCmd())
 	MigrateCmd.GroupID = cli.GroupIDAdministration
 	return MigrateCmd
 }
@@ -382,4 +383,34 @@ func enablePseudonymizeConfig(vaultDir string) error {
 		return fmt.Errorf("save config: %w", err)
 	}
 	return nil
+}
+
+func newMigratePathsCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "paths",
+		Aliases: []string{"xdg"},
+		Short:   "Preview the legacy path migration without writing",
+		Long: `Preview the migration from the legacy ~/.symvault layout to the
+XDG config, data, and cache directories. This command never writes,
+modifies, or removes files.`,
+		Example: `  symvault migrate paths
+  symvault migrate xdg`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			plan, err := configpkg.PreviewLegacyToXDG()
+			if err != nil {
+				return fmt.Errorf("preview path migration: %w", err)
+			}
+			if !plan.NeedsMigration {
+				cli.PrintlnQuietAware("No legacy path migration is needed.")
+				return nil
+			}
+			cli.PrintlnQuietAware(fmt.Sprintf("Legacy path migration would copy %d item(s):", len(plan.Items)))
+			for _, item := range plan.Items {
+				cli.PrintlnQuietAware(fmt.Sprintf("  %s -> %s (%d bytes)", item.Source, item.Destination, item.Bytes))
+			}
+			cli.PrintlnQuietAware("Preview only: no changes written.")
+			return nil
+		},
+	}
 }

--- a/cmd/admin/migrate_paths_test.go
+++ b/cmd/admin/migrate_paths_test.go
@@ -1,0 +1,36 @@
+package admin
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestMigratePathsPreviewIsNonMutating(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "config"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(home, "data"))
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(home, "cache"))
+	legacy := filepath.Join(home, ".symvault")
+	if err := os.MkdirAll(legacy, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(legacy, "config.yaml"), []byte("vault: {}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newMigratePathsCmd()
+	if err := cmd.RunE(cmd, nil); err != nil {
+		t.Fatalf("preview command failed: %v", err)
+	}
+	for _, path := range []string{
+		filepath.Join(home, "config"),
+		filepath.Join(home, "data"),
+		filepath.Join(home, "cache"),
+	} {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("preview created %s", path)
+		}
+	}
+}

--- a/internal/config/config_load.go
+++ b/internal/config/config_load.go
@@ -234,7 +234,7 @@ func loadSectionFields(doc *yaml.Node) map[string]map[string]bool {
 	if root.Kind != yaml.MappingNode {
 		return nil
 	}
-	sections := []string{"vault", "git", "mcp", "update", "clipboard", "audit", "logging", "security"}
+	sections := []string{configSectionVault, SyncMethodGit, configSectionMCP, "update", "clipboard", configSectionAudit, "logging", "security"}
 	result := make(map[string]map[string]bool)
 	for i := 0; i < len(root.Content)-1; i += 2 {
 		key := root.Content[i].Value
@@ -247,7 +247,7 @@ func loadSectionFields(doc *yaml.Node) map[string]map[string]bool {
 						fieldKey := secNode.Content[j].Value
 						fields[fieldKey] = true
 						switch {
-						case fieldKey == "oauth" && sec == "mcp":
+						case fieldKey == "oauth" && sec == configSectionMCP:
 							oAuthNode := secNode.Content[j+1]
 							if oAuthNode.Kind == yaml.MappingNode {
 								oAuthFields := make(map[string]bool)
@@ -256,7 +256,7 @@ func loadSectionFields(doc *yaml.Node) map[string]map[string]bool {
 								}
 								result["mcp_oauth"] = oAuthFields
 							}
-						case fieldKey == "perplexity" && sec == "mcp":
+						case fieldKey == "perplexity" && sec == configSectionMCP:
 							perpNode := secNode.Content[j+1]
 							if perpNode.Kind == yaml.MappingNode {
 								perpFields := make(map[string]bool)

--- a/internal/config/config_merge.go
+++ b/internal/config/config_merge.go
@@ -116,13 +116,13 @@ func mergeAgentProfiles(cfg *Config, raw Config, agentFields map[string]map[stri
 
 func mergeSections(cfg *Config, raw Config, sectionFields map[string]map[string]bool) {
 	if raw.Vault != nil {
-		cfg.Vault = mergeVaultConfig(raw.Vault, sectionFields["vault"], raw.AuthMethod, &cfg.AuthMethod)
+		cfg.Vault = mergeVaultConfig(raw.Vault, sectionFields[configSectionVault], raw.AuthMethod, &cfg.AuthMethod)
 	}
 	if raw.Git != nil {
-		cfg.Git = mergeGitConfig(raw.Git, sectionFields["git"])
+		cfg.Git = mergeGitConfig(raw.Git, sectionFields[SyncMethodGit])
 	}
 	if raw.MCP != nil {
-		cfg.MCP = mergeMCPConfig(raw.MCP, sectionFields["mcp"], sectionFields["mcp_oauth"], sectionFields["mcp_perplexity"])
+		cfg.MCP = mergeMCPConfig(raw.MCP, sectionFields[configSectionMCP], sectionFields["mcp_oauth"], sectionFields["mcp_perplexity"])
 	}
 	if raw.Update != nil {
 		cfg.Update = mergeUpdateConfig(raw.Update, sectionFields["update"])
@@ -131,7 +131,7 @@ func mergeSections(cfg *Config, raw Config, sectionFields map[string]map[string]
 		cfg.Clipboard = mergeClipboardConfig(raw.Clipboard, sectionFields["clipboard"])
 	}
 	if raw.Audit != nil {
-		cfg.Audit = mergeAuditConfig(raw.Audit, sectionFields["audit"])
+		cfg.Audit = mergeAuditConfig(raw.Audit, sectionFields[configSectionAudit])
 	}
 	if raw.Logging != nil {
 		cfg.Logging = mergeLoggingConfig(raw.Logging, sectionFields["logging"])

--- a/internal/config/dottedpath.go
+++ b/internal/config/dottedpath.go
@@ -58,7 +58,7 @@ func KnownConfigKeys() []string {
 		"agents.*.skillVersion",
 
 		// Vault
-		"vault",
+		configSectionVault,
 		"vault.path",
 		"vault.default_recipients",
 		"vault.confirm_remove",
@@ -77,14 +77,14 @@ func KnownConfigKeys() []string {
 		"vault.argon2id_threads",
 
 		// Git
-		"git",
+		SyncMethodGit,
 		"git.commit_template",
 		"git.auto_push",
 		"git.auto_pull",
 		"git.auto_pull_interval",
 
 		// MCP
-		"mcp",
+		configSectionMCP,
 		"mcp.bind",
 		"mcp.port",
 		"mcp.stdio",
@@ -114,7 +114,7 @@ func KnownConfigKeys() []string {
 		"clipboard.copyByDefault",
 
 		// Audit
-		"audit",
+		configSectionAudit,
 		"audit.maxSizeMb",
 		"audit.maxBackups",
 		"audit.maxAgeDays",

--- a/internal/config/migrate.go
+++ b/internal/config/migrate.go
@@ -13,9 +13,10 @@ import (
 )
 
 const (
-	migrationMarker    = ".migrated"
-	migrationStateFile = ".migration-state.json"
-	migrationBackupDir = ".migration-backup"
+	migrationMarker        = ".migrated"
+	migrationStateFile     = ".migration-state.json"
+	migrationBackupDir     = ".migration-backup"
+	migrationKindDirectory = "directory"
 )
 
 // MigrationItem describes one source/destination pair without exposing data.
@@ -100,7 +101,7 @@ func appendMigrationItems(plan *MigrationPlan, base, rel, dst string) error {
 		return fmt.Errorf("refusing symlink: %s", rel)
 	}
 	if info.IsDir() {
-		plan.Items = append(plan.Items, MigrationItem{Source: src, Destination: dst, Kind: "directory"})
+		plan.Items = append(plan.Items, MigrationItem{Source: src, Destination: dst, Kind: migrationKindDirectory})
 		return filepath.WalkDir(src, func(path string, entry fs.DirEntry, walkErr error) error {
 			if walkErr != nil {
 				return walkErr
@@ -119,7 +120,7 @@ func appendMigrationItems(plan *MigrationPlan, base, rel, dst string) error {
 			kind := "file"
 			var size int64
 			if entry.IsDir() {
-				kind = "directory"
+				kind = migrationKindDirectory
 			} else {
 				fi, err := entry.Info()
 				if err != nil {
@@ -186,7 +187,7 @@ func MigrateLegacyToXDG() (bool, error) {
 		if !isTopLevelMigrationItem(plan.Items, item) {
 			continue
 		}
-		if item.Kind == "directory" {
+		if item.Kind == migrationKindDirectory {
 			if _, err := os.Lstat(item.Destination); err == nil {
 				return false, fmt.Errorf("destination collision: %s", item.Destination)
 			}
@@ -222,7 +223,7 @@ func MigrateLegacyToXDG() (bool, error) {
 
 func isTopLevelMigrationItem(items []MigrationItem, candidate MigrationItem) bool {
 	for _, item := range items {
-		if item.Kind == "directory" && item.Source != candidate.Source && strings.HasPrefix(candidate.Source, item.Source+string(filepath.Separator)) {
+		if item.Kind == migrationKindDirectory && item.Source != candidate.Source && strings.HasPrefix(candidate.Source, item.Source+string(filepath.Separator)) {
 			return false
 		}
 	}
@@ -271,17 +272,17 @@ func copyEntry(src, dst string) error {
 		return fmt.Errorf("refusing symlink: %s", src)
 	}
 	if info.IsDir() {
-		if err := os.MkdirAll(dst, 0o700); err != nil {
-			return err
+		if mkdirErr := os.MkdirAll(dst, 0o700); mkdirErr != nil {
+			return mkdirErr
 		}
 		_ = os.Chmod(dst, 0o700)
-		entries, err := os.ReadDir(src)
-		if err != nil {
-			return err
+		entries, readErr := os.ReadDir(src)
+		if readErr != nil {
+			return readErr
 		}
 		for _, e := range entries {
-			if err := copyEntry(filepath.Join(src, e.Name()), filepath.Join(dst, e.Name())); err != nil {
-				return err
+			if copyErr := copyEntry(filepath.Join(src, e.Name()), filepath.Join(dst, e.Name())); copyErr != nil {
+				return copyErr
 			}
 		}
 		return nil
@@ -290,11 +291,11 @@ func copyEntry(src, dst string) error {
 	if err != nil {
 		return err
 	}
-	if err := os.MkdirAll(filepath.Dir(dst), 0o700); err != nil {
-		return err
+	if mkdirErr := os.MkdirAll(filepath.Dir(dst), 0o700); mkdirErr != nil {
+		return mkdirErr
 	}
-	if err := os.WriteFile(dst, data, 0o600); err != nil {
-		return err
+	if writeErr := os.WriteFile(dst, data, 0o600); writeErr != nil {
+		return writeErr
 	}
 	_ = os.Chmod(dst, 0o600)
 	got, err := os.ReadFile(dst)
@@ -304,7 +305,7 @@ func copyEntry(src, dst string) error {
 	return nil
 }
 
-func writeJSONAtomic(path string, value any, mode os.FileMode) error {
+func writeJSONAtomic(path string, value any, mode os.FileMode) (returnErr error) {
 	var data []byte
 	var err error
 	if b, ok := value.([]byte); ok {
@@ -320,21 +321,29 @@ func writeJSONAtomic(path string, value any, mode os.FileMode) error {
 		return err
 	}
 	name := tmp.Name()
-	defer os.Remove(name)
+	defer func() {
+		if removeErr := os.Remove(name); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) && returnErr == nil {
+			returnErr = fmt.Errorf("remove temporary migration state: %w", removeErr)
+		}
+	}()
 	if err := tmp.Chmod(mode); err != nil {
-		tmp.Close()
-		return err
+		return closeMigrationTemp(tmp, err)
 	}
 	if _, err := tmp.Write(data); err != nil {
-		tmp.Close()
-		return err
+		return closeMigrationTemp(tmp, err)
 	}
 	if err := tmp.Sync(); err != nil {
-		tmp.Close()
-		return err
+		return closeMigrationTemp(tmp, err)
 	}
 	if err := tmp.Close(); err != nil {
 		return err
 	}
 	return os.Rename(name, path)
+}
+
+func closeMigrationTemp(tmp *os.File, operationErr error) error {
+	if closeErr := tmp.Close(); closeErr != nil {
+		return fmt.Errorf("%w; close temporary migration state: %w", operationErr, closeErr)
+	}
+	return operationErr
 }

--- a/internal/config/migrate.go
+++ b/internal/config/migrate.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -380,77 +379,7 @@ func migrationPhase(phase string) error {
 }
 
 func copyEntry(src, dst string) error {
-	info, err := os.Lstat(src)
-	if err != nil {
-		return err
-	}
-	if info.Mode()&os.ModeSymlink != 0 {
-		return fmt.Errorf("refusing symlink: %s", src)
-	}
-	if info.IsDir() {
-		if err := fsutil.SafeMkdirAll(filepath.Dir(dst), 0o700); err != nil {
-			return err
-		}
-		// Destination directories are created exclusively. Never merge into an
-		// existing directory: doing so would make ownership and recovery
-		// ambiguous, and would reintroduce a check-then-use race.
-		if err := os.Mkdir(dst, 0o700); err != nil {
-			return err
-		}
-		entries, err := os.ReadDir(src)
-		if err != nil {
-			return err
-		}
-		for _, e := range entries {
-			if err := copyEntry(filepath.Join(src, e.Name()), filepath.Join(dst, e.Name())); err != nil {
-				return err
-			}
-		}
-		return nil
-	}
-
-	// Open the source with O_NOFOLLOW on Unix, then read from that descriptor.
-	// This closes the Lstat-to-ReadFile symlink race at the source boundary.
-	file, err := openMigrationSource(src)
-	if err != nil {
-		return err
-	}
-	defer file.Close()
-	openedInfo, err := file.Stat()
-	if err != nil {
-		return err
-	}
-	if !openedInfo.Mode().IsRegular() {
-		return fmt.Errorf("refusing non-regular source: %s", src)
-	}
-	data, err := io.ReadAll(io.LimitReader(file, maxMigrationBytes+1))
-	if err != nil {
-		return err
-	}
-	if int64(len(data)) > maxMigrationBytes {
-		return fmt.Errorf("source exceeds migration size limit: %s", src)
-	}
-	// O_EXCL makes the destination decision atomic: a concurrent creator or
-	// symlink is an error, never an overwrite or traversal.
-	if err := fsutil.SafeMkdirAll(filepath.Dir(dst), 0o700); err != nil {
-		return err
-	}
-	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
-	if err != nil {
-		return err
-	}
-	written, writeErr := out.Write(data)
-	closeErr := out.Close()
-	if writeErr != nil {
-		return writeErr
-	}
-	if closeErr != nil {
-		return closeErr
-	}
-	if written != len(data) {
-		return io.ErrShortWrite
-	}
-	return nil
+	return secureCopyEntry(src, dst)
 }
 
 func writeJSONAtomic(path string, value any) (returnErr error) {

--- a/internal/config/migrate.go
+++ b/internal/config/migrate.go
@@ -1,155 +1,340 @@
 package config
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
-	"time"
 )
 
-const migrationMarker = ".migrated"
+const (
+	migrationMarker    = ".migrated"
+	migrationStateFile = ".migration-state.json"
+	migrationBackupDir = ".migration-backup"
+)
 
-// MigrateLegacyToXDG migrates data from legacy ~/.symvault/ to XDG paths.
-// It is a no-op if:
-//   - Legacy dir doesn't exist
-//   - XDG data dir already exists (migration already done)
-//   - SYMVAULT_NO_PATH_MIGRATION=1 is set
-//
-// Returns true if migration was performed.
+// MigrationItem describes one source/destination pair without exposing data.
+type MigrationItem struct {
+	Source      string `json:"source"`
+	Destination string `json:"destination"`
+	Kind        string `json:"kind"`
+	Bytes       int64  `json:"bytes"`
+}
+
+// MigrationPlan is the complete, non-mutating description of a migration.
+type MigrationPlan struct {
+	LegacyDir      string          `json:"legacy_dir"`
+	Items          []MigrationItem `json:"items"`
+	NeedsMigration bool            `json:"needs_migration"`
+}
+
+type migrationState struct {
+	Version   int      `json:"version"`
+	BackupDir string   `json:"backup_dir"`
+	Published []string `json:"published"`
+}
+
+// MigrationPhaseHook is used by tests to inject an interruption between phases.
+// Production callers should leave it nil.
+var MigrationPhaseHook func(string) error
+
+// PreviewLegacyToXDG returns a complete migration summary and never writes.
+func PreviewLegacyToXDG() (MigrationPlan, error) {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return MigrationPlan{}, nil
+	}
+	legacy := filepath.Join(home, LegacyVaultSubdir)
+	info, err := os.Lstat(legacy)
+	if errors.Is(err, os.ErrNotExist) {
+		return MigrationPlan{LegacyDir: legacy}, nil
+	}
+	if err != nil {
+		return MigrationPlan{}, err
+	}
+	if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return MigrationPlan{}, fmt.Errorf("legacy path is not a directory: %s", legacy)
+	}
+	if _, err := os.Lstat(filepath.Join(legacy, migrationMarker)); err == nil {
+		return MigrationPlan{LegacyDir: legacy}, nil
+	}
+
+	plan := MigrationPlan{LegacyDir: legacy, NeedsMigration: true}
+	groups := []struct{ src, dst string }{
+		{"config.yaml", filepath.Join(DefaultConfigDir(), "config.yaml")},
+		{"vault", filepath.Join(DefaultDataDir(), "vault")},
+		{"audit", filepath.Join(DefaultDataDir(), "audit")},
+		{"devices.json", filepath.Join(DefaultDataDir(), "devices.json")},
+		{"pairing", filepath.Join(DefaultDataDir(), "pairing")},
+		{"update-cache.json", filepath.Join(DefaultCacheDir(), "update-cache.json")},
+	}
+	for _, g := range groups {
+		if err := appendMigrationItems(&plan, legacy, g.src, g.dst); err != nil {
+			return MigrationPlan{}, err
+		}
+	}
+	sort.Slice(plan.Items, func(i, j int) bool { return plan.Items[i].Destination < plan.Items[j].Destination })
+	return plan, nil
+}
+
+func appendMigrationItems(plan *MigrationPlan, base, rel, dst string) error {
+	src := filepath.Join(base, rel)
+	cleanBase, _ := filepath.Abs(base)
+	cleanSrc, _ := filepath.Abs(src)
+	if cleanSrc != cleanBase && !strings.HasPrefix(cleanSrc, cleanBase+string(filepath.Separator)) {
+		return fmt.Errorf("path traversal: %s", rel)
+	}
+	info, err := os.Lstat(src)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("refusing symlink: %s", rel)
+	}
+	if info.IsDir() {
+		plan.Items = append(plan.Items, MigrationItem{Source: src, Destination: dst, Kind: "directory"})
+		return filepath.WalkDir(src, func(path string, entry fs.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
+			}
+			if path == src {
+				return nil
+			}
+			if entry.Type()&os.ModeSymlink != 0 {
+				return fmt.Errorf("refusing symlink: %s", path)
+			}
+			relPath, err := filepath.Rel(src, path)
+			if err != nil {
+				return err
+			}
+			target := filepath.Join(dst, relPath)
+			kind := "file"
+			var size int64
+			if entry.IsDir() {
+				kind = "directory"
+			} else {
+				fi, err := entry.Info()
+				if err != nil {
+					return err
+				}
+				size = fi.Size()
+			}
+			plan.Items = append(plan.Items, MigrationItem{Source: path, Destination: target, Kind: kind, Bytes: size})
+			return nil
+		})
+	}
+	return appendFileItem(plan, src, dst, info)
+}
+
+func appendFileItem(plan *MigrationPlan, src, dst string, info os.FileInfo) error {
+	return func() error {
+		plan.Items = append(plan.Items, MigrationItem{Source: src, Destination: dst, Kind: "file", Bytes: info.Size()})
+		return nil
+	}()
+}
+
+// MigrateLegacyToXDG performs a verified, recoverable migration. Source data is retained.
 func MigrateLegacyToXDG() (bool, error) {
 	if os.Getenv("SYMVAULT_NO_PATH_MIGRATION") == "1" {
 		return false, nil
 	}
-
-	home, err := os.UserHomeDir()
-	if err != nil || home == "" {
-		return false, nil
+	plan, err := PreviewLegacyToXDG()
+	if err != nil || !plan.NeedsMigration {
+		return false, err
 	}
-
-	legacyDir := filepath.Join(home, LegacyVaultSubdir)
-	xdgDataDir := DefaultDataDir()
-	xdgConfigDir := DefaultConfigDir()
-	xdgCacheDir := DefaultCacheDir()
-
-	// Check if legacy exists.
-	legacyInfo, err := os.Stat(legacyDir)
-	if err != nil || !legacyInfo.IsDir() {
-		return false, nil // No legacy dir, nothing to migrate.
-	}
-
-	// Check if migration marker exists.
-	markerPath := filepath.Join(legacyDir, migrationMarker)
-	if _, err := os.Stat(markerPath); err == nil {
-		return false, nil // Already migrated.
-	}
-
-	// Check if XDG data dir already exists (someone manually migrated).
-	if _, err := os.Stat(xdgDataDir); err == nil {
-		// XDG exists — leave marker and return.
-		writeMarker(legacyDir)
-		return false, nil
-	}
-
-	// Perform migration.
-	// 1. Create XDG directories.
-	for _, dir := range []string{xdgConfigDir, xdgDataDir, xdgCacheDir} {
-		if err := os.MkdirAll(dir, 0o700); err != nil {
-			return false, fmt.Errorf("create XDG dir %s: %w", dir, err)
+	statePath := filepath.Join(plan.LegacyDir, migrationStateFile)
+	if _, err := os.Lstat(statePath); err == nil {
+		if err := RecoverLegacyToXDGMigration(); err != nil {
+			return false, err
 		}
 	}
-
-	// 2. Migrate config.
-	if err := migrateFile(legacyDir, "config.yaml", filepath.Join(xdgConfigDir, "config.yaml")); err != nil {
-		return false, fmt.Errorf("migrate config.yaml: %w", err)
+	if err := migrationPhase("previewed"); err != nil {
+		return false, err
 	}
-
-	// 3. Migrate vault data (entire directory).
-	if err := migrateDir(legacyDir, "vault", filepath.Join(xdgDataDir, "vault")); err != nil {
-		return false, fmt.Errorf("migrate vault/: %w", err)
+	backup := filepath.Join(plan.LegacyDir, migrationBackupDir)
+	if err := os.MkdirAll(backup, 0o700); err != nil {
+		return false, fmt.Errorf("create backup: %w", err)
 	}
-
-	// 4. Migrate audit.
-	if err := migrateDir(legacyDir, "audit", filepath.Join(xdgDataDir, "audit")); err != nil {
-		return false, fmt.Errorf("migrate audit/: %w", err)
+	for _, item := range plan.Items {
+		if item.Source == filepath.Join(plan.LegacyDir, migrationMarker) {
+			continue
+		}
+		rel, _ := filepath.Rel(plan.LegacyDir, item.Source)
+		if err := copyEntry(item.Source, filepath.Join(backup, rel)); err != nil {
+			return false, fmt.Errorf("backup %s: %w", rel, err)
+		}
 	}
-
-	// 5. Migrate devices.json.
-	if err := migrateFile(legacyDir, "devices.json", filepath.Join(xdgDataDir, "devices.json")); err != nil {
-		return false, fmt.Errorf("migrate devices.json: %w", err)
+	if err := migrationPhase("backed-up"); err != nil {
+		return false, err
 	}
-
-	// 6. Migrate pairing.
-	if err := migrateDir(legacyDir, "pairing", filepath.Join(xdgDataDir, "pairing")); err != nil {
-		return false, fmt.Errorf("migrate pairing/: %w", err)
+	state := migrationState{Version: 1, BackupDir: backup}
+	if err := writeJSONAtomic(statePath, state, 0o600); err != nil {
+		return false, err
 	}
-
-	// 7. Migrate update cache.
-	if err := migrateFile(legacyDir, "update-cache.json", filepath.Join(xdgCacheDir, "update-cache.json")); err != nil {
-		return false, fmt.Errorf("migrate update-cache.json: %w", err)
+	if err := migrationPhase("state-published"); err != nil {
+		return false, err
 	}
-
-	// 8. Leave marker.
-	writeMarker(legacyDir)
-
-	fmt.Fprintf(os.Stderr, "Migrated symvault data from %s to XDG paths.\n", legacyDir)
-
+	for _, item := range plan.Items {
+		if !isTopLevelMigrationItem(plan.Items, item) {
+			continue
+		}
+		if item.Kind == "directory" {
+			if _, err := os.Lstat(item.Destination); err == nil {
+				return false, fmt.Errorf("destination collision: %s", item.Destination)
+			}
+			if err := copyEntry(item.Source, item.Destination); err != nil {
+				return false, err
+			}
+		} else if _, err := os.Lstat(item.Destination); errors.Is(err, os.ErrNotExist) {
+			if err := copyEntry(item.Source, item.Destination); err != nil {
+				return false, err
+			}
+		} else {
+			return false, fmt.Errorf("destination collision: %s", item.Destination)
+		}
+		state.Published = append(state.Published, item.Destination)
+		if err := writeJSONAtomic(statePath, state, 0o600); err != nil {
+			return false, err
+		}
+		if err := migrationPhase("published"); err != nil {
+			return false, err
+		}
+	}
+	if err := migrationPhase("verified"); err != nil {
+		return false, err
+	}
+	if err := writeJSONAtomic(filepath.Join(plan.LegacyDir, migrationMarker), []byte("migration complete\n"), 0o600); err != nil {
+		return false, err
+	}
+	if err := os.Remove(statePath); err != nil {
+		return false, fmt.Errorf("remove migration state: %w", err)
+	}
 	return true, nil
 }
 
-func migrateFile(baseDir, relPath, dst string) error {
-	src := filepath.Join(baseDir, relPath)
-	cleaned := filepath.Clean(src)
-	cleanBase := filepath.Clean(baseDir)
-	if cleaned != cleanBase && !strings.HasPrefix(cleaned, cleanBase+string(filepath.Separator)) {
-		return fmt.Errorf("path traversal: %s escapes base %s", relPath, baseDir)
-	}
-	data, err := os.ReadFile(cleaned)
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return nil
+func isTopLevelMigrationItem(items []MigrationItem, candidate MigrationItem) bool {
+	for _, item := range items {
+		if item.Kind == "directory" && item.Source != candidate.Source && strings.HasPrefix(candidate.Source, item.Source+string(filepath.Separator)) {
+			return false
 		}
-		return err
 	}
-	return os.WriteFile(dst, data, 0o600)
+	return true
 }
 
-func migrateDir(baseDir, srcRel, dst string) error {
-	src := filepath.Join(baseDir, srcRel)
-	cleaned := filepath.Clean(src)
-	cleanBase := filepath.Clean(baseDir)
-	if cleaned != cleanBase && !strings.HasPrefix(cleaned, cleanBase+string(filepath.Separator)) {
-		return fmt.Errorf("path traversal: %s escapes base %s", srcRel, baseDir)
+// RecoverLegacyToXDGMigration removes only destinations recorded as published by an incomplete run.
+func RecoverLegacyToXDGMigration() error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return err
 	}
-	entries, err := os.ReadDir(cleaned)
+	statePath := filepath.Join(home, LegacyVaultSubdir, migrationStateFile)
+	data, err := os.ReadFile(statePath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return nil
 		}
 		return err
 	}
-	if err := os.MkdirAll(dst, 0o700); err != nil {
-		return err
+	var state migrationState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return fmt.Errorf("invalid migration state: %w", err)
 	}
-	for _, entry := range entries {
-		dstPath := filepath.Join(dst, entry.Name())
-		entryRel := filepath.Join(srcRel, entry.Name())
-		if entry.IsDir() {
-			if err := migrateDir(baseDir, entryRel, dstPath); err != nil {
-				return err
-			}
-		} else {
-			if err := migrateFile(baseDir, entryRel, dstPath); err != nil {
-				return err
-			}
+	for i := len(state.Published) - 1; i >= 0; i-- {
+		if err := os.RemoveAll(state.Published[i]); err != nil {
+			return err
 		}
+	}
+	return os.Remove(statePath)
+}
+
+func migrationPhase(phase string) error {
+	if MigrationPhaseHook != nil {
+		return MigrationPhaseHook(phase)
 	}
 	return nil
 }
 
-func writeMarker(legacyDir string) {
-	markerPath := filepath.Join(legacyDir, migrationMarker)
-	content := fmt.Sprintf("migrated at %s\n", time.Now().Format(time.RFC3339))
-	_ = os.WriteFile(markerPath, []byte(content), 0o600) // Best-effort; caller continues regardless.
+func copyEntry(src, dst string) error {
+	info, err := os.Lstat(src)
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("refusing symlink: %s", src)
+	}
+	if info.IsDir() {
+		if err := os.MkdirAll(dst, 0o700); err != nil {
+			return err
+		}
+		_ = os.Chmod(dst, 0o700)
+		entries, err := os.ReadDir(src)
+		if err != nil {
+			return err
+		}
+		for _, e := range entries {
+			if err := copyEntry(filepath.Join(src, e.Name()), filepath.Join(dst, e.Name())); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	data, err := os.ReadFile(src)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(dst), 0o700); err != nil {
+		return err
+	}
+	if err := os.WriteFile(dst, data, 0o600); err != nil {
+		return err
+	}
+	_ = os.Chmod(dst, 0o600)
+	got, err := os.ReadFile(dst)
+	if err != nil || !bytes.Equal(got, data) {
+		return fmt.Errorf("verification failed for %s", dst)
+	}
+	return nil
+}
+
+func writeJSONAtomic(path string, value any, mode os.FileMode) error {
+	var data []byte
+	var err error
+	if b, ok := value.([]byte); ok {
+		data = b
+	} else {
+		data, err = json.Marshal(value)
+	}
+	if err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".migration-tmp-")
+	if err != nil {
+		return err
+	}
+	name := tmp.Name()
+	defer os.Remove(name)
+	if err := tmp.Chmod(mode); err != nil {
+		tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(name, path)
 }

--- a/internal/config/migrate.go
+++ b/internal/config/migrate.go
@@ -38,6 +38,7 @@ type migrationState struct {
 	Version   int      `json:"version"`
 	BackupDir string   `json:"backup_dir"`
 	Published []string `json:"published"`
+	Planned   []string `json:"planned"`
 }
 
 // MigrationPhaseHook is used by tests to inject an interruption between phases.
@@ -177,6 +178,14 @@ func MigrateLegacyToXDG() (bool, error) {
 		return false, err
 	}
 	state := migrationState{Version: 1, BackupDir: backup}
+	for _, item := range plan.Items {
+		if isTopLevelMigrationItem(plan.Items, item) {
+			if err := validateMigrationDestination(item.Destination, plan); err != nil {
+				return false, err
+			}
+			state.Planned = append(state.Planned, item.Destination)
+		}
+	}
 	if err := writeJSONAtomic(statePath, state, 0o600); err != nil {
 		return false, err
 	}
@@ -187,25 +196,24 @@ func MigrateLegacyToXDG() (bool, error) {
 		if !isTopLevelMigrationItem(plan.Items, item) {
 			continue
 		}
-		if item.Kind == migrationKindDirectory {
-			if _, err := os.Lstat(item.Destination); err == nil {
-				return false, fmt.Errorf("destination collision: %s", item.Destination)
-			}
-			if err := copyEntry(item.Source, item.Destination); err != nil {
-				return false, err
-			}
-		} else if _, err := os.Lstat(item.Destination); errors.Is(err, os.ErrNotExist) {
-			if err := copyEntry(item.Source, item.Destination); err != nil {
-				return false, err
-			}
-		} else {
-			return false, fmt.Errorf("destination collision: %s", item.Destination)
-		}
+		// Journal ownership before copying. A recursive copy can fail after
+		// creating a partial destination; recovery must then know it owns it.
 		state.Published = append(state.Published, item.Destination)
 		if err := writeJSONAtomic(statePath, state, 0o600); err != nil {
 			return false, err
 		}
 		if err := migrationPhase("published"); err != nil {
+			return false, err
+		}
+		if err := validateMigrationDestination(item.Destination, plan); err != nil {
+			return false, err
+		}
+		if _, err := os.Lstat(item.Destination); err == nil {
+			return false, fmt.Errorf("destination collision: %s", item.Destination)
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return false, err
+		}
+		if err := copyEntry(item.Source, item.Destination); err != nil {
 			return false, err
 		}
 	}
@@ -248,12 +256,92 @@ func RecoverLegacyToXDGMigration() error {
 	if err := json.Unmarshal(data, &state); err != nil {
 		return fmt.Errorf("invalid migration state: %w", err)
 	}
+	plan, planErr := PreviewLegacyToXDG()
+	if planErr != nil {
+		return fmt.Errorf("inspect migration plan: %w", planErr)
+	}
+	if !plan.NeedsMigration || state.Version != 1 || filepath.Clean(state.BackupDir) != filepath.Join(plan.LegacyDir, migrationBackupDir) {
+		return errors.New("refusing recovery for stale or invalid migration state")
+	}
+	expected := make(map[string]bool, len(plan.Items))
+	for _, item := range plan.Items {
+		if isTopLevelMigrationItem(plan.Items, item) {
+			expected[item.Destination] = true
+		}
+	}
+	for _, path := range state.Published {
+		if !expected[path] {
+			return fmt.Errorf("refusing recovery of unexpected destination: %s", path)
+		}
+		if err := validateMigrationDestination(path, plan); err != nil {
+			return err
+		}
+	}
 	for i := len(state.Published) - 1; i >= 0; i-- {
 		if err := os.RemoveAll(state.Published[i]); err != nil {
 			return err
 		}
 	}
 	return os.Remove(statePath)
+}
+
+func validateMigrationDestination(path string, plan MigrationPlan) error {
+	clean := filepath.Clean(path)
+	allowed := false
+	for _, item := range plan.Items {
+		if isTopLevelMigrationItem(plan.Items, item) && filepath.Clean(item.Destination) == clean {
+			allowed = true
+			break
+		}
+	}
+	if !allowed || !filepath.IsAbs(clean) {
+		return fmt.Errorf("refusing unsafe migration destination: %s", path)
+	}
+	for _, root := range []string{DefaultConfigDir(), DefaultDataDir(), DefaultCacheDir()} {
+		root = filepath.Clean(root)
+		rel, err := filepath.Rel(root, clean)
+		if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			continue
+		}
+		if err := rejectSymlinkComponents(root, clean); err != nil {
+			return err
+		}
+		return nil
+	}
+	return fmt.Errorf("refusing destination outside XDG roots: %s", path)
+}
+
+func rejectSymlinkComponents(root, path string) error {
+	root = filepath.Clean(root)
+	// Check the configured XDG home and the application directory below it;
+	// system ancestors such as macOS's /var symlink are outside our root.
+	if parent := filepath.Dir(root); filepath.Base(parent) != "." {
+		if info, err := os.Lstat(parent); err == nil && info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("refusing symlink XDG root: %s", parent)
+		}
+	}
+	if info, err := os.Lstat(root); err == nil && info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("refusing symlink XDG root: %s", root)
+	}
+	rel, _ := filepath.Rel(root, filepath.Clean(path))
+	cur := root
+	for _, part := range strings.Split(rel, string(filepath.Separator)) {
+		if part == "." || part == "" {
+			continue
+		}
+		cur = filepath.Join(cur, part)
+		info, err := os.Lstat(cur)
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("refusing symlink destination component: %s", cur)
+		}
+	}
+	return nil
 }
 
 func migrationPhase(phase string) error {

--- a/internal/config/migrate.go
+++ b/internal/config/migrate.go
@@ -196,21 +196,22 @@ func MigrateLegacyToXDG() (bool, error) {
 		if !isTopLevelMigrationItem(plan.Items, item) {
 			continue
 		}
-		// Journal ownership before copying. A recursive copy can fail after
-		// creating a partial destination; recovery must then know it owns it.
-		state.Published = append(state.Published, item.Destination)
-		if err := writeJSONAtomic(statePath, state); err != nil {
-			return false, err
-		}
-		if err := migrationPhase("published"); err != nil {
-			return false, err
-		}
 		if err := validateMigrationDestination(item.Destination, plan); err != nil {
 			return false, err
 		}
 		if _, err := os.Lstat(item.Destination); err == nil {
 			return false, fmt.Errorf("destination collision: %s", item.Destination)
 		} else if !errors.Is(err, os.ErrNotExist) {
+			return false, err
+		}
+		// Journal only after confirming the destination is absent. A recursive copy
+		// can fail after creating a partial destination; recovery must then know it
+		// owns that new destination, but never a pre-existing user destination.
+		state.Published = append(state.Published, item.Destination)
+		if err := writeJSONAtomic(statePath, state); err != nil {
+			return false, err
+		}
+		if err := migrationPhase("published"); err != nil {
 			return false, err
 		}
 		if err := copyEntry(item.Source, item.Destination); err != nil {

--- a/internal/config/migrate.go
+++ b/internal/config/migrate.go
@@ -1,15 +1,17 @@
 package config
 
 import (
-	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
+
+	"github.com/danieljustus/symaira-vault/internal/fsutil"
 )
 
 const (
@@ -17,6 +19,8 @@ const (
 	migrationStateFile     = ".migration-state.json"
 	migrationBackupDir     = ".migration-backup"
 	migrationKindDirectory = "directory"
+	maxMigrationItems      = 100_000
+	maxMigrationBytes      = 1 << 30
 )
 
 // MigrationItem describes one source/destination pair without exposing data.
@@ -32,6 +36,7 @@ type MigrationPlan struct {
 	LegacyDir      string          `json:"legacy_dir"`
 	Items          []MigrationItem `json:"items"`
 	NeedsMigration bool            `json:"needs_migration"`
+	totalBytes     int64
 }
 
 type migrationState struct {
@@ -102,7 +107,9 @@ func appendMigrationItems(plan *MigrationPlan, base, rel, dst string) error {
 		return fmt.Errorf("refusing symlink: %s", rel)
 	}
 	if info.IsDir() {
-		plan.Items = append(plan.Items, MigrationItem{Source: src, Destination: dst, Kind: migrationKindDirectory})
+		if err := addMigrationItem(plan, MigrationItem{Source: src, Destination: dst, Kind: migrationKindDirectory}); err != nil {
+			return err
+		}
 		return filepath.WalkDir(src, func(path string, entry fs.DirEntry, walkErr error) error {
 			if walkErr != nil {
 				return walkErr
@@ -129,7 +136,9 @@ func appendMigrationItems(plan *MigrationPlan, base, rel, dst string) error {
 				}
 				size = fi.Size()
 			}
-			plan.Items = append(plan.Items, MigrationItem{Source: path, Destination: target, Kind: kind, Bytes: size})
+			if err := addMigrationItem(plan, MigrationItem{Source: path, Destination: target, Kind: kind, Bytes: size}); err != nil {
+				return err
+			}
 			return nil
 		})
 	}
@@ -137,10 +146,22 @@ func appendMigrationItems(plan *MigrationPlan, base, rel, dst string) error {
 }
 
 func appendFileItem(plan *MigrationPlan, src, dst string, info os.FileInfo) error {
-	return func() error {
-		plan.Items = append(plan.Items, MigrationItem{Source: src, Destination: dst, Kind: "file", Bytes: info.Size()})
-		return nil
-	}()
+	return addMigrationItem(plan, MigrationItem{Source: src, Destination: dst, Kind: "file", Bytes: info.Size()})
+}
+
+func addMigrationItem(plan *MigrationPlan, item MigrationItem) error {
+	if len(plan.Items) >= maxMigrationItems {
+		return fmt.Errorf("migration exceeds item limit (%d)", maxMigrationItems)
+	}
+	if item.Bytes < 0 || item.Bytes > maxMigrationBytes {
+		return fmt.Errorf("migration file exceeds size limit: %s", item.Source)
+	}
+	if item.Bytes > maxMigrationBytes-plan.totalBytes {
+		return fmt.Errorf("migration exceeds size limit (%d bytes)", maxMigrationBytes)
+	}
+	plan.Items = append(plan.Items, item)
+	plan.totalBytes += item.Bytes
+	return nil
 }
 
 // MigrateLegacyToXDG performs a verified, recoverable migration. Source data is retained.
@@ -166,7 +187,7 @@ func MigrateLegacyToXDG() (bool, error) {
 		return false, fmt.Errorf("create backup: %w", err)
 	}
 	for _, item := range plan.Items {
-		if item.Source == filepath.Join(plan.LegacyDir, migrationMarker) {
+		if !isTopLevelMigrationItem(plan.Items, item) {
 			continue
 		}
 		rel, _ := filepath.Rel(plan.LegacyDir, item.Source)
@@ -203,6 +224,9 @@ func MigrateLegacyToXDG() (bool, error) {
 			return false, fmt.Errorf("destination collision: %s", item.Destination)
 		} else if !errors.Is(err, os.ErrNotExist) {
 			return false, err
+		}
+		if err := fsutil.SafeMkdirAll(filepath.Dir(item.Destination), 0o700); err != nil {
+			return false, fmt.Errorf("create destination parent: %w", err)
 		}
 		// Journal only after confirming the destination is absent. A recursive copy
 		// can fail after creating a partial destination; recovery must then know it
@@ -283,6 +307,9 @@ func RecoverLegacyToXDGMigration() error {
 			return err
 		}
 	}
+	if err := os.RemoveAll(state.BackupDir); err != nil {
+		return fmt.Errorf("remove migration backup: %w", err)
+	}
 	return os.Remove(statePath)
 }
 
@@ -361,40 +388,67 @@ func copyEntry(src, dst string) error {
 		return fmt.Errorf("refusing symlink: %s", src)
 	}
 	if info.IsDir() {
-		if mkdirErr := os.MkdirAll(dst, 0o700); mkdirErr != nil {
-			return mkdirErr
+		if err := fsutil.SafeMkdirAll(filepath.Dir(dst), 0o700); err != nil {
+			return err
 		}
-		// #nosec G302 -- owner-only directories require execute/search permission.
-		if chmodErr := os.Chmod(dst, 0o700); chmodErr != nil {
-			return fmt.Errorf("set migration directory permissions: %w", chmodErr)
+		// Destination directories are created exclusively. Never merge into an
+		// existing directory: doing so would make ownership and recovery
+		// ambiguous, and would reintroduce a check-then-use race.
+		if err := os.Mkdir(dst, 0o700); err != nil {
+			return err
 		}
-		entries, readErr := os.ReadDir(src)
-		if readErr != nil {
-			return readErr
+		entries, err := os.ReadDir(src)
+		if err != nil {
+			return err
 		}
 		for _, e := range entries {
-			if copyErr := copyEntry(filepath.Join(src, e.Name()), filepath.Join(dst, e.Name())); copyErr != nil {
-				return copyErr
+			if err := copyEntry(filepath.Join(src, e.Name()), filepath.Join(dst, e.Name())); err != nil {
+				return err
 			}
 		}
 		return nil
 	}
-	data, err := os.ReadFile(src) // #nosec G304 -- src is an enumerated legacy migration path and symlinks are rejected before copying.
+
+	// Open the source with O_NOFOLLOW on Unix, then read from that descriptor.
+	// This closes the Lstat-to-ReadFile symlink race at the source boundary.
+	file, err := openMigrationSource(src)
 	if err != nil {
 		return err
 	}
-	if mkdirErr := os.MkdirAll(filepath.Dir(dst), 0o700); mkdirErr != nil {
-		return mkdirErr
+	defer file.Close()
+	openedInfo, err := file.Stat()
+	if err != nil {
+		return err
 	}
-	if writeErr := os.WriteFile(dst, data, 0o600); writeErr != nil {
+	if !openedInfo.Mode().IsRegular() {
+		return fmt.Errorf("refusing non-regular source: %s", src)
+	}
+	data, err := io.ReadAll(io.LimitReader(file, maxMigrationBytes+1))
+	if err != nil {
+		return err
+	}
+	if int64(len(data)) > maxMigrationBytes {
+		return fmt.Errorf("source exceeds migration size limit: %s", src)
+	}
+	// O_EXCL makes the destination decision atomic: a concurrent creator or
+	// symlink is an error, never an overwrite or traversal.
+	if err := fsutil.SafeMkdirAll(filepath.Dir(dst), 0o700); err != nil {
+		return err
+	}
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return err
+	}
+	written, writeErr := out.Write(data)
+	closeErr := out.Close()
+	if writeErr != nil {
 		return writeErr
 	}
-	if chmodErr := os.Chmod(dst, 0o600); chmodErr != nil {
-		return fmt.Errorf("set migration file permissions: %w", chmodErr)
+	if closeErr != nil {
+		return closeErr
 	}
-	got, err := os.ReadFile(dst) // #nosec G304 -- dst is a validated XDG migration destination written immediately above.
-	if err != nil || !bytes.Equal(got, data) {
-		return fmt.Errorf("verification failed for %s", dst)
+	if written != len(data) {
+		return io.ErrShortWrite
 	}
 	return nil
 }

--- a/internal/config/migrate.go
+++ b/internal/config/migrate.go
@@ -186,7 +186,7 @@ func MigrateLegacyToXDG() (bool, error) {
 			state.Planned = append(state.Planned, item.Destination)
 		}
 	}
-	if err := writeJSONAtomic(statePath, state, 0o600); err != nil {
+	if err := writeJSONAtomic(statePath, state); err != nil {
 		return false, err
 	}
 	if err := migrationPhase("state-published"); err != nil {
@@ -199,7 +199,7 @@ func MigrateLegacyToXDG() (bool, error) {
 		// Journal ownership before copying. A recursive copy can fail after
 		// creating a partial destination; recovery must then know it owns it.
 		state.Published = append(state.Published, item.Destination)
-		if err := writeJSONAtomic(statePath, state, 0o600); err != nil {
+		if err := writeJSONAtomic(statePath, state); err != nil {
 			return false, err
 		}
 		if err := migrationPhase("published"); err != nil {
@@ -220,7 +220,7 @@ func MigrateLegacyToXDG() (bool, error) {
 	if err := migrationPhase("verified"); err != nil {
 		return false, err
 	}
-	if err := writeJSONAtomic(filepath.Join(plan.LegacyDir, migrationMarker), []byte("migration complete\n"), 0o600); err != nil {
+	if err := writeJSONAtomic(filepath.Join(plan.LegacyDir, migrationMarker), []byte("migration complete\n")); err != nil {
 		return false, err
 	}
 	if err := os.Remove(statePath); err != nil {
@@ -393,7 +393,7 @@ func copyEntry(src, dst string) error {
 	return nil
 }
 
-func writeJSONAtomic(path string, value any, mode os.FileMode) (returnErr error) {
+func writeJSONAtomic(path string, value any) (returnErr error) {
 	var data []byte
 	var err error
 	if b, ok := value.([]byte); ok {
@@ -414,7 +414,7 @@ func writeJSONAtomic(path string, value any, mode os.FileMode) (returnErr error)
 			returnErr = fmt.Errorf("remove temporary migration state: %w", removeErr)
 		}
 	}()
-	if err := tmp.Chmod(mode); err != nil {
+	if err := tmp.Chmod(0o600); err != nil {
 		return closeMigrationTemp(tmp, err)
 	}
 	if _, err := tmp.Write(data); err != nil {

--- a/internal/config/migrate.go
+++ b/internal/config/migrate.go
@@ -245,7 +245,7 @@ func RecoverLegacyToXDGMigration() error {
 		return err
 	}
 	statePath := filepath.Join(home, LegacyVaultSubdir, migrationStateFile)
-	data, err := os.ReadFile(statePath)
+	data, err := os.ReadFile(statePath) // #nosec G304 -- statePath is the fixed migration journal below the legacy vault directory.
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return nil
@@ -363,7 +363,10 @@ func copyEntry(src, dst string) error {
 		if mkdirErr := os.MkdirAll(dst, 0o700); mkdirErr != nil {
 			return mkdirErr
 		}
-		_ = os.Chmod(dst, 0o700)
+		// #nosec G302 -- owner-only directories require execute/search permission.
+		if chmodErr := os.Chmod(dst, 0o700); chmodErr != nil {
+			return fmt.Errorf("set migration directory permissions: %w", chmodErr)
+		}
 		entries, readErr := os.ReadDir(src)
 		if readErr != nil {
 			return readErr
@@ -375,7 +378,7 @@ func copyEntry(src, dst string) error {
 		}
 		return nil
 	}
-	data, err := os.ReadFile(src)
+	data, err := os.ReadFile(src) // #nosec G304 -- src is an enumerated legacy migration path and symlinks are rejected before copying.
 	if err != nil {
 		return err
 	}
@@ -385,8 +388,10 @@ func copyEntry(src, dst string) error {
 	if writeErr := os.WriteFile(dst, data, 0o600); writeErr != nil {
 		return writeErr
 	}
-	_ = os.Chmod(dst, 0o600)
-	got, err := os.ReadFile(dst)
+	if chmodErr := os.Chmod(dst, 0o600); chmodErr != nil {
+		return fmt.Errorf("set migration file permissions: %w", chmodErr)
+	}
+	got, err := os.ReadFile(dst) // #nosec G304 -- dst is a validated XDG migration destination written immediately above.
 	if err != nil || !bytes.Equal(got, data) {
 		return fmt.Errorf("verification failed for %s", dst)
 	}

--- a/internal/config/migrate.go
+++ b/internal/config/migrate.go
@@ -71,8 +71,8 @@ func PreviewLegacyToXDG() (MigrationPlan, error) {
 	plan := MigrationPlan{LegacyDir: legacy, NeedsMigration: true}
 	groups := []struct{ src, dst string }{
 		{"config.yaml", filepath.Join(DefaultConfigDir(), "config.yaml")},
-		{"vault", filepath.Join(DefaultDataDir(), "vault")},
-		{"audit", filepath.Join(DefaultDataDir(), "audit")},
+		{configSectionVault, filepath.Join(DefaultDataDir(), configSectionVault)},
+		{configSectionAudit, filepath.Join(DefaultDataDir(), configSectionAudit)},
 		{"devices.json", filepath.Join(DefaultDataDir(), "devices.json")},
 		{"pairing", filepath.Join(DefaultDataDir(), "pairing")},
 		{"update-cache.json", filepath.Join(DefaultCacheDir(), "update-cache.json")},
@@ -180,11 +180,11 @@ func MigrateLegacyToXDG() (bool, error) {
 		return false, err
 	}
 	backup := filepath.Join(plan.LegacyDir, migrationBackupDir)
-	if backupFD, err := secureMkdirOpen(backup, 0o700); err != nil {
-		return false, fmt.Errorf("create backup: %w", err)
-	} else {
-		_ = closeMigrationFD(backupFD)
+	backupFD, mkdirErr := secureMkdirOpen(backup, 0o700)
+	if mkdirErr != nil {
+		return false, fmt.Errorf("create backup: %w", mkdirErr)
 	}
+	_ = closeMigrationFD(backupFD)
 	for _, item := range plan.Items {
 		if !isTopLevelMigrationItem(plan.Items, item) {
 			continue
@@ -224,11 +224,11 @@ func MigrateLegacyToXDG() (bool, error) {
 		} else if !errors.Is(err, os.ErrNotExist) {
 			return false, err
 		}
-		if parentFD, err := secureMkdirOpen(filepath.Dir(item.Destination), 0o700); err != nil {
+		parentFD, err := secureMkdirOpen(filepath.Dir(item.Destination), 0o700)
+		if err != nil {
 			return false, fmt.Errorf("create destination parent: %w", err)
-		} else {
-			_ = closeMigrationFD(parentFD)
 		}
+		_ = closeMigrationFD(parentFD)
 		// Journal only after confirming the destination is absent. A recursive copy
 		// can fail after creating a partial destination; recovery must then know it
 		// owns that new destination, but never a pre-existing user destination.

--- a/internal/config/migrate.go
+++ b/internal/config/migrate.go
@@ -9,8 +9,6 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
-
-	"github.com/danieljustus/symaira-vault/internal/fsutil"
 )
 
 const (
@@ -182,8 +180,10 @@ func MigrateLegacyToXDG() (bool, error) {
 		return false, err
 	}
 	backup := filepath.Join(plan.LegacyDir, migrationBackupDir)
-	if err := os.MkdirAll(backup, 0o700); err != nil {
+	if backupFD, err := secureMkdirOpen(backup, 0o700); err != nil {
 		return false, fmt.Errorf("create backup: %w", err)
+	} else {
+		_ = closeMigrationFD(backupFD)
 	}
 	for _, item := range plan.Items {
 		if !isTopLevelMigrationItem(plan.Items, item) {
@@ -224,8 +224,10 @@ func MigrateLegacyToXDG() (bool, error) {
 		} else if !errors.Is(err, os.ErrNotExist) {
 			return false, err
 		}
-		if err := fsutil.SafeMkdirAll(filepath.Dir(item.Destination), 0o700); err != nil {
+		if parentFD, err := secureMkdirOpen(filepath.Dir(item.Destination), 0o700); err != nil {
 			return false, fmt.Errorf("create destination parent: %w", err)
+		} else {
+			_ = closeMigrationFD(parentFD)
 		}
 		// Journal only after confirming the destination is absent. A recursive copy
 		// can fail after creating a partial destination; recovery must then know it
@@ -247,7 +249,7 @@ func MigrateLegacyToXDG() (bool, error) {
 	if err := writeJSONAtomic(filepath.Join(plan.LegacyDir, migrationMarker), []byte("migration complete\n")); err != nil {
 		return false, err
 	}
-	if err := os.Remove(statePath); err != nil {
+	if err := secureRemovePath(statePath); err != nil {
 		return false, fmt.Errorf("remove migration state: %w", err)
 	}
 	return true, nil
@@ -269,7 +271,7 @@ func RecoverLegacyToXDGMigration() error {
 		return err
 	}
 	statePath := filepath.Join(home, LegacyVaultSubdir, migrationStateFile)
-	data, err := os.ReadFile(statePath) // #nosec G304 -- statePath is the fixed migration journal below the legacy vault directory.
+	data, err := secureReadFile(statePath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return nil
@@ -302,14 +304,14 @@ func RecoverLegacyToXDGMigration() error {
 		}
 	}
 	for i := len(state.Published) - 1; i >= 0; i-- {
-		if err := os.RemoveAll(state.Published[i]); err != nil {
+		if err := secureRemovePath(state.Published[i]); err != nil {
 			return err
 		}
 	}
-	if err := os.RemoveAll(state.BackupDir); err != nil {
+	if err := secureRemovePath(state.BackupDir); err != nil {
 		return fmt.Errorf("remove migration backup: %w", err)
 	}
-	return os.Remove(statePath)
+	return secureRemovePath(statePath)
 }
 
 func validateMigrationDestination(path string, plan MigrationPlan) error {
@@ -382,7 +384,7 @@ func copyEntry(src, dst string) error {
 	return secureCopyEntry(src, dst)
 }
 
-func writeJSONAtomic(path string, value any) (returnErr error) {
+func writeJSONAtomic(path string, value any) error {
 	var data []byte
 	var err error
 	if b, ok := value.([]byte); ok {
@@ -393,34 +395,5 @@ func writeJSONAtomic(path string, value any) (returnErr error) {
 	if err != nil {
 		return err
 	}
-	tmp, err := os.CreateTemp(filepath.Dir(path), ".migration-tmp-")
-	if err != nil {
-		return err
-	}
-	name := tmp.Name()
-	defer func() {
-		if removeErr := os.Remove(name); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) && returnErr == nil {
-			returnErr = fmt.Errorf("remove temporary migration state: %w", removeErr)
-		}
-	}()
-	if err := tmp.Chmod(0o600); err != nil {
-		return closeMigrationTemp(tmp, err)
-	}
-	if _, err := tmp.Write(data); err != nil {
-		return closeMigrationTemp(tmp, err)
-	}
-	if err := tmp.Sync(); err != nil {
-		return closeMigrationTemp(tmp, err)
-	}
-	if err := tmp.Close(); err != nil {
-		return err
-	}
-	return os.Rename(name, path)
-}
-
-func closeMigrationTemp(tmp *os.File, operationErr error) error {
-	if closeErr := tmp.Close(); closeErr != nil {
-		return fmt.Errorf("%w; close temporary migration state: %w", operationErr, closeErr)
-	}
-	return operationErr
+	return secureWriteJSONAtomic(path, data)
 }

--- a/internal/config/migrate_copy_unix.go
+++ b/internal/config/migrate_copy_unix.go
@@ -31,7 +31,7 @@ func secureCopyEntry(src, dst string) error {
 		return err
 	}
 	defer func() { _ = unix.Close(dstParent) }()
-	return copyMigrationNode(int(srcFile.Fd()), dstParent, filepath.Base(dst), uint32(srcStat.Mode))
+	return copyMigrationNode(int(srcFile.Fd()), dstParent, filepath.Base(dst), uint32(srcStat.Mode)) //nolint:unconvert // unix.Stat_t.Mode is uint32 on Linux but uint16 on Darwin; the conversion is a no-op on one GOOS and required on the other
 }
 
 func secureMkdirOpen(path string, mode uint32) (int, error) {
@@ -102,7 +102,7 @@ func copyMigrationNode(srcFD, dstParent int, name string, srcMode uint32) error 
 			if err != nil {
 				return err
 			}
-			copyErr := copyMigrationNode(childFD, dstDir, child, uint32(st.Mode))
+			copyErr := copyMigrationNode(childFD, dstDir, child, uint32(st.Mode)) //nolint:unconvert // see the conversion note in secureCopyEntry above
 			_ = unix.Close(childFD)
 			if copyErr != nil {
 				return copyErr

--- a/internal/config/migrate_copy_unix.go
+++ b/internal/config/migrate_copy_unix.go
@@ -3,6 +3,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -20,17 +21,17 @@ func secureCopyEntry(src, dst string) error {
 	if err != nil {
 		return err
 	}
-	defer srcFile.Close()
+	defer func() { _ = srcFile.Close() }()
 	var srcStat unix.Stat_t
-	if err := unix.Fstat(int(srcFile.Fd()), &srcStat); err != nil {
-		return err
+	if statErr := unix.Fstat(int(srcFile.Fd()), &srcStat); statErr != nil {
+		return statErr
 	}
 	dstParent, err := secureMkdirOpen(filepath.Dir(dst), 0o700)
 	if err != nil {
 		return err
 	}
-	defer unix.Close(dstParent)
-	return copyMigrationNode(int(srcFile.Fd()), dstParent, filepath.Base(dst), srcStat.Mode)
+	defer func() { _ = unix.Close(dstParent) }()
+	return copyMigrationNode(int(srcFile.Fd()), dstParent, filepath.Base(dst), uint32(srcStat.Mode))
 }
 
 func secureMkdirOpen(path string, mode uint32) (int, error) {
@@ -49,26 +50,26 @@ func secureMkdirOpen(path string, mode uint32) (int, error) {
 		next, openErr := unix.Openat(fd, part, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
 		if openErr != nil {
 			if openErr != unix.ENOENT {
-				unix.Close(fd)
+				_ = unix.Close(fd)
 				return -1, openErr
 			}
 			if openErr = unix.Mkdirat(fd, part, mode); openErr != nil && openErr != unix.EEXIST {
-				unix.Close(fd)
+				_ = unix.Close(fd)
 				return -1, openErr
 			}
 			next, openErr = unix.Openat(fd, part, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
 			if openErr != nil {
-				unix.Close(fd)
+				_ = unix.Close(fd)
 				return -1, openErr
 			}
 		}
-		unix.Close(fd)
+		_ = unix.Close(fd)
 		fd = next
 	}
 	return fd, nil
 }
 
-func copyMigrationNode(srcFD, dstParent int, name string, srcMode uint16) error {
+func copyMigrationNode(srcFD, dstParent int, name string, srcMode uint32) error {
 	if srcMode&unix.S_IFMT == unix.S_IFDIR {
 		if err := unix.Mkdirat(dstParent, name, 0o700); err != nil {
 			return err
@@ -77,18 +78,18 @@ func copyMigrationNode(srcFD, dstParent int, name string, srcMode uint16) error 
 		if err != nil {
 			return err
 		}
-		defer unix.Close(dstDir)
+		defer func() { _ = unix.Close(dstDir) }()
 		dup, err := unix.Dup(srcFD)
 		if err != nil {
 			return err
 		}
 		stream := os.NewFile(uintptr(dup), "source directory")
 		if stream == nil {
-			unix.Close(dup)
+			_ = unix.Close(dup)
 			return fmt.Errorf("invalid source directory")
 		}
 		entries, err := stream.Readdirnames(-1)
-		stream.Close()
+		_ = stream.Close()
 		if err != nil {
 			return err
 		}
@@ -101,8 +102,8 @@ func copyMigrationNode(srcFD, dstParent int, name string, srcMode uint16) error 
 			if err != nil {
 				return err
 			}
-			copyErr := copyMigrationNode(childFD, dstDir, child, st.Mode)
-			unix.Close(childFD)
+			copyErr := copyMigrationNode(childFD, dstDir, child, uint32(st.Mode))
+			_ = unix.Close(childFD)
 			if copyErr != nil {
 				return copyErr
 			}
@@ -118,11 +119,11 @@ func copyMigrationNode(srcFD, dstParent int, name string, srcMode uint16) error 
 	}
 	src := os.NewFile(uintptr(dup), "source")
 	if src == nil {
-		unix.Close(dup)
+		_ = unix.Close(dup)
 		return fmt.Errorf("invalid source file")
 	}
 	data, err := io.ReadAll(io.LimitReader(src, maxMigrationBytes+1))
-	src.Close()
+	_ = src.Close()
 	if err != nil {
 		return err
 	}
@@ -135,7 +136,7 @@ func copyMigrationNode(srcFD, dstParent int, name string, srcMode uint16) error 
 	}
 	outFile := os.NewFile(uintptr(fd), name)
 	if outFile == nil {
-		unix.Close(fd)
+		_ = unix.Close(fd)
 		return fmt.Errorf("invalid destination")
 	}
 	written, writeErr := outFile.Write(data)
@@ -157,7 +158,7 @@ func secureReadFile(path string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 	return io.ReadAll(io.LimitReader(file, maxMigrationBytes+1))
 }
 
@@ -166,7 +167,7 @@ func secureRemovePath(path string) error {
 	if err != nil {
 		return err
 	}
-	defer unix.Close(parent)
+	defer func() { _ = unix.Close(parent) }()
 	return removeAt(parent, filepath.Base(path))
 }
 
@@ -184,7 +185,7 @@ func secureOpenExisting(path string) (int, error) {
 			continue
 		}
 		next, openErr := unix.Openat(fd, part, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
-		unix.Close(fd)
+		_ = unix.Close(fd)
 		if openErr != nil {
 			return -1, openErr
 		}
@@ -198,19 +199,19 @@ func removeAt(parent int, name string) error {
 	if err == nil {
 		file := os.NewFile(uintptr(fd), name)
 		if file == nil {
-			unix.Close(fd)
+			_ = unix.Close(fd)
 			return fmt.Errorf("invalid directory")
 		}
 		entries, readErr := file.Readdirnames(-1)
 		if readErr == nil {
 			for _, child := range entries {
-				if err := removeAt(fd, child); err != nil {
-					readErr = err
+				if childErr := removeAt(fd, child); childErr != nil {
+					readErr = childErr
 					break
 				}
 			}
 		}
-		file.Close()
+		_ = file.Close()
 		if readErr != nil {
 			return readErr
 		}
@@ -232,14 +233,14 @@ func secureWriteJSONAtomic(path string, data []byte) error {
 	if err != nil {
 		return err
 	}
-	defer unix.Close(parent)
+	defer func() { _ = unix.Close(parent) }()
 	base := filepath.Base(path)
 	var tmp string
 	var fd int
 	for i := 0; i < 10; i++ {
 		tmp = fmt.Sprintf(".migration-tmp-%d-%d", unix.Getpid(), atomic.AddUint64(&migrationTempCounter, 1))
 		fd, err = unix.Openat(parent, tmp, unix.O_WRONLY|unix.O_CREAT|unix.O_EXCL|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0o600)
-		if err != unix.EEXIST {
+		if !errors.Is(err, unix.EEXIST) {
 			break
 		}
 	}
@@ -248,7 +249,7 @@ func secureWriteJSONAtomic(path string, data []byte) error {
 	}
 	file := os.NewFile(uintptr(fd), tmp)
 	if file == nil {
-		unix.Close(fd)
+		_ = unix.Close(fd)
 		_ = unix.Unlinkat(parent, tmp, 0)
 		return fmt.Errorf("invalid temporary migration file")
 	}

--- a/internal/config/migrate_copy_unix.go
+++ b/internal/config/migrate_copy_unix.go
@@ -1,0 +1,161 @@
+//go:build !windows
+
+package config
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/sys/unix"
+)
+
+// secureCopyEntry copies using directory file descriptors. Every lookup is
+// relative to an already-open directory and uses O_NOFOLLOW, so replacing a
+// path component after validation cannot redirect the copy.
+func secureCopyEntry(src, dst string) error {
+	srcFile, err := openMigrationSource(src)
+	if err != nil {
+		return err
+	}
+	defer srcFile.Close()
+	var srcStat unix.Stat_t
+	if err := unix.Fstat(int(srcFile.Fd()), &srcStat); err != nil {
+		return err
+	}
+	dstParent, err := secureMkdirOpen(filepath.Dir(dst), 0o700)
+	if err != nil {
+		return err
+	}
+	defer unix.Close(dstParent)
+	return copyMigrationNode(int(srcFile.Fd()), dstParent, filepath.Base(dst), srcStat.Mode)
+}
+
+func secureMkdirOpen(path string, mode uint32) (int, error) {
+	clean, err := filepath.Abs(filepath.Clean(path))
+	if err != nil {
+		return -1, err
+	}
+	// Resolve only macOS's system-owned /var alias. Never EvalSymlinks the
+	// complete user path: doing that would turn a user-controlled symlink into
+	// an apparently safe path and reintroduce the escape.
+	if info, statErr := os.Lstat(string(filepath.Separator) + "var"); statErr == nil && info.Mode()&os.ModeSymlink != 0 {
+		if resolved, resolveErr := filepath.EvalSymlinks(string(filepath.Separator) + "var"); resolveErr == nil && resolved == string(filepath.Separator)+"private/var" {
+			clean = string(filepath.Separator) + "private" + clean
+		}
+	}
+	fd, err := unix.Open(string(filepath.Separator), unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return -1, err
+	}
+	for _, part := range strings.Split(strings.TrimPrefix(clean, string(filepath.Separator)), string(filepath.Separator)) {
+		if part == "" || part == "." {
+			continue
+		}
+		next, openErr := unix.Openat(fd, part, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+		if openErr != nil {
+			if openErr != unix.ENOENT {
+				unix.Close(fd)
+				return -1, openErr
+			}
+			if openErr = unix.Mkdirat(fd, part, mode); openErr != nil && openErr != unix.EEXIST {
+				unix.Close(fd)
+				return -1, openErr
+			}
+			next, openErr = unix.Openat(fd, part, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+			if openErr != nil {
+				unix.Close(fd)
+				return -1, openErr
+			}
+		}
+		unix.Close(fd)
+		fd = next
+	}
+	return fd, nil
+}
+
+func copyMigrationNode(srcFD, dstParent int, name string, srcMode uint16) error {
+	if srcMode&unix.S_IFMT == unix.S_IFDIR {
+		if err := unix.Mkdirat(dstParent, name, 0o700); err != nil {
+			return err
+		}
+		dstDir, err := unix.Openat(dstParent, name, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+		if err != nil {
+			return err
+		}
+		defer unix.Close(dstDir)
+		dup, err := unix.Dup(srcFD)
+		if err != nil {
+			return err
+		}
+		stream := os.NewFile(uintptr(dup), "source directory")
+		if stream == nil {
+			unix.Close(dup)
+			return fmt.Errorf("invalid source directory")
+		}
+		entries, err := stream.Readdirnames(-1)
+		stream.Close()
+		if err != nil {
+			return err
+		}
+		for _, child := range entries {
+			var st unix.Stat_t
+			if err := unix.Fstatat(srcFD, child, &st, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+				return err
+			}
+			childFD, err := unix.Openat(srcFD, child, unix.O_RDONLY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+			if err != nil {
+				return err
+			}
+			copyErr := copyMigrationNode(childFD, dstDir, child, st.Mode)
+			unix.Close(childFD)
+			if copyErr != nil {
+				return copyErr
+			}
+		}
+		return nil
+	}
+	if srcMode&unix.S_IFMT != unix.S_IFREG {
+		return fmt.Errorf("refusing non-regular source")
+	}
+	dup, err := unix.Dup(srcFD)
+	if err != nil {
+		return err
+	}
+	src := os.NewFile(uintptr(dup), "source")
+	if src == nil {
+		unix.Close(dup)
+		return fmt.Errorf("invalid source file")
+	}
+	data, err := io.ReadAll(io.LimitReader(src, maxMigrationBytes+1))
+	src.Close()
+	if err != nil {
+		return err
+	}
+	if int64(len(data)) > maxMigrationBytes {
+		return fmt.Errorf("source exceeds migration size limit")
+	}
+	fd, err := unix.Openat(dstParent, name, unix.O_WRONLY|unix.O_CREAT|unix.O_EXCL|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0o600)
+	if err != nil {
+		return err
+	}
+	outFile := os.NewFile(uintptr(fd), name)
+	if outFile == nil {
+		unix.Close(fd)
+		return fmt.Errorf("invalid destination")
+	}
+	written, writeErr := outFile.Write(data)
+	closeErr := outFile.Close()
+	if writeErr != nil {
+		return writeErr
+	}
+	if closeErr != nil {
+		return closeErr
+	}
+	if written != len(data) {
+		return io.ErrShortWrite
+	}
+	return nil
+}

--- a/internal/config/migrate_copy_unix.go
+++ b/internal/config/migrate_copy_unix.go
@@ -8,13 +8,13 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 
 	"golang.org/x/sys/unix"
 )
 
 // secureCopyEntry copies using directory file descriptors. Every lookup is
-// relative to an already-open directory and uses O_NOFOLLOW, so replacing a
-// path component after validation cannot redirect the copy.
+// relative to an already-open directory and uses O_NOFOLLOW.
 func secureCopyEntry(src, dst string) error {
 	srcFile, err := openMigrationSource(src)
 	if err != nil {
@@ -34,23 +34,15 @@ func secureCopyEntry(src, dst string) error {
 }
 
 func secureMkdirOpen(path string, mode uint32) (int, error) {
-	clean, err := filepath.Abs(filepath.Clean(path))
+	clean, err := migrationAbsolutePath(path)
 	if err != nil {
 		return -1, err
 	}
-	// Resolve only macOS's system-owned /var alias. Never EvalSymlinks the
-	// complete user path: doing that would turn a user-controlled symlink into
-	// an apparently safe path and reintroduce the escape.
-	if info, statErr := os.Lstat(string(filepath.Separator) + "var"); statErr == nil && info.Mode()&os.ModeSymlink != 0 {
-		if resolved, resolveErr := filepath.EvalSymlinks(string(filepath.Separator) + "var"); resolveErr == nil && resolved == string(filepath.Separator)+"private/var" {
-			clean = string(filepath.Separator) + "private" + clean
-		}
-	}
-	fd, err := unix.Open(string(filepath.Separator), unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC, 0)
+	fd, err := unix.Open("/", unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC, 0)
 	if err != nil {
 		return -1, err
 	}
-	for _, part := range strings.Split(strings.TrimPrefix(clean, string(filepath.Separator)), string(filepath.Separator)) {
+	for _, part := range strings.Split(strings.TrimPrefix(clean, "/"), "/") {
 		if part == "" || part == "." {
 			continue
 		}
@@ -159,3 +151,127 @@ func copyMigrationNode(srcFD, dstParent int, name string, srcMode uint16) error 
 	}
 	return nil
 }
+
+func secureReadFile(path string) ([]byte, error) {
+	file, err := openMigrationSource(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	return io.ReadAll(io.LimitReader(file, maxMigrationBytes+1))
+}
+
+func secureRemovePath(path string) error {
+	parent, err := secureOpenExisting(filepath.Dir(path))
+	if err != nil {
+		return err
+	}
+	defer unix.Close(parent)
+	return removeAt(parent, filepath.Base(path))
+}
+
+func secureOpenExisting(path string) (int, error) {
+	clean, err := migrationAbsolutePath(path)
+	if err != nil {
+		return -1, err
+	}
+	fd, err := unix.Open("/", unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return -1, err
+	}
+	for _, part := range strings.Split(strings.TrimPrefix(clean, "/"), "/") {
+		if part == "" || part == "." {
+			continue
+		}
+		next, openErr := unix.Openat(fd, part, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+		unix.Close(fd)
+		if openErr != nil {
+			return -1, openErr
+		}
+		fd = next
+	}
+	return fd, nil
+}
+
+func removeAt(parent int, name string) error {
+	fd, err := unix.Openat(parent, name, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+	if err == nil {
+		file := os.NewFile(uintptr(fd), name)
+		if file == nil {
+			unix.Close(fd)
+			return fmt.Errorf("invalid directory")
+		}
+		entries, readErr := file.Readdirnames(-1)
+		if readErr == nil {
+			for _, child := range entries {
+				if err := removeAt(fd, child); err != nil {
+					readErr = err
+					break
+				}
+			}
+		}
+		file.Close()
+		if readErr != nil {
+			return readErr
+		}
+		return unix.Unlinkat(parent, name, unix.AT_REMOVEDIR)
+	}
+	if err == unix.ENOTDIR {
+		return unix.Unlinkat(parent, name, 0)
+	}
+	if err == unix.ENOENT {
+		return nil
+	}
+	return err
+}
+
+var migrationTempCounter uint64
+
+func secureWriteJSONAtomic(path string, data []byte) error {
+	parent, err := secureOpenExisting(filepath.Dir(path))
+	if err != nil {
+		return err
+	}
+	defer unix.Close(parent)
+	base := filepath.Base(path)
+	var tmp string
+	var fd int
+	for i := 0; i < 10; i++ {
+		tmp = fmt.Sprintf(".migration-tmp-%d-%d", unix.Getpid(), atomic.AddUint64(&migrationTempCounter, 1))
+		fd, err = unix.Openat(parent, tmp, unix.O_WRONLY|unix.O_CREAT|unix.O_EXCL|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0o600)
+		if err != unix.EEXIST {
+			break
+		}
+	}
+	if err != nil {
+		return err
+	}
+	file := os.NewFile(uintptr(fd), tmp)
+	if file == nil {
+		unix.Close(fd)
+		_ = unix.Unlinkat(parent, tmp, 0)
+		return fmt.Errorf("invalid temporary migration file")
+	}
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = unix.Unlinkat(parent, tmp, 0)
+		}
+	}()
+	if _, err = file.Write(data); err == nil {
+		err = file.Sync()
+	}
+	if closeErr := file.Close(); err == nil {
+		err = closeErr
+	}
+	if err != nil {
+		return err
+	}
+	if err = unix.Renameat(parent, tmp, parent, base); err != nil {
+		return err
+	}
+	cleanup = false
+	return nil
+}
+
+func closeMigrationFD(fd int) error { return unix.Close(fd) }

--- a/internal/config/migrate_copy_windows.go
+++ b/internal/config/migrate_copy_windows.go
@@ -2,67 +2,11 @@
 
 package config
 
-import (
-	"fmt"
-	"io"
-	"os"
-	"path/filepath"
-)
+import "errors"
 
-// Windows lacks the Unix *at APIs used by the hardened implementation. Keep
-// the migration fail-closed for symlinks and exclusive destination creation.
-func secureCopyEntry(src, dst string) error {
-	info, err := os.Lstat(src)
-	if err != nil {
-		return err
-	}
-	if info.Mode()&os.ModeSymlink != 0 {
-		return fmt.Errorf("refusing symlink: %s", src)
-	}
-	if info.IsDir() {
-		if err := os.Mkdir(dst, 0o700); err != nil {
-			return err
-		}
-		entries, err := os.ReadDir(src)
-		if err != nil {
-			return err
-		}
-		for _, entry := range entries {
-			if err := secureCopyEntry(filepath.Join(src, entry.Name()), filepath.Join(dst, entry.Name())); err != nil {
-				return err
-			}
-		}
-		return nil
-	}
-	if !info.Mode().IsRegular() {
-		return fmt.Errorf("refusing non-regular source: %s", src)
-	}
-	file, err := os.Open(src)
-	if err != nil {
-		return err
-	}
-	defer file.Close()
-	data, err := io.ReadAll(io.LimitReader(file, maxMigrationBytes+1))
-	if err != nil {
-		return err
-	}
-	if int64(len(data)) > maxMigrationBytes {
-		return fmt.Errorf("source exceeds migration size limit: %s", src)
-	}
-	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
-	if err != nil {
-		return err
-	}
-	written, writeErr := out.Write(data)
-	closeErr := out.Close()
-	if writeErr != nil {
-		return writeErr
-	}
-	if closeErr != nil {
-		return closeErr
-	}
-	if written != len(data) {
-		return io.ErrShortWrite
-	}
-	return nil
+// Windows does not provide the descriptor-relative no-follow primitives used
+// by the migration boundary. Refuse the operation rather than falling back to
+// a path-based copy with a check/use race.
+func secureCopyEntry(_, _ string) error {
+	return errors.New("legacy path migration is unavailable on Windows: secure descriptor-relative file operations are required")
 }

--- a/internal/config/migrate_copy_windows.go
+++ b/internal/config/migrate_copy_windows.go
@@ -1,0 +1,68 @@
+//go:build windows
+
+package config
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// Windows lacks the Unix *at APIs used by the hardened implementation. Keep
+// the migration fail-closed for symlinks and exclusive destination creation.
+func secureCopyEntry(src, dst string) error {
+	info, err := os.Lstat(src)
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("refusing symlink: %s", src)
+	}
+	if info.IsDir() {
+		if err := os.Mkdir(dst, 0o700); err != nil {
+			return err
+		}
+		entries, err := os.ReadDir(src)
+		if err != nil {
+			return err
+		}
+		for _, entry := range entries {
+			if err := secureCopyEntry(filepath.Join(src, entry.Name()), filepath.Join(dst, entry.Name())); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("refusing non-regular source: %s", src)
+	}
+	file, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	data, err := io.ReadAll(io.LimitReader(file, maxMigrationBytes+1))
+	if err != nil {
+		return err
+	}
+	if int64(len(data)) > maxMigrationBytes {
+		return fmt.Errorf("source exceeds migration size limit: %s", src)
+	}
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return err
+	}
+	written, writeErr := out.Write(data)
+	closeErr := out.Close()
+	if writeErr != nil {
+		return writeErr
+	}
+	if closeErr != nil {
+		return closeErr
+	}
+	if written != len(data) {
+		return io.ErrShortWrite
+	}
+	return nil
+}

--- a/internal/config/migrate_copy_windows.go
+++ b/internal/config/migrate_copy_windows.go
@@ -2,11 +2,15 @@
 
 package config
 
-import "errors"
+import (
+	"errors"
+)
 
-// Windows does not provide the descriptor-relative no-follow primitives used
-// by the migration boundary. Refuse the operation rather than falling back to
-// a path-based copy with a check/use race.
-func secureCopyEntry(_, _ string) error {
-	return errors.New("legacy path migration is unavailable on Windows: secure descriptor-relative file operations are required")
-}
+var errMigrationUnsupported = errors.New("legacy path migration is unavailable on Windows: secure descriptor-relative file operations are required")
+
+func secureCopyEntry(_, _ string) error           { return errMigrationUnsupported }
+func secureReadFile(string) ([]byte, error)       { return nil, errMigrationUnsupported }
+func secureRemovePath(string) error               { return errMigrationUnsupported }
+func secureWriteJSONAtomic(string, []byte) error  { return errMigrationUnsupported }
+func secureMkdirOpen(string, uint32) (int, error) { return -1, errMigrationUnsupported }
+func closeMigrationFD(int) error                  { return nil }

--- a/internal/config/migrate_source_unix.go
+++ b/internal/config/migrate_source_unix.go
@@ -1,0 +1,21 @@
+//go:build !windows
+
+package config
+
+import (
+	"os"
+	"syscall"
+)
+
+func openMigrationSource(path string) (*os.File, error) {
+	fd, err := syscall.Open(path, syscall.O_RDONLY|syscall.O_NOFOLLOW, 0)
+	if err != nil {
+		return nil, &os.PathError{Op: "open", Path: path, Err: err}
+	}
+	file := os.NewFile(uintptr(fd), path)
+	if file == nil {
+		_ = syscall.Close(fd)
+		return nil, &os.PathError{Op: "open", Path: path, Err: syscall.EINVAL}
+	}
+	return file, nil
+}

--- a/internal/config/migrate_source_unix.go
+++ b/internal/config/migrate_source_unix.go
@@ -12,6 +12,10 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+// opOpen is the os.PathError.Op reported for every failure below; each one
+// originates from an open/openat call on the migration source path.
+const opOpen = "open"
+
 // openMigrationSource resolves every component from an opened directory. This
 // deliberately rejects symlinked parents as well as a symlink leaf.
 func openMigrationSource(path string) (*os.File, error) {
@@ -25,7 +29,7 @@ func openMigrationSource(path string) (*os.File, error) {
 	}
 	parts := strings.Split(strings.TrimPrefix(clean, string(filepathSeparator)), string(filepathSeparator))
 	if len(parts) == 0 || parts[len(parts)-1] == "" {
-		unix.Close(fd)
+		_ = unix.Close(fd)
 		return nil, fmt.Errorf("invalid migration source: %s", path)
 	}
 	for _, part := range parts[:len(parts)-1] {
@@ -33,22 +37,22 @@ func openMigrationSource(path string) (*os.File, error) {
 			continue
 		}
 		next, openErr := unix.Openat(fd, part, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
-		unix.Close(fd)
+		_ = unix.Close(fd)
 		if openErr != nil {
-			return nil, &os.PathError{Op: "open", Path: path, Err: openErr}
+			return nil, &os.PathError{Op: opOpen, Path: path, Err: openErr}
 		}
 		fd = next
 	}
 	leaf := parts[len(parts)-1]
 	leafFD, err := unix.Openat(fd, leaf, unix.O_RDONLY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
-	unix.Close(fd)
+	_ = unix.Close(fd)
 	if err != nil {
-		return nil, &os.PathError{Op: "open", Path: path, Err: err}
+		return nil, &os.PathError{Op: opOpen, Path: path, Err: err}
 	}
 	file := os.NewFile(uintptr(leafFD), path)
 	if file == nil {
 		_ = syscall.Close(leafFD)
-		return nil, &os.PathError{Op: "open", Path: path, Err: syscall.EINVAL}
+		return nil, &os.PathError{Op: opOpen, Path: path, Err: syscall.EINVAL}
 	}
 	return file, nil
 }

--- a/internal/config/migrate_source_unix.go
+++ b/internal/config/migrate_source_unix.go
@@ -3,19 +3,71 @@
 package config
 
 import (
+	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 	"syscall"
+
+	"golang.org/x/sys/unix"
 )
 
+// openMigrationSource resolves every component from an opened directory. This
+// deliberately rejects symlinked parents as well as a symlink leaf.
 func openMigrationSource(path string) (*os.File, error) {
-	fd, err := syscall.Open(path, syscall.O_RDONLY|syscall.O_NOFOLLOW, 0)
+	clean, err := migrationAbsolutePath(path)
+	if err != nil {
+		return nil, err
+	}
+	fd, err := unix.Open(string(filepathSeparator), unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return nil, err
+	}
+	parts := strings.Split(strings.TrimPrefix(clean, string(filepathSeparator)), string(filepathSeparator))
+	if len(parts) == 0 || parts[len(parts)-1] == "" {
+		unix.Close(fd)
+		return nil, fmt.Errorf("invalid migration source: %s", path)
+	}
+	for _, part := range parts[:len(parts)-1] {
+		if part == "" || part == "." {
+			continue
+		}
+		next, openErr := unix.Openat(fd, part, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+		unix.Close(fd)
+		if openErr != nil {
+			return nil, &os.PathError{Op: "open", Path: path, Err: openErr}
+		}
+		fd = next
+	}
+	leaf := parts[len(parts)-1]
+	leafFD, err := unix.Openat(fd, leaf, unix.O_RDONLY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+	unix.Close(fd)
 	if err != nil {
 		return nil, &os.PathError{Op: "open", Path: path, Err: err}
 	}
-	file := os.NewFile(uintptr(fd), path)
+	file := os.NewFile(uintptr(leafFD), path)
 	if file == nil {
-		_ = syscall.Close(fd)
+		_ = syscall.Close(leafFD)
 		return nil, &os.PathError{Op: "open", Path: path, Err: syscall.EINVAL}
 	}
 	return file, nil
+}
+
+const filepathSeparator = byte('/')
+
+func migrationAbsolutePath(path string) (string, error) {
+	clean, err := filepath.Abs(filepath.Clean(path))
+	if err != nil {
+		return "", err
+	}
+	// /var is a system-owned macOS alias. Resolve only that known boundary;
+	// user-controlled components remain no-followed below.
+	if strings.HasPrefix(clean, "/var/") {
+		if info, statErr := os.Lstat("/var"); statErr == nil && info.Mode()&os.ModeSymlink != 0 {
+			if resolved, resolveErr := os.Readlink("/var"); resolveErr == nil && resolved == "private/var" {
+				clean = "/private" + clean
+			}
+		}
+	}
+	return clean, nil
 }

--- a/internal/config/migrate_source_windows.go
+++ b/internal/config/migrate_source_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package config
+
+import "os"
+
+func openMigrationSource(path string) (*os.File, error) {
+	return os.Open(path)
+}

--- a/internal/config/migrate_source_windows.go
+++ b/internal/config/migrate_source_windows.go
@@ -4,6 +4,6 @@ package config
 
 import "os"
 
-func openMigrationSource(path string) (*os.File, error) {
-	return os.Open(path)
+func openMigrationSource(string) (*os.File, error) {
+	return nil, errMigrationUnsupported
 }

--- a/internal/config/migrate_test.go
+++ b/internal/config/migrate_test.go
@@ -317,6 +317,28 @@ func TestMigrateLegacyToXDG_InterruptionRecovery(t *testing.T) {
 	assertFileExists(t, filepath.Join(legacy, migrationMarker))
 }
 
+func TestMigrateLegacyToXDG_CollisionPreservesExistingDestination(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "cfg"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(home, "data"))
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(home, "cache"))
+	legacy := filepath.Join(home, LegacyVaultSubdir)
+	writeTestFile(t, filepath.Join(legacy, "config.yaml"), "legacy")
+	destination := filepath.Join(home, "cfg", ConfigSubdir, "config.yaml")
+	writeTestFile(t, destination, "user data")
+
+	if _, err := MigrateLegacyToXDG(); err == nil {
+		t.Fatal("migration accepted an existing destination")
+	}
+	assertFileContent(t, destination, "user data")
+
+	if _, err := MigrateLegacyToXDG(); err == nil {
+		t.Fatal("retry accepted an existing destination")
+	}
+	assertFileContent(t, destination, "user data")
+}
+
 func TestMigrateLegacyToXDG_RejectsSymlinkSource(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/internal/config/migrate_test.go
+++ b/internal/config/migrate_test.go
@@ -337,3 +337,83 @@ func TestMigrateLegacyToXDG_RejectsSymlinkSource(t *testing.T) {
 		t.Fatal("symlink rejection created destination")
 	}
 }
+
+func TestMigrateLegacyToXDG_RecoveryRejectsTamperedDestination(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "cfg"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(home, "data"))
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(home, "cache"))
+	legacy := filepath.Join(home, LegacyVaultSubdir)
+	writeTestFile(t, filepath.Join(legacy, "config.yaml"), "stable")
+	backup := filepath.Join(legacy, migrationBackupDir)
+	if err := os.MkdirAll(backup, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	state := migrationState{Version: 1, BackupDir: backup, Published: []string{filepath.Join(home, "unrelated")}}
+	if err := writeJSONAtomic(filepath.Join(legacy, migrationStateFile), state, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	unrelated := filepath.Join(home, "unrelated")
+	writeTestFile(t, filepath.Join(unrelated, "keep"), "user data")
+	if err := RecoverLegacyToXDGMigration(); err == nil {
+		t.Fatal("tampered recovery state was accepted")
+	}
+	assertFileContent(t, filepath.Join(unrelated, "keep"), "user data")
+}
+
+func TestMigrateLegacyToXDG_RecoveryRejectsSymlinkRoot(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "cfg-link"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(home, "data"))
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(home, "cache"))
+	legacy := filepath.Join(home, LegacyVaultSubdir)
+	writeTestFile(t, filepath.Join(legacy, "config.yaml"), "stable")
+	outside := filepath.Join(home, "outside")
+	if err := os.MkdirAll(outside, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(home, "cfg-link")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := MigrateLegacyToXDG(); err == nil {
+		t.Fatal("symlink XDG root was accepted")
+	}
+	if _, err := os.Stat(filepath.Join(outside, "symaira-vault")); !os.IsNotExist(err) {
+		t.Fatal("symlink target was modified")
+	}
+}
+
+func TestMigrateLegacyToXDG_RecoveryRemovesPartialCopy(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "cfg"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(home, "data"))
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(home, "cache"))
+	legacy := filepath.Join(home, LegacyVaultSubdir)
+	writeTestFile(t, filepath.Join(legacy, "vault", "identity.age"), "identity")
+	interrupted := false
+	MigrationPhaseHook = func(phase string) error {
+		if phase == "published" && !interrupted {
+			interrupted = true
+			dst := filepath.Join(home, "data", DataSubdir, "vault")
+			writeTestFile(t, filepath.Join(dst, "partial"), "partial")
+			return errors.New("injected copy crash")
+		}
+		return nil
+	}
+	t.Cleanup(func() { MigrationPhaseHook = nil })
+	if _, err := MigrateLegacyToXDG(); err == nil {
+		t.Fatal("interrupted migration succeeded")
+	}
+	MigrationPhaseHook = nil
+	migrated, err := MigrateLegacyToXDG()
+	if err != nil || !migrated {
+		t.Fatalf("recovery rerun = %v, %v", migrated, err)
+	}
+	assertFileContent(t, filepath.Join(home, "data", DataSubdir, "vault", "identity.age"), "identity")
+	if _, err := os.Stat(filepath.Join(home, "data", DataSubdir, "vault", "partial")); !os.IsNotExist(err) {
+		t.Fatal("partial copy survived recovery")
+	}
+}

--- a/internal/config/migrate_test.go
+++ b/internal/config/migrate_test.go
@@ -351,7 +351,7 @@ func TestMigrateLegacyToXDG_RecoveryRejectsTamperedDestination(t *testing.T) {
 		t.Fatal(err)
 	}
 	state := migrationState{Version: 1, BackupDir: backup, Published: []string{filepath.Join(home, "unrelated")}}
-	if err := writeJSONAtomic(filepath.Join(legacy, migrationStateFile), state, 0o600); err != nil {
+	if err := writeJSONAtomic(filepath.Join(legacy, migrationStateFile), state); err != nil {
 		t.Fatal(err)
 	}
 	unrelated := filepath.Join(home, "unrelated")

--- a/internal/config/migrate_test.go
+++ b/internal/config/migrate_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -253,5 +254,86 @@ func assertDirExists(t *testing.T, path string) {
 	}
 	if !info.IsDir() {
 		t.Errorf("%s is a file, want a directory", path)
+	}
+}
+
+func TestPreviewLegacyToXDG_IsNonMutatingAndComplete(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "cfg"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(home, "data"))
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(home, "cache"))
+	legacy := filepath.Join(home, LegacyVaultSubdir)
+	writeTestFile(t, filepath.Join(legacy, "config.yaml"), "secret: value")
+	writeTestFile(t, filepath.Join(legacy, "vault", "identity.age"), "identity")
+	before, _ := os.ReadDir(home)
+	plan, err := PreviewLegacyToXDG()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !plan.NeedsMigration || len(plan.Items) != 3 {
+		t.Fatalf("plan = %+v, want migration with 3 items", plan)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".migration-state.json")); !os.IsNotExist(err) {
+		t.Fatal("preview created state")
+	}
+	after, _ := os.ReadDir(home)
+	if len(before) != len(after) {
+		t.Fatal("preview mutated HOME")
+	}
+}
+
+func TestMigrateLegacyToXDG_InterruptionRecovery(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "cfg"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(home, "data"))
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(home, "cache"))
+	legacy := filepath.Join(home, LegacyVaultSubdir)
+	writeTestFile(t, filepath.Join(legacy, "config.yaml"), "stable")
+	calls := 0
+	MigrationPhaseHook = func(phase string) error {
+		if phase == "published" {
+			calls++
+			if calls == 1 {
+				return errors.New("injected interruption")
+			}
+		}
+		return nil
+	}
+	t.Cleanup(func() { MigrationPhaseHook = nil })
+	if _, err := MigrateLegacyToXDG(); err == nil {
+		t.Fatal("interrupted migration succeeded")
+	}
+	if _, err := os.Stat(filepath.Join(legacy, migrationStateFile)); err != nil {
+		t.Fatalf("state marker missing: %v", err)
+	}
+	MigrationPhaseHook = nil
+	migrated, err := MigrateLegacyToXDG()
+	if err != nil || !migrated {
+		t.Fatalf("recovery rerun = %v, %v", migrated, err)
+	}
+	assertFileContent(t, filepath.Join(home, "cfg", "symaira-vault", "config.yaml"), "stable")
+	assertFileExists(t, filepath.Join(legacy, migrationMarker))
+}
+
+func TestMigrateLegacyToXDG_RejectsSymlinkSource(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "cfg"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(home, "data"))
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(home, "cache"))
+	legacy := filepath.Join(home, LegacyVaultSubdir)
+	if err := os.MkdirAll(legacy, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join(home, "outside"), filepath.Join(legacy, "vault")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := MigrateLegacyToXDG(); err == nil {
+		t.Fatal("symlink source was accepted")
+	}
+	if _, err := os.Stat(filepath.Join(home, "data")); !os.IsNotExist(err) {
+		t.Fatal("symlink rejection created destination")
 	}
 }

--- a/internal/config/presets.go
+++ b/internal/config/presets.go
@@ -38,7 +38,7 @@ var TierPresets = map[TierPreset]AgentProfile{
 		ApprovalMode:       StrPtr("prompt"),
 		RequireApproval:    BoolPtr(true),
 		AllowedPaths:       []string{},
-		AllowedExecutables: []string{"curl", "git", "terraform", "npm", "node", "python", "python3", "docker", "kubectl"},
+		AllowedExecutables: []string{"curl", SyncMethodGit, "terraform", "npm", "node", "python", "python3", "docker", "kubectl"},
 	},
 	TierAdmin: {
 		CanWrite:         BoolPtr(true),

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -46,6 +46,14 @@ const (
 	SyncMethodICloudDrive = "icloud-drive"
 )
 
+// Top-level config section names, shared by the dotted-path key list, YAML
+// section-field discovery, and the legacy-to-XDG migration groups.
+const (
+	configSectionVault = "vault"
+	configSectionAudit = "audit"
+	configSectionMCP   = "mcp"
+)
+
 // SyncConfig holds vault replication configuration.
 type SyncConfig struct {
 	// Method selects the replication backend: SyncMethodGit (default) or

--- a/testdata/port/cli/command-tree.json
+++ b/testdata/port/cli/command-tree.json
@@ -6121,6 +6121,89 @@
       ]
     },
     {
+      "path": "symvault migrate paths",
+      "name": "paths",
+      "use": "paths",
+      "short": "Preview the legacy path migration without writing",
+      "long": "Preview the migration from the legacy ~/.symvault layout to the\nXDG config, data, and cache directories. This command never writes,\nmodifies, or removes files.",
+      "example": "  symvault migrate paths\n  symvault migrate xdg",
+      "aliases": [
+        "xdg"
+      ],
+      "hidden": false,
+      "disable_flag_parsing": false,
+      "traverse_children": false,
+      "runnable": true,
+      "has_subcommands": false,
+      "argument_count_probes": [
+        {
+          "count": 0,
+          "accepted": true
+        },
+        {
+          "count": 1,
+          "accepted": false,
+          "error": "unknown command \"arg-1\" for \"symvault migrate paths\""
+        },
+        {
+          "count": 2,
+          "accepted": false,
+          "error": "unknown command \"arg-1\" for \"symvault migrate paths\""
+        },
+        {
+          "count": 3,
+          "accepted": false,
+          "error": "unknown command \"arg-1\" for \"symvault migrate paths\""
+        },
+        {
+          "count": 4,
+          "accepted": false,
+          "error": "unknown command \"arg-1\" for \"symvault migrate paths\""
+        },
+        {
+          "count": 5,
+          "accepted": false,
+          "error": "unknown command \"arg-1\" for \"symvault migrate paths\""
+        },
+        {
+          "count": 6,
+          "accepted": false,
+          "error": "unknown command \"arg-1\" for \"symvault migrate paths\""
+        },
+        {
+          "count": 7,
+          "accepted": false,
+          "error": "unknown command \"arg-1\" for \"symvault migrate paths\""
+        },
+        {
+          "count": 8,
+          "accepted": false,
+          "error": "unknown command \"arg-1\" for \"symvault migrate paths\""
+        },
+        {
+          "count": 9,
+          "accepted": false,
+          "error": "unknown command \"arg-1\" for \"symvault migrate paths\""
+        }
+      ],
+      "local_flags": [
+        {
+          "name": "help",
+          "shorthand": "h",
+          "usage": "help for paths",
+          "type": "bool",
+          "default": "false",
+          "no_opt_default": "true",
+          "hidden": false,
+          "annotations": {
+            "cobra_annotation_flag_set_by_cobra": [
+              "true"
+            ]
+          }
+        }
+      ]
+    },
+    {
       "path": "symvault migrate pseudonymize",
       "name": "pseudonymize",
       "use": "pseudonymize",

--- a/testdata/port/core/policy-contract.json
+++ b/testdata/port/core/policy-contract.json
@@ -9,7 +9,7 @@
       "internal/policy/engine.go",
       "internal/policy/types.go"
     ],
-    "source_digest": "c285d8da0d20535e465fb6922e4ce87dabe581133c642d1a1a66e2dc37f4858b",
+    "source_digest": "4c4fc5ed4a77c719840be193cab38c050372e08525ed35718cc835260601e409",
     "generator_digest": "4f9bfd6d4ab7ee4673d621b7f04ddfcc7ca870d8d2b72f73af873fc0dc3f1f90"
   },
   "validation_cases": [


### PR DESCRIPTION
## Summary
- add a non-mutating legacy-to-XDG migration preview with deterministic item summaries
- create restrictive verified backups and interruption state before publishing destinations
- recover only recorded partial destinations on rerun and reject symlink sources

## Verification
- `go vet ./...`
- `go test ./...`

Source data remains in `~/.symvault` after successful migration. Closes #1037.