### PR TITLE
fix(test): skip remaining migrate tests on Windows for the same reason as their siblings

### DIFF
--- a/internal/config/migrate_test.go
+++ b/internal/config/migrate_test.go
@@ -258,6 +258,9 @@ func assertDirExists(t *testing.T, path string) {
 }
 
 func TestPreviewLegacyToXDG_IsNonMutatingAndComplete(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows: HOME env behavior differs")
+	}
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "cfg"))
@@ -284,6 +287,9 @@ func TestPreviewLegacyToXDG_IsNonMutatingAndComplete(t *testing.T) {
 }
 
 func TestMigrateLegacyToXDG_InterruptionRecovery(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows: HOME env behavior differs")
+	}
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "cfg"))
@@ -318,6 +324,9 @@ func TestMigrateLegacyToXDG_InterruptionRecovery(t *testing.T) {
 }
 
 func TestMigrateLegacyToXDG_CollisionPreservesExistingDestination(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows: HOME env behavior differs")
+	}
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "cfg"))
@@ -340,6 +349,9 @@ func TestMigrateLegacyToXDG_CollisionPreservesExistingDestination(t *testing.T) 
 }
 
 func TestMigrateLegacyToXDG_RejectsSymlinkSource(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows: HOME env behavior differs")
+	}
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "cfg"))
@@ -361,6 +373,9 @@ func TestMigrateLegacyToXDG_RejectsSymlinkSource(t *testing.T) {
 }
 
 func TestMigrateLegacyToXDG_RecoveryRejectsTamperedDestination(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows: HOME env behavior differs")
+	}
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "cfg"))
@@ -385,6 +400,9 @@ func TestMigrateLegacyToXDG_RecoveryRejectsTamperedDestination(t *testing.T) {
 }
 
 func TestMigrateLegacyToXDG_RecoveryRejectsSymlinkRoot(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows: HOME env behavior differs")
+	}
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "cfg-link"))
@@ -408,6 +426,9 @@ func TestMigrateLegacyToXDG_RecoveryRejectsSymlinkRoot(t *testing.T) {
 }
 
 func TestMigrateLegacyToXDG_RecoveryRemovesPartialCopy(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows: HOME env behavior differs")
+	}
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "cfg"))


### PR DESCRIPTION
## Summary
- `os.UserHomeDir()` reads `%USERPROFILE%` on Windows, not `HOME` — so on `windows-latest` CI, `PreviewLegacyToXDG()`/`MigrateLegacyToXDG()` silently operate against the real runner home directory instead of each test's own `t.TempDir()`
- 5 of 12 tests in `internal/config/migrate_test.go` already carry `if runtime.GOOS == "windows" { t.Skip("skipping on windows: HOME env behavior differs") }` for exactly this reason (added before #1039); 7 were missed and are red on main's postmerge `Test (windows-latest)` job right now — 4 fail outright (mismatched item counts, or the intentional "migration unavailable on Windows" stub error surfacing because the test unexpectedly reached a real, non-empty directory), 3 pass only by coincidence (any error from touching the wrong directory happens to satisfy a loose `err == nil` assertion)
- Add the identical guard to the remaining 7, so the whole file is consistent about the same already-accepted, pre-existing limitation — no behavior change, no weakened check, no new limitation introduced

## Verification
- `go build ./...`
- `go test ./internal/config/... -v -run "Migrat|PreviewLegacyToXDG"` (all 12 PASS on macOS, where the guard doesn't trigger)
- `go test ./...` (full suite, no failures)
- `golangci-lint run ./internal/config/...` and `GOOS=linux GOARCH=amd64 golangci-lint run ./internal/config/...` (0 issues both)
- `GOOS=windows GOARCH=amd64 go vet ./internal/config/...`
- `make fmt-check`