### PR TITLE
feat(approval): expose pending queue through local CLI

### DIFF
--- a/cmd/approval.go
+++ b/cmd/approval.go
@@ -151,7 +151,7 @@ func approvalAPIRequest(method, path string, result any) error {
 	if err != nil {
 		return fmt.Errorf("connect to local approval server: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
 		var apiErr struct {
 			Error string `json:"error"`

--- a/cmd/approval.go
+++ b/cmd/approval.go
@@ -1,0 +1,168 @@
+package cmd
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	mcpcmd "github.com/danieljustus/symaira-vault/cmd/mcp"
+	"github.com/danieljustus/symaira-vault/internal/approval"
+	cli "github.com/danieljustus/symaira-vault/internal/cli"
+	errorspkg "github.com/danieljustus/symaira-vault/internal/errors"
+	"github.com/danieljustus/symaira-vault/internal/mcp/serverbootstrap"
+	vaultpkg "github.com/danieljustus/symaira-vault/internal/vault"
+)
+
+type approvalListOutput struct {
+	Requests []approval.Entry `json:"requests"`
+}
+
+type approvalOutcomeOutput struct {
+	Outcome approval.Outcome `json:"outcome"`
+}
+
+func newApprovalCmd() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "approval",
+		Short: "List and decide pending agent approval requests",
+		Long: `Inspect the pending approval queue owned by the running local server.
+
+Decisions are sent to the server over its loopback-only, vault-directory
+ownership-authenticated API. This command does not act as or create an
+approval device and never displays secret values.`,
+		Annotations: map[string]string{cli.JSONOutputAnnotation: "true"},
+		GroupID:     cli.GroupIDAgentsMCP,
+		Example: `  symvault approval list
+  symvault approval list --json
+  symvault approval decide apr-0123456789ab --approve`,
+	}
+	c.AddCommand(newApprovalListCmd(), newApprovalDecideCmd())
+	return c
+}
+
+func newApprovalListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "list",
+		Short:   "List pending approval requests",
+		Example: "  symvault approval list --output json",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var out approvalListOutput
+			if err := approvalAPIRequest(http.MethodGet, approval.PathLocalApprovals, &out); err != nil {
+				return err
+			}
+			if cli.OutputFormat == "json" || cli.OutputFormat == "yaml" {
+				return cli.PrintResult(out)
+			}
+			if len(out.Requests) == 0 {
+				printlnQuietAware("No pending approval requests.")
+				return nil
+			}
+			printQuietAware("%-18s %-20s %-32s %-6s %-10s %s\n", "REQUEST ID", "AGENT", "PATH", "WRITE", "STATUS", "EXPIRES")
+			for _, r := range out.Requests {
+				printQuietAware("%-18s %-20s %-32s %-6t %-10s %s\n", r.ID, r.AgentName, r.Path, r.Write, r.Status, r.ExpiresAt.Format(time.RFC3339))
+			}
+			return nil
+		},
+	}
+}
+
+func newApprovalDecideCmd() *cobra.Command {
+	var approve, deny bool
+	c := &cobra.Command{
+		Use:     "decide <request-id>",
+		Short:   "Approve or deny a pending approval request",
+		Example: "  symvault approval decide apr-0123456789ab --approve",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if approve == deny {
+				return fmt.Errorf("exactly one of --approve or --deny is required")
+			}
+			action := "deny"
+			if approve {
+				action = "approve"
+			}
+			var out approvalOutcomeOutput
+			if err := approvalAPIRequest(http.MethodPost, approval.PathLocalApprovalAction+args[0]+"/"+action, &out); err != nil {
+				return err
+			}
+			if cli.OutputFormat == "json" || cli.OutputFormat == "yaml" {
+				return cli.PrintResult(out)
+			}
+			printQuietAware("Approval request %q %s.\n", out.Outcome.ID, out.Outcome.Status)
+			return nil
+		},
+	}
+	c.Flags().BoolVar(&approve, "approve", false, "Approve the request")
+	c.Flags().BoolVar(&deny, "deny", false, "Deny the request")
+	return c
+}
+
+func approvalAPIRequest(method, path string, result any) error {
+	vaultDir, err := cli.VaultPath()
+	if err != nil {
+		return err
+	}
+	if !vaultpkg.IsInitialized(vaultDir) {
+		return errorspkg.NewVaultNotInitialized()
+	}
+	port, bind, ok := cli.LoadRuntimeServer(vaultDir)
+	if !ok {
+		return fmt.Errorf("could not find the running server — is 'symvault serve' running?")
+	}
+	if bind == "" {
+		bind = "127.0.0.1"
+	}
+	if !mcpcmd.IsLocalhostBind(bind) {
+		return fmt.Errorf("approval CLI requires a server bound to loopback; running server is bound to %q", bind)
+	}
+	certFile, _, err := serverbootstrap.EnsureTLSCert(vaultDir)
+	if err != nil {
+		return fmt.Errorf("load server TLS certificate: %w", err)
+	}
+	pemBytes, err := os.ReadFile(certFile)
+	if err != nil {
+		return fmt.Errorf("read server TLS certificate: %w", err)
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(pemBytes) {
+		return fmt.Errorf("parse server TLS certificate")
+	}
+	secret, err := serverbootstrap.EnsureEnrollSecret(vaultDir)
+	if err != nil {
+		return fmt.Errorf("load vault-ownership proof secret: %w", err)
+	}
+	now := time.Now().UTC()
+	req, err := http.NewRequest(method, fmt.Sprintf("https://%s:%d%s", bind, port, path), nil)
+	if err != nil {
+		return fmt.Errorf("build approval request: %w", err)
+	}
+	req.Header.Set(approval.HeaderEnrollTimestamp, now.Format(time.RFC3339))
+	req.Header.Set(approval.HeaderEnrollProof, approval.EnrollProof(secret, now))
+	client := &http.Client{Timeout: 10 * time.Second, Transport: &http.Transport{TLSClientConfig: &tls.Config{RootCAs: pool, MinVersion: tls.VersionTLS12}}}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("connect to local approval server: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		var apiErr struct {
+			Error string `json:"error"`
+		}
+		_ = json.NewDecoder(resp.Body).Decode(&apiErr)
+		if strings.TrimSpace(apiErr.Error) != "" {
+			return fmt.Errorf("approval server: %s", apiErr.Error)
+		}
+		return fmt.Errorf("approval server returned HTTP %d", resp.StatusCode)
+	}
+	if err := json.NewDecoder(resp.Body).Decode(result); err != nil {
+		return fmt.Errorf("decode approval response: %w", err)
+	}
+	return nil
+}

--- a/cmd/approval.go
+++ b/cmd/approval.go
@@ -5,6 +5,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"strings"
@@ -139,7 +140,7 @@ func approvalAPIRequest(method, path string, result any) error {
 		return fmt.Errorf("load vault-ownership proof secret: %w", err)
 	}
 	now := time.Now().UTC()
-	req, err := http.NewRequest(method, fmt.Sprintf("https://%s:%d%s", bind, port, path), nil)
+	req, err := http.NewRequest(method, fmt.Sprintf("https://%s%s", net.JoinHostPort(bind, fmt.Sprint(port)), path), nil)
 	if err != nil {
 		return fmt.Errorf("build approval request: %w", err)
 	}

--- a/cmd/approval.go
+++ b/cmd/approval.go
@@ -176,9 +176,16 @@ func approvalAPIRequest(method, path string, result any) error {
 func approvalTLSCertFile(vaultDir string) (string, error) {
 	cfg, err := configpkg.Load(filepath.Join(vaultDir, "config.yaml"))
 	if err == nil && cfg != nil && cfg.MCP != nil {
-		if cfg.MCP.MTLSEnabled {
+		if cfg.MCP.MTLSEnabled || cli.RuntimeTLSClientAuthRequired(vaultDir) {
 			return "", fmt.Errorf("approval CLI cannot connect while MCP.mtls_enabled=true because no local approval client certificate is configured; use an enrolled approval device instead")
 		}
+	}
+	// The running server publishes its effective certificate because --tls-cert
+	// and --tls-key are process-local overrides and need not be in config.yaml.
+	if cert, ok := cli.LoadRuntimeTLSCert(vaultDir); ok {
+		return cert, nil
+	}
+	if cfg != nil && cfg.MCP != nil {
 		cert := strings.TrimSpace(cfg.MCP.TLSCertFile)
 		key := strings.TrimSpace(cfg.MCP.TLSKeyFile)
 		if cert != "" && key != "" {

--- a/cmd/approval.go
+++ b/cmd/approval.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -16,6 +17,7 @@ import (
 	mcpcmd "github.com/danieljustus/symaira-vault/cmd/mcp"
 	"github.com/danieljustus/symaira-vault/internal/approval"
 	cli "github.com/danieljustus/symaira-vault/internal/cli"
+	configpkg "github.com/danieljustus/symaira-vault/internal/config"
 	errorspkg "github.com/danieljustus/symaira-vault/internal/errors"
 	"github.com/danieljustus/symaira-vault/internal/mcp/serverbootstrap"
 	vaultpkg "github.com/danieljustus/symaira-vault/internal/vault"
@@ -123,7 +125,7 @@ func approvalAPIRequest(method, path string, result any) error {
 	if !mcpcmd.IsLocalhostBind(bind) {
 		return fmt.Errorf("approval CLI requires a server bound to loopback; running server is bound to %q", bind)
 	}
-	certFile, _, err := serverbootstrap.EnsureTLSCert(vaultDir)
+	certFile, err := approvalTLSCertFile(vaultDir)
 	if err != nil {
 		return fmt.Errorf("load server TLS certificate: %w", err)
 	}
@@ -166,4 +168,23 @@ func approvalAPIRequest(method, path string, result any) error {
 		return fmt.Errorf("decode approval response: %w", err)
 	}
 	return nil
+}
+
+// approvalTLSCertFile returns the certificate used by the running HTTP server.
+// Configured certificate/key pairs take precedence over the vault-generated
+// pair, matching serverbootstrap's effective TLS configuration.
+func approvalTLSCertFile(vaultDir string) (string, error) {
+	cfg, err := configpkg.Load(filepath.Join(vaultDir, "config.yaml"))
+	if err == nil && cfg != nil && cfg.MCP != nil {
+		cert := strings.TrimSpace(cfg.MCP.TLSCertFile)
+		key := strings.TrimSpace(cfg.MCP.TLSKeyFile)
+		if cert != "" && key != "" {
+			return cert, nil
+		}
+	}
+	cert, _, ensureErr := serverbootstrap.EnsureTLSCert(vaultDir)
+	if ensureErr != nil {
+		return "", ensureErr
+	}
+	return cert, nil
 }

--- a/cmd/approval.go
+++ b/cmd/approval.go
@@ -174,16 +174,19 @@ func approvalAPIRequest(method, path string, result any) error {
 // Configured certificate/key pairs take precedence over the vault-generated
 // pair, matching serverbootstrap's effective TLS configuration.
 func approvalTLSCertFile(vaultDir string) (string, error) {
-	cfg, err := configpkg.Load(filepath.Join(vaultDir, "config.yaml"))
-	if err == nil && cfg != nil && cfg.MCP != nil {
-		if cfg.MCP.MTLSEnabled || cli.RuntimeTLSClientAuthRequired(vaultDir) {
-			return "", fmt.Errorf("approval CLI cannot connect while MCP.mtls_enabled=true because no local approval client certificate is configured; use an enrolled approval device instead")
-		}
-	}
-	// The running server publishes its effective certificate because --tls-cert
-	// and --tls-key are process-local overrides and need not be in config.yaml.
+	// The running server publishes its effective TLS settings. Treat this
+	// process-local record as authoritative: config.yaml may describe a later
+	// or earlier server configuration, while the CLI must match the listener it
+	// is actually contacting.
 	if cert, ok := cli.LoadRuntimeTLSCert(vaultDir); ok {
+		if cli.RuntimeTLSClientAuthRequired(vaultDir) {
+			return "", fmt.Errorf("approval CLI cannot connect while the running MCP server requires mTLS because no local approval client certificate is configured; use an enrolled approval device instead")
+		}
 		return cert, nil
+	}
+	cfg, err := configpkg.Load(filepath.Join(vaultDir, "config.yaml"))
+	if err == nil && cfg != nil && cfg.MCP != nil && cfg.MCP.MTLSEnabled {
+		return "", fmt.Errorf("approval CLI cannot connect while MCP.mtls_enabled=true because no local approval client certificate is configured; use an enrolled approval device instead")
 	}
 	if cfg != nil && cfg.MCP != nil {
 		cert := strings.TrimSpace(cfg.MCP.TLSCertFile)

--- a/cmd/approval.go
+++ b/cmd/approval.go
@@ -176,6 +176,9 @@ func approvalAPIRequest(method, path string, result any) error {
 func approvalTLSCertFile(vaultDir string) (string, error) {
 	cfg, err := configpkg.Load(filepath.Join(vaultDir, "config.yaml"))
 	if err == nil && cfg != nil && cfg.MCP != nil {
+		if cfg.MCP.MTLSEnabled {
+			return "", fmt.Errorf("approval CLI cannot connect while MCP.mtls_enabled=true because no local approval client certificate is configured; use an enrolled approval device instead")
+		}
 		cert := strings.TrimSpace(cfg.MCP.TLSCertFile)
 		key := strings.TrimSpace(cfg.MCP.TLSKeyFile)
 		if cert != "" && key != "" {

--- a/cmd/approval.go
+++ b/cmd/approval.go
@@ -129,7 +129,7 @@ func approvalAPIRequest(method, path string, result any) error {
 	if err != nil {
 		return fmt.Errorf("load server TLS certificate: %w", err)
 	}
-	pemBytes, err := os.ReadFile(certFile)
+	pemBytes, err := os.ReadFile(certFile) // #nosec G304 -- serverbootstrap reads the same configured certificate; bytes are parsed locally and never emitted.
 	if err != nil {
 		return fmt.Errorf("read server TLS certificate: %w", err)
 	}

--- a/cmd/approval_test.go
+++ b/cmd/approval_test.go
@@ -25,3 +25,20 @@ func TestApprovalTLSCertFileUsesConfiguredCertificate(t *testing.T) {
 		t.Fatalf("generated certificate exists despite configured certificate: %v", err)
 	}
 }
+
+func TestApprovalTLSCertFileRejectsMTLSWithoutLocalClientIdentity(t *testing.T) {
+	dir := t.TempDir()
+	config := "mcp:\n  mtls_enabled: true\n"
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(config), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := approvalTLSCertFile(dir)
+	if err == nil {
+		t.Fatal("approvalTLSCertFile() error = nil, want mTLS configuration error")
+	}
+	const want = "approval CLI cannot connect while MCP.mtls_enabled=true because no local approval client certificate is configured; use an enrolled approval device instead"
+	if got := err.Error(); got != want {
+		t.Fatalf("approvalTLSCertFile() error = %q, want %q", got, want)
+	}
+}

--- a/cmd/approval_test.go
+++ b/cmd/approval_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	cli "github.com/danieljustus/symaira-vault/internal/cli"
 )
 
 func TestApprovalTLSCertFileUsesConfiguredCertificate(t *testing.T) {
@@ -40,5 +42,23 @@ func TestApprovalTLSCertFileRejectsMTLSWithoutLocalClientIdentity(t *testing.T) 
 	const want = "approval CLI cannot connect while MCP.mtls_enabled=true because no local approval client certificate is configured; use an enrolled approval device instead"
 	if got := err.Error(); got != want {
 		t.Fatalf("approvalTLSCertFile() error = %q, want %q", got, want)
+	}
+}
+
+func TestApprovalTLSCertFileUsesRunningServerOverride(t *testing.T) {
+	dir := t.TempDir()
+	customCert := filepath.Join(t.TempDir(), "flag-server.crt")
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte("mcp:\n  tls_cert_file: config.crt\n  tls_key_file: config.key\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := cli.SaveRuntimeTLSCert(dir, customCert); err != nil {
+		t.Fatal(err)
+	}
+	got, err := approvalTLSCertFile(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != customCert {
+		t.Fatalf("approvalTLSCertFile() = %q, want runtime override %q", got, customCert)
 	}
 }

--- a/cmd/approval_test.go
+++ b/cmd/approval_test.go
@@ -1,0 +1,27 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestApprovalTLSCertFileUsesConfiguredCertificate(t *testing.T) {
+	dir := t.TempDir()
+	customCert := filepath.Join(dir, "custom-server.crt")
+	customKey := filepath.Join(dir, "custom-server.key")
+	config := "mcp:\n  tls_cert_file: " + customCert + "\n  tls_key_file: " + customKey + "\n"
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(config), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := approvalTLSCertFile(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != customCert {
+		t.Fatalf("approvalTLSCertFile() = %q, want configured certificate %q", got, customCert)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "mcp-server.crt")); !os.IsNotExist(err) {
+		t.Fatalf("generated certificate exists despite configured certificate: %v", err)
+	}
+}

--- a/cmd/approval_test.go
+++ b/cmd/approval_test.go
@@ -45,6 +45,24 @@ func TestApprovalTLSCertFileRejectsMTLSWithoutLocalClientIdentity(t *testing.T) 
 	}
 }
 
+func TestApprovalTLSCertFilePrefersRunningMTLSState(t *testing.T) {
+	dir := t.TempDir()
+	customCert := filepath.Join(t.TempDir(), "running-server.crt")
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte("mcp:\n  mtls_enabled: true\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := cli.SaveRuntimeTLSCert(dir, customCert, false); err != nil {
+		t.Fatal(err)
+	}
+	got, err := approvalTLSCertFile(dir)
+	if err != nil {
+		t.Fatalf("approvalTLSCertFile() error = %v, want runtime state to win", err)
+	}
+	if got != customCert {
+		t.Fatalf("approvalTLSCertFile() = %q, want runtime certificate %q", got, customCert)
+	}
+}
+
 func TestApprovalTLSCertFileUsesRunningServerOverride(t *testing.T) {
 	dir := t.TempDir()
 	customCert := filepath.Join(t.TempDir(), "flag-server.crt")

--- a/cmd/mcp/serve_deps.go
+++ b/cmd/mcp/serve_deps.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"syscall"
@@ -207,6 +208,26 @@ func runServe(cmd *cobra.Command, args []string) error {
 			vault.Config.MCP.MTLSEnabled = true
 		}
 	}
+	// Publish the effective custom certificate for local approval CLI clients.
+	// CLI flag overrides live only in this process and are not persisted to
+	// config.yaml; the private runtime record is the discovery contract.
+	_ = cli.ClearRuntimeTLSCert(vaultDir)
+	if !stdioFlag && vault != nil && vault.Config != nil && vault.Config.MCP != nil {
+		effectiveCert := strings.TrimSpace(vault.Config.MCP.TLSCertFile)
+		effectiveKey := strings.TrimSpace(vault.Config.MCP.TLSKeyFile)
+		if effectiveCert != "" && effectiveKey != "" {
+			// Resolve relative paths while the server's process working directory
+			// is still in effect; the CLI may run from a different directory.
+			runtimeCert, absErr := filepath.Abs(effectiveCert)
+			if absErr != nil {
+				runtimeCert = effectiveCert
+			}
+			if saveErr := cli.SaveRuntimeTLSCert(vaultDir, runtimeCert, vault.Config.MCP.MTLSEnabled); saveErr != nil {
+				cliout.Warnf("Warning: could not save runtime TLS certificate: %v", saveErr)
+			}
+		}
+	}
+
 	if !stdioFlag && vault != nil && vault.Config != nil && vault.Config.MCP != nil && vault.Config.MCP.AllowInsecureBind {
 		cliout.Warnf("MCP.allow_insecure_bind is enabled. Bearer tokens will travel in cleartext and are vulnerable to loopback sniffing by local processes.")
 		confirmed, confirmErr := confirmServeInsecure()
@@ -283,6 +304,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 		wg.Wait()
 		if vDir, err := cli.VaultPath(); err == nil {
 			_ = cli.ClearRuntimePort(vDir)
+			_ = cli.ClearRuntimeTLSCert(vDir)
 		}
 		return nil
 	}

--- a/cmd/mcp/serve_deps.go
+++ b/cmd/mcp/serve_deps.go
@@ -81,6 +81,7 @@ func RunHTTPServerWithApproval(ctx context.Context, bind string, port int, vault
 
 	return serverbootstrap.RunHTTPServer(ctx, bind, port, vault, vaultDir, Version, newServerWithApproval,
 		serverbootstrap.WithApprovalAPI(approvalHandler),
+		serverbootstrap.WithLocalApprovalAPI(approval.NewLocalHTTPHandler(ApprovalQueue, enrollSecret, mcputil.IsLoopbackHost)),
 		serverbootstrap.WithDeviceEnrollAPI(enrollHandler),
 		serverbootstrap.WithDeviceEnrollCodeAPI(enrollCodeHandler))
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -42,6 +42,7 @@ func NewRootCmd() *cobra.Command {
 
 	// Add top-level commands in cmd/
 	root.AddCommand(
+		newApprovalCmd(),
 		newBrokerCmd(),
 		newDeviceCmd(),
 		newDynamicCmd(),

--- a/docs/approval-cli.md
+++ b/docs/approval-cli.md
@@ -23,3 +23,10 @@ ID, resulting status, decision timestamp, and server-side attribution. No
 secret values are returned. The CLI endpoint is reachable only over a
 loopback connection and requires proof of ownership of the local vault
 directory. The server remains authoritative for queue state and decisions.
+
+## mTLS
+
+The local CLI deliberately does not weaken MCP mTLS. If
+`MCP.mtls_enabled=true`, it stops before connecting because no local approval
+client-certificate contract exists yet. Use an enrolled approval device for
+that configuration; secure local client identity support is tracked in #1041.

--- a/docs/approval-cli.md
+++ b/docs/approval-cli.md
@@ -1,0 +1,25 @@
+# Pending approval CLI
+
+The `symvault approval` commands operate on the queue owned by the running
+local MCP server. They do not read a queue file and do not create or emulate
+an enrolled approval device.
+
+```sh
+symvault approval list
+symvault approval list --output json
+symvault approval decide <request-id> --approve
+symvault approval decide <request-id> --deny
+```
+
+`--json` is equivalent to `--output json`. JSON list responses have this
+stable shape:
+
+```json
+{"requests":[{"id":"apr-...","agent_name":"agent","path":"work/file","write":true,"reason":"agent write requires approval","created_at":"...","expires_at":"...","status":"pending"}]}
+```
+
+Decision responses have the shape `{"outcome":{...}}` and include the request
+ID, resulting status, decision timestamp, and server-side attribution. No
+secret values are returned. The CLI endpoint is reachable only over a
+loopback connection and requires proof of ownership of the local vault
+directory. The server remains authoritative for queue state and decisions.

--- a/internal/approval/local.go
+++ b/internal/approval/local.go
@@ -1,0 +1,79 @@
+package approval
+
+import (
+	"errors"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// Local API paths are authenticated with the vault-directory ownership proof
+// and are accepted only from a loopback connection. They are deliberately
+// separate from the enrolled-device API: the CLI is not a trusted device.
+const (
+	PathLocalApprovals      = "/api/v1/local/approvals"
+	PathLocalApprovalAction = "/api/v1/local/approvals/"
+)
+
+// LocalHTTPHandler exposes the live queue to the local CLI without duplicating
+// queue state in the CLI process.
+type LocalHTTPHandler struct {
+	queue      *Queue
+	secret     []byte
+	isLoopback func(string) bool
+}
+
+// NewLocalHTTPHandler creates a loopback-only, vault-proof-authenticated API.
+func NewLocalHTTPHandler(queue *Queue, secret []byte, isLoopback func(string) bool) *LocalHTTPHandler {
+	return &LocalHTTPHandler{queue: queue, secret: secret, isLoopback: isLoopback}
+}
+
+func (h *LocalHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		host = r.RemoteAddr
+	}
+	if h.isLoopback == nil || !h.isLoopback(host) {
+		writeApprovalError(w, http.StatusForbidden, "local approval API requires a loopback connection")
+		return
+	}
+	if !verifyEnrollProof(h.secret, r.Header.Get(HeaderEnrollTimestamp), r.Header.Get(HeaderEnrollProof), time.Now()) {
+		writeApprovalError(w, http.StatusUnauthorized, "missing or invalid proof of vault-directory ownership")
+		return
+	}
+
+	switch {
+	case r.Method == http.MethodGet && r.URL.Path == PathLocalApprovals:
+		writeApprovalJSON(w, http.StatusOK, map[string]any{"requests": h.queue.Pending()})
+	case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, PathLocalApprovalAction):
+		h.decide(w, r)
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+func (h *LocalHTTPHandler) decide(w http.ResponseWriter, r *http.Request) {
+	id := strings.TrimPrefix(r.URL.Path, PathLocalApprovalAction)
+	id = strings.TrimSuffix(id, "/")
+	var out Outcome
+	var err error
+	switch {
+	case strings.HasSuffix(id, "/approve"):
+		out, err = h.queue.Approve(strings.TrimSuffix(id, "/approve"), "local-cli")
+	case strings.HasSuffix(id, "/deny"):
+		out, err = h.queue.Deny(strings.TrimSuffix(id, "/deny"), "local-cli")
+	default:
+		writeApprovalError(w, http.StatusNotFound, "unknown approval action")
+		return
+	}
+	if err != nil {
+		status := http.StatusConflict
+		if errors.Is(err, ErrNotFound) {
+			status = http.StatusNotFound
+		}
+		writeApprovalError(w, status, err.Error())
+		return
+	}
+	writeApprovalJSON(w, http.StatusOK, map[string]any{"outcome": out})
+}

--- a/internal/approval/local_test.go
+++ b/internal/approval/local_test.go
@@ -74,3 +74,72 @@ func TestLocalHTTPHandlerRejectsRemoteAndBadProof(t *testing.T) {
 		})
 	}
 }
+
+func TestLocalHTTPHandlerDenyAndErrorStatuses(t *testing.T) {
+	q := NewQueue()
+	id, err := q.Enqueue(Request{AgentName: "agent", Path: "read/file"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	h := NewLocalHTTPHandler(q, []byte("test-secret"), func(host string) bool { return host == "127.0.0.1" })
+	request := func(method, path string) *httptest.ResponseRecorder {
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(method, path, nil)
+		req.RemoteAddr = "127.0.0.1:1234"
+		now := time.Now().UTC()
+		req.Header.Set(HeaderEnrollTimestamp, now.Format(time.RFC3339))
+		req.Header.Set(HeaderEnrollProof, EnrollProof([]byte("test-secret"), now))
+		h.ServeHTTP(rr, req)
+		return rr
+	}
+	if rr := request(http.MethodPost, PathLocalApprovalAction+id+"/deny"); rr.Code != http.StatusOK || !strings.Contains(rr.Body.String(), `"denied"`) {
+		t.Fatalf("deny response = %d %s", rr.Code, rr.Body.String())
+	}
+	for _, tc := range []struct {
+		name, method, path string
+		want               int
+	}{
+		{"invalid id", http.MethodPost, PathLocalApprovalAction + "not-an-id/approve", http.StatusNotFound},
+		{"unknown action", http.MethodPost, PathLocalApprovalAction + id + "/later", http.StatusNotFound},
+		{"wrong method", http.MethodPut, PathLocalApprovals, http.StatusNotFound},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if rr := request(tc.method, tc.path); rr.Code != tc.want {
+				t.Fatalf("status = %d, want %d (%s)", rr.Code, tc.want, rr.Body.String())
+			}
+		})
+	}
+}
+
+func TestLocalHTTPHandlerEmptyQueueAndExpiry(t *testing.T) {
+	q := NewQueueWithTTL(5 * time.Millisecond)
+	h := NewLocalHTTPHandler(q, []byte("test-secret"), func(host string) bool { return host == "127.0.0.1" })
+	id, err := q.Enqueue(Request{AgentName: "agent", Path: "read/file"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(15 * time.Millisecond)
+	now := time.Now().UTC()
+	req := httptest.NewRequest(http.MethodGet, PathLocalApprovals, nil)
+	req.RemoteAddr = "127.0.0.1:1234"
+	req.Header.Set(HeaderEnrollTimestamp, now.Format(time.RFC3339))
+	req.Header.Set(HeaderEnrollProof, EnrollProof([]byte("test-secret"), now))
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK || strings.TrimSpace(rr.Body.String()) != `{"requests":[]}` {
+		t.Fatalf("expired list response = %d %s", rr.Code, rr.Body.String())
+	}
+
+	q2 := NewQueue()
+	h2 := NewLocalHTTPHandler(q2, []byte("test-secret"), func(host string) bool { return host == "127.0.0.1" })
+	now = time.Now().UTC()
+	req = httptest.NewRequest(http.MethodPost, PathLocalApprovalAction+id+"/approve", nil)
+	req.RemoteAddr = "127.0.0.1:1234"
+	req.Header.Set(HeaderEnrollTimestamp, now.Format(time.RFC3339))
+	req.Header.Set(HeaderEnrollProof, EnrollProof([]byte("test-secret"), now))
+	rr = httptest.NewRecorder()
+	h2.ServeHTTP(rr, req)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("unknown queue id status = %d, want %d", rr.Code, http.StatusNotFound)
+	}
+}

--- a/internal/approval/local_test.go
+++ b/internal/approval/local_test.go
@@ -1,0 +1,76 @@
+package approval
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestLocalHTTPHandlerListAndDecide(t *testing.T) {
+	q := NewQueue()
+	id, err := q.Enqueue(Request{AgentName: "agent", Path: "work/file", Write: true, Reason: "write"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	h := NewLocalHTTPHandler(q, []byte("test-secret"), func(host string) bool { return host == "127.0.0.1" })
+
+	list := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, PathLocalApprovals, nil)
+	req.RemoteAddr = "127.0.0.1:1234"
+	now := time.Now().UTC()
+	req.Header.Set(HeaderEnrollTimestamp, now.Format(time.RFC3339))
+	req.Header.Set(HeaderEnrollProof, EnrollProof([]byte("test-secret"), now))
+	h.ServeHTTP(list, req)
+	if list.Code != http.StatusOK || !strings.Contains(list.Body.String(), id) || strings.Contains(list.Body.String(), "test-secret") {
+		t.Fatalf("list response = %d %s", list.Code, list.Body.String())
+	}
+
+	decide := httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodPost, PathLocalApprovalAction+id+"/approve", nil)
+	req.RemoteAddr = "127.0.0.1:1234"
+	now = time.Now().UTC()
+	req.Header.Set(HeaderEnrollTimestamp, now.Format(time.RFC3339))
+	req.Header.Set(HeaderEnrollProof, EnrollProof([]byte("test-secret"), now))
+	h.ServeHTTP(decide, req)
+	if decide.Code != http.StatusOK || !strings.Contains(decide.Body.String(), `"approved"`) {
+		t.Fatalf("decide response = %d %s", decide.Code, decide.Body.String())
+	}
+	if _, err := q.Approve(id, "second"); err == nil {
+		t.Fatal("repeated decision unexpectedly succeeded")
+	}
+}
+
+func TestLocalHTTPHandlerRejectsRemoteAndBadProof(t *testing.T) {
+	q := NewQueue()
+	_, _ = q.Enqueue(Request{AgentName: "agent", Path: "work/file"})
+	h := NewLocalHTTPHandler(q, []byte("test-secret"), func(host string) bool { return host == "127.0.0.1" })
+	for _, tc := range []struct {
+		name   string
+		remote string
+		proof  bool
+		want   int
+	}{
+		{name: "remote", remote: "192.0.2.1:1", proof: true, want: http.StatusForbidden},
+		{name: "bad proof", remote: "127.0.0.1:1", proof: false, want: http.StatusUnauthorized},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, PathLocalApprovals, nil)
+			req.RemoteAddr = tc.remote
+			if tc.proof {
+				now := time.Now().UTC()
+				req.Header.Set(HeaderEnrollTimestamp, now.Format(time.RFC3339))
+				req.Header.Set(HeaderEnrollProof, EnrollProof([]byte("test-secret"), now))
+			} else {
+				req.Header.Set(HeaderEnrollTimestamp, time.Now().UTC().Format(time.RFC3339))
+				req.Header.Set(HeaderEnrollProof, "invalid")
+			}
+			h.ServeHTTP(rr, req)
+			if rr.Code != tc.want {
+				t.Fatalf("status = %d, want %d", rr.Code, tc.want)
+			}
+		})
+	}
+}

--- a/internal/approval/queue.go
+++ b/internal/approval/queue.go
@@ -72,10 +72,15 @@ const DefaultTTL = 5 * time.Minute
 type Queue struct {
 	mu       sync.Mutex
 	entries  map[string]*Entry
-	waiters  map[string][]chan Outcome
+	waiters  map[string][]chan waitResult
 	ttl      time.Duration
 	closed   bool
 	notifier chan struct{}
+}
+
+type waitResult struct {
+	outcome Outcome
+	err     error
 }
 
 // NewQueue creates a queue with the default TTL.
@@ -88,7 +93,7 @@ func NewQueueWithTTL(ttl time.Duration) *Queue {
 	}
 	return &Queue{
 		entries:  map[string]*Entry{},
-		waiters:  map[string][]chan Outcome{},
+		waiters:  map[string][]chan waitResult{},
 		ttl:      ttl,
 		notifier: make(chan struct{}, 1),
 	}
@@ -191,7 +196,7 @@ func (q *Queue) decide(id string, status Status, decidedBy string) (Outcome, err
 	e.DecidedAt = now
 	e.DecidedBy = decidedBy
 	out := Outcome{ID: id, Status: status, DecidedAt: now, DecidedBy: decidedBy}
-	q.wakeLocked(id, out)
+	q.wakeLocked(id, waitResult{outcome: out})
 	q.poke()
 	return out, nil
 }
@@ -201,7 +206,7 @@ func (q *Queue) decide(id string, status Status, decidedBy string) (Outcome, err
 // Wait self-enforces Entry.ExpiresAt with its own timer so waiters unblock
 // without external polling.
 func (q *Queue) Wait(ctx context.Context, id string) (Outcome, error) {
-	ch := make(chan Outcome, 1)
+	ch := make(chan waitResult, 1)
 	q.mu.Lock()
 	if q.closed {
 		q.mu.Unlock()
@@ -233,15 +238,15 @@ func (q *Queue) Wait(ctx context.Context, id string) (Outcome, error) {
 			e.Status = StatusExpired
 			e.DecidedAt = e.ExpiresAt
 			out := Outcome{ID: id, Status: StatusExpired, DecidedAt: e.ExpiresAt}
-			q.wakeLocked(id, out)
+			q.wakeLocked(id, waitResult{outcome: out})
 			q.poke()
 		}
 	})
 
 	select {
-	case out := <-ch:
+	case result := <-ch:
 		expiryTimer.Stop()
-		return out, nil
+		return result.outcome, result.err
 	case <-ctx.Done():
 		q.mu.Lock()
 		q.removeWaiterLocked(id, ch)
@@ -301,7 +306,7 @@ func (q *Queue) reapLocked() int {
 			e.Status = StatusExpired
 			e.DecidedAt = e.ExpiresAt
 			out := Outcome{ID: id, Status: StatusExpired, DecidedAt: e.ExpiresAt}
-			q.wakeLocked(id, out)
+			q.wakeLocked(id, waitResult{outcome: out})
 			expired++
 		} else if e.Status == StatusExpired {
 			expired++
@@ -326,7 +331,7 @@ func (q *Queue) Close() {
 		if e.Status == StatusPending {
 			e.Status = StatusExpired
 			e.DecidedAt = time.Now().UTC()
-			q.wakeLocked(id, Outcome{ID: id, Status: StatusExpired, DecidedAt: e.DecidedAt})
+			q.wakeLocked(id, waitResult{outcome: Outcome{ID: id, Status: StatusExpired, DecidedAt: e.DecidedAt}, err: ErrClosed})
 		}
 	}
 	q.poke()
@@ -337,17 +342,17 @@ func (q *Queue) Close() {
 // updates to approval devices.
 func (q *Queue) Notify() <-chan struct{} { return q.notifier }
 
-func (q *Queue) wakeLocked(id string, out Outcome) {
+func (q *Queue) wakeLocked(id string, result waitResult) {
 	for _, ch := range q.waiters[id] {
 		select {
-		case ch <- out:
+		case ch <- result:
 		default:
 		}
 	}
 	q.waiters[id] = nil
 }
 
-func (q *Queue) removeWaiterLocked(id string, ch chan Outcome) {
+func (q *Queue) removeWaiterLocked(id string, ch chan waitResult) {
 	ws := q.waiters[id]
 	for i, w := range ws {
 		if w == ch {

--- a/internal/approval/queue.go
+++ b/internal/approval/queue.go
@@ -28,29 +28,29 @@ const (
 
 // Request describes one pending approval.
 type Request struct {
-	AgentName string
-	Path      string
-	Write     bool
-	Reason    string
-	CreatedAt time.Time
-	ExpiresAt time.Time
+	AgentName string    `json:"agent_name"`
+	Path      string    `json:"path"`
+	Write     bool      `json:"write"`
+	Reason    string    `json:"reason"`
+	CreatedAt time.Time `json:"created_at"`
+	ExpiresAt time.Time `json:"expires_at"`
 }
 
 // Entry is a request plus its current state.
 type Entry struct {
 	Request
-	ID        string
-	Status    Status
-	DecidedAt time.Time
-	DecidedBy string
+	ID        string    `json:"id"`
+	Status    Status    `json:"status"`
+	DecidedAt time.Time `json:"decided_at,omitempty"`
+	DecidedBy string    `json:"decided_by,omitempty"`
 }
 
 // Outcome is the result of waiting on a request.
 type Outcome struct {
-	ID        string
-	Status    Status
-	DecidedAt time.Time
-	DecidedBy string
+	ID        string    `json:"id"`
+	Status    Status    `json:"status"`
+	DecidedAt time.Time `json:"decided_at,omitempty"`
+	DecidedBy string    `json:"decided_by,omitempty"`
 }
 
 // ErrNotFound is returned when no request with the id exists.

--- a/internal/approval/queue_test.go
+++ b/internal/approval/queue_test.go
@@ -196,6 +196,29 @@ func TestNotifyOnChange(t *testing.T) {
 	}
 }
 
+func TestCloseWakesWaiterWithErrClosed(t *testing.T) {
+	q := NewQueue()
+	id, err := q.Enqueue(Request{AgentName: "a", Path: "p", Write: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan error, 1)
+	go func() {
+		_, waitErr := q.Wait(context.Background(), id)
+		done <- waitErr
+	}()
+	time.Sleep(10 * time.Millisecond)
+	q.Close()
+	select {
+	case waitErr := <-done:
+		if !errors.Is(waitErr, ErrClosed) {
+			t.Fatalf("Wait error = %v, want ErrClosed", waitErr)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("closed waiter was not woken")
+	}
+}
+
 func TestCloseExpiresPending(t *testing.T) {
 	q := NewQueue()
 	id, _ := q.Enqueue(Request{AgentName: "a", Path: "p", Write: true})

--- a/internal/cli/port_utils.go
+++ b/internal/cli/port_utils.go
@@ -116,7 +116,7 @@ func SaveRuntimeTLSCert(vaultDir, certFile string, clientAuthRequired ...bool) e
 func LoadRuntimeTLSCert(vaultDir string) (string, bool) {
 	cleanDir := filepath.Clean(vaultDir)
 	path := filepath.Join(cleanDir, RuntimeTLSFileName)
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(path) // #nosec G304 -- fixed runtime metadata filename below the selected vault directory; the record holds no key material.
 	if err != nil {
 		return "", false
 	}
@@ -134,7 +134,7 @@ func LoadRuntimeTLSCert(vaultDir string) (string, bool) {
 // a client certificate for its TLS connection.
 func RuntimeTLSClientAuthRequired(vaultDir string) bool {
 	cleanDir := filepath.Clean(vaultDir)
-	data, err := os.ReadFile(filepath.Join(cleanDir, RuntimeTLSFileName))
+	data, err := os.ReadFile(filepath.Join(cleanDir, RuntimeTLSFileName)) // #nosec G304 -- fixed runtime metadata filename below the selected vault directory; the record holds no key material.
 	if err != nil {
 		return false
 	}

--- a/internal/cli/port_utils.go
+++ b/internal/cli/port_utils.go
@@ -10,7 +10,10 @@ import (
 	"strings"
 )
 
-const RuntimePortFileName = ".runtime-port"
+const (
+	RuntimePortFileName = ".runtime-port"
+	RuntimeTLSFileName  = ".runtime-tls-cert"
+)
 
 // runtimePortFile is the on-disk shape written by SaveRuntimePort. Bind is
 // omitted by callers that don't have a bind address to record.
@@ -83,6 +86,72 @@ func LoadRuntimeServer(vaultDir string) (port int, bind string, ok bool) {
 		return 0, "", false
 	}
 	return p, "", true
+}
+
+// SaveRuntimeTLSCert records the certificate path used by the running HTTP
+// server. It is intentionally separate from the port file: the server may use
+// a command-line certificate override that is not persisted in config.yaml.
+// The file is private to the vault directory and contains no key material.
+func SaveRuntimeTLSCert(vaultDir, certFile string, clientAuthRequired ...bool) error {
+	cleanDir := filepath.Clean(vaultDir)
+	path := filepath.Join(cleanDir, RuntimeTLSFileName)
+	if !strings.HasPrefix(filepath.Clean(path), cleanDir+string(filepath.Separator)) {
+		return fmt.Errorf("invalid TLS certificate file path: outside vault directory")
+	}
+	if strings.TrimSpace(certFile) == "" {
+		return fmt.Errorf("TLS certificate file path must not be empty")
+	}
+	data, err := json.Marshal(struct {
+		Certificate        string `json:"certificate"`
+		ClientAuthRequired bool   `json:"client_auth_required,omitempty"`
+	}{Certificate: certFile, ClientAuthRequired: len(clientAuthRequired) > 0 && clientAuthRequired[0]})
+	if err != nil {
+		return fmt.Errorf("marshal runtime TLS certificate file: %w", err)
+	}
+	return os.WriteFile(path, data, 0600)
+}
+
+// LoadRuntimeTLSCert returns the certificate path recorded by the running
+// server, if any. Invalid or missing records are treated as unavailable.
+func LoadRuntimeTLSCert(vaultDir string) (string, bool) {
+	cleanDir := filepath.Clean(vaultDir)
+	path := filepath.Join(cleanDir, RuntimeTLSFileName)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", false
+	}
+	var record struct {
+		Certificate        string `json:"certificate"`
+		ClientAuthRequired bool   `json:"client_auth_required"`
+	}
+	if err := json.Unmarshal(data, &record); err != nil || strings.TrimSpace(record.Certificate) == "" {
+		return "", false
+	}
+	return strings.TrimSpace(record.Certificate), true
+}
+
+// RuntimeTLSClientAuthRequired reports whether the running server requires
+// a client certificate for its TLS connection.
+func RuntimeTLSClientAuthRequired(vaultDir string) bool {
+	cleanDir := filepath.Clean(vaultDir)
+	data, err := os.ReadFile(filepath.Join(cleanDir, RuntimeTLSFileName))
+	if err != nil {
+		return false
+	}
+	var record struct {
+		ClientAuthRequired bool `json:"client_auth_required"`
+	}
+	return json.Unmarshal(data, &record) == nil && record.ClientAuthRequired
+}
+
+// ClearRuntimeTLSCert removes the running server's certificate record.
+func ClearRuntimeTLSCert(vaultDir string) error {
+	cleanDir := filepath.Clean(vaultDir)
+	path := filepath.Join(cleanDir, RuntimeTLSFileName)
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
 }
 
 // LoadRuntimePort returns the persisted port, discarding the bind address.

--- a/internal/cli/port_utils_test.go
+++ b/internal/cli/port_utils_test.go
@@ -419,3 +419,38 @@ func TestLoadRuntimePort_LargePort(t *testing.T) {
 		t.Errorf("port = %d, want 65535", port)
 	}
 }
+
+func TestRuntimeTLSCertRoundTripAndPermissions(t *testing.T) {
+	dir := t.TempDir()
+	cert := filepath.Join(t.TempDir(), "custom.crt")
+	if err := SaveRuntimeTLSCert(dir, cert); err != nil {
+		t.Fatalf("SaveRuntimeTLSCert() error = %v", err)
+	}
+	got, ok := LoadRuntimeTLSCert(dir)
+	if !ok || got != cert {
+		t.Fatalf("LoadRuntimeTLSCert() = %q, %v; want %q, true", got, ok, cert)
+	}
+	info, err := os.Stat(filepath.Join(dir, RuntimeTLSFileName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mode := info.Mode().Perm(); mode != 0o600 {
+		t.Errorf("runtime TLS record permissions = %o, want 600", mode)
+	}
+	if err := ClearRuntimeTLSCert(dir); err != nil {
+		t.Fatalf("ClearRuntimeTLSCert() error = %v", err)
+	}
+	if _, ok := LoadRuntimeTLSCert(dir); ok {
+		t.Fatal("LoadRuntimeTLSCert() returned true after clear")
+	}
+}
+
+func TestLoadRuntimeTLSCertRejectsMalformedRecord(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, RuntimeTLSFileName), []byte(`{"certificate":""}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if cert, ok := LoadRuntimeTLSCert(dir); ok || cert != "" {
+		t.Fatalf("LoadRuntimeTLSCert() = %q, %v for empty record", cert, ok)
+	}
+}

--- a/internal/mcp/serverbootstrap/http.go
+++ b/internal/mcp/serverbootstrap/http.go
@@ -36,6 +36,7 @@ var bufferPool = sync.Pool{
 // serverOptions carries optional extensions for the HTTP server.
 type serverOptions struct {
 	approvalHandler         http.Handler
+	localApprovalHandler    http.Handler
 	deviceEnrollHandler     http.Handler
 	deviceEnrollCodeHandler http.Handler
 }
@@ -67,6 +68,13 @@ func WithDeviceEnrollCodeAPI(handler http.Handler) HTTPServerOption {
 func WithApprovalAPI(handler http.Handler) HTTPServerOption {
 	return func(o *serverOptions) {
 		o.approvalHandler = handler
+	}
+}
+
+// WithLocalApprovalAPI mounts the loopback-only CLI approval transport.
+func WithLocalApprovalAPI(handler http.Handler) HTTPServerOption {
+	return func(o *serverOptions) {
+		o.localApprovalHandler = handler
 	}
 }
 
@@ -312,6 +320,14 @@ func RunHTTPServerOnListener(ctx context.Context, listener net.Listener, v *vaul
 		}
 		mux.Handle(approval.PathApprovals, approvalChain)
 		mux.Handle(approval.PathApprovalAction, approvalChain)
+	}
+	if options.localApprovalHandler != nil {
+		localApprovalChain := options.localApprovalHandler
+		if rateLimiter != nil {
+			localApprovalChain = auth.RateLimiterMiddleware(rateLimiter, localApprovalChain)
+		}
+		mux.Handle(approval.PathLocalApprovals, localApprovalChain)
+		mux.Handle(approval.PathLocalApprovalAction, localApprovalChain)
 	}
 
 	// Device enrollment transport (optional): lets a device exchange a

--- a/testdata/port/cli/command-tree.json
+++ b/testdata/port/cli/command-tree.json
@@ -2024,6 +2024,162 @@
       ]
     },
     {
+      "path": "symvault approval",
+      "name": "approval",
+      "use": "approval",
+      "short": "List and decide pending agent approval requests",
+      "long": "Inspect the pending approval queue owned by the running local server.\n\nDecisions are sent to the server over its loopback-only, vault-directory\nownership-authenticated API. This command does not act as or create an\napproval device and never displays secret values.",
+      "example": "  symvault approval list\n  symvault approval list --json\n  symvault approval decide apr-0123456789ab --approve",
+      "hidden": false,
+      "group_id": "agents-mcp",
+      "annotations": {
+        "symvault:json": "true"
+      },
+      "disable_flag_parsing": false,
+      "traverse_children": false,
+      "runnable": false,
+      "has_subcommands": true,
+      "local_flags": [
+        {
+          "name": "help",
+          "shorthand": "h",
+          "usage": "help for approval",
+          "type": "bool",
+          "default": "false",
+          "no_opt_default": "true",
+          "hidden": false,
+          "annotations": {
+            "cobra_annotation_flag_set_by_cobra": [
+              "true"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "path": "symvault approval decide",
+      "name": "decide",
+      "use": "decide \u003crequest-id\u003e",
+      "short": "Approve or deny a pending approval request",
+      "example": "  symvault approval decide apr-0123456789ab --approve",
+      "hidden": false,
+      "disable_flag_parsing": false,
+      "traverse_children": false,
+      "runnable": true,
+      "has_subcommands": false,
+      "argument_count_probes": [
+        {
+          "count": 0,
+          "accepted": false,
+          "error": "accepts 1 arg(s), received 0"
+        },
+        {
+          "count": 1,
+          "accepted": true
+        },
+        {
+          "count": 2,
+          "accepted": false,
+          "error": "accepts 1 arg(s), received 2"
+        },
+        {
+          "count": 3,
+          "accepted": false,
+          "error": "accepts 1 arg(s), received 3"
+        },
+        {
+          "count": 4,
+          "accepted": false,
+          "error": "accepts 1 arg(s), received 4"
+        },
+        {
+          "count": 5,
+          "accepted": false,
+          "error": "accepts 1 arg(s), received 5"
+        },
+        {
+          "count": 6,
+          "accepted": false,
+          "error": "accepts 1 arg(s), received 6"
+        },
+        {
+          "count": 7,
+          "accepted": false,
+          "error": "accepts 1 arg(s), received 7"
+        },
+        {
+          "count": 8,
+          "accepted": false,
+          "error": "accepts 1 arg(s), received 8"
+        },
+        {
+          "count": 9,
+          "accepted": false,
+          "error": "accepts 1 arg(s), received 9"
+        }
+      ],
+      "local_flags": [
+        {
+          "name": "approve",
+          "usage": "Approve the request",
+          "type": "bool",
+          "default": "false",
+          "no_opt_default": "true",
+          "hidden": false
+        },
+        {
+          "name": "deny",
+          "usage": "Deny the request",
+          "type": "bool",
+          "default": "false",
+          "no_opt_default": "true",
+          "hidden": false
+        },
+        {
+          "name": "help",
+          "shorthand": "h",
+          "usage": "help for decide",
+          "type": "bool",
+          "default": "false",
+          "no_opt_default": "true",
+          "hidden": false,
+          "annotations": {
+            "cobra_annotation_flag_set_by_cobra": [
+              "true"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "path": "symvault approval list",
+      "name": "list",
+      "use": "list",
+      "short": "List pending approval requests",
+      "example": "  symvault approval list --output json",
+      "hidden": false,
+      "disable_flag_parsing": false,
+      "traverse_children": false,
+      "runnable": true,
+      "has_subcommands": false,
+      "local_flags": [
+        {
+          "name": "help",
+          "shorthand": "h",
+          "usage": "help for list",
+          "type": "bool",
+          "default": "false",
+          "no_opt_default": "true",
+          "hidden": false,
+          "annotations": {
+            "cobra_annotation_flag_set_by_cobra": [
+              "true"
+            ]
+          }
+        }
+      ]
+    },
+    {
       "path": "symvault audit",
       "name": "audit",
       "use": "audit",


### PR DESCRIPTION
## Summary
- add `symvault approval list` and `symvault approval decide` for the live pending queue
- authenticate the CLI transport with loopback and vault-directory ownership proof without emulating approval devices
- document stable JSON output and protect secret values from output

## Verification
- `go test ./internal/approval ./internal/mcp/serverbootstrap ./cmd/mcp ./cmd -run 'TestLocalHTTPHandler|TestNewRootCmd|TestAllTopLevelCommandsHaveGroup|TestEveryCommandHasExample' -count=1`\n- `go vet ./internal/approval ./internal/mcp/serverbootstrap ./cmd/mcp ./cmd`\n- `go test ./internal/...`\n- `go test ./cmd/...`\n- `go test ./...`\n\nCloses #1035