### PR TITLE
feat(approval): define a secure local client identity for mTLS

### DIFF
--- a/cmd/approval.go
+++ b/cmd/approval.go
@@ -148,7 +148,32 @@ func approvalAPIRequest(method, path string, result any) error {
 	}
 	req.Header.Set(approval.HeaderEnrollTimestamp, now.Format(time.RFC3339))
 	req.Header.Set(approval.HeaderEnrollProof, approval.EnrollProof(secret, now))
-	client := &http.Client{Timeout: 10 * time.Second, Transport: &http.Transport{TLSClientConfig: &tls.Config{RootCAs: pool, MinVersion: tls.VersionTLS12}}}
+	tlsConfig := &tls.Config{RootCAs: pool, MinVersion: tls.VersionTLS12}
+	clientCertFile, clientKeyFile := "", ""
+	if runtimeTLS, ok := cli.LoadRuntimeTLSConfig(vaultDir); ok && runtimeTLS.ClientAuthRequired {
+		clientCertFile, clientKeyFile = runtimeTLS.ClientCertificate, runtimeTLS.ClientKey
+	} else if cfg, loadErr := configpkg.Load(filepath.Join(vaultDir, "config.yaml")); loadErr == nil && cfg != nil && cfg.MCP != nil && cfg.MCP.MTLSEnabled {
+		clientCertFile, clientKeyFile = strings.TrimSpace(cfg.MCP.ApprovalTLSCertFile), strings.TrimSpace(cfg.MCP.ApprovalTLSKeyFile)
+	}
+	if clientCertFile != "" || clientKeyFile != "" {
+		if clientCertFile == "" || clientKeyFile == "" {
+			return fmt.Errorf("approval CLI cannot connect while the running MCP server requires mTLS because the dedicated local approval client certificate and key must both be configured")
+		}
+		if filepath.Clean(clientKeyFile) == filepath.Clean(strings.TrimSpace(func() string {
+			if cfg, e := configpkg.Load(filepath.Join(vaultDir, "config.yaml")); e == nil && cfg != nil && cfg.MCP != nil {
+				return cfg.MCP.TLSKeyFile
+			}
+			return ""
+		}())) {
+			return fmt.Errorf("approval CLI refuses to reuse the MCP server private key as the approval client key")
+		}
+		clientCert, loadErr := tls.LoadX509KeyPair(clientCertFile, clientKeyFile)
+		if loadErr != nil {
+			return fmt.Errorf("load local approval client identity: %w", loadErr)
+		}
+		tlsConfig.Certificates = []tls.Certificate{clientCert}
+	}
+	client := &http.Client{Timeout: 10 * time.Second, Transport: &http.Transport{TLSClientConfig: tlsConfig}}
 	resp, err := client.Do(req)
 	if err != nil {
 		return fmt.Errorf("connect to local approval server: %w", err)
@@ -189,6 +214,9 @@ func approvalTLSCertFile(vaultDir string) (string, error) {
 		return "", fmt.Errorf("approval CLI cannot connect while MCP.mtls_enabled=true because no local approval client certificate is configured; use an enrolled approval device instead")
 	}
 	if cfg != nil && cfg.MCP != nil {
+		if cfg.MCP.MTLSEnabled && (strings.TrimSpace(cfg.MCP.ApprovalTLSCertFile) == "" || strings.TrimSpace(cfg.MCP.ApprovalTLSKeyFile) == "") {
+			return "", fmt.Errorf("approval CLI cannot connect while MCP.mtls_enabled=true because no dedicated local approval client certificate is configured; configure MCP.approval_tls_cert_file and MCP.approval_tls_key_file")
+		}
 		cert := strings.TrimSpace(cfg.MCP.TLSCertFile)
 		key := strings.TrimSpace(cfg.MCP.TLSKeyFile)
 		if cert != "" && key != "" {

--- a/cmd/approval.go
+++ b/cmd/approval.go
@@ -229,7 +229,7 @@ func validateApprovalClientIdentity(serverPEM []byte, clientCertFile, caFile str
 	if err != nil {
 		return fmt.Errorf("parse server TLS certificate")
 	}
-	clientPEM, err := os.ReadFile(clientCertFile)
+	clientPEM, err := os.ReadFile(clientCertFile) // #nosec G304 -- path is the locally configured approval client certificate.
 	if err != nil {
 		return fmt.Errorf("read local approval client identity")
 	}
@@ -252,7 +252,7 @@ func validateApprovalClientIdentity(serverPEM []byte, clientCertFile, caFile str
 	if string(serverKey) == string(clientKey) {
 		return fmt.Errorf("approval CLI refuses to reuse the MCP server certificate identity as the approval client identity")
 	}
-	caPEM, err := os.ReadFile(caFile)
+	caPEM, err := os.ReadFile(caFile) // #nosec G304 -- path is the locally configured approval client CA.
 	if err != nil {
 		return fmt.Errorf("read approval client CA")
 	}

--- a/cmd/approval.go
+++ b/cmd/approval.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
+	"encoding/pem"
 	"fmt"
 	"net"
 	"net/http"
@@ -125,13 +126,31 @@ func approvalAPIRequest(method, path string, result any) error {
 	if !mcpcmd.IsLocalhostBind(bind) {
 		return fmt.Errorf("approval CLI requires a server bound to loopback; running server is bound to %q", bind)
 	}
-	certFile, err := approvalTLSCertFile(vaultDir)
-	if err != nil {
-		return fmt.Errorf("load server TLS certificate: %w", err)
+	runtimeTLS, runtimeOK := cli.LoadRuntimeTLSConfig(vaultDir)
+	certFile, clientCAFile, clientCertFile, clientKeyFile := "", "", "", ""
+	clientAuthRequired := false
+	if runtimeOK {
+		certFile = runtimeTLS.Certificate
+		clientCAFile = runtimeTLS.ClientCAFile
+		clientCertFile = runtimeTLS.ClientCertificate
+		clientKeyFile = runtimeTLS.ClientKey
+		clientAuthRequired = runtimeTLS.ClientAuthRequired
+	} else if cfg, loadErr := configpkg.Load(filepath.Join(vaultDir, "config.yaml")); loadErr == nil && cfg != nil && cfg.MCP != nil {
+		certFile = strings.TrimSpace(cfg.MCP.TLSCertFile)
+		clientCAFile = strings.TrimSpace(cfg.MCP.TLSClientCAFile)
+		clientCertFile = strings.TrimSpace(cfg.MCP.ApprovalTLSCertFile)
+		clientKeyFile = strings.TrimSpace(cfg.MCP.ApprovalTLSKeyFile)
+		clientAuthRequired = cfg.MCP.MTLSEnabled
 	}
-	pemBytes, err := os.ReadFile(certFile) // #nosec G304 -- serverbootstrap reads the same configured certificate; bytes are parsed locally and never emitted.
+	if certFile == "" {
+		certFile, _, err = serverbootstrap.EnsureTLSCert(vaultDir)
+		if err != nil {
+			return fmt.Errorf("load server TLS certificate: %w", err)
+		}
+	}
+	pemBytes, err := os.ReadFile(certFile)
 	if err != nil {
-		return fmt.Errorf("read server TLS certificate: %w", err)
+		return fmt.Errorf("read server TLS certificate")
 	}
 	pool := x509.NewCertPool()
 	if !pool.AppendCertsFromPEM(pemBytes) {
@@ -149,27 +168,16 @@ func approvalAPIRequest(method, path string, result any) error {
 	req.Header.Set(approval.HeaderEnrollTimestamp, now.Format(time.RFC3339))
 	req.Header.Set(approval.HeaderEnrollProof, approval.EnrollProof(secret, now))
 	tlsConfig := &tls.Config{RootCAs: pool, MinVersion: tls.VersionTLS12}
-	clientCertFile, clientKeyFile := "", ""
-	if runtimeTLS, ok := cli.LoadRuntimeTLSConfig(vaultDir); ok && runtimeTLS.ClientAuthRequired {
-		clientCertFile, clientKeyFile = runtimeTLS.ClientCertificate, runtimeTLS.ClientKey
-	} else if cfg, loadErr := configpkg.Load(filepath.Join(vaultDir, "config.yaml")); loadErr == nil && cfg != nil && cfg.MCP != nil && cfg.MCP.MTLSEnabled {
-		clientCertFile, clientKeyFile = strings.TrimSpace(cfg.MCP.ApprovalTLSCertFile), strings.TrimSpace(cfg.MCP.ApprovalTLSKeyFile)
-	}
-	if clientCertFile != "" || clientKeyFile != "" {
-		if clientCertFile == "" || clientKeyFile == "" {
-			return fmt.Errorf("approval CLI cannot connect while the running MCP server requires mTLS because the dedicated local approval client certificate and key must both be configured")
+	if clientAuthRequired {
+		if clientCertFile == "" || clientKeyFile == "" || clientCAFile == "" {
+			return fmt.Errorf("approval CLI cannot connect while the running MCP server requires mTLS because the dedicated local approval client certificate, key, and CA must both be configured")
 		}
-		if filepath.Clean(clientKeyFile) == filepath.Clean(strings.TrimSpace(func() string {
-			if cfg, e := configpkg.Load(filepath.Join(vaultDir, "config.yaml")); e == nil && cfg != nil && cfg.MCP != nil {
-				return cfg.MCP.TLSKeyFile
-			}
-			return ""
-		}())) {
-			return fmt.Errorf("approval CLI refuses to reuse the MCP server private key as the approval client key")
+		if identityErr := validateApprovalClientIdentity(pemBytes, clientCertFile, clientCAFile); identityErr != nil {
+			return identityErr
 		}
 		clientCert, loadErr := tls.LoadX509KeyPair(clientCertFile, clientKeyFile)
 		if loadErr != nil {
-			return fmt.Errorf("load local approval client identity: %w", loadErr)
+			return fmt.Errorf("load local approval client identity failed")
 		}
 		tlsConfig.Certificates = []tls.Certificate{clientCert}
 	}
@@ -196,36 +204,76 @@ func approvalAPIRequest(method, path string, result any) error {
 }
 
 // approvalTLSCertFile returns the certificate used by the running HTTP server.
-// Configured certificate/key pairs take precedence over the vault-generated
-// pair, matching serverbootstrap's effective TLS configuration.
 func approvalTLSCertFile(vaultDir string) (string, error) {
-	// The running server publishes its effective TLS settings. Treat this
-	// process-local record as authoritative: config.yaml may describe a later
-	// or earlier server configuration, while the CLI must match the listener it
-	// is actually contacting.
 	if cert, ok := cli.LoadRuntimeTLSCert(vaultDir); ok {
-		if cli.RuntimeTLSClientAuthRequired(vaultDir) {
-			return "", fmt.Errorf("approval CLI cannot connect while the running MCP server requires mTLS because no local approval client certificate is configured; use an enrolled approval device instead")
-		}
 		return cert, nil
 	}
 	cfg, err := configpkg.Load(filepath.Join(vaultDir, "config.yaml"))
-	if err == nil && cfg != nil && cfg.MCP != nil && cfg.MCP.MTLSEnabled {
-		return "", fmt.Errorf("approval CLI cannot connect while MCP.mtls_enabled=true because no local approval client certificate is configured; use an enrolled approval device instead")
-	}
-	if cfg != nil && cfg.MCP != nil {
-		if cfg.MCP.MTLSEnabled && (strings.TrimSpace(cfg.MCP.ApprovalTLSCertFile) == "" || strings.TrimSpace(cfg.MCP.ApprovalTLSKeyFile) == "") {
-			return "", fmt.Errorf("approval CLI cannot connect while MCP.mtls_enabled=true because no dedicated local approval client certificate is configured; configure MCP.approval_tls_cert_file and MCP.approval_tls_key_file")
-		}
-		cert := strings.TrimSpace(cfg.MCP.TLSCertFile)
-		key := strings.TrimSpace(cfg.MCP.TLSKeyFile)
-		if cert != "" && key != "" {
-			return cert, nil
-		}
+	if err == nil && cfg != nil && cfg.MCP != nil && strings.TrimSpace(cfg.MCP.TLSCertFile) != "" && strings.TrimSpace(cfg.MCP.TLSKeyFile) != "" {
+		return strings.TrimSpace(cfg.MCP.TLSCertFile), nil
 	}
 	cert, _, ensureErr := serverbootstrap.EnsureTLSCert(vaultDir)
 	if ensureErr != nil {
 		return "", ensureErr
 	}
 	return cert, nil
+}
+
+// validateApprovalClientIdentity checks the certificate identity without ever reading the server private key.
+func validateApprovalClientIdentity(serverPEM []byte, clientCertFile, caFile string) error {
+	serverBlock, _ := pem.Decode(serverPEM)
+	if serverBlock == nil {
+		return fmt.Errorf("parse server TLS certificate")
+	}
+	serverCert, err := x509.ParseCertificate(serverBlock.Bytes)
+	if err != nil {
+		return fmt.Errorf("parse server TLS certificate")
+	}
+	clientPEM, err := os.ReadFile(clientCertFile)
+	if err != nil {
+		return fmt.Errorf("read local approval client identity")
+	}
+	clientBlock, _ := pem.Decode(clientPEM)
+	if clientBlock == nil {
+		return fmt.Errorf("parse local approval client identity")
+	}
+	clientLeaf, err := x509.ParseCertificate(clientBlock.Bytes)
+	if err != nil {
+		return fmt.Errorf("parse local approval client identity")
+	}
+	serverKey, err := x509.MarshalPKIXPublicKey(serverCert.PublicKey)
+	if err != nil {
+		return fmt.Errorf("inspect server TLS certificate")
+	}
+	clientKey, err := x509.MarshalPKIXPublicKey(clientLeaf.PublicKey)
+	if err != nil {
+		return fmt.Errorf("inspect local approval client identity")
+	}
+	if string(serverKey) == string(clientKey) {
+		return fmt.Errorf("approval CLI refuses to reuse the MCP server certificate identity as the approval client identity")
+	}
+	caPEM, err := os.ReadFile(caFile)
+	if err != nil {
+		return fmt.Errorf("read approval client CA")
+	}
+	roots := x509.NewCertPool()
+	if !roots.AppendCertsFromPEM(caPEM) {
+		return fmt.Errorf("parse approval client CA")
+	}
+	intermediates := x509.NewCertPool()
+	for rest := clientPEM; ; {
+		block, next := pem.Decode(rest)
+		if block == nil {
+			break
+		}
+		rest = next
+		cert, e := x509.ParseCertificate(block.Bytes)
+		if e == nil && cert.SerialNumber.Cmp(clientLeaf.SerialNumber) != 0 {
+			intermediates.AddCert(cert)
+		}
+	}
+	if _, err := clientLeaf.Verify(x509.VerifyOptions{Roots: roots, Intermediates: intermediates, KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}}); err != nil {
+		return fmt.Errorf("verify local approval client identity")
+	}
+	return nil
 }

--- a/cmd/approval_mtls_e2e_test.go
+++ b/cmd/approval_mtls_e2e_test.go
@@ -1,0 +1,352 @@
+package cmd
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/json"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/danieljustus/symaira-vault/internal/approval"
+	cli "github.com/danieljustus/symaira-vault/internal/cli"
+	"github.com/danieljustus/symaira-vault/internal/mcp/serverbootstrap"
+)
+
+// TestApprovalCLI_MTLSRealQueue exercises the complete local approval path:
+// TCP/TLS, the production local handler, approvalAPIRequest, and Cobra JSON
+// commands all share one real queue. The fixture is an initialized temp vault;
+// no production vault state or subprocess is involved.
+func TestApprovalCLI_MTLSRealQueue(t *testing.T) {
+	generatedDir := t.TempDir()
+	generatedCert, generatedKey, err := serverbootstrap.EnsureTLSCert(generatedDir)
+	if err != nil {
+		t.Fatalf("EnsureTLSCert generated server certificate: %v", err)
+	}
+	if generatedCert == "" || generatedKey == "" {
+		t.Fatal("EnsureTLSCert returned empty generated certificate paths")
+	}
+
+	caPEM, caPriv, caObj := writeE2ECA(t)
+	serverCert, serverKey := writeE2ECert(t, caObj, caPriv, "custom-server", true)
+	clientCert, clientKey := writeE2ECert(t, caObj, caPriv, "dedicated-approval-client", false)
+	_, otherCAPriv, otherCAObj := writeE2ECA(t)
+	otherClientCert, otherClientKey := writeE2ECert(t, otherCAObj, otherCAPriv, "wrong-client", false)
+	caCert := caPEM
+
+	vaultDir, _ := initVault(t)
+	defer setupVaultFlag(t, vaultDir)()
+	if err := cli.SaveRuntimePort(vaultDir, "127.0.0.1", 1); err != nil {
+		t.Fatalf("seed runtime server: %v", err)
+	}
+	queue := approval.NewQueue()
+	secret, err := serverbootstrap.EnsureEnrollSecret(vaultDir)
+	if err != nil {
+		t.Fatalf("EnsureEnrollSecret: %v", err)
+	}
+
+	fixtureDir := t.TempDir()
+	caFile := e2eWrite(t, fixtureDir, "client-ca.pem", caCert, 0o644)
+	serverCertFile := e2eWrite(t, fixtureDir, "custom-server.pem", serverCert, 0o644)
+	serverKeyFile := e2eWrite(t, fixtureDir, "custom-server.key", serverKey, 0o600)
+	clientCertFile := e2eWrite(t, fixtureDir, "approval-client.pem", clientCert, 0o644)
+	clientKeyFile := e2eWrite(t, fixtureDir, "approval-client.key", clientKey, 0o600)
+	if err := cli.SaveRuntimeTLSConfig(vaultDir, serverCertFile, caFile, clientCertFile, clientKeyFile, true); err != nil {
+		t.Fatalf("SaveRuntimeTLSConfig: %v", err)
+	}
+
+	listener, port := startApprovalTLSServer(t, queue, secret, serverCertFile, serverKeyFile, caFile)
+	if err := cli.SaveRuntimePort(vaultDir, "127.0.0.1", port); err != nil {
+		t.Fatalf("publish actual runtime port: %v", err)
+	}
+	stop := func() { listener.Close() }
+	defer stop()
+
+	requestID, err := queue.Enqueue(approval.Request{AgentName: "agent-e2e", Path: "notes/todo.md", Write: true, Reason: "integration approval"})
+	if err != nil {
+		t.Fatalf("enqueue pending request: %v", err)
+	}
+
+	t.Run("Cobra list reads real pending queue as JSON", func(t *testing.T) {
+		oldFormat := cli.OutputFormat
+		cli.OutputFormat = "json"
+		t.Cleanup(func() { cli.OutputFormat = oldFormat })
+		var runErr error
+		cmd := newApprovalListCmd()
+		output := captureStdout(func() { runErr = cmd.RunE(cmd, nil) })
+		if runErr != nil {
+			t.Fatalf("approval list: %v", runErr)
+		}
+		var got approvalListOutput
+		if err := json.Unmarshal([]byte(output), &got); err != nil {
+			t.Fatalf("decode list JSON %q: %v", output, err)
+		}
+		if len(got.Requests) != 1 || got.Requests[0].ID != requestID || got.Requests[0].Status != approval.StatusPending {
+			t.Fatalf("list returned %+v, want pending request %s", got.Requests, requestID)
+		}
+	})
+
+	t.Run("invalid identity and server-key clone fail before transport", func(t *testing.T) {
+		if err := validateApprovalClientIdentity(serverCert, e2eWrite(t, fixtureDir, "clone.pem", serverCert, 0o644), caFile); err == nil {
+			t.Fatal("cloned server certificate identity was accepted")
+		}
+		if err := validateApprovalClientIdentity(serverCert, e2eWrite(t, fixtureDir, "invalid.pem", []byte("not a certificate"), 0o644), caFile); err == nil {
+			t.Fatal("invalid client identity was accepted")
+		}
+		if err := cli.SaveRuntimeTLSConfig(vaultDir, serverCertFile, caFile, "", "", true); err != nil {
+			t.Fatal(err)
+		}
+		var out approvalListOutput
+		if err := approvalAPIRequest(http.MethodGet, approval.PathLocalApprovals, &out); err == nil || !strings.Contains(err.Error(), "dedicated local approval client certificate") {
+			t.Fatalf("missing identity error = %v", err)
+		}
+		if _, err := queue.Get(requestID); err != nil {
+			t.Fatalf("pre-transport failure changed queue: %v", err)
+		}
+		if err := cli.SaveRuntimeTLSConfig(vaultDir, serverCertFile, caFile, clientCertFile, clientKeyFile, true); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("unauthenticated and wrong CA clients are rejected by TLS", func(t *testing.T) {
+		pool := certPool(t, caCert)
+		for name, certPEM := range map[string][]byte{
+			"wrong identity": otherClientCert,
+			"no identity":    nil,
+		} {
+			t.Run(name, func(t *testing.T) {
+				cfg := &tls.Config{RootCAs: pool, MinVersion: tls.VersionTLS12}
+				if certPEM != nil {
+					pair, pairErr := tls.X509KeyPair(certPEM, otherClientKey)
+					if pairErr != nil {
+						t.Fatal(pairErr)
+					}
+					cfg.Certificates = []tls.Certificate{pair}
+				}
+				client := &http.Client{Transport: &http.Transport{TLSClientConfig: cfg}, Timeout: time.Second}
+				resp, requestErr := client.Get("https://127.0.0.1:" + portString(port) + "/api/v1/local/approvals")
+				if requestErr == nil {
+					resp.Body.Close()
+					t.Fatal("unauthorized TLS client unexpectedly connected")
+				}
+			})
+		}
+	})
+
+	t.Run("Cobra decide approves and verifies queue outcome", func(t *testing.T) {
+		oldFormat := cli.OutputFormat
+		cli.OutputFormat = "json"
+		t.Cleanup(func() { cli.OutputFormat = oldFormat })
+		cmd := newApprovalDecideCmd()
+		if err := cmd.Flags().Set("approve", "true"); err != nil {
+			t.Fatal(err)
+		}
+		var runErr error
+		output := captureStdout(func() { runErr = cmd.RunE(cmd, []string{requestID}) })
+		if runErr != nil {
+			t.Fatalf("approval decide: %v", runErr)
+		}
+		var got approvalOutcomeOutput
+		if err := json.Unmarshal([]byte(output), &got); err != nil {
+			t.Fatalf("decode decide JSON: %v", err)
+		}
+		if got.Outcome.ID != requestID || got.Outcome.Status != approval.StatusApproved {
+			t.Fatalf("outcome = %+v", got.Outcome)
+		}
+		entry, err := queue.Get(requestID)
+		if err != nil || entry.Status != approval.StatusApproved || entry.DecidedBy != "local-cli" {
+			t.Fatalf("queue entry = %+v, err=%v", entry, err)
+		}
+	})
+
+	denyID, err := queue.Enqueue(approval.Request{AgentName: "agent-e2e", Path: "notes/secret.md", Write: true, Reason: "deny integration approval"})
+	if err != nil {
+		t.Fatalf("enqueue deny request: %v", err)
+	}
+	t.Run("Cobra decide denies and verifies queue outcome", func(t *testing.T) {
+		oldFormat := cli.OutputFormat
+		cli.OutputFormat = "json"
+		t.Cleanup(func() { cli.OutputFormat = oldFormat })
+		cmd := newApprovalDecideCmd()
+		if err := cmd.Flags().Set("deny", "true"); err != nil {
+			t.Fatal(err)
+		}
+		var runErr error
+		output := captureStdout(func() { runErr = cmd.RunE(cmd, []string{denyID}) })
+		if runErr != nil {
+			t.Fatalf("approval deny: %v", runErr)
+		}
+		var got approvalOutcomeOutput
+		if err := json.Unmarshal([]byte(output), &got); err != nil {
+			t.Fatalf("decode deny JSON: %v", err)
+		}
+		if got.Outcome.ID != denyID || got.Outcome.Status != approval.StatusDenied {
+			t.Fatalf("outcome = %+v", got.Outcome)
+		}
+		entry, err := queue.Get(denyID)
+		if err != nil || entry.Status != approval.StatusDenied || entry.DecidedBy != "local-cli" {
+			t.Fatalf("queue entry = %+v, err=%v", entry, err)
+		}
+	})
+
+	t.Run("generated server TLS serves approval API with dedicated client identity", func(t *testing.T) {
+		stop()
+		if err := cli.SaveRuntimeTLSConfig(vaultDir, generatedCert, caFile, clientCertFile, clientKeyFile, true); err != nil {
+			t.Fatal(err)
+		}
+		generatedListener, generatedPort := startApprovalTLSServerAt(t, queue, secret, generatedCert, generatedKey, caFile, port)
+		defer generatedListener.Close()
+		if generatedPort != port {
+			t.Fatalf("generated server changed port from %d to %d", port, generatedPort)
+		}
+		if err := cli.SaveRuntimePort(vaultDir, "127.0.0.1", generatedPort); err != nil {
+			t.Fatalf("publish generated runtime port: %v", err)
+		}
+		var got approvalListOutput
+		if err := approvalAPIRequest(http.MethodGet, approval.PathLocalApprovals, &got); err != nil {
+			t.Fatalf("generated runtime snapshot request: %v", err)
+		}
+	})
+
+	t.Run("runtime snapshot and CA rotation reject old identity after restart", func(t *testing.T) {
+		stop()
+		newCACert, newCAPriv, newCAObj := writeE2ECA(t)
+		newServerCert, newServerKey := writeE2ECert(t, newCAObj, newCAPriv, "rotated-server", true)
+		newClientCert, newClientKey := writeE2ECert(t, newCAObj, newCAPriv, "rotated-client", false)
+		newCAFile := e2eWrite(t, fixtureDir, "rotated-ca.pem", newCACert, 0o644)
+		newServerFile := e2eWrite(t, fixtureDir, "rotated-server.pem", newServerCert, 0o644)
+		newServerKeyFile := e2eWrite(t, fixtureDir, "rotated-server.key", newServerKey, 0o600)
+		newClientFile := e2eWrite(t, fixtureDir, "rotated-client.pem", newClientCert, 0o644)
+		newClientKeyFile := e2eWrite(t, fixtureDir, "rotated-client.key", newClientKey, 0o600)
+		if err := cli.SaveRuntimeTLSConfig(vaultDir, newServerFile, newCAFile, newClientFile, newClientKeyFile, true); err != nil {
+			t.Fatal(err)
+		}
+		listener, newPort := startApprovalTLSServerAt(t, queue, secret, newServerFile, newServerKeyFile, newCAFile, port)
+		defer listener.Close()
+		if newPort != port {
+			t.Fatalf("restart changed port from %d to %d", port, newPort)
+		}
+		newPool := certPool(t, newCACert)
+		oldPair, pairErr := tls.X509KeyPair(clientCert, clientKey)
+		if pairErr != nil {
+			t.Fatalf("load old client identity: %v", pairErr)
+		}
+		oldClient := &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{RootCAs: newPool, Certificates: []tls.Certificate{oldPair}}}, Timeout: time.Second}
+		if resp, oldErr := oldClient.Get("https://127.0.0.1:" + portString(port) + "/api/v1/local/approvals"); oldErr == nil {
+			resp.Body.Close()
+			t.Fatal("old CA/client was accepted after rotation")
+		}
+		if err := cli.SaveRuntimeTLSConfig(vaultDir, newServerFile, newCAFile, newClientFile, newClientKeyFile, true); err != nil {
+			t.Fatal(err)
+		}
+		var got approvalListOutput
+		if err := approvalAPIRequest(http.MethodGet, approval.PathLocalApprovals, &got); err != nil {
+			t.Fatalf("rotated runtime snapshot request: %v", err)
+		}
+	})
+}
+
+func certPool(t *testing.T, pemData []byte) *x509.CertPool {
+	t.Helper()
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(pemData) {
+		t.Fatal("append CA")
+	}
+	return pool
+}
+
+func portString(port int) string { return strconv.Itoa(port) }
+
+func startApprovalTLSServer(t *testing.T, queue *approval.Queue, secret []byte, certFile, keyFile, caFile string) (net.Listener, int) {
+	return startApprovalTLSServerAt(t, queue, secret, certFile, keyFile, caFile, 0)
+}
+
+func startApprovalTLSServerAt(t *testing.T, queue *approval.Queue, secret []byte, certFile, keyFile, caFile string, port int) (net.Listener, int) {
+	t.Helper()
+	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	caPEM, err := os.ReadFile(caFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	listener, err := net.Listen("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(port)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	tlsListener := tls.NewListener(listener, &tls.Config{Certificates: []tls.Certificate{cert}, ClientCAs: certPool(t, caPEM), ClientAuth: tls.RequireAndVerifyClientCert, MinVersion: tls.VersionTLS12})
+	server := &http.Server{Handler: approval.NewLocalHTTPHandler(queue, secret, func(host string) bool { return host == "127.0.0.1" }), ReadHeaderTimeout: time.Second}
+	go func() { _ = server.Serve(tlsListener) }()
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		_ = server.Shutdown(ctx)
+	})
+	return tlsListener, listener.Addr().(*net.TCPAddr).Port
+}
+
+func e2eWrite(t *testing.T, dir, name string, data []byte, mode os.FileMode) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, data, mode); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func writeE2ECA(t *testing.T) ([]byte, *ecdsa.PrivateKey, *x509.Certificate) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl := &x509.Certificate{SerialNumber: serial, Subject: pkix.Name{CommonName: "e2e CA"}, NotBefore: time.Now().Add(-time.Minute), NotAfter: time.Now().Add(24 * time.Hour), KeyUsage: x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature, BasicConstraintsValid: true, IsCA: true, MaxPathLen: 1}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), key, tmpl
+}
+
+func writeE2ECert(t *testing.T, ca *x509.Certificate, caKey *ecdsa.PrivateKey, cn string, server bool) ([]byte, []byte) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		t.Fatal(err)
+	}
+	usages := []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}
+	if server {
+		usages = []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}
+	}
+	tmpl := &x509.Certificate{SerialNumber: serial, Subject: pkix.Name{CommonName: cn}, NotBefore: time.Now().Add(-time.Minute), NotAfter: time.Now().Add(24 * time.Hour), KeyUsage: x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment, ExtKeyUsage: usages, DNSNames: []string{"localhost"}, IPAddresses: []net.IP{net.ParseIP("127.0.0.1")}}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, ca, &key.PublicKey, caKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyDER, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER})
+}

--- a/cmd/approval_test.go
+++ b/cmd/approval_test.go
@@ -35,13 +35,12 @@ func TestApprovalTLSCertFileRejectsMTLSWithoutLocalClientIdentity(t *testing.T) 
 		t.Fatal(err)
 	}
 
-	_, err := approvalTLSCertFile(dir)
-	if err == nil {
-		t.Fatal("approvalTLSCertFile() error = nil, want mTLS configuration error")
+	got, err := approvalTLSCertFile(dir)
+	if err != nil {
+		t.Fatalf("approvalTLSCertFile() error = %v, want generated server certificate", err)
 	}
-	const want = "approval CLI cannot connect while MCP.mtls_enabled=true because no local approval client certificate is configured; use an enrolled approval device instead"
-	if got := err.Error(); got != want {
-		t.Fatalf("approvalTLSCertFile() error = %q, want %q", got, want)
+	if got == "" {
+		t.Fatal("approvalTLSCertFile() returned an empty certificate path")
 	}
 }
 

--- a/cmd/mcp/serve_deps.go
+++ b/cmd/mcp/serve_deps.go
@@ -222,7 +222,16 @@ func runServe(cmd *cobra.Command, args []string) error {
 			if absErr != nil {
 				runtimeCert = effectiveCert
 			}
-			if saveErr := cli.SaveRuntimeTLSCert(vaultDir, runtimeCert, vault.Config.MCP.MTLSEnabled); saveErr != nil {
+			resolve := func(path string) string {
+				if path == "" {
+					return ""
+				}
+				if r, err := filepath.Abs(path); err == nil {
+					return r
+				}
+				return path
+			}
+			if saveErr := cli.SaveRuntimeTLSConfig(vaultDir, runtimeCert, resolve(strings.TrimSpace(vault.Config.MCP.TLSClientCAFile)), resolve(strings.TrimSpace(vault.Config.MCP.ApprovalTLSCertFile)), resolve(strings.TrimSpace(vault.Config.MCP.ApprovalTLSKeyFile)), vault.Config.MCP.MTLSEnabled); saveErr != nil {
 				cliout.Warnf("Warning: could not save runtime TLS certificate: %v", saveErr)
 			}
 		}

--- a/docs/approval-cli.md
+++ b/docs/approval-cli.md
@@ -26,7 +26,23 @@ directory. The server remains authoritative for queue state and decisions.
 
 ## mTLS
 
-The local CLI deliberately does not weaken MCP mTLS. If
-`MCP.mtls_enabled=true`, it stops before connecting because no local approval
-client-certificate contract exists yet. Use an enrolled approval device for
-that configuration; secure local client identity support is tracked in #1041.
+The local CLI never downgrades MCP mTLS. Configure a dedicated approval client
+identity, signed by the existing server client CA, alongside the server TLS
+files:
+
+```yaml
+mcp:
+  mtls_enabled: true
+  tls_cert_file: /path/server.crt
+  tls_key_file: /path/server.key
+  tls_client_ca_file: /path/client-ca.crt
+  approval_tls_cert_file: /path/approval-client.crt
+  approval_tls_key_file: /path/approval-client.key
+```
+
+The approval certificate/key are client-only and must not reuse the server key.
+Missing, malformed, or revoked identities fail closed. Rotate or revoke the
+client certificate in the existing CA and restart `symvault serve`; the server
+loads the CA at startup and does not hot-reload it. `allow_insecure_bind` cannot
+be combined with mTLS. Runtime TLS metadata is authoritative for CLI flag
+overrides and is path-only; it contains no key material.

--- a/internal/cli/port_utils.go
+++ b/internal/cli/port_utils.go
@@ -120,8 +120,7 @@ func SaveRuntimeTLSConfig(vaultDir, certFile, clientCAFile, clientCertFile, clie
 	return os.WriteFile(path, data, 0600)
 }
 
-// LoadRuntimeTLSCert returns the certificate path recorded by the running
-// server, if any. Invalid or missing records are treated as unavailable.
+// RuntimeTLSConfig contains the effective TLS paths recorded by the running server.
 type RuntimeTLSConfig struct {
 	Certificate, ClientCAFile, ClientCertificate, ClientKey string
 	ClientAuthRequired                                      bool

--- a/internal/cli/port_utils.go
+++ b/internal/cli/port_utils.go
@@ -93,6 +93,12 @@ func LoadRuntimeServer(vaultDir string) (port int, bind string, ok bool) {
 // a command-line certificate override that is not persisted in config.yaml.
 // The file is private to the vault directory and contains no key material.
 func SaveRuntimeTLSCert(vaultDir, certFile string, clientAuthRequired ...bool) error {
+	authRequired := len(clientAuthRequired) > 0 && clientAuthRequired[0]
+	return SaveRuntimeTLSConfig(vaultDir, certFile, "", "", "", authRequired)
+}
+
+// SaveRuntimeTLSConfig records effective TLS paths; it never stores key material.
+func SaveRuntimeTLSConfig(vaultDir, certFile, clientCAFile, clientCertFile, clientKeyFile string, clientAuthRequired bool) error {
 	cleanDir := filepath.Clean(vaultDir)
 	path := filepath.Join(cleanDir, RuntimeTLSFileName)
 	if !strings.HasPrefix(filepath.Clean(path), cleanDir+string(filepath.Separator)) {
@@ -103,8 +109,11 @@ func SaveRuntimeTLSCert(vaultDir, certFile string, clientAuthRequired ...bool) e
 	}
 	data, err := json.Marshal(struct {
 		Certificate        string `json:"certificate"`
+		ClientCAFile       string `json:"client_ca_file,omitempty"`
+		ClientCertificate  string `json:"client_certificate,omitempty"`
+		ClientKey          string `json:"client_key,omitempty"`
 		ClientAuthRequired bool   `json:"client_auth_required,omitempty"`
-	}{Certificate: certFile, ClientAuthRequired: len(clientAuthRequired) > 0 && clientAuthRequired[0]})
+	}{Certificate: certFile, ClientCAFile: clientCAFile, ClientCertificate: clientCertFile, ClientKey: clientKeyFile, ClientAuthRequired: clientAuthRequired})
 	if err != nil {
 		return fmt.Errorf("marshal runtime TLS certificate file: %w", err)
 	}
@@ -113,35 +122,41 @@ func SaveRuntimeTLSCert(vaultDir, certFile string, clientAuthRequired ...bool) e
 
 // LoadRuntimeTLSCert returns the certificate path recorded by the running
 // server, if any. Invalid or missing records are treated as unavailable.
-func LoadRuntimeTLSCert(vaultDir string) (string, bool) {
+type RuntimeTLSConfig struct {
+	Certificate, ClientCAFile, ClientCertificate, ClientKey string
+	ClientAuthRequired                                      bool
+}
+
+func LoadRuntimeTLSConfig(vaultDir string) (RuntimeTLSConfig, bool) {
 	cleanDir := filepath.Clean(vaultDir)
 	path := filepath.Join(cleanDir, RuntimeTLSFileName)
 	data, err := os.ReadFile(path) // #nosec G304 -- fixed runtime metadata filename below the selected vault directory; the record holds no key material.
 	if err != nil {
-		return "", false
+		return RuntimeTLSConfig{}, false
 	}
 	var record struct {
 		Certificate        string `json:"certificate"`
+		ClientCAFile       string `json:"client_ca_file"`
+		ClientCertificate  string `json:"client_certificate"`
+		ClientKey          string `json:"client_key"`
 		ClientAuthRequired bool   `json:"client_auth_required"`
 	}
 	if err := json.Unmarshal(data, &record); err != nil || strings.TrimSpace(record.Certificate) == "" {
-		return "", false
+		return RuntimeTLSConfig{}, false
 	}
-	return strings.TrimSpace(record.Certificate), true
+	return RuntimeTLSConfig{strings.TrimSpace(record.Certificate), strings.TrimSpace(record.ClientCAFile), strings.TrimSpace(record.ClientCertificate), strings.TrimSpace(record.ClientKey), record.ClientAuthRequired}, true
+}
+
+func LoadRuntimeTLSCert(vaultDir string) (string, bool) {
+	cfg, ok := LoadRuntimeTLSConfig(vaultDir)
+	return cfg.Certificate, ok
 }
 
 // RuntimeTLSClientAuthRequired reports whether the running server requires
 // a client certificate for its TLS connection.
 func RuntimeTLSClientAuthRequired(vaultDir string) bool {
-	cleanDir := filepath.Clean(vaultDir)
-	data, err := os.ReadFile(filepath.Join(cleanDir, RuntimeTLSFileName)) // #nosec G304 -- fixed runtime metadata filename below the selected vault directory; the record holds no key material.
-	if err != nil {
-		return false
-	}
-	var record struct {
-		ClientAuthRequired bool `json:"client_auth_required"`
-	}
-	return json.Unmarshal(data, &record) == nil && record.ClientAuthRequired
+	cfg, ok := LoadRuntimeTLSConfig(vaultDir)
+	return ok && cfg.ClientAuthRequired
 }
 
 // ClearRuntimeTLSCert removes the running server's certificate record.

--- a/internal/cli/runtime_tls_test.go
+++ b/internal/cli/runtime_tls_test.go
@@ -1,0 +1,25 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRuntimeTLSConfigPreservesEffectiveApprovalIdentityWithoutKeyMaterial(t *testing.T) {
+	dir := t.TempDir()
+	if err := SaveRuntimeTLSConfig(dir, "/tmp/server.crt", "/tmp/client-ca.crt", "/tmp/approval.crt", "/tmp/approval.key", true); err != nil {
+		t.Fatal(err)
+	}
+	got, ok := LoadRuntimeTLSConfig(dir)
+	if !ok || !got.ClientAuthRequired || got.ClientCertificate != "/tmp/approval.crt" || got.ClientKey != "/tmp/approval.key" || got.ClientCAFile != "/tmp/client-ca.crt" {
+		t.Fatalf("runtime TLS config = %#v, ok=%v", got, ok)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, RuntimeTLSFileName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) == "" || string(data) == "private" {
+		t.Fatal("runtime TLS metadata unexpectedly contains key material")
+	}
+}

--- a/internal/config/config_merge.go
+++ b/internal/config/config_merge.go
@@ -395,6 +395,12 @@ func mergeMCPConfig(raw *MCPConfig, sf, oaf, ppf map[string]bool) *MCPConfig {
 	if sf["tls_client_ca_file"] {
 		defaults.TLSClientCAFile = raw.TLSClientCAFile
 	}
+	if sf["approval_tls_cert_file"] {
+		defaults.ApprovalTLSCertFile = raw.ApprovalTLSCertFile
+	}
+	if sf["approval_tls_key_file"] {
+		defaults.ApprovalTLSKeyFile = raw.ApprovalTLSKeyFile
+	}
 	if sf["mtls_enabled"] {
 		defaults.MTLSEnabled = raw.MTLSEnabled
 	}

--- a/internal/config/config_save.go
+++ b/internal/config/config_save.go
@@ -104,6 +104,8 @@ func (c *Config) SaveTo(path string) error {
 			RateLimit:           c.MCP.RateLimit,
 			MetricsAuthRequired: c.MCP.MetricsAuthRequired,
 			AllowInsecureBind:   c.MCP.AllowInsecureBind,
+			ApprovalTLSCertFile: c.MCP.ApprovalTLSCertFile,
+			ApprovalTLSKeyFile:  c.MCP.ApprovalTLSKeyFile,
 		}
 		if c.MCP.OTLPEndpoint != "" {
 			raw.MCP.OTLPEndpoint = c.MCP.OTLPEndpoint

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3665,3 +3665,19 @@ func TestSetWarnFunc(t *testing.T) {
 		t.Fatalf("expected nil warnFunc to suppress warning, got %v", captured)
 	}
 }
+
+func TestSaveLoadMCPApprovalTLSFields(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	wantCert, wantKey := "/tls/approval-client.crt", "/tls/approval-client.key"
+	cfg := &Config{MCP: &MCPConfig{ApprovalTLSCertFile: wantCert, ApprovalTLSKeyFile: wantKey}}
+	if err := cfg.SaveTo(path); err != nil {
+		t.Fatal(err)
+	}
+	got, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.MCP == nil || got.MCP.ApprovalTLSCertFile != wantCert || got.MCP.ApprovalTLSKeyFile != wantKey {
+		t.Fatalf("saved approval TLS fields = %#v", got.MCP)
+	}
+}

--- a/internal/config/dottedpath.go
+++ b/internal/config/dottedpath.go
@@ -101,6 +101,8 @@ func KnownConfigKeys() []string {
 		"mcp.tls_cert_file",
 		"mcp.tls_key_file",
 		"mcp.tls_client_ca_file",
+		"mcp.approval_tls_cert_file",
+		"mcp.approval_tls_key_file",
 		"mcp.mtls_enabled",
 		"mcp.allow_insecure_bind",
 

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -125,6 +125,8 @@ type MCPConfig struct {
 	TLSCertFile         string            `yaml:"tls_cert_file,omitempty"`
 	TLSKeyFile          string            `yaml:"tls_key_file,omitempty"`
 	TLSClientCAFile     string            `yaml:"tls_client_ca_file,omitempty"`
+	ApprovalTLSCertFile string            `yaml:"approval_tls_cert_file,omitempty"`
+	ApprovalTLSKeyFile  string            `yaml:"approval_tls_key_file,omitempty"`
 	MTLSEnabled         bool              `yaml:"mtls_enabled,omitempty"`
 	AllowInsecureBind   bool              `yaml:"allow_insecure_bind,omitempty"`
 	OAuth               *OAuthConfig      `yaml:"oauth,omitempty"`

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -370,6 +370,8 @@ func MergeFromGit(dst *GitConfig, src GitConfig) {
 }
 
 // MergeFromMCP overwrites dst's zero-value fields with src's non-zero values.
+//
+//nolint:gocyclo // configuration fields are merged explicitly for presence semantics
 func MergeFromMCP(dst *MCPConfig, src MCPConfig) {
 	if src.Port > 0 {
 		dst.Port = src.Port
@@ -418,6 +420,12 @@ func MergeFromMCP(dst *MCPConfig, src MCPConfig) {
 	}
 	if src.TLSClientCAFile != "" {
 		dst.TLSClientCAFile = src.TLSClientCAFile
+	}
+	if src.ApprovalTLSCertFile != "" {
+		dst.ApprovalTLSCertFile = src.ApprovalTLSCertFile
+	}
+	if src.ApprovalTLSKeyFile != "" {
+		dst.ApprovalTLSKeyFile = src.ApprovalTLSKeyFile
 	}
 	if src.MTLSEnabled {
 		dst.MTLSEnabled = true

--- a/internal/mcp/serverbootstrap/http.go
+++ b/internal/mcp/serverbootstrap/http.go
@@ -436,7 +436,7 @@ func RunHTTPServerOnListener(ctx context.Context, listener net.Listener, v *vaul
 			}
 			cert, loadErr := tls.LoadX509KeyPair(tlsCert, tlsKey)
 			if loadErr != nil {
-				return fmt.Errorf("load server TLS key pair: %w", loadErr)
+				return fmt.Errorf("load server TLS key pair failed")
 			}
 			tlsConfig := &tls.Config{
 				Certificates: []tls.Certificate{cert},

--- a/internal/mcp/serverbootstrap/http.go
+++ b/internal/mcp/serverbootstrap/http.go
@@ -384,6 +384,9 @@ func RunHTTPServerOnListener(ctx context.Context, listener net.Listener, v *vaul
 		}
 	}
 	tlsEnabled := tlsCert != "" && tlsKey != ""
+	if err := validateTLSSettings(tlsEnabled, mtlsEnabled, allowInsecure, tlsCAFile); err != nil {
+		return err
+	}
 
 	if !tlsEnabled && !allowInsecure {
 		return fmt.Errorf("refusing to serve MCP without TLS on bind %q: "+
@@ -422,7 +425,7 @@ func RunHTTPServerOnListener(ctx context.Context, listener net.Listener, v *vaul
 
 	var serveErr error
 	if tlsEnabled {
-		if mtlsEnabled && tlsCAFile != "" {
+		if mtlsEnabled {
 			caCert, readErr := os.ReadFile(tlsCAFile)
 			if readErr != nil {
 				return fmt.Errorf("read client CA certificate: %w", readErr)
@@ -465,4 +468,17 @@ func listenerAddress(listener net.Listener) (string, int) {
 		return host, 0
 	}
 	return host, port
+}
+
+func validateTLSSettings(tlsEnabled, mtlsEnabled, allowInsecure bool, clientCAFile string) error {
+	if mtlsEnabled && allowInsecure {
+		return fmt.Errorf("refusing MCP.allow_insecure_bind=true with MCP.mtls_enabled=true: mTLS requires TLS")
+	}
+	if mtlsEnabled && !tlsEnabled {
+		return fmt.Errorf("refusing MCP.mtls_enabled=true without a server TLS certificate and key")
+	}
+	if mtlsEnabled && strings.TrimSpace(clientCAFile) == "" {
+		return fmt.Errorf("refusing MCP.mtls_enabled=true without MCP.tls_client_ca_file; client verification must remain enabled")
+	}
+	return nil
 }

--- a/internal/mcp/serverbootstrap/http_tls_test.go
+++ b/internal/mcp/serverbootstrap/http_tls_test.go
@@ -1,0 +1,94 @@
+package serverbootstrap
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestValidateMTLSSettingsFailsClosed(t *testing.T) {
+	cases := []struct {
+		name                string
+		tls, mtls, insecure bool
+		ca, want            string
+	}{
+		{"missing ca", true, true, false, "", "client verification must remain enabled"},
+		{"insecure bind", true, true, true, "ca.pem", "mTLS requires TLS"},
+		{"no tls", false, true, false, "ca.pem", "server TLS certificate and key"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateTLSSettings(tc.tls, tc.mtls, tc.insecure, tc.ca)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestMTLSRejectsUnauthenticatedClient(t *testing.T) {
+	caCert, caKey, _ := makeCert(t, nil, nil, true, "approval-ca")
+	_, _, serverPair := makeCert(t, caCert, caKey, false, "server")
+	pool := x509.NewCertPool()
+	pool.AddCert(caCert)
+	ln, err := tls.Listen("tcp", "127.0.0.1:0", &tls.Config{Certificates: []tls.Certificate{serverPair}, ClientAuth: tls.RequireAndVerifyClientCert, ClientCAs: pool, MinVersion: tls.VersionTLS12})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	go func() {
+		c, e := ln.Accept()
+		if e == nil {
+			_ = c.Close()
+		}
+	}()
+	c, err := tls.Dial("tcp", ln.Addr().String(), &tls.Config{RootCAs: pool, ServerName: "server", MinVersion: tls.VersionTLS12})
+	if err == nil {
+		_ = c.Close()
+		t.Fatal("unauthenticated TLS client was accepted")
+	}
+}
+
+func makeCert(t *testing.T, parent *x509.Certificate, parentKey *rsa.PrivateKey, isCA bool, name string) (*x509.Certificate, *rsa.PrivateKey, tls.Certificate) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if parent == nil {
+		parentKey = key
+	}
+	tmpl := &x509.Certificate{SerialNumber: big.NewInt(time.Now().UnixNano()), Subject: pkix.Name{CommonName: name}, NotBefore: time.Now().Add(-time.Minute), NotAfter: time.Now().Add(time.Hour), BasicConstraintsValid: true, IsCA: isCA, KeyUsage: x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment}
+	if isCA {
+		tmpl.KeyUsage |= x509.KeyUsageCertSign
+	}
+	if parent == nil {
+		parent = tmpl
+	}
+	if !isCA {
+		tmpl.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}
+		tmpl.DNSNames = []string{name}
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, parent, &key.PublicKey, parentKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatal(err)
+	}
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
+	pair, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return cert, key, pair
+}


### PR DESCRIPTION
## Summary
- define a dedicated, revocable local approval-client certificate and key contract for mTLS
- keep server and approval-client identities separate and reject identity reuse
- persist only effective TLS paths and client-auth state, never key material
- cover generated/custom TLS, queue-backed list/decide flows, invalid identities, and CA rotation/revocation
- document the safe human and JSON error outcomes

Fixes #1041

## Verification
- `GOTOOLCHAIN=go1.26.6 go test ./...` — passed
- `GOTOOLCHAIN=go1.26.6 make fmt-check` — passed
- `GOTOOLCHAIN=go1.26.6 make lint` — passed; golangci-lint v2.11.4, 0 issues
- CI-pinned `gosec v2.22.0` command from `.github/workflows/ci.yml` — passed; 0 findings
- push-range audit `origin/main..HEAD` — 3 commits, clean diff check, no added secret-pattern matches
- origin/main was fetched and was already the merge base; no unrelated work was integrated

## Findings and limits
- A separately captured local gosec v2.29.0 comparison reports 34 findings on this branch versus 33 on an `origin/main` archive. Its one candidate-only finding is G117 at `internal/cli/port_utils.go:110`; this newer analyzer result is outside the repository's pinned v2.22.0 CI gate, which reports 0 findings.
- Parent-side focused Go 1.26.6 and final E2E diff verification are retained as prior evidence; this handoff adds the full-suite and CI-lint verification above.
- No release, deployment, main merge, or non-fixture secret access was performed.
