### PR TITLE
fix(test): skip Unix-permission-bit assertions on Windows

### DIFF
--- a/internal/cli/port_utils_test.go
+++ b/internal/cli/port_utils_test.go
@@ -430,12 +430,14 @@ func TestRuntimeTLSCertRoundTripAndPermissions(t *testing.T) {
 	if !ok || got != cert {
 		t.Fatalf("LoadRuntimeTLSCert() = %q, %v; want %q, true", got, ok, cert)
 	}
-	info, err := os.Stat(filepath.Join(dir, RuntimeTLSFileName))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if mode := info.Mode().Perm(); mode != 0o600 {
-		t.Errorf("runtime TLS record permissions = %o, want 600", mode)
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(filepath.Join(dir, RuntimeTLSFileName))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if mode := info.Mode().Perm(); mode != 0o600 {
+			t.Errorf("runtime TLS record permissions = %o, want 600", mode)
+		}
 	}
 	if err := ClearRuntimeTLSCert(dir); err != nil {
 		t.Fatalf("ClearRuntimeTLSCert() error = %v", err)

--- a/internal/mcp/install/install_test.go
+++ b/internal/mcp/install/install_test.go
@@ -668,12 +668,14 @@ args = ["--keep", "value"]
 	if string(repeated) != text {
 		t.Fatal("repeated install changed file bytes")
 	}
-	info, err := os.Stat(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got := info.Mode().Perm(); got != 0o600 {
-		t.Fatalf("permissions = %o, want 600", got)
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := info.Mode().Perm(); got != 0o600 {
+			t.Fatalf("permissions = %o, want 600", got)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- `TestRuntimeTLSCertRoundTripAndPermissions` (#1040) and `TestTOMLInstallPreservesUnmanagedContent` (#1038) both assert `os.FileMode.Perm() == 0600` unconditionally
- NTFS does not honor POSIX permission bits the way `os.WriteFile`'s mode argument implies; both are currently failing on `windows-latest` with `permissions = 666, want 600`, which is red on main's postmerge `Test (windows-latest)` job right now
- Guard just the permission assertion in each test with the same `runtime.GOOS == "windows"` check already used by `TestSaveRuntimePort_SecurityBits` in the same package; the round-trip and content assertions in both tests still run on every platform

## Verification
- `go build ./...`
- `go test ./internal/cli/... ./internal/mcp/install/...`
- `GOOS=windows GOARCH=amd64 go vet ./internal/cli/... ./internal/mcp/install/...`
- `make fmt-check`