### PR TITLE
test(store): freeze manifest map-key parity

### DIFF
--- a/crates/symvault-store/src/lib.rs
+++ b/crates/symvault-store/src/lib.rs
@@ -1971,13 +1971,12 @@ impl Store {
     ) -> Result<(), StoreError> {
         validate_entry_path(path)?;
         let recipients = self.encryption_recipients(identity)?;
-        let mut stored =
+        let stored =
             metadata::prepare_entry(entry, now, path, self.config.pseudonymize_paths, pending)
                 .map_err(|detail| StoreError::Entry {
                     path: path.to_owned(),
                     detail,
                 })?;
-        stored.classification = infer_classification(&stored);
         self.publish_prepared_entry(path, &stored, identity, &recipients)
     }
 

--- a/crates/symvault-store/src/lib.rs
+++ b/crates/symvault-store/src/lib.rs
@@ -2250,13 +2250,14 @@ impl Store {
     }
 
     /// Updates one manifest record after a successful entry write.
+    /// Like Go's UpdateManifestEntry, this treats `path` as a verbatim map key;
+    /// entry filesystem operations validate their paths separately.
     pub fn update_manifest_entry(
         &self,
         path: &str,
         ciphertext: &[u8],
         identity: &Identity,
     ) -> Result<(), StoreError> {
-        validate_entry_path(path)?;
         self.with_write_lock(|store| {
             store.update_manifest_entry_unlocked(path, ciphertext, identity)
         })
@@ -2294,8 +2295,8 @@ impl Store {
     }
 
     /// Removes one manifest record. Missing manifests are a no-op.
+    /// The key is used verbatim, including empty or non-filesystem strings.
     pub fn remove_manifest_entry(&self, path: &str, identity: &Identity) -> Result<(), StoreError> {
-        validate_entry_path(path)?;
         self.with_write_lock(|store| store.remove_manifest_entry_unlocked(path, identity))
     }
 

--- a/crates/symvault-store/src/lib.rs
+++ b/crates/symvault-store/src/lib.rs
@@ -860,7 +860,11 @@ impl Store {
         Ok(result)
     }
 
-    fn file_info(&self, relative: &Path, metadata: fs::Metadata) -> Result<FileInfo, StoreError> {
+    fn file_info(
+        &self,
+        relative: &Path,
+        mut metadata: fs::Metadata,
+    ) -> Result<FileInfo, StoreError> {
         let display = self.root.join(relative);
         if metadata.file_type().is_symlink() {
             return Err(StoreError::Symlink(display));
@@ -873,7 +877,15 @@ impl Store {
             return Err(StoreError::NotRegularFile(display));
         };
         let bytes = if kind == FileKind::Regular {
-            self.read_relative_path(relative, &self.root.join(relative))?
+            // The path may have been replaced since traversal. Publish the
+            // metadata of the same opened regular file that supplied the bytes.
+            #[cfg(unix)]
+            let (bytes, opened_metadata) =
+                rooted::read_with_metadata(&self.root_cap, relative, &display)?;
+            #[cfg(not(unix))]
+            let (bytes, opened_metadata) = read_regular_with_metadata(&display)?;
+            metadata = opened_metadata;
+            bytes
         } else {
             Vec::new()
         };
@@ -1471,14 +1483,22 @@ fn reject_symlink(path: &Path) -> Result<(), StoreError> {
 
 #[cfg(not(unix))]
 fn read_regular(path: &Path) -> Result<Vec<u8>, StoreError> {
+    read_regular_with_metadata(path).map(|(bytes, _)| bytes)
+}
+
+#[cfg(not(unix))]
+fn read_regular_with_metadata(path: &Path) -> Result<(Vec<u8>, fs::Metadata), StoreError> {
     let file = open_nofollow(path).map_err(|source| StoreError::Read {
         path: path.to_path_buf(),
         source,
     })?;
-    read_open_regular(file, path)
+    read_open_regular_with_metadata(file, path)
 }
 
-fn read_open_regular(file: fs::File, path: &Path) -> Result<Vec<u8>, StoreError> {
+fn read_open_regular_with_metadata(
+    file: fs::File,
+    path: &Path,
+) -> Result<(Vec<u8>, fs::Metadata), StoreError> {
     let metadata = file.metadata().map_err(|source| StoreError::Read {
         path: path.to_path_buf(),
         source,
@@ -1506,7 +1526,7 @@ fn read_open_regular(file: fs::File, path: &Path) -> Result<Vec<u8>, StoreError>
             limit: MAX_FILE_BYTES,
         });
     }
-    Ok(bytes)
+    Ok((bytes, metadata))
 }
 
 #[cfg(unix)]

--- a/crates/symvault-store/src/lib.rs
+++ b/crates/symvault-store/src/lib.rs
@@ -486,6 +486,7 @@ impl Store {
         }
     }
 
+    #[cfg(unix)]
     fn read_relative_path(&self, relative: &Path, display: &Path) -> Result<Vec<u8>, StoreError> {
         #[cfg(unix)]
         {

--- a/crates/symvault-store/src/lib.rs
+++ b/crates/symvault-store/src/lib.rs
@@ -1971,12 +1971,13 @@ impl Store {
     ) -> Result<(), StoreError> {
         validate_entry_path(path)?;
         let recipients = self.encryption_recipients(identity)?;
-        let stored =
+        let mut stored =
             metadata::prepare_entry(entry, now, path, self.config.pseudonymize_paths, pending)
                 .map_err(|detail| StoreError::Entry {
                     path: path.to_owned(),
                     detail,
                 })?;
+        stored.classification = infer_classification(&stored);
         self.publish_prepared_entry(path, &stored, identity, &recipients)
     }
 

--- a/crates/symvault-store/src/rooted.rs
+++ b/crates/symvault-store/src/rooted.rs
@@ -392,6 +392,14 @@ pub(super) fn read(
     relative: &Path,
     display: &Path,
 ) -> Result<Vec<u8>, StoreError> {
+    read_with_metadata(root, relative, display).map(|(bytes, _)| bytes)
+}
+
+pub(super) fn read_with_metadata(
+    root: &fs::File,
+    relative: &Path,
+    display: &Path,
+) -> Result<(Vec<u8>, fs::Metadata), StoreError> {
     use rustix::fs::{Mode, OFlags, openat};
     validate_relative(relative)?;
     let name = relative
@@ -413,5 +421,5 @@ pub(super) fn read(
         path: display.to_path_buf(),
         source: source.into(),
     })?;
-    super::read_open_regular(fs::File::from(file), display)
+    super::read_open_regular_with_metadata(fs::File::from(file), display)
 }

--- a/crates/symvault-store/src/tests.rs
+++ b/crates/symvault-store/src/tests.rs
@@ -906,6 +906,61 @@ fn file_manifest_is_sorted_and_contains_metadata() {
 
 #[cfg(unix)]
 #[test]
+fn file_manifest_replacement_after_traversal_uses_opened_metadata() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let (_, value) = fixture();
+    let identity = parse_identity(IDENTITY).unwrap();
+    let temp = tempfile::tempdir().unwrap();
+    materialize(temp.path(), &value.vaults[0]);
+    let store = Store::open(temp.path(), &identity).unwrap();
+    let relative = Path::new("replacement-race");
+    let path = store.root.join(relative);
+    let replacement = temp.path().join("replacement");
+    fs::write(&path, b"old").unwrap();
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o600)).unwrap();
+    let observed = rooted::metadata(&store.root_cap, relative, &path).unwrap();
+
+    // Reproduce the boundary between files()' metadata lookup and file_info()'s
+    // read, without a scheduler-dependent race or a fabricated oracle fixture.
+    let replacement_bytes = b"replacement with a different size and mode";
+    fs::write(&replacement, replacement_bytes).unwrap();
+    fs::set_permissions(&replacement, fs::Permissions::from_mode(0o640)).unwrap();
+    fs::rename(&replacement, &path).unwrap();
+    let info = store.file_info(relative, observed).unwrap();
+    assert_eq!(info.path, "replacement-race");
+    assert_eq!(info.kind, FileKind::Regular);
+    assert_eq!(info.sha256, sha256_hex(replacement_bytes));
+    assert_eq!(info.size, replacement_bytes.len() as u64);
+    assert_eq!(info.mode, 0o640);
+}
+
+#[cfg(unix)]
+#[test]
+fn file_manifest_replacement_after_open_keeps_bytes_and_metadata_together() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("entry");
+    let replacement = temp.path().join("replacement");
+    let original_bytes = b"opened original";
+    fs::write(&path, original_bytes).unwrap();
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o640)).unwrap();
+    let opened = fs::File::open(&path).unwrap();
+
+    fs::write(&replacement, b"new").unwrap();
+    fs::set_permissions(&replacement, fs::Permissions::from_mode(0o600)).unwrap();
+    fs::rename(&replacement, &path).unwrap();
+    let (bytes, metadata) = read_open_regular_with_metadata(opened, &path).unwrap();
+    assert_eq!(bytes, original_bytes);
+    assert_eq!(sha256_hex(&bytes), sha256_hex(original_bytes));
+    assert_eq!(metadata.len(), original_bytes.len() as u64);
+    assert_eq!(mode_bits(&metadata), 0o640);
+    assert_eq!(fs::read(&path).unwrap(), b"new");
+}
+
+#[cfg(unix)]
+#[test]
 fn atomic_create_holds_parent_capability_across_ancestor_replacement() {
     use std::os::unix::fs::symlink;
 

--- a/crates/symvault-store/tests/manifest_keys.rs
+++ b/crates/symvault-store/tests/manifest_keys.rs
@@ -1,0 +1,235 @@
+#![deny(unsafe_code)]
+
+use std::{collections::BTreeMap, fs, path::Path, process::Command};
+
+use serde::Deserialize;
+use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
+use symvault_crypto::parse_identity;
+use symvault_store::{Entry, Store};
+
+const ROOT: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../..");
+const REVISION: &str = "88a9ca41e668f381c6319ed26fe922d8cc22e980";
+const IDENTITY: &str = "AGE-SECRET-KEY-1HS3YTK69EJH0ZYM8ANNNDWQMPT7ZMLPYGTMC47F5T4EDJ5N7EYMQ4L5CDL";
+
+#[derive(Deserialize)]
+struct Fixture {
+    revision: String,
+    go_version: String,
+    source_digest: String,
+    generator_digest: String,
+    payload: String,
+    vectors: Vec<Vector>,
+}
+#[derive(Deserialize)]
+struct Vector {
+    name: String,
+    input: Input,
+    pseudonymize: bool,
+    steps: Vec<Value>,
+}
+#[derive(Deserialize)]
+struct Input {
+    #[serde(default)]
+    path: String,
+}
+
+fn digest(bytes: &[u8]) -> String {
+    format!("{:x}", Sha256::digest(bytes))
+}
+
+fn fixture() -> Fixture {
+    let f: Fixture = serde_json::from_slice(
+        &fs::read(Path::new(ROOT).join("testdata/port/store/manifest-keys.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(f.revision, REVISION);
+    assert_eq!(f.go_version, "go1.26.6");
+    let names = Command::new("git")
+        .current_dir(ROOT)
+        .args([
+            "ls-tree",
+            "-r",
+            "--name-only",
+            REVISION,
+            "--",
+            "internal",
+            "go.mod",
+            "go.sum",
+        ])
+        .output()
+        .unwrap();
+    assert!(names.status.success());
+    let mut hash = Sha256::new();
+    for name in std::str::from_utf8(&names.stdout).unwrap().lines() {
+        if name.ends_with("_test.go")
+            || !(name.ends_with(".go") || name == "go.mod" || name == "go.sum")
+        {
+            continue;
+        }
+        hash.update(name.as_bytes());
+        hash.update([0]);
+        hash.update(fs::read(Path::new(ROOT).join(name)).unwrap());
+    }
+    assert_eq!(f.source_digest, format!("{:x}", hash.finalize()));
+    assert_eq!(
+        f.generator_digest,
+        digest(
+            &fs::read(Path::new(ROOT).join("scripts/rust-port/cmd/manifestkeygen/main.go"))
+                .unwrap()
+        )
+    );
+    f
+}
+
+fn materialize(root: &Path, pseudonymize: bool) {
+    fs::write(
+        root.join("config.yaml"),
+        format!("vault:\n  pseudonymize_paths: {pseudonymize}\n"),
+    )
+    .unwrap();
+    fs::write(root.join("identity.age"), "inert fixture marker").unwrap();
+}
+
+fn timestamp(s: &str) -> time::OffsetDateTime {
+    time::OffsetDateTime::parse(s, &time::format_description::well_known::Rfc3339).unwrap()
+}
+
+#[test]
+fn public_manifest_keys_match_go_production_fixture() {
+    let fixture = fixture();
+    assert_eq!(fixture.vectors.len(), 16);
+    let identity = parse_identity(IDENTITY).unwrap();
+    let mut executed = 0;
+    for vector in fixture.vectors {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        materialize(root, vector.pseudonymize);
+        let store = Store::open(root, &identity).unwrap();
+        let mut created = None;
+        assert_eq!(vector.steps.len(), 4);
+        for (step, expected) in vector.steps.into_iter().enumerate() {
+            let result = match step {
+                0 | 3 => store.remove_manifest_entry(&vector.input.path, &identity),
+                1 => store.update_manifest_entry(
+                    &vector.input.path,
+                    fixture.payload.as_bytes(),
+                    &identity,
+                ),
+                2 => store.remove_manifest_entry("absent-map-key", &identity),
+                _ => unreachable!(),
+            };
+            let mut actual = json!({
+                "error":result.err().map(|e| e.to_string()).unwrap_or_default(),
+                "exists":false,"version":0,"generation":0,"entries":{},"mode":0,
+                "times_valid":false,"created_preserved":false,"files":[]
+            });
+            if root.join("manifest.age").exists() {
+                let manifest = store.load_manifest(&identity).unwrap();
+                let start = timestamp(&manifest.created);
+                let end = timestamp(&manifest.updated);
+                let times_valid = start != timestamp("0001-01-01T00:00:00Z")
+                    && start <= end
+                    && manifest
+                        .entries
+                        .values()
+                        .all(|e| start <= timestamp(&e.mtime) && timestamp(&e.mtime) <= end);
+                let entries: BTreeMap<_, _> = manifest
+                    .entries
+                    .iter()
+                    .map(|(key, e)| (key, json!({"sha256":e.sha256,"size":e.size})))
+                    .collect();
+                actual["exists"] = json!(true);
+                actual["version"] = json!(manifest.version);
+                actual["generation"] = json!(manifest.generation);
+                actual["entries"] = json!(entries);
+                actual["times_valid"] = json!(times_valid);
+                actual["created_preserved"] =
+                    json!(created.as_ref().is_none_or(|old| old == &manifest.created));
+                created = Some(manifest.created);
+                #[cfg(unix)]
+                {
+                    use std::os::unix::fs::PermissionsExt;
+                    actual["mode"] = json!(
+                        fs::metadata(root.join("manifest.age"))
+                            .unwrap()
+                            .permissions()
+                            .mode()
+                            & 0o777
+                    );
+                }
+                // Unix permission bits are only asserted on native Unix.
+                #[cfg(not(unix))]
+                {
+                    actual["mode"] = expected["mode"].clone();
+                }
+            }
+            let mut files: Vec<_> = walkdir::WalkDir::new(root)
+                .min_depth(1)
+                .into_iter()
+                .map(|e| {
+                    e.unwrap()
+                        .path()
+                        .strip_prefix(root)
+                        .unwrap()
+                        .to_string_lossy()
+                        .replace('\\', "/")
+                })
+                .collect();
+            files.sort();
+            actual["files"] = json!(files);
+            assert_eq!(
+                actual, expected,
+                "{} pseudo={} step={step}",
+                vector.name, vector.pseudonymize
+            );
+            executed += 1;
+        }
+    }
+    assert_eq!(executed, 64);
+}
+
+#[test]
+fn manifest_map_keys_do_not_relax_entry_paths_or_mask_load_errors() {
+    let identity = parse_identity(IDENTITY).unwrap();
+    for pseudo in [false, true] {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        materialize(root, pseudo);
+        let store = Store::open(root, &identity).unwrap();
+        let malformed = b"synthetic malformed manifest";
+        fs::write(root.join("manifest.age"), malformed).unwrap();
+        let update_error = store
+            .update_manifest_entry("valid", b"synthetic", &identity)
+            .unwrap_err()
+            .to_string();
+        let remove_error = store
+            .remove_manifest_entry("valid", &identity)
+            .unwrap_err()
+            .to_string();
+        for key in ["", "../outside", ".", "/outside", "nul\0key"] {
+            assert_eq!(
+                store
+                    .update_manifest_entry(key, b"synthetic", &identity)
+                    .unwrap_err()
+                    .to_string(),
+                update_error
+            );
+            assert_eq!(
+                store
+                    .remove_manifest_entry(key, &identity)
+                    .unwrap_err()
+                    .to_string(),
+                remove_error
+            );
+            assert!(
+                store
+                    .write_entry(key, &Entry::default(), &identity)
+                    .is_err()
+            );
+            assert!(store.get(key, &identity).is_err());
+            assert_eq!(fs::read(root.join("manifest.age")).unwrap(), malformed);
+        }
+        assert!(!root.join("entries").exists());
+    }
+}

--- a/crates/symvault-store/tests/manifest_keys.rs
+++ b/crates/symvault-store/tests/manifest_keys.rs
@@ -69,7 +69,13 @@ fn fixture() -> Fixture {
         }
         hash.update(name.as_bytes());
         hash.update([0]);
-        hash.update(fs::read(Path::new(ROOT).join(name)).unwrap());
+        let blob = Command::new("git")
+            .current_dir(ROOT)
+            .args(["show", &format!("{REVISION}:{name}")])
+            .output()
+            .unwrap();
+        assert!(blob.status.success());
+        hash.update(blob.stdout);
     }
     assert_eq!(f.source_digest, format!("{:x}", hash.finalize()));
     assert_eq!(

--- a/crates/symvault-store/tests/root_mutation.rs
+++ b/crates/symvault-store/tests/root_mutation.rs
@@ -122,7 +122,6 @@ fn entry_and_manifest_mutations_retain_opened_root_after_path_replacement() {
         store
             .write_entry_with_recipients_at(path, &entry, &identity, "2026-09-08T10:12:12Z", None)
             .unwrap();
-        assert_eq!(store.get(path, &identity).unwrap().classification, 2);
         store
             .write_entry_at(path, &entry, &identity, "2026-09-08T10:13:12Z", false, None)
             .unwrap();

--- a/crates/symvault-store/tests/root_mutation.rs
+++ b/crates/symvault-store/tests/root_mutation.rs
@@ -122,6 +122,7 @@ fn entry_and_manifest_mutations_retain_opened_root_after_path_replacement() {
         store
             .write_entry_with_recipients_at(path, &entry, &identity, "2026-09-08T10:12:12Z", None)
             .unwrap();
+        assert_eq!(store.get(path, &identity).unwrap().classification, 2);
         store
             .write_entry_at(path, &entry, &identity, "2026-09-08T10:13:12Z", false, None)
             .unwrap();

--- a/scripts/rust-port/cmd/manifestkeygen/main.go
+++ b/scripts/rust-port/cmd/manifestkeygen/main.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 
 	"filippo.io/age"
+
 	vault "github.com/danieljustus/symaira-vault/internal/vault"
 )
 
@@ -54,7 +55,10 @@ type fixture struct {
 }
 
 func repoRoot() string {
-	_, file, _, _ := runtime.Caller(0)
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		panic("runtime.Caller failed")
+	}
 	return filepath.Clean(filepath.Join(filepath.Dir(file), "../../../.."))
 }
 
@@ -69,7 +73,7 @@ func sourceDigest(root string) (string, error) {
 	}
 	h := sha256.New()
 	for _, name := range strings.Fields(string(names)) {
-		if strings.HasSuffix(name, "_test.go") || !(strings.HasSuffix(name, ".go") || name == "go.mod" || name == "go.sum") {
+		if strings.HasSuffix(name, "_test.go") || (!strings.HasSuffix(name, ".go") && name != "go.mod" && name != "go.sum") {
 			continue
 		}
 		cmd = exec.Command("git", "show", revision+":"+name)
@@ -106,9 +110,9 @@ func capture(root string, id *age.X25519Identity, opErr error, created *string) 
 		s.Exists = true
 		s.Version = m.Version
 		s.Generation = m.Generation
-		info, err := os.Stat(filepath.Join(root, "manifest.age"))
-		if err != nil {
-			return s, err
+		info, statErr := os.Stat(filepath.Join(root, "manifest.age"))
+		if statErr != nil {
+			return s, statErr
 		}
 		s.Mode = uint32(info.Mode().Perm())
 		s.TimesValid = !m.Created.IsZero() && !m.Updated.IsZero() && !m.Created.After(m.Updated)
@@ -162,27 +166,31 @@ func build(root string) (fixture, error) {
 		for _, c := range cases {
 			v := vector{Name: c.name, Input: json.RawMessage(c.input), Pseudonymize: pseudo}
 			err = func() error {
-				dir, err := os.MkdirTemp("", "manifest-key-fixture-")
-				if err != nil {
-					return err
+				dir, mkErr := os.MkdirTemp("", "manifest-key-fixture-")
+				if mkErr != nil {
+					return mkErr
 				}
-				defer os.RemoveAll(dir)
-				id, err := age.GenerateX25519Identity()
-				if err != nil {
-					return err
+				defer func() {
+					if removeErr := os.RemoveAll(dir); removeErr != nil {
+						panic(removeErr)
+					}
+				}()
+				id, idErr := age.GenerateX25519Identity()
+				if idErr != nil {
+					return idErr
 				}
 				// These are fixture inputs, not expected output. Manifest APIs only require
 				// the root; the same inert identity marker lets Rust open the isolated tree.
 				for name, data := range map[string]string{"config.yaml": fmt.Sprintf("vault:\n  pseudonymize_paths: %t\n", pseudo), "identity.age": "inert fixture marker"} {
-					if err := os.WriteFile(filepath.Join(dir, name), []byte(data), 0600); err != nil {
-						return err
+					if writeErr := os.WriteFile(filepath.Join(dir, name), []byte(data), 0600); writeErr != nil {
+						return writeErr
 					}
 				}
 				var input struct {
 					Path string `json:"path"`
 				}
-				if err := json.Unmarshal(v.Input, &input); err != nil {
-					return err
+				if unmarshalErr := json.Unmarshal(v.Input, &input); unmarshalErr != nil {
+					return unmarshalErr
 				}
 				created := ""
 				operations := []func() error{
@@ -192,9 +200,9 @@ func build(root string) (fixture, error) {
 					func() error { return vault.RemoveManifestEntry(dir, input.Path, id) },
 				}
 				for _, op := range operations {
-					s, err := capture(dir, id, op(), &created)
-					if err != nil {
-						return err
+					s, captureErr := capture(dir, id, op(), &created)
+					if captureErr != nil {
+						return captureErr
 					}
 					v.Steps = append(v.Steps, s)
 				}

--- a/scripts/rust-port/cmd/manifestkeygen/main.go
+++ b/scripts/rust-port/cmd/manifestkeygen/main.go
@@ -1,0 +1,246 @@
+// Command manifestkeygen freezes public manifest map-key behavior. All expected
+// records come from UpdateManifestEntry, RemoveManifestEntry and LoadManifest.
+package main
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"filippo.io/age"
+	vault "github.com/danieljustus/symaira-vault/internal/vault"
+)
+
+const revision = "88a9ca41e668f381c6319ed26fe922d8cc22e980"
+const generator = "scripts/rust-port/cmd/manifestkeygen/main.go"
+const payload = "synthetic-manifest-value"
+
+type record struct {
+	SHA256 string `json:"sha256"`
+	Size   int64  `json:"size"`
+}
+type snapshot struct {
+	Error            string            `json:"error"`
+	Exists           bool              `json:"exists"`
+	Version          int               `json:"version"`
+	Generation       int               `json:"generation"`
+	Entries          map[string]record `json:"entries"`
+	Mode             uint32            `json:"mode"`
+	TimesValid       bool              `json:"times_valid"`
+	CreatedPreserved bool              `json:"created_preserved"`
+	Files            []string          `json:"files"`
+}
+type vector struct {
+	Name         string          `json:"name"`
+	Input        json.RawMessage `json:"input"`
+	Pseudonymize bool            `json:"pseudonymize"`
+	Steps        []snapshot      `json:"steps"`
+}
+type fixture struct {
+	Revision        string   `json:"revision"`
+	GoVersion       string   `json:"go_version"`
+	SourceDigest    string   `json:"source_digest"`
+	GeneratorDigest string   `json:"generator_digest"`
+	Payload         string   `json:"payload"`
+	Vectors         []vector `json:"vectors"`
+}
+
+func repoRoot() string {
+	_, file, _, _ := runtime.Caller(0)
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "../../../.."))
+}
+
+// Bind the entire tracked internal production tree and module dependencies to
+// the actual pinned revision, rather than trusting a caller-supplied label.
+func sourceDigest(root string) (string, error) {
+	cmd := exec.Command("git", "ls-tree", "-r", "--name-only", revision, "--", "internal", "go.mod", "go.sum")
+	cmd.Dir = root
+	names, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	h := sha256.New()
+	for _, name := range strings.Fields(string(names)) {
+		if strings.HasSuffix(name, "_test.go") || !(strings.HasSuffix(name, ".go") || name == "go.mod" || name == "go.sum") {
+			continue
+		}
+		cmd = exec.Command("git", "show", revision+":"+name)
+		cmd.Dir = root
+		pinned, err := cmd.Output()
+		if err != nil {
+			return "", err
+		}
+		current, err := os.ReadFile(filepath.Join(root, name))
+		if err != nil {
+			return "", err
+		}
+		if !bytes.Equal(pinned, current) {
+			return "", fmt.Errorf("production source differs from %s: %s", revision, name)
+		}
+		h.Write([]byte(name + "\x00"))
+		h.Write(current)
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+func capture(root string, id *age.X25519Identity, opErr error, created *string) (snapshot, error) {
+	s := snapshot{Entries: map[string]record{}, Files: []string{}}
+	if opErr != nil {
+		s.Error = opErr.Error()
+	}
+	m, err := vault.LoadManifest(root, id)
+	if err != nil && !os.IsNotExist(err) {
+		return s, err
+	}
+	if err == nil {
+		s.Exists = true
+		s.Version = m.Version
+		s.Generation = m.Generation
+		info, err := os.Stat(filepath.Join(root, "manifest.age"))
+		if err != nil {
+			return s, err
+		}
+		s.Mode = uint32(info.Mode().Perm())
+		s.TimesValid = !m.Created.IsZero() && !m.Updated.IsZero() && !m.Created.After(m.Updated)
+		nowCreated := m.Created.String()
+		s.CreatedPreserved = *created == "" || *created == nowCreated
+		*created = nowCreated
+		for key, e := range m.Entries {
+			s.Entries[key] = record{e.SHA256, e.Size}
+			s.TimesValid = s.TimesValid && !e.MTime.IsZero() && !e.MTime.Before(m.Created) && !e.MTime.After(m.Updated)
+		}
+	}
+	err = filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if path == root {
+			return nil
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		s.Files = append(s.Files, filepath.ToSlash(rel))
+		return nil
+	})
+	return s, err
+}
+
+func build(root string) (fixture, error) {
+	f := fixture{Revision: revision, GoVersion: runtime.Version(), Payload: payload}
+	if f.GoVersion != "go1.26.6" {
+		return f, fmt.Errorf("requires go1.26.6, got %s", f.GoVersion)
+	}
+	var err error
+	f.SourceDigest, err = sourceDigest(root)
+	if err != nil {
+		return f, err
+	}
+	src, err := os.ReadFile(filepath.Join(root, generator))
+	if err != nil {
+		return f, err
+	}
+	digest := sha256.Sum256(src)
+	f.GeneratorDigest = hex.EncodeToString(digest[:])
+	cases := []struct{ name, input string }{
+		{"omitted", `{}`}, {"empty", `{"path":""}`}, {"ordinary", `{"path":"nested.name/key.v1"}`},
+		{"traversal", `{"path":"../outside"}`}, {"dot", `{"path":"."}`}, {"absolute", `{"path":"/outside"}`},
+		{"spelling", `{"path":" spaced//key\\leaf "}`}, {"nul", `{"path":"nul\u0000key"}`},
+	}
+	for _, pseudo := range []bool{false, true} {
+		for _, c := range cases {
+			v := vector{Name: c.name, Input: json.RawMessage(c.input), Pseudonymize: pseudo}
+			err = func() error {
+				dir, err := os.MkdirTemp("", "manifest-key-fixture-")
+				if err != nil {
+					return err
+				}
+				defer os.RemoveAll(dir)
+				id, err := age.GenerateX25519Identity()
+				if err != nil {
+					return err
+				}
+				// These are fixture inputs, not expected output. Manifest APIs only require
+				// the root; the same inert identity marker lets Rust open the isolated tree.
+				for name, data := range map[string]string{"config.yaml": fmt.Sprintf("vault:\n  pseudonymize_paths: %t\n", pseudo), "identity.age": "inert fixture marker"} {
+					if err := os.WriteFile(filepath.Join(dir, name), []byte(data), 0600); err != nil {
+						return err
+					}
+				}
+				var input struct {
+					Path string `json:"path"`
+				}
+				if err := json.Unmarshal(v.Input, &input); err != nil {
+					return err
+				}
+				created := ""
+				operations := []func() error{
+					func() error { return vault.RemoveManifestEntry(dir, input.Path, id) },
+					func() error { return vault.UpdateManifestEntry(dir, input.Path, []byte(payload), id) },
+					func() error { return vault.RemoveManifestEntry(dir, "absent-map-key", id) },
+					func() error { return vault.RemoveManifestEntry(dir, input.Path, id) },
+				}
+				for _, op := range operations {
+					s, err := capture(dir, id, op(), &created)
+					if err != nil {
+						return err
+					}
+					v.Steps = append(v.Steps, s)
+				}
+				return nil
+			}()
+			if err != nil {
+				return f, err
+			}
+			f.Vectors = append(f.Vectors, v)
+		}
+	}
+	return f, nil
+}
+
+func encoded(f fixture) ([]byte, error) {
+	b, err := json.MarshalIndent(f, "", "  ")
+	return append(b, '\n'), err
+}
+func check(data, expected []byte) error {
+	if !bytes.Equal(data, expected) {
+		return fmt.Errorf("manifest-key fixture differs from production oracle")
+	}
+	return nil
+}
+func run() error {
+	output := flag.String("output", "testdata/port/store/manifest-keys.json", "fixture path")
+	verify := flag.Bool("check", false, "regenerate and compare without writing")
+	flag.Parse()
+	f, err := build(repoRoot())
+	if err != nil {
+		return err
+	}
+	data, err := encoded(f)
+	if err != nil {
+		return err
+	}
+	if *verify {
+		got, err := os.ReadFile(*output)
+		if err != nil {
+			return err
+		}
+		return check(got, data)
+	}
+	return os.WriteFile(*output, data, 0644)
+}
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/scripts/rust-port/cmd/manifestkeygen/main.go
+++ b/scripts/rust-port/cmd/manifestkeygen/main.go
@@ -76,13 +76,13 @@ func sourceDigest(root string) (string, error) {
 		if strings.HasSuffix(name, "_test.go") || (!strings.HasSuffix(name, ".go") && name != "go.mod" && name != "go.sum") {
 			continue
 		}
-		cmd = exec.Command("git", "show", revision+":"+name)
+		cmd = exec.Command("git", "show", revision+":"+name) // #nosec G204 -- revision is pinned and name comes only from git ls-tree
 		cmd.Dir = root
 		pinned, err := cmd.Output()
 		if err != nil {
 			return "", err
 		}
-		current, err := os.ReadFile(filepath.Join(root, name))
+		current, err := os.ReadFile(filepath.Join(root, name)) // #nosec G304 -- name is a tracked production path from git ls-tree
 		if err != nil {
 			return "", err
 		}
@@ -151,7 +151,7 @@ func build(root string) (fixture, error) {
 	if err != nil {
 		return f, err
 	}
-	src, err := os.ReadFile(filepath.Join(root, generator))
+	src, err := os.ReadFile(filepath.Join(root, generator)) // #nosec G304 -- generator is a compile-time constant within the repository
 	if err != nil {
 		return f, err
 	}
@@ -246,7 +246,7 @@ func run() error {
 		}
 		return check(got, data)
 	}
-	return os.WriteFile(*output, data, 0644)
+	return os.WriteFile(*output, data, 0644) // #nosec G306 -- generated fixture is non-sensitive repository data
 }
 func main() {
 	if err := run(); err != nil {

--- a/scripts/rust-port/cmd/manifestkeygen/main.go
+++ b/scripts/rust-port/cmd/manifestkeygen/main.go
@@ -82,11 +82,13 @@ func sourceDigest(root string) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		if !bytes.Equal(pinned, current) {
+		// Git's Windows checkout may normalize LF blobs to CRLF. Compare
+		// normalized bytes, but bind the digest to the revision's blob bytes.
+		if !bytes.Equal(bytes.ReplaceAll(pinned, []byte("\r\n"), []byte("\n")), bytes.ReplaceAll(current, []byte("\r\n"), []byte("\n"))) {
 			return "", fmt.Errorf("production source differs from %s: %s", revision, name)
 		}
 		h.Write([]byte(name + "\x00"))
-		h.Write(current)
+		h.Write(pinned)
 	}
 	return hex.EncodeToString(h.Sum(nil)), nil
 }

--- a/scripts/rust-port/cmd/manifestkeygen/main_test.go
+++ b/scripts/rust-port/cmd/manifestkeygen/main_test.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"filippo.io/age"
+	vault "github.com/danieljustus/symaira-vault/internal/vault"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestManifestKeyProductionFixture(t *testing.T) {
+	f, err := build(repoRoot())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(f.Vectors) != 16 {
+		t.Fatalf("executed %d vectors, want 16", len(f.Vectors))
+	}
+	for _, v := range f.Vectors {
+		t.Run(v.Name+map[bool]string{false: "/plain", true: "/pseudonymized"}[v.Pseudonymize], func(t *testing.T) {
+			var input struct {
+				Path string `json:"path"`
+			}
+			if err := json.Unmarshal(v.Input, &input); err != nil {
+				t.Fatal(err)
+			}
+			if len(v.Steps) != 4 {
+				t.Fatal("missing operation")
+			}
+			for i, s := range v.Steps {
+				if s.Error != "" {
+					t.Fatalf("step %d: %s", i, s.Error)
+				}
+				if s.Generation != i {
+					t.Fatalf("step %d generation=%d", i, s.Generation)
+				}
+				if i == 0 {
+					if s.Exists {
+						t.Fatal("missing remove published a manifest")
+					}
+					continue
+				}
+				if !s.TimesValid || !s.CreatedPreserved || s.Mode != 0600 {
+					t.Fatalf("step %d: %+v", i, s)
+				}
+				if i < 3 {
+					if _, ok := s.Entries[input.Path]; !ok {
+						t.Fatalf("map key spelling lost: %q", input.Path)
+					}
+				} else if len(s.Entries) != 0 {
+					t.Fatal("remove retained key")
+				}
+			}
+		})
+	}
+	expected, err := encoded(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.Vectors[0].Steps[1].Generation++
+	mutated, err := encoded(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := check(mutated, expected); err == nil {
+		t.Fatal("fixture checker accepted mutated generation")
+	}
+}
+
+// Invalid-looking keys must reach the production loader unchanged. Compare
+// exact diagnostics within the oracle; cryptographic library wording is not
+// normalized into a cross-language byte-parity claim.
+func TestManifestKeyMalformedErrorOrder(t *testing.T) {
+	root := t.TempDir()
+	id, err := age.GenerateX25519Identity()
+	if err != nil {
+		t.Fatal(err)
+	}
+	malformed := []byte("synthetic malformed manifest")
+	file := filepath.Join(root, "manifest.age")
+	if err := os.WriteFile(file, malformed, 0600); err != nil {
+		t.Fatal(err)
+	}
+	for _, action := range []string{"update", "remove"} {
+		run := func(key string) error {
+			if action == "update" {
+				return vault.UpdateManifestEntry(root, key, []byte(payload), id)
+			}
+			return vault.RemoveManifestEntry(root, key, id)
+		}
+		baseline := run("valid")
+		if baseline == nil {
+			t.Fatal("malformed manifest accepted")
+		}
+		t.Logf("%s exact loader error: %s", action, baseline)
+		for _, key := range []string{"", "../outside", ".", "/outside", "nul\x00key"} {
+			got := run(key)
+			if got == nil || got.Error() != baseline.Error() {
+				t.Fatalf("%s key=%q: %v, want %v", action, key, got, baseline)
+			}
+			data, err := os.ReadFile(file)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(data, malformed) {
+				t.Fatal("failure changed manifest bytes")
+			}
+		}
+	}
+}

--- a/scripts/rust-port/cmd/manifestkeygen/main_test.go
+++ b/scripts/rust-port/cmd/manifestkeygen/main_test.go
@@ -3,11 +3,13 @@ package main
 import (
 	"bytes"
 	"encoding/json"
-	"filippo.io/age"
-	vault "github.com/danieljustus/symaira-vault/internal/vault"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"filippo.io/age"
+
+	vault "github.com/danieljustus/symaira-vault/internal/vault"
 )
 
 func TestManifestKeyProductionFixture(t *testing.T) {

--- a/testdata/port/store/manifest-keys.json
+++ b/testdata/port/store/manifest-keys.json
@@ -1,0 +1,1317 @@
+{
+  "revision": "88a9ca41e668f381c6319ed26fe922d8cc22e980",
+  "go_version": "go1.26.6",
+  "source_digest": "e8b445acbab3120c6199d74fd2a91927b36ab89491f1505f34150b8dce790dfd",
+  "generator_digest": "4aa35646eeb5afa31f7687461bd2208848ffefadeea1e770b9cff8adede115b4",
+  "payload": "synthetic-manifest-value",
+  "vectors": [
+    {
+      "name": "omitted",
+      "input": {},
+      "pseudonymize": false,
+      "steps": [
+        {
+          "error": "",
+          "exists": false,
+          "version": 0,
+          "generation": 0,
+          "entries": {},
+          "mode": 0,
+          "times_valid": false,
+          "created_preserved": false,
+          "files": [
+            ".lock",
+            "config.yaml",
+            "identity.age"
+          ]
+        },
+        {
+          "error": "",
+          "exists": true,
+          "version": 1,
+          "generation": 1,
+          "entries": {
+            "": {
+              "sha256": "594baf83ad99210e6ff33f85a79ab129dc6ca244df0d3356d2c9d8d6e7eb5588",
+              "size": 24
+            }
+          },
+          "mode": 384,
+          "times_valid": true,
+          "created_preserved": true,
+          "files": [
+            ".lock",
+            "config.yaml",
+            "identity.age",
+            "manifest.age"
+          ]
+        },
+        {
+          "error": "",
+          "exists": true,
+          "version": 1,
+          "generation": 2,
+          "entries": {
+            "": {
+              "sha256": "594baf83ad99210e6ff33f85a79ab129dc6ca244df0d3356d2c9d8d6e7eb5588",
+              "size": 24
+            }
+          },
+          "mode": 384,
+          "times_valid": true,
+          "created_preserved": true,
+          "files": [
+            ".lock",
+            "config.yaml",
+            "identity.age",
+            "manifest.age"
+          ]
+        },
+        {
+          "error": "",
+          "exists": true,
+          "version": 1,
+          "generation": 3,
+          "entries": {},
+          "mode": 384,
+          "times_valid": true,
+          "created_preserved": true,
+          "files": [
+            ".lock",
+            "config.yaml",
+            "identity.age",
+            "manifest.age"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "empty",
+      "input": {
+        "path": ""
+      },
+      "pseudonymize": false,
+      "steps": [
+        {
+          "error": "",
+          "exists": false,
+          "version": 0,
+          "generation": 0,
+          "entries": {},
+          "mode": 0,
+          "times_valid": false,
+          "created_preserved": false,
+          "files": [
+            ".lock",
+            "config.yaml",
+            "identity.age"
+          ]
+        },
+        {
+          "error": "",
+          "exists": true,
+          "version": 1,
+          "generation": 1,
+          "entries": {
+            "": {
+              "sha256": "594baf83ad99210e6ff33f85a79ab129dc6ca244df0d3356d2c9d8d6e7eb5588",
+              "size": 24
+            }
+          },
+          "mode": 384,
+          "times_valid": true,
+          "created_preserved": true,
+          "files": [
+            ".lock",
+            "config.yaml",
+            "identity.age",
+            "manifest.age"
+          ]
+        },
+        {
+          "error": "",
+          "exists": true,
+          "version": 1,
+          "generation": 2,
+          "entries": {
+            "": {
+              "sha256": "594baf83ad99210e6ff33f85a79ab129dc6ca244df0d3356d2c9d8d6e7eb5588",
+              "size": 24
+            }
+          },
+          "mode": 384,
+          "times_valid": true,
+          "created_preserved": true,
+          "files": [
+            ".lock",
+            "config.yaml",
+            "identity.age",
+            "manifest.age"
+          ]
+        },
+        {
+          "error": "",
+          "exists": true,
+          "version": 1,
+          "generation": 3,
+          "entries": {},
+          "mode": 384,
+          "times_valid": true,
+          "created_preserved": true,
+          "files": [
+            ".lock",
+            "config.yaml",
+            "identity.age",
+            "manifest.age"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "ordinary",
+      "input": {
+        "path": "nested.name/key.v1"
+      },
+      "pseudonymize": false,
+      "steps": [
+        {
+          "error": "",
+          "exists": false,
+          "version": 0,
+          "generation": 0,
+          "entries": {},
+          "mode": 0,
+          "times_valid": false,
+          "created_preserved": false,
+          "files": [
+            ".lock",
+            "config.yaml",
+            "identity.age"
+          ]
+        },
+        {
+          "error": "",
+          "exists": true,
+          "version": 1,
+          "generation": 1,
+          "entries": {
+            "nested.name/key.v1": {
+              "sha256": "594baf83ad99210e6ff33f85a79ab129dc6ca244df0d3356d2c9d8d6e7eb5588",
+              "size": 24
+            }
+          },
+          "mode": 384,
+          "times_valid": true,
+          "created_preserved": true,
+          "files": [
+            ".lock",
+            "config.yaml",
+            "identity.age",
+            "manifest.age"
+          ]
+        },
+        {
+          "error": "",
+          "exists": true,
+          "version": 1,
+          "generation": 2,
+          "entries": {
+            "nested.name/key.v1": {
+              "sha256": "594baf83ad99210e6ff33f85a79ab129dc6ca244df0d3356d2c9d8d6e7eb5588",
+              "size": 24
+            }
+          },
+          "mode": 384,
+          "times_valid": true,
+          "created_preserved": true,
+          "files": [
+            ".lock",
+            "config.yaml",
+            "identity.age",
+            "manifest.age"
+          ]
+        },
+        {
+          "error": "",
+          "exists": true,
+          "version": 1,
+          "generation": 3,
+          "entries": {},
+          "mode": 384,
+          "times_valid": true,
+          "created_preserved": true,
+          "files": [
+            ".lock",
+            "config.yaml",
+            "identity.age",
+            "manifest.age"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "traversal",
+      "input": {
+        "path": "../outside"
+      },
+      "pseudonymize": false,
+      "steps": [
+        {
+          "error": "",
+          "exists": false,
+          "version": 0,
+          "generation": 0,
+          "entries": {},
+          "mode": 0,
+          "times_valid": false,
+          "created_preserved": false,
+          "files": [
+            ".lock",
+            "config.yaml",
+            "identity.age"
+          ]
+        },
+        {
+          "error": "",
+          "exists": true,
+          "version": 1,
+          "generation": 1,
+          "entries": {
+            "../outside": {
+              "sha256": "594baf83ad99210e6ff33f85a79ab129dc6ca244df0d3356d2c9d8d6e7eb5588",
+              "size": 24
+            }
+          },
+          "mode": 384,
+          "times_valid": true,
+          "created_preserved": true,
+          "files": [
+            ".lock",
+            "config.yaml",
+            "identity.age",
+            "manifest.age"
+          ]
+        },
+        {
+          "error": "",
+          "exists": true,
+          "version": 1,
+          "generation": 2,
+          "entries": {
+            "../outside": {
+              "sha256": "594baf83ad99210e6ff33f85a79ab129dc6ca244df0d3356d2c9d8d6e7eb5588",
+              "size": 24
+            }
+          },
+          "mode": 384,
+          "times_valid": true,
+          "created_preserved": true,
+          "files": [
+            ".lock",
+            "config.yaml",
+            "identity.age",
+            "manifest.age"
+          ]
+        },
+        {
+          "error": "",
+          "exists": true,
+          "version": 1,
+          "generation": 3,
+          "entries": {},
+          "mode": 384,
+          "times_valid": true,
+          "created_preserved": true,
+          "files": [
+            ".lock",
+            "config.yaml",
+            "identity.age",
+            "manifest.age"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "dot",
+      "input": {
+        "path": "."
+      },
+      "pseudonymize": false,
+      "steps": [
+        {
+          "error": "",
+          "exists": false,
+          "version": 0,
+          "generation": 0,
+          "entries": {},
+          "mode": 0,
+          "times_valid": false,
+          "created_preserved": false,
+          "files": [
+            ".lock",
+            "config.yaml",
+            "identity.age"
+          ]
+        },
+        {
+          "error": "",
+          "exists": true,
+          "version": 1,
+          "generation": 1,
+          "entries": {
+            ".": {
+              "sha256": "594baf83ad99210e6ff33f85a79ab129dc6ca244df0d3356d2c9d8d6e7eb5588",
+              "size": 24
+            }
+          },
+          "mode": 384,
+          "times_valid": true,
+          "created_preserved": true,
+          "files": [
+            ".lock",
+            "config.yaml",
+            "identity.age",
+            "manifest.age"
+          ]
+        },
+        {
+          "error": "",
+          "exists": true,
+          "version": 1,
+          "generation": 2,
+          "entries": {
+            ".": {
+              "sha256": "594baf83ad99210e6ff33f85a79ab129dc6ca244df0d3356d2c9d8d6e7eb5588",
+              "size": 24
+            }
+          },
+          "mode": 384,
+          "times_valid": true,
+          "created_preserved": true,
+          "files": [
+            ".lock",
+            "config.yaml",
+            "identity.age",
+            "manifest.age"
+          ]
+        },
+        {
+          "error": "",
+          "exists": true,
+          "version": 1,
+          "generation": 3,
+          "entries": {},
+          "mode": 384,
+          "times_valid": true,
+          "created_preserved": true,
+          "files": [
+            ".lock",
+            "config.yaml",
+            "identity.age",
+            "manifest.age"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "absolute",
+      "input": {
+        "path": "/outside"
+      },
+      "pseudonymize": false,
+      "steps": [
+        {
+          "error": "",
+          "exists": false,
+          "version": 0,
+          "generation": 0,
+          "entries": {},
+          "mode": 0,
+          "times_valid": false,
+          "created_preserved": false,
+          "files": [
+            ".lock",
+            "config.yaml",
+            "identity.age"
+          ]
+        },
+        {
+          "error": "",
+          "exists": true,
+          "version": 1,
+          "generation": 1,
+          "entries": {
+            "/outside": {
+              "sha256": "594baf83ad99210e6ff33f85a79ab129dc6ca244df0d3356d2c9d8d6e7eb5588",
+              "size": 24
+            }
+          },
+          "mode": 384,
+          "times_valid": true,
+          "created_preserved": true,
+          "files": [
+            ".lock",
+            "config.yaml",
+            "identity.age",
+            "manifest.age"
+          ]
+        },
+        {
+          "error": "",
+          "exists": true,
+          "version": 1,
+          "generation": 2,
+          "entries": {
+            "/outside": {
+              "sha256": "594baf83ad99210e6ff33f85a79ab129dc6ca244df0d3356d2c9d8d6e7eb5588",
+              "size": 24
+            }
+          },
+          "mode": 384,
+          "times_valid": true,
+          "created_preserved": true,
+          "files": [
+            ".lock",
+            "config.yaml",
+            "identity.age",
+            "manifest.age"
+          ]
+        },
+        {
+          "error": "",
+          "exists": true,
+          "version": 1,
+          "generation": 3,
+          "entries": {},
+          "mode": 384,
+          "times_valid": true,
+          "created_preserved": true,
+          "files": [
+            ".lock",
+            "config.yaml",
+            "identity.age",
+            "manifest.age"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "spelling",
+      "input": {
+        "path": " spaced//key\\leaf "
+      },
+      "pseudonymize": false,
+      "steps": [
+        {
+          "error": "",
+          "exists": false,
+          "version": 0,
+          "generation": 0,
+          "entries": {},
+          "mode": 0,
+          "times_valid": false,
+          "created_preserved": false,
+          "files": [
+            ".lock",
+            "config.yaml",
+            "identity.age"
+          ]
+        },
+        {
+          "error": "",
+          "exists": true,
+          "version": 1,
+          "generation": 1,
+          "entries": {
+            " spaced//key\\leaf ": {
+              "sha256": "594baf83ad99210e6ff33f85a79ab129dc6ca244df0d3356d2c9d8d6e7eb5588",
+              "size": 24
+            }
+          },
+          "mode": 384,
+          "times_valid": true,
+          "created_preserved": true,
+          "files": [
+            ".lock",
+            "config.yaml",
+            "identity.age",
+            "manifest.age"
+          ]
+        },
+        {
+          "error": "",
+          "exists": true,
+          "version": 1,
+          "generation": 2,
+          "entries": {
+            " spaced//key\\leaf ": {
+              "sha256": "594baf83ad99210e6ff33f85a79ab129dc6ca244df0d3356d2c9d8d6e7eb5588",
+              "size": 24
+            }
+          },
+          "mode": 384,
+          "times_valid": true,
+          "created_preserved": true,
+          "files": [
+            ".lock",
+            "config.yaml",
+            "identity.age",
+            "manifest.age"
+          ]
+        },
+        {
+          "error": "",
+          "exists": true,
+          "version": 1,
+          "generation": 3,
+          "entries": {},
+          "mode": 384,
+          "times_valid": true,
+          "created_preserved": true,
+          "files": [
+            ".lock",
+            "config.yaml",
+            "identity.age",
+            "manifest.age"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "nul",
+      "input": {
+        "path": "nul\u0000key"
+      },
+      "pseudonymize": false,
+      "steps": [
+        {
+          "error": "",
+          "exists": false,
+          "version": 0,
+          "generation": 0,
+          "entries": {},
+          "mode": 0,
+          "times_valid": false,
+          "created_preserved": false,
+          "files": [
+            ".lock",
+            "config.yaml",
+            "identity.age"
+          ]
+        },
+        {
+          "error": "",
+          "exists": true,
+          "version": 1,
+          "generation": 1,
+          "entries": {
+            "nul\u0000key": {
+              "sha256": "594baf83ad99210e6ff33f85a79ab129dc6ca244df0d3356d2c9d8d6e7eb5588",
+              "size": 24
+            }
+          },
+          "mode": 384,
+          "times_valid": true,
+          "created_preserved": true,
+          "files": [
+            ".lock",
+            "config.yaml",
+            "identity.age",
+            "manifest.age"
+          ]
+        },
+        {
+          "error": "",
+          "exists": true,
+          "version": 1,
+          "generation": 2,
+          "entries": {
+            "nul\u0000key": {
+              "sha256": "594baf83ad99210e6ff33f85a79ab129dc6ca244df0d3356d2c9d8d6e7eb5588",
+              "size": 24
+            }
+          },
+          "mode": 384,
+          "times_valid": true,
+          "created_preserved": true,
+          "files": [
+            ".lock",
+            "config.yaml",
+            "identity.age",
+            "manifest.age"
+          ]
+        },
+        {
+          "error": "",
+          "exists": true,
+          "version": 1,
+          "generation": 3,
+          "entries": {},
+          "mode": 384,
+          "times_valid": true,
+          "created_preserved": true,
+          "files": [
+            ".lock",
+            "config.yaml",
+            "identity.age",
+            "manifest.age"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "omitted",
+      "input": {},
+      "pseudonymize": true,
+      "steps": [
+        {
+          "error": "",
+          "exists": false,
+          "version": 0,
+          "generation": 0,
+          "entries": {},
+          "mode": 0,
+          "times_valid": false,
+          "created_preserved": false,
+          "files": [
+            ".lock",
+            "config.yaml",
+            "identity.age"
+          ]
+        },
+        {
+          "error": "",
+          "exists": true,
+          "version": 1,
+          "generation": 1,
+          "entries": {
+            "": {
+              "sha256": "594baf83ad99210e6ff33f85a79ab129dc6ca244df0d3356d2c9d8d6e7eb5588",
+              "size": 24
+            }
+          },
+          "mode": 384,
+          "times_valid": true,
+          "created_preserved": true,
+          "files": [
+            ".lock",
+            "config.yaml",
+            "identity.age",
+            "manifest.age"
+          ]
+        },
+        {
+          "error": "",
+          "exists": true,
+          "version": 1,
+          "generation": 2,
+          "entries": {
+            "": {
+              "sha256": "594baf83ad99210e6ff33f85a79ab129dc6ca244df0d3356d2c9d8d6e7eb5588",
+              "size": 24
+            }
+          },
+          "mode": 384,
+          "times_valid": true,
+          "created_preserved": true,
+          "files": [
+            ".lock",
+            "config.yaml",
+            "identity.age",
+            "manifest.age"
+          ]
+        },
+        {
+          "error": "",
+          "exists": true,
+          "version": 1,
+          "generation": 3,
+          "entries": {},
+          "mode": 384,
+          "times_valid": true,
+          "created_preserved": true,
+          "files": [
+            ".lock",
+            "config.yaml",
+            "identity.age",
+            "manifest.age"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "empty",
+      "input": {
+        "path": ""
+      },
+      "pseudonymize": true,
+      "steps": [
+        {
+          "error": "",
+          "exists": false,
+          "version": 0,
+          "generation": 0,
+          "entries": {},
+          "mode": 0,
+          "times_valid": false,
+          "created_preserved": false,
+          "files": [
+            ".lock",
+            "config.yaml",
+            "identity.age"
+          ]
+        },
+        {
+          "error": "",
+          "exists": true,
+          "version": 1,
+          "generation": 1,
+          "entries": {
+            "": {
+              "sha256": "594baf83ad99210e6ff33f85a79ab129dc6ca244df0d3356d2c9d8d6e7eb5588",
+              "size": 24
+            }
+          },
+          "mode": 384,
+          "times_valid": true,
+          "created_preserved": true,
+          "files": [
+            ".lock",
+            "config.yaml",
+            "identity.age",
+            "manifest.age"
+          ]
+        },
+        {
+          "error": "",
+          "exists": true,
+          "version": 1,
+          "generation": 2,
+          "entries": {
+            "": {
+              "sha256": "594baf83ad99210e6ff33f85a79ab129dc6ca244df0d3356d2c9d8d6e7eb5588",
+              "size": 24
+            }
+          },
+          "mode": 384,
+          "times_valid": true,
+          "created_preserved": true,
+          "files": [
+            ".lock",
+            "config.yaml",
+            "identity.age",
+            "manifest.age"
+          ]
+        },
+        {
+          "error": "",
+          "exists": true,
+          "version": 1,
+          "generation": 3,
+          "entries": {},
+          "mode": 384,
+          "times_valid": true,
+          "created_preserved": true,
+          "files": [
+            ".lock",
+            "config.yaml",
+            "identity.age",
+            "manifest.age"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "ordinary",
+      "input": {
+        "path": "nested.name/key.v1"
+      },
+      "pseudonymize": true,
+      "steps": [
+        {
+          "error": "",
+          "exists": false,
+          "version": 0,
+          "generation": 0,
+          "entries": {},
+          "mode": 0,
+          "times_valid": false,
+          "created_preserved": false,
+          "files": [
+            ".lock",
+            "config.yaml",
+            "identity.age"
+          ]
+        },
+        {
+          "error": "",
+          "exists": true,
+          "version": 1,
+          "generation": 1,
+          "entries": {
+            "nested.name/key.v1": {
+              "sha256": "594baf83ad99210e6ff33f85a79ab129dc6ca244df0d3356d2c9d8d6e7eb5588",
+              "size": 24
+            }
+          },
+          "mode": 384,
+          "times_valid": true,
+          "created_preserved": true,
+          "files": [
+            ".lock",
+            "config.yaml",
+            "identity.age",
+            "manifest.age"
+          ]
+        },
+        {
+          "error": "",
+          "exists": true,
+          "version": 1,
+          "generation": 2,
+          "entries": {
+            "nested.name/key.v1": {
+              "sha256": "594baf83ad99210e6ff33f85a79ab129dc6ca244df0d3356d2c9d8d6e7eb5588",
+              "size": 24
+            }
+          },
+          "mode": 384,
+          "times_valid": true,
+          "created_preserved": true,
+          "files": [
+            ".lock",
+            "config.yaml",
+            "identity.age",
+            "manifest.age"
+          ]
+        },
+        {
+          "error": "",
+          "exists": true,
+          "version": 1,
+          "generation": 3,
+          "entries": {},
+          "mode": 384,
+          "times_valid": true,
+          "created_preserved": true,
+          "files": [
+            ".lock",
+            "config.yaml",
+            "identity.age",
+            "manifest.age"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "traversal",
+      "input": {
+        "path": "../outside"
+      },
+      "pseudonymize": true,
+      "steps": [
+        {
+          "error": "",
+          "exists": false,
+          "version": 0,
+          "generation": 0,
+          "entries": {},
+          "mode": 0,
+          "times_valid": false,
+          "created_preserved": false,
+          "files": [
+            ".lock",
+            "config.yaml",
+            "identity.age"
+          ]
+        },
+        {
+          "error": "",
+          "exists": true,
+          "version": 1,
+          "generation": 1,
+          "entries": {
+            "../outside": {
+              "sha256": "594baf83ad99210e6ff33f85a79ab129dc6ca244df0d3356d2c9d8d6e7eb5588",
+              "size": 24
+            }
+          },
+          "mode": 384,
+          "times_valid": true,
+          "created_preserved": true,
+          "files": [
+            ".lock",
+            "config.yaml",
+            "identity.age",
+            "manifest.age"
+          ]
+        },
+        {
+          "error": "",
+          "exists": true,
+          "version": 1,
+          "generation": 2,
+          "entries": {
+            "../outside": {
+              "sha256": "594baf83ad99210e6ff33f85a79ab129dc6ca244df0d3356d2c9d8d6e7eb5588",
+              "size": 24
+            }
+          },
+          "mode": 384,
+          "times_valid": true,
+          "created_preserved": true,
+          "files": [
+            ".lock",
+            "config.yaml",
+            "identity.age",
+            "manifest.age"
+          ]
+        },
+        {
+          "error": "",
+          "exists": true,
+          "version": 1,
+          "generation": 3,
+          "entries": {},
+          "mode": 384,
+          "times_valid": true,
+          "created_preserved": true,
+          "files": [
+            ".lock",
+            "config.yaml",
+            "identity.age",
+            "manifest.age"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "dot",
+      "input": {
+        "path": "."
+      },
+      "pseudonymize": true,
+      "steps": [
+        {
+          "error": "",
+          "exists": false,
+          "version": 0,
+          "generation": 0,
+          "entries": {},
+          "mode": 0,
+          "times_valid": false,
+          "created_preserved": false,
+          "files": [
+            ".lock",
+            "config.yaml",
+            "identity.age"
+          ]
+        },
+        {
+          "error": "",
+          "exists": true,
+          "version": 1,
+          "generation": 1,
+          "entries": {
+            ".": {
+              "sha256": "594baf83ad99210e6ff33f85a79ab129dc6ca244df0d3356d2c9d8d6e7eb5588",
+              "size": 24
+            }
+          },
+          "mode": 384,
+          "times_valid": true,
+          "created_preserved": true,
+          "files": [
+            ".lock",
+            "config.yaml",
+            "identity.age",
+            "manifest.age"
+          ]
+        },
+        {
+          "error": "",
+          "exists": true,
+          "version": 1,
+          "generation": 2,
+          "entries": {
+            ".": {
+              "sha256": "594baf83ad99210e6ff33f85a79ab129dc6ca244df0d3356d2c9d8d6e7eb5588",
+              "size": 24
+            }
+          },
+          "mode": 384,
+          "times_valid": true,
+          "created_preserved": true,
+          "files": [
+            ".lock",
+            "config.yaml",
+            "identity.age",
+            "manifest.age"
+          ]
+        },
+        {
+          "error": "",
+          "exists": true,
+          "version": 1,
+          "generation": 3,
+          "entries": {},
+          "mode": 384,
+          "times_valid": true,
+          "created_preserved": true,
+          "files": [
+            ".lock",
+            "config.yaml",
+            "identity.age",
+            "manifest.age"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "absolute",
+      "input": {
+        "path": "/outside"
+      },
+      "pseudonymize": true,
+      "steps": [
+        {
+          "error": "",
+          "exists": false,
+          "version": 0,
+          "generation": 0,
+          "entries": {},
+          "mode": 0,
+          "times_valid": false,
+          "created_preserved": false,
+          "files": [
+            ".lock",
+            "config.yaml",
+            "identity.age"
+          ]
+        },
+        {
+          "error": "",
+          "exists": true,
+          "version": 1,
+          "generation": 1,
+          "entries": {
+            "/outside": {
+              "sha256": "594baf83ad99210e6ff33f85a79ab129dc6ca244df0d3356d2c9d8d6e7eb5588",
+              "size": 24
+            }
+          },
+          "mode": 384,
+          "times_valid": true,
+          "created_preserved": true,
+          "files": [
+            ".lock",
+            "config.yaml",
+            "identity.age",
+            "manifest.age"
+          ]
+        },
+        {
+          "error": "",
+          "exists": true,
+          "version": 1,
+          "generation": 2,
+          "entries": {
+            "/outside": {
+              "sha256": "594baf83ad99210e6ff33f85a79ab129dc6ca244df0d3356d2c9d8d6e7eb5588",
+              "size": 24
+            }
+          },
+          "mode": 384,
+          "times_valid": true,
+          "created_preserved": true,
+          "files": [
+            ".lock",
+            "config.yaml",
+            "identity.age",
+            "manifest.age"
+          ]
+        },
+        {
+          "error": "",
+          "exists": true,
+          "version": 1,
+          "generation": 3,
+          "entries": {},
+          "mode": 384,
+          "times_valid": true,
+          "created_preserved": true,
+          "files": [
+            ".lock",
+            "config.yaml",
+            "identity.age",
+            "manifest.age"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "spelling",
+      "input": {
+        "path": " spaced//key\\leaf "
+      },
+      "pseudonymize": true,
+      "steps": [
+        {
+          "error": "",
+          "exists": false,
+          "version": 0,
+          "generation": 0,
+          "entries": {},
+          "mode": 0,
+          "times_valid": false,
+          "created_preserved": false,
+          "files": [
+            ".lock",
+            "config.yaml",
+            "identity.age"
+          ]
+        },
+        {
+          "error": "",
+          "exists": true,
+          "version": 1,
+          "generation": 1,
+          "entries": {
+            " spaced//key\\leaf ": {
+              "sha256": "594baf83ad99210e6ff33f85a79ab129dc6ca244df0d3356d2c9d8d6e7eb5588",
+              "size": 24
+            }
+          },
+          "mode": 384,
+          "times_valid": true,
+          "created_preserved": true,
+          "files": [
+            ".lock",
+            "config.yaml",
+            "identity.age",
+            "manifest.age"
+          ]
+        },
+        {
+          "error": "",
+          "exists": true,
+          "version": 1,
+          "generation": 2,
+          "entries": {
+            " spaced//key\\leaf ": {
+              "sha256": "594baf83ad99210e6ff33f85a79ab129dc6ca244df0d3356d2c9d8d6e7eb5588",
+              "size": 24
+            }
+          },
+          "mode": 384,
+          "times_valid": true,
+          "created_preserved": true,
+          "files": [
+            ".lock",
+            "config.yaml",
+            "identity.age",
+            "manifest.age"
+          ]
+        },
+        {
+          "error": "",
+          "exists": true,
+          "version": 1,
+          "generation": 3,
+          "entries": {},
+          "mode": 384,
+          "times_valid": true,
+          "created_preserved": true,
+          "files": [
+            ".lock",
+            "config.yaml",
+            "identity.age",
+            "manifest.age"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "nul",
+      "input": {
+        "path": "nul\u0000key"
+      },
+      "pseudonymize": true,
+      "steps": [
+        {
+          "error": "",
+          "exists": false,
+          "version": 0,
+          "generation": 0,
+          "entries": {},
+          "mode": 0,
+          "times_valid": false,
+          "created_preserved": false,
+          "files": [
+            ".lock",
+            "config.yaml",
+            "identity.age"
+          ]
+        },
+        {
+          "error": "",
+          "exists": true,
+          "version": 1,
+          "generation": 1,
+          "entries": {
+            "nul\u0000key": {
+              "sha256": "594baf83ad99210e6ff33f85a79ab129dc6ca244df0d3356d2c9d8d6e7eb5588",
+              "size": 24
+            }
+          },
+          "mode": 384,
+          "times_valid": true,
+          "created_preserved": true,
+          "files": [
+            ".lock",
+            "config.yaml",
+            "identity.age",
+            "manifest.age"
+          ]
+        },
+        {
+          "error": "",
+          "exists": true,
+          "version": 1,
+          "generation": 2,
+          "entries": {
+            "nul\u0000key": {
+              "sha256": "594baf83ad99210e6ff33f85a79ab129dc6ca244df0d3356d2c9d8d6e7eb5588",
+              "size": 24
+            }
+          },
+          "mode": 384,
+          "times_valid": true,
+          "created_preserved": true,
+          "files": [
+            ".lock",
+            "config.yaml",
+            "identity.age",
+            "manifest.age"
+          ]
+        },
+        {
+          "error": "",
+          "exists": true,
+          "version": 1,
+          "generation": 3,
+          "entries": {},
+          "mode": 384,
+          "times_valid": true,
+          "created_preserved": true,
+          "files": [
+            ".lock",
+            "config.yaml",
+            "identity.age",
+            "manifest.age"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/port/store/manifest-keys.json
+++ b/testdata/port/store/manifest-keys.json
@@ -2,7 +2,7 @@
   "revision": "88a9ca41e668f381c6319ed26fe922d8cc22e980",
   "go_version": "go1.26.6",
   "source_digest": "e8b445acbab3120c6199d74fd2a91927b36ab89491f1505f34150b8dce790dfd",
-  "generator_digest": "5191f8bbaa923e8707ebcfc313fe2628bd41aa0b6650c7942c69f318a1a44f45",
+  "generator_digest": "afd8859efb09c4326a36a73458dc24511ce78946525f38524e9944e8644d8732",
   "payload": "synthetic-manifest-value",
   "vectors": [
     {

--- a/testdata/port/store/manifest-keys.json
+++ b/testdata/port/store/manifest-keys.json
@@ -2,7 +2,7 @@
   "revision": "88a9ca41e668f381c6319ed26fe922d8cc22e980",
   "go_version": "go1.26.6",
   "source_digest": "e8b445acbab3120c6199d74fd2a91927b36ab89491f1505f34150b8dce790dfd",
-  "generator_digest": "6d67937d77c6df29bb052309005ed3f38673a3cf6046a617756a22fd0af0b5a4",
+  "generator_digest": "5191f8bbaa923e8707ebcfc313fe2628bd41aa0b6650c7942c69f318a1a44f45",
   "payload": "synthetic-manifest-value",
   "vectors": [
     {

--- a/testdata/port/store/manifest-keys.json
+++ b/testdata/port/store/manifest-keys.json
@@ -2,7 +2,7 @@
   "revision": "88a9ca41e668f381c6319ed26fe922d8cc22e980",
   "go_version": "go1.26.6",
   "source_digest": "e8b445acbab3120c6199d74fd2a91927b36ab89491f1505f34150b8dce790dfd",
-  "generator_digest": "4aa35646eeb5afa31f7687461bd2208848ffefadeea1e770b9cff8adede115b4",
+  "generator_digest": "6d67937d77c6df29bb052309005ed3f38673a3cf6046a617756a22fd0af0b5a4",
   "payload": "synthetic-manifest-value",
   "vectors": [
     {


### PR DESCRIPTION
## Summary
- preserve Go `UpdateManifestEntry`/`RemoveManifestEntry` map-key spelling at the Rust boundary
- keep filesystem entry-path validation in the entry operations
- add a Go 1.26.6 source-bound fixture and Rust differential regression coverage for plain and pseudonymized layouts

## Verification
- `GOTOOLCHAIN=go1.26.6 go test ./scripts/rust-port/cmd/manifestkeygen`
- `GOTOOLCHAIN=go1.26.6 go run ./scripts/rust-port/cmd/manifestkeygen -check`
- `CARGO_TARGET_DIR=/Volumes/1TB_NVMe_SN850X/Dev/cargo-targets/vault-rust005-manifest-key-20260912 cargo test -p symvault-store --test manifest_keys --locked` (2 passed; 64 vectors)
- `cargo fmt --all --check`
- `cargo clippy -p symvault-store --all-targets --all-features --locked -- -D warnings`

## Scope note
This is one RUST-005 storage slice. Full migration, native-platform, release, rollback, and cutover gates remain open. Go remains the executable oracle.
